### PR TITLE
Warn when locmem cache is used with cached sessions

### DIFF
--- a/saleor/core/__init__.py
+++ b/saleor/core/__init__.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from babel.numbers import get_territory_currencies
 from django.conf import settings
+from django.core.checks import register, Tags, Warning
 from django_countries import countries
 from django_countries.fields import Country
 from geolite2 import geolite2
@@ -27,3 +28,19 @@ def get_currency_for_country(country):
         if main_currency in settings.AVAILABLE_CURRENCIES:
             return main_currency
     return settings.DEFAULT_CURRENCY
+
+
+@register(Tags.caches)
+def my_check(app_configs, **kwargs):
+    errors = []
+    cached_engines = {
+        'django.contrib.sessions.backends.cache',
+        'django.contrib.sessions.backends.cached_db'}
+    if ('locmem' in settings.CACHES['default']['BACKEND'] and
+            settings.SESSION_ENGINE in cached_engines):
+        errors.append(
+            Warning(
+                'Session caching cannot work with locmem backend',
+                'User sessions need to be globally shared, use a cache server like Redis.',
+                'saleor.W001'))
+    return errors

--- a/saleor/core/__init__.py
+++ b/saleor/core/__init__.py
@@ -30,7 +30,7 @@ def get_currency_for_country(country):
     return settings.DEFAULT_CURRENCY
 
 
-@register(Tags.caches)
+@register()
 def my_check(app_configs, **kwargs):
     errors = []
     cached_engines = {

--- a/saleor/core/__init__.py
+++ b/saleor/core/__init__.py
@@ -31,7 +31,7 @@ def get_currency_for_country(country):
 
 
 @register()
-def my_check(app_configs, **kwargs):
+def check_session_caching(app_configs, **kwargs):
     errors = []
     cached_engines = {
         'django.contrib.sessions.backends.cache',


### PR DESCRIPTION
Local memory caching will break all sorts of things when combined with sessions. This adds a system checks framework warning when such a combination is used.

Fixes #526 