### PR TITLE
Remove partitioning from cart view

### DIFF
--- a/saleor/cart/views.py
+++ b/saleor/cart/views.py
@@ -48,7 +48,6 @@ def index(request, product_id=None):
             if request.is_ajax():
                 response = {'error': form.errors}
                 return JsonResponse(response, status=400)
-    cart_partitioner = cart.partition()
     return TemplateResponse(
         request, 'cart/index.html', {
-            'cart': cart_partitioner})
+            'cart': cart})

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -41,8 +41,7 @@
         </tr>
         </tfoot>
         <tbody>
-        {% for group in cart %}
-            {% for line in group %}
+            {% for line in cart %}
                 <tr class="cart-item">
                     <td class="hidden-xs">
                         <a href="{{ line.product.get_absolute_url }}">
@@ -85,7 +84,6 @@
                         {% gross line.get_total %}
                     </td>
                 </tr>
-                {% endfor %}
             {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
In cart view items are no longer grouped by kind of shipping. Fixes #538 