### PR TITLE
Reduce number of warnings

### DIFF
--- a/saleor/product/migrations/0003_auto_20150820_2016.py
+++ b/saleor/product/migrations/0003_auto_20150820_2016.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('product', '0002_auto_20150722_0545'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='product',
+            name='attributes',
+            field=models.ManyToManyField(related_name='products', to='product.ProductAttribute', blank=True),
+        ),
+    ]

--- a/saleor/product/models/base.py
+++ b/saleor/product/models/base.py
@@ -88,7 +88,7 @@ class Product(models.Model, ItemRange):
     available_on = models.DateField(
         pgettext_lazy('Product field', 'available on'), blank=True, null=True)
     attributes = models.ManyToManyField(
-        'ProductAttribute', related_name='products', blank=True, null=True)
+        'ProductAttribute', related_name='products', blank=True)
 
     objects = ProductManager()
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -116,13 +116,13 @@ INSTALLED_APPS = [
     'django.contrib.webdesign',
 
     # Local apps
+    'saleor.userprofile',
+    'saleor.product',
     'saleor.cart',
     'saleor.checkout',
     'saleor.core',
-    'saleor.product',
     'saleor.order',
     'saleor.registration',
-    'saleor.userprofile',
     'saleor.dashboard',
 
     # External apps


### PR DESCRIPTION
As mentioned in #341, there are too many warnings on the console after a fresh install. This is an attempt to fix those warnings.

So far, these are the things I've done:
- Removed `null=True` on a ManyToManyField
- Tweaked order of local apps

Warnings are now currently...

```
/Users/dashmug/Projects/saleor/saleor/order/models.py:31: RemovedInDjango19Warning: Model class saleor.order.models.Order doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Order(models.Model, ItemSet):

/Users/dashmug/Projects/saleor/saleor/order/models.py:161: RemovedInDjango19Warning: Model class saleor.order.models.DeliveryGroup doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class DeliveryGroup(models.Model, ItemSet):

/Users/dashmug/Projects/saleor/saleor/order/models.py:275: RemovedInDjango19Warning: Model class saleor.order.models.OrderedItem doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderedItem(models.Model, ItemLine):

/Users/dashmug/Projects/saleor/saleor/order/models.py:328: RemovedInDjango19Warning: Model class saleor.order.models.Payment doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Payment(BasePayment):

/Users/dashmug/Projects/saleor/saleor/order/models.py:371: RemovedInDjango19Warning: Model class saleor.order.models.OrderHistoryEntry doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderHistoryEntry(models.Model):

/Users/dashmug/Projects/saleor/saleor/order/models.py:390: RemovedInDjango19Warning: Model class saleor.order.models.OrderNote doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderNote(models.Model):

/Users/dashmug/Projects/saleor/saleor/order/models.py:31: RemovedInDjango19Warning: Model class saleor.order.models.Order doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Order(models.Model, ItemSet):

/Users/dashmug/Projects/saleor/saleor/order/models.py:161: RemovedInDjango19Warning: Model class saleor.order.models.DeliveryGroup doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class DeliveryGroup(models.Model, ItemSet):

/Users/dashmug/Projects/saleor/saleor/order/models.py:275: RemovedInDjango19Warning: Model class saleor.order.models.OrderedItem doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderedItem(models.Model, ItemLine):

/Users/dashmug/Projects/saleor/saleor/order/models.py:328: RemovedInDjango19Warning: Model class saleor.order.models.Payment doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class Payment(BasePayment):

/Users/dashmug/Projects/saleor/saleor/order/models.py:371: RemovedInDjango19Warning: Model class saleor.order.models.OrderHistoryEntry doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderHistoryEntry(models.Model):

/Users/dashmug/Projects/saleor/saleor/order/models.py:390: RemovedInDjango19Warning: Model class saleor.order.models.OrderNote doesn't declare an explicit app_label and either isn't in an application in INSTALLED_APPS or else was imported before its application was loaded. This will no longer be supported in Django 1.9.
  class OrderNote(models.Model):

Performing system checks...

System check identified some issues:

WARNINGS:

order.Payment.customer_ip_address: (fields.W900) IPAddressField has been deprecated. Support for it (except in historical migrations) will be removed in Django 1.9.
    HINT: Use GenericIPAddressField instead.
```

Before: 20 Removed in Django 1.9 warnings + 2 system check issues
After: 12 Removed in Django 1.9 warnings + 1 system check issue