### PR TITLE
Add ability to cache python env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,14 @@ RUN \
  apt-get clean && \
  ln -s /usr/bin/nodejs /usr/bin/node
 
-ADD . /app
-WORKDIR /app
-
-RUN pip install -r requirements.txt
+ADD setup.py /app/setup.py
+RUN cd /app && pip install -e .[PaaS]
 
 ADD package.json /node/package.json
 RUN cd /node && npm install
+
+ADD . /app
+WORKDIR /app
 
 EXPOSE 8000
 ENTRYPOINT ["/app/compose/entrypoint.sh"]


### PR DESCRIPTION
This PR allows to use the intermediate (cached) image that contains the Python environment.