### PR TITLE
Feature/email improvement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ cryptography==1.3.2       # via django-payments
 cssselect==0.9.1          # via premailer
 cssutils==1.0.1           # via premailer
 dj-database-url==0.4.1
-dj-email-url==0.0.6
+dj-email-url==0.0.7
 django-absolute==0.3      # via django-emailit
 django-bootstrap3==7.0.1
 django-cache-url==1.0.0

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -147,7 +147,9 @@ class Order(models.Model, ItemSet):
             reverse('order:details', kwargs={'token': self.token}))
         context = {'payment_url': payment_url}
 
-        emailit.api.send_mail(email, context, 'order/emails/confirm_email')
+        emailit.api.send_mail(
+                email, context, 'order/emails/confirm_email',
+                from_email=settings.ORDER_FROM_EMAIL)
 
     def get_last_payment_status(self):
         last_payment = self.payments.last()
@@ -377,7 +379,8 @@ class Payment(BasePayment):
             reverse('order:details', kwargs={'token': self.order.token}))
         context = {'order_url': order_url}
         emailit.api.send_mail(
-            email, context, 'order/payment/emails/confirm_email')
+            email, context, 'order/payment/emails/confirm_email',
+            from_email=settings.ORDER_FROM_EMAIL)
 
     def get_purchased_items(self):
         items = [PurchasedItem(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -43,7 +43,13 @@ USE_TZ = True
 EMAIL_URL = os.environ.get('EMAIL_URL', 'console://')
 email_config = dj_email_url.parse(EMAIL_URL)
 
-vars().update(email_config)
+EMAIL_FILE_PATH = email_config['EMAIL_FILE_PATH']
+EMAIL_HOST_USER = email_config['EMAIL_HOST_USER']
+EMAIL_HOST_PASSWORD = email_config['EMAIL_HOST_PASSWORD']
+EMAIL_HOST = email_config['EMAIL_HOST']
+EMAIL_PORT = email_config['EMAIL_PORT']
+EMAIL_BACKEND = email_config['EMAIL_BACKEND']
+EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -43,13 +43,7 @@ USE_TZ = True
 EMAIL_URL = os.environ.get('EMAIL_URL', 'console://')
 email_config = dj_email_url.parse(EMAIL_URL)
 
-EMAIL_FILE_PATH = email_config['EMAIL_FILE_PATH']
-EMAIL_HOST_USER = email_config['EMAIL_HOST_USER']
-EMAIL_HOST_PASSWORD = email_config['EMAIL_HOST_PASSWORD']
-EMAIL_HOST = email_config['EMAIL_HOST']
-EMAIL_PORT = email_config['EMAIL_PORT']
-EMAIL_BACKEND = email_config['EMAIL_BACKEND']
-EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
+vars().update(email_config)
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -50,6 +50,8 @@ EMAIL_HOST = email_config['EMAIL_HOST']
 EMAIL_PORT = email_config['EMAIL_PORT']
 EMAIL_BACKEND = email_config['EMAIL_BACKEND']
 EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
+EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
+
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -45,6 +45,7 @@ email_config = dj_email_url.parse(EMAIL_URL)
 
 vars().update(email_config)
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
+ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 
 
 MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media')


### PR DESCRIPTION
Using different email in the case of order, payment and refund is common.
I mostly use `DEFAULT_FROM_EMAIL ` for subscription email.
This way, if the users can also add `ORDER_FROM_EMAIL` if it's necessary.