### PR TITLE
Debug mode by default

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,6 +9,7 @@
     "BUILDPACK_URL": "https://github.com/ddollar/heroku-buildpack-multi.git",
     "DJANGO_SETTINGS_MODULE": "saleor.settings",
     "ALLOWED_HOSTS": "*",
+    "DEBUG": "False",
     "SECRET_KEY": {
       "description": "A secret key for verifying the integrity of signed cookies.",
       "generator": "secret"

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -5,7 +5,7 @@ import dj_database_url
 from django.contrib.messages import constants as messages
 
 
-DEBUG = ast.literal_eval(os.environ.get('DEBUG', True))
+DEBUG = ast.literal_eval(os.environ.get('DEBUG', 'True'))
 TEMPLATE_DEBUG = DEBUG
 
 SITE_ID = 1
@@ -39,7 +39,7 @@ EMAIL_HOST = os.environ.get('EMAIL_HOST')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_PORT = os.environ.get('EMAIL_PORT')
-EMAIL_USE_TLS = ast.literal_eval(os.environ.get('EMAIL_USE_TLS', False))
+EMAIL_USE_TLS = ast.literal_eval(os.environ.get('EMAIL_USE_TLS', 'False'))
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,10 +1,11 @@
+import ast
 import os.path
 
 import dj_database_url
 from django.contrib.messages import constants as messages
 
 
-DEBUG = bool(os.environ.get('DEBUG', False))
+DEBUG = ast.literal_eval(os.environ.get('DEBUG', True))
 TEMPLATE_DEBUG = DEBUG
 
 SITE_ID = 1

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -39,7 +39,7 @@ EMAIL_HOST = os.environ.get('EMAIL_HOST')
 EMAIL_HOST_PASSWORD = os.environ.get('EMAIL_HOST_PASSWORD')
 EMAIL_HOST_USER = os.environ.get('EMAIL_HOST_USER')
 EMAIL_PORT = os.environ.get('EMAIL_PORT')
-EMAIL_USE_TLS = bool(os.environ.get('EMAIL_USE_TLS', False))
+EMAIL_USE_TLS = ast.literal_eval(os.environ.get('EMAIL_USE_TLS', False))
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 
 


### PR DESCRIPTION
This PR enables debug mode by default and allows us to use Python bool values in the environment variables:
```
export DEBUG=False
```