### PR TITLE
Fix redis url

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -29,6 +29,9 @@ CACHE_URL = os.environ.get('CACHE_URL',
                            os.environ.get('REDIS_URL', 'locmem://'))
 CACHES = {'default': django_cache_url.parse(CACHE_URL)}
 
+if 'redis' in CACHES['default']['BACKEND']:
+    CACHES['default']['LOCATION'] = CACHE_URL
+
 SQLITE_DB_URL = 'sqlite:///' + os.path.join(PROJECT_ROOT, 'dev.sqlite')
 DATABASES = {'default': dj_database_url.config(default=SQLITE_DB_URL)}
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -25,12 +25,13 @@ ADMINS = (
 MANAGERS = ADMINS
 INTERNAL_IPS = os.environ.get('INTERNAL_IPS', '127.0.0.1').split()
 
-CACHE_URL = os.environ.get('CACHE_URL',
-                           os.environ.get('REDIS_URL', 'locmem://'))
-CACHES = {'default': django_cache_url.parse(CACHE_URL)}
+CACHES = {'default': django_cache_url.config()}
 
-if 'redis' in CACHES['default']['BACKEND']:
-    CACHES['default']['LOCATION'] = CACHE_URL
+if os.environ.get('REDIS_URL'):
+    CACHES = {
+        'default': {
+            'BACKEND': 'django_redis.cache.RedisCache',
+            'LOCATION': os.environ.get('REDIS_URL')}}
 
 SQLITE_DB_URL = 'sqlite:///' + os.path.join(PROJECT_ROOT, 'dev.sqlite')
 DATABASES = {'default': dj_database_url.config(default=SQLITE_DB_URL)}

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -28,10 +28,9 @@ INTERNAL_IPS = os.environ.get('INTERNAL_IPS', '127.0.0.1').split()
 CACHES = {'default': django_cache_url.config()}
 
 if os.environ.get('REDIS_URL'):
-    CACHES = {
-        'default': {
-            'BACKEND': 'django_redis.cache.RedisCache',
-            'LOCATION': os.environ.get('REDIS_URL')}}
+    CACHES['default'] = {
+        'BACKEND': 'django_redis.cache.RedisCache',
+        'LOCATION': os.environ.get('REDIS_URL')}
 
 SQLITE_DB_URL = 'sqlite:///' + os.path.join(PROJECT_ROOT, 'dev.sqlite')
 DATABASES = {'default': dj_database_url.config(default=SQLITE_DB_URL)}


### PR DESCRIPTION
`django-redis >= 4.5.0` requires url scheme but [django-cache-url](https://github.com/ghickman/django-cache-url/pull/28) doesn't support this yet.