### PR TITLE
Create example orders with total net/tax values

### DIFF
--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -99,9 +99,7 @@ class Checkout(ProcessManager):
         if self.request.user.is_authenticated():
             order.anonymous_user_email = ''
         order.tracking_client_id = analytics.get_client_id(self.request)
-        order.total_net = self.get_total()
-        # Tax is not calculated by default
-        order.total_tax = Price(0, currency=settings.DEFAULT_CURRENCY)
+        order.total = self.get_total()
         order.save()
         return order
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -155,9 +155,15 @@ class Order(models.Model, ItemSet):
 
     @property
     def total(self):
-        gross = self.total_net.net + self.total_tax.gross
-        return Price(net=self.total_net.net, gross=gross,
-                     currency=settings.DEFAULT_CURRENCY)
+        if self.total_net is not None:
+            gross = self.total_net.net + self.total_tax.gross
+            return Price(net=self.total_net.net, gross=gross,
+                         currency=settings.DEFAULT_CURRENCY)
+
+    @total.setter
+    def total(self, price):
+        self.total_net = price
+        self.total_tax = Price(price.tax, currency=price.currency)
 
 
 class DeliveryGroupManager(models.Manager):

--- a/saleor/order/test_order.py
+++ b/saleor/order/test_order.py
@@ -1,3 +1,5 @@
+from prices import Price
+
 from .models import Order
 
 
@@ -6,3 +8,16 @@ def test_total_property():
     assert order.total.gross == 25
     assert order.total.tax == 5
     assert order.total.net == 20
+
+
+def test_total_property_empty_value():
+    order = Order(total_net=None, total_tax=None)
+    assert order.total is None
+
+
+def test_total_setter():
+    price = Price(net=10, gross=20, currency='USD')
+    order = Order()
+    order.total = price
+    assert order.total_net.net == 10
+    assert order.total_tax.net == 10

--- a/saleor/test_settings.py
+++ b/saleor/test_settings.py
@@ -1,3 +1,5 @@
 from .settings import *
 
 SECRET_KEY = 'NOTREALLY'
+
+DEFAULT_CURRENCY = 'USD'


### PR DESCRIPTION
This PR:
 - [x] fixes creation of example orders by counting `total net/tax` values
 - [x] prevents throwing exceptions by `total` property when fields are empty