### PR TITLE
Add simple wsgi health check

### DIFF
--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -14,7 +14,6 @@ framework.
 
 """
 import os
-
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'saleor.settings')
 
 # This application object is used by any WSGI server configured to use this
@@ -26,3 +25,6 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
+from .health_check import health_check
+
+application = health_check(application, '/health/')

--- a/saleor/wsgi/health_check.py
+++ b/saleor/wsgi/health_check.py
@@ -1,0 +1,8 @@
+
+def health_check(application, health_url):
+    def health_check_wrapper(environ, start_response):
+        if environ.get('PATH_INFO') == health_url:
+            start_response('200 OK', [('Content-Type', 'text/plain')])
+            return []
+        return application(environ, start_response)
+    return health_check_wrapper


### PR DESCRIPTION
Add basic health check under `/health/` URL. WSGI app will simply return HTTP 200 response from that URL, without touching internal django request processing (middleware stack, etc)