### PR TITLE
Fix shipping vouchers for 'Any Country'

### DIFF
--- a/saleor/discount/test_discounts.py
+++ b/saleor/discount/test_discounts.py
@@ -98,6 +98,7 @@ def test_value_voucher_checkout_discount_not_applicable(settings):
     'shipping_cost, shipping_country_code, discount_value, discount_type, apply_to, expected_value', [  # noqa
         (10, None, 50, Voucher.DISCOUNT_VALUE_PERCENTAGE, None, 5),
         (10, None, 20, Voucher.DISCOUNT_VALUE_FIXED, None, 10),
+        (5, 'PL', 5, Voucher.DISCOUNT_VALUE_FIXED, None, 5),
         (5, 'PL', 5, Voucher.DISCOUNT_VALUE_FIXED, 'PL', 5)])
 def test_shipping_voucher_checkout_discount(settings, shipping_cost,
                                             shipping_country_code,

--- a/saleor/order/templates/order/details.html
+++ b/saleor/order/templates/order/details.html
@@ -3,6 +3,7 @@
 {% load gross from prices_i18n %}
 {% load i18n %}
 {% load staticfiles %}
+{% load discount_amount_for from prices %}
 
 {% block title %}{% trans "Order" %} {{ order }} — {{ block.super }}{% endblock %}
 
@@ -108,4 +109,24 @@
             </table>
         </div>
     {% endfor %}
+    {% if order.discount_amount %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                {{ order.discount_name }}
+            </div>
+            <div class="panel-body text-right">
+                <strong>{% gross order.discount|discount_amount_for:order.total %}</strong>
+            </div>
+        </div>
+    {% endif %}
+    {% if order.discount_amount or groups|length > 1 %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                {% trans "Total" %}
+            </div>
+            <div class="panel-body text-right">
+                <strong>{% gross order.total %}</strong>
+            </div>
+        </div>
+    {% endif %}
 {% endblock content %}

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -61,7 +61,7 @@ class ShippingMethodCountryQueryset(models.QuerySet):
 @python_2_unicode_compatible
 class ShippingMethodCountry(models.Model):
 
-    ANY_COUNTRY = ''
+    ANY_COUNTRY = None
     COUNTRY_CODE_CHOICES = [(ANY_COUNTRY, _('Any country'))] + list(COUNTRIES.items())
 
     country_code = models.CharField(


### PR DESCRIPTION
Applying shipping voucher that is set to 'All countries' raises an error, when selected shipping method has special pricing for selected shipping country.
Also order summary page doesn't contain information about applied discounts, so it looks like we've applied a discount, but our order is not discounted.