### PR TITLE
Disable client side validation in voucher form

### DIFF
--- a/templates/dashboard/discount/voucher_form.html
+++ b/templates/dashboard/discount/voucher_form.html
@@ -41,7 +41,7 @@
 {% block menu_discounts_class %} active{% endblock %}
 
 {% block content %}
-    <form method="post" enctype="multipart/form-data" id="form-vouchers">
+    <form method="post" enctype="multipart/form-data" id="form-vouchers" novalidate>
         {% csrf_token %}
         {% if form.non_field_errors %}
             <blockquote>


### PR DESCRIPTION
Closes #572 

We should check other forms as well, or find another solution that would allow us to disable client-side validation globally