### PR TITLE
Use a valid SPDX license expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "git://github.com/mirumee/saleor.git"
   },
   "author": "Mirumee Software",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "bugs": {
     "url": "https://github.com/mirumee/saleor/issues"
   },


### PR DESCRIPTION
This PR adds a valid [SPDX license expression](https://spdx.org/licenses/) and gets rid of the npm warning:
```
npm WARN package.json saleor@0.0.0 license should be a valid SPDX license expression
```