### PR TITLE
Get rid of deprecated and unused templatetag

### DIFF
--- a/saleor/dashboard/templates/dashboard/customer/detail.html
+++ b/saleor/dashboard/templates/dashboard/customer/detail.html
@@ -1,7 +1,6 @@
 {% extends "dashboard/base.html" %}
 {% load prices_i18n %}
 {% load i18n %}
-{% load bootstrap %}
 {% load status %}
 
 {% block title %}{{ customer }} - {% trans "Customers" %} - {{ block.super }}{% endblock %}

--- a/saleor/dashboard/templates/dashboard/order/modal_capture.html
+++ b/saleor/dashboard/templates/dashboard/order/modal_capture.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load babel %}
-{% load bootstrap %}
 {% load materializecss %}
 {% load prices_i18n %}
 

--- a/saleor/dashboard/templates/dashboard/order/modal_refund.html
+++ b/saleor/dashboard/templates/dashboard/order/modal_refund.html
@@ -1,6 +1,5 @@
 {% load i18n %}
 {% load babel %}
-{% load bootstrap %}
 {% load materializecss %}
 {% load prices_i18n %}
 

--- a/saleor/dashboard/templates/dashboard/order/modal_ship_delivery_group.html
+++ b/saleor/dashboard/templates/dashboard/order/modal_ship_delivery_group.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load bootstrap %}
 {% load materializecss %}
 
 <form id="ship-delivery-group-form" method="post" role="form" action="{% url 'dashboard:ship-delivery-group' order_pk=order.pk group_pk=group.pk %}" class="form-async">

--- a/saleor/dashboard/templates/dashboard/payments/detail.html
+++ b/saleor/dashboard/templates/dashboard/payments/detail.html
@@ -1,7 +1,6 @@
 {% extends "dashboard/base.html" %}
 {% load prices_i18n %}
 {% load i18n %}
-{% load bootstrap %}
 {% load status %}
 {% load utils %}
 


### PR DESCRIPTION
This PR removes unused `bootstrap` templatetag.
Fixes #456.