### PR TITLE
Fix for missing sortablejs import

### DIFF
--- a/saleor/static/js_src/dashboard.jsx
+++ b/saleor/static/js_src/dashboard.jsx
@@ -1,5 +1,6 @@
 var $ = require('jquery');
 var Dropzone = require('dropzone');
+var Sortable = require('sortablejs');
 
 require('jquery-ui/datepicker');
 require('jquery-match-height');


### PR DESCRIPTION
I was getting a 'Sortable not defined' error and it seems there's no import for sortablejs anywhere.