### PR TITLE
Remove unnecessary broken add_error method.

### DIFF
--- a/saleor/cart/forms.py
+++ b/saleor/cart/forms.py
@@ -72,10 +72,6 @@ class AddToCartForm(forms.Form):
     def get_variant(self, cleaned_data):
         raise NotImplementedError()
 
-    def add_error(self, name, value):
-        errors = self.errors.setdefault(name, self.error_class())
-        errors.append(value)
-
 
 class ReplaceCartLineForm(AddToCartForm):
     """Replace quantity form


### PR DESCRIPTION
This method is now implemented by Django itself, but in a subtly different way. With this implementation, if you raise a ValidationError in the clean() method it will getting added to form.errors under they key `None` instead of `NON_FIELD_ERRORS`, and therefore silently disappear from rendering.