### PR TITLE
Cleanup docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,22 +5,16 @@ db:
     - POSTGRES_PASSWORD=saleor
 redis:
   image: redis
-mailcatcher:
-  image: schickling/mailcatcher
-  ports:
-    - '1080:1080'
 web:
   build: .
   command: python manage.py runserver 0.0.0.0:8000
   environment:
     - DATABASE_URL=postgres://saleor:saleor@db/saleor
     - DEFAULT_FROM_EMAIL=noreply@example.com
-    - EMAIL_URL=smtp://:@mailcatcher:1025/
     - REDIS_URL=redis://redis:6379/0
     - SECRET_KEY=changeme
   links:
     - db
-    - mailcatcher
     - redis
   ports:
     - '8000:8000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,8 @@ db:
     - '5432:5432'
 redis:
   image: redis
+  ports:
+    - '6379:6379'
 web:
   build: .
   command: python manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ db:
   environment:
     - POSTGRES_USER=saleor
     - POSTGRES_PASSWORD=saleor
+  ports:
+    - '5432:5432'
 redis:
   image: redis
 web:


### PR DESCRIPTION
We decided to drop mailcatcher from default docker installation and leave console email backend enabled by default.
Also PostgreSQL port is now exposed to allow local database connections.