### PR TITLE
Don't test with Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,12 @@ env:
     - DJANGO_SETTINGS_MODULE=saleor.test_settings
   matrix:
     - TOXENV=py27-django18
-    - TOXENV=py27-django19
     - TOXENV=py27-django110
     - TOXENV=py27-django_master
     - TOXENV=py34-django18
-    - TOXENV=py34-django19
     - TOXENV=py34-django110
     - TOXENV=py34-django_master
     - TOXENV=py35-django18
-    - TOXENV=py35-django19
     - TOXENV=py35-django110
     - TOXENV=py35-django_master
 matrix:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django{18,19,110,_master}
+envlist = py{27,34,35}-django{18,110,_master}
 skipsdist = True
 
 [testenv]
@@ -9,7 +9,6 @@ deps =
     pytest-cov
 commands =
     django18: pip install "django>=1.8,!=1.8.6,<1.9a0" --upgrade
-    django19: pip install "django>=1.9,<1.10a0" --upgrade
     django110: pip install "django>=1.10a1,<1.11a0" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput


### PR DESCRIPTION
We don't need to execute tests with Django 1.9, it's enough to have current LTS version (1.8), latest stable (1.10) and latest master.