### PR TITLE
Add ability to reuse the cached image layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.5
 ENV PYTHONUNBUFFERED 1
 
-ADD . /app
+ADD requirements.txt /app/
 RUN pip install -r /app/requirements.txt
+
+ADD . /app
 WORKDIR /app
 
 EXPOSE 8000


### PR DESCRIPTION
This PR tells Docker to use the cached image layer containing all dependencies.