### PR TITLE
Fix Amazon S3 link in doc

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -39,7 +39,7 @@ First steps
 
 
 .. note::
- Heroku's storage is volatile. This means that all instances of your application will have separate disks and will lose all changes made to the local disk each time the application is restarted. The best approach is to use cloud storage such as [[Amazon S3|Storage: Amazon S3]].
+ Heroku's storage is volatile. This means that all instances of your application will have separate disks and will lose all changes made to the local disk each time the application is restarted. The best approach is to use cloud storage such as `Amazon S3 <http://aws.amazon.com/s3/>`_.
 
 
 Deploy


### PR DESCRIPTION
This PR fix broken link to 'Amazon S3' storage. 
I don't know if this outdated link should target Amazon site or just storage related section in Saleor documentation, but there is no any section like this in current RTD docs.