### PR TITLE
Read requirements from the .txt file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ class PyTest(TestCommand):
         sys.exit(errno)
 
 
-with open('requirements.in', 'r') as req_file:
+with open('requirements.txt', 'r') as req_file:
     requirements = req_file.readlines()
 
 


### PR DESCRIPTION
The following commands should be equivalent:
```
python setup.py install
pip install -r requirements.txt
```