### PR TITLE
Update packages: postcss, autoprefixer, csswring

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -87,7 +87,7 @@ module.exports = function(grunt) {
       options: {
         map: true,
         processors: [
-          require("autoprefixer-core"),
+          require("autoprefixer"),
           require("csswring")
         ]
       },

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "node": "0.10.x"
   },
   "dependencies": {
-    "autoprefixer-core": "~5.2.0",
+    "autoprefixer": "~6.0.3",
     "bower": "^1.3.12",
-    "csswring": "~3.0.5",
+    "csswring": "^4.0.0",
     "grunt": "~0.4.5",
     "grunt-babel": "~5.0.1",
     "grunt-browser-sync": "~2.1.3",
@@ -27,7 +27,7 @@
     "grunt-contrib-less": "~0.11.2",
     "grunt-contrib-uglify": "~0.9.1",
     "grunt-contrib-watch": "~0.6.1",
-    "grunt-postcss": "~0.4.0",
+    "grunt-postcss": "^0.7.0",
     "grunt-sass": "~1.0.0",
     "load-grunt-tasks": "~3.2.0"
   }


### PR DESCRIPTION
[Autoprefixer-core](https://www.npmjs.com/package/autoprefixer-core) is depricated and [autoprefixer](https://www.npmjs.com/package/autoprefixer) is recommended as a replacement. This change required update of `grunt-postcss` and `csswring` versions to eliminate all errors at grunt tasks.