### PR TITLE
Added Posgresql to Prerequisites Doc

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ Before you are ready to run Saleor you will need certain software installed on y
 
     $ npm i webpack -g
 
-#. `posgresql <https://www.postgresql.org//>`_ version 2.5.4 or above
+#. `posgresql <https://www.postgresql.org/>`_ version 2.5.4 or above
 
 We also strongly recommend creating a virtual environment before proceeding with installation.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,6 +24,8 @@ Before you are ready to run Saleor you will need certain software installed on y
 
     $ npm i webpack -g
 
+#. `posgresql <https://www.postgresql.org//>`_ version 2.5.4 or above
+
 We also strongly recommend creating a virtual environment before proceeding with installation.
 
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ Before you are ready to run Saleor you will need certain software installed on y
 
     $ npm i webpack -g
 
-#. `posgresql <https://www.postgresql.org/>`_ version 2.5.4 or above
+#. `posgresql <https://www.postgresql.org/>`_ version 9 or above
 
 We also strongly recommend creating a virtual environment before proceeding with installation.
 


### PR DESCRIPTION
## Scope

Posgres is requirement for psycopg2 to be installed as a pip package. 
Without it, `pip install -r requirements.txt` will not successfully run.

