### PR TITLE
Mailcatcher container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,12 +6,21 @@ db:
     - DB_PASS=saleor
 redis:
   image: redis
+mailcatcher:
+ image: schickling/mailcatcher
+ ports:
+  - '1080:1080'
 web:
   build: .
   environment:
     - SECRET_KEY=changeme
+    - DEFAULT_FROM_EMAIL=info@getsaleor.com
+    - EMAIL_BACKEND_MODULE=smtp
+    - EMAIL_HOST=mailcatcher
+    - EMAIL_PORT=1025
   links:
     - db
+    - mailcatcher
     - redis
   ports:
     - '8000:8000'


### PR DESCRIPTION
This PR adds `mailcatcher` container which allows to display all emails sent from `saleor`.

By default, `mailcatcher` is configured to listen on port `1080`.

![mailcatcher](https://cloud.githubusercontent.com/assets/1451824/11369062/679e44e2-92bd-11e5-9f88-ecce4e493b34.png)
