### PR TITLE
Don't provide a fallback SECRET_KEY

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -89,7 +89,7 @@ TEMPLATES = [{
         'string_if_invalid': '<< MISSING VARIABLE "%s" >>' if DEBUG else ''}}]
 
 # Make this unique, and don't share it with anybody.
-SECRET_KEY = os.environ.get('SECRET_KEY', '{{ secret_key }}')
+SECRET_KEY = os.environ.get('SECRET_KEY')
 
 MIDDLEWARE_CLASSES = [
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/tox.ini
+++ b/tox.ini
@@ -5,11 +5,13 @@ envlist = py{27,34,35}-django{18,19,_master}
 deps =
     -rrequirements.txt
     coverage
-commands=
+commands =
     django18: pip install "django>=1.8,!=1.8.6,<1.9a0" --upgrade
     django19: pip install "django>=1.9a1,<1.10a0" --upgrade
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     coverage run setup.py test
+setenv =
+    DJANGO_SETTINGS_MODULE = saleor.test_settings
 
 [pytest]
 testpaths = saleor


### PR DESCRIPTION
We'll end up with tons of projects having their SECRET_KEY set to literally `{{ secret_key }}`. This is certainly not what we want.