### PR TITLE
add missing migrations

### DIFF
--- a/saleor/order/migrations/0002_auto_20150820_1955.py
+++ b/saleor/order/migrations/0002_auto_20150820_1955.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('order', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='payment',
+            options={'ordering': ('-pk',)},
+        ),
+    ]

--- a/saleor/product/migrations/0003_auto_20150820_1955.py
+++ b/saleor/product/migrations/0003_auto_20150820_1955.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0002_auto_20150722_0545'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='product',
+            name='description',
+            field=models.TextField(verbose_name='description'),
+        ),
+    ]


### PR DESCRIPTION
A fresh install of Saleor seems to have missing migrations as evidenced by running `saleor makemigrations` right after project setup.

This pull request aims to add those missing migrations.