### PR TITLE
Corrected class typo in dashboard order template

### DIFF
--- a/saleor/dashboard/templates/dashboard/order/detail.html
+++ b/saleor/dashboard/templates/dashboard/order/detail.html
@@ -289,7 +289,7 @@
 
     <div class="card tab-content" id="order-history">
         <div class="data-table-container">
-            <table class="bordered hooverable responsive data-table">
+            <table class="bordered hoverable responsive data-table">
                 <thead>
                     <tr>
                         <th>Date</th>


### PR DESCRIPTION
'hooverable' to 'hoverable' in order-history tab