### PR TITLE
Replace whitenoise with uwsgi's static-map

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,4 +34,3 @@ requests>=1.2.0
 satchless>=1.1.2,<1.2a0
 unidecode
 uwsgi>=2.0.0
-whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -61,7 +61,6 @@ stripe==1.29.1            # via django-payments
 suds-jurko==0.6           # via django-payments
 unidecode==0.4.19
 uwsgi==2.0.12
-whitenoise==2.0.6
 xmltodict==0.9.2          # via django-payments
 
 # The following packages are commented out because they are

--- a/saleor/wsgi/static.py
+++ b/saleor/wsgi/static.py
@@ -1,9 +1,0 @@
-import os
-
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'saleor.settings')
-
-from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
-
-application = get_wsgi_application()
-application = DjangoWhiteNoise(application)

--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -2,5 +2,6 @@
 die-on-term = true
 http-socket = :$(PORT)
 master = true
-module = saleor.wsgi.static:application
+module = saleor.wsgi:application
 processes = 4
+static-map = /static=/app/static


### PR DESCRIPTION
Gets rid of `whitenoise` and defaults to static-mapping using uWSGI.

Fixes #465 