### PR TITLE
Copy shipping address for orders

### DIFF
--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -192,23 +192,29 @@ class Checkout(object):
         return Address.objects.are_identical(
             self.shipping_address, self.billing_address)
 
-    def _save_address(self, address, is_billing=False, is_shipping=False):
+    def _save_address(self, address, is_billing=False, is_shipping=False,
+                      create_copy=False):
         if self.user.is_authenticated() and address.id is None:
             address = User.objects.store_address(
                 self.user, address, shipping=is_shipping, billing=is_billing)
         elif address.id is None:
             address.save()
+        if create_copy:
+            address.pk = None
+            address.user = None
+            address.save()
+            return address
         return address
 
     @transaction.atomic
     def create_order(self):
         if self.is_shipping_required:
             shipping_address = self._save_address(
-                self.shipping_address, is_shipping=True)
+                self.shipping_address, is_shipping=True, create_copy=True)
         else:
             shipping_address = None
         billing_address = self._save_address(
-            self.billing_address, is_billing=True)
+            self.billing_address, is_billing=True, create_copy=True)
 
         order_data = {
             'billing_address': billing_address,
@@ -306,7 +312,7 @@ def load_checkout(view):
         except KeyError:
             session_data = ''
         tracking_code = analytics.get_client_id(request)
-        
+
         checkout = Checkout.from_storage(
             session_data, cart, request.user, tracking_code)
         response = view(request, checkout, cart)

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -192,29 +192,36 @@ class Checkout(object):
         return Address.objects.are_identical(
             self.shipping_address, self.billing_address)
 
-    def _save_address(self, address, is_billing=False, is_shipping=False,
-                      create_copy=False):
-        if self.user.is_authenticated() and address.id is None:
-            address = User.objects.store_address(
-                self.user, address, shipping=is_shipping, billing=is_billing)
-        elif address.id is None:
-            address.save()
-        if create_copy:
-            address.pk = None
-            address.user = None
-            address.save()
-            return address
+    def _add_to_user_address_book(self, address, is_billing=False,
+                                  is_shipping=False):
+        if self.user.is_authenticated():
+            User.objects.store_address(
+                self.user, address, shipping=is_shipping,
+                billing=is_billing)
+
+    def _get_address_copy(self, address):
+        address.user = None
+        address.pk = None
+        address.save()
         return address
+
+    def _save_order_billing_address(self):
+        return self._get_address_copy(self.billing_address)
+
+    def _save_order_shipping_address(self):
+        return self._get_address_copy(self.shipping_address)
 
     @transaction.atomic
     def create_order(self):
         if self.is_shipping_required:
-            shipping_address = self._save_address(
-                self.shipping_address, is_shipping=True, create_copy=True)
+            shipping_address = self._save_order_shipping_address()
+            self._add_to_user_address_book(
+                self.shipping_address, is_shipping=True)
         else:
             shipping_address = None
-        billing_address = self._save_address(
-            self.billing_address, is_billing=True, create_copy=True)
+        billing_address = self._save_order_billing_address()
+        self._add_to_user_address_book(
+            self.shipping_address, is_billing=True)
 
         order_data = {
             'billing_address': billing_address,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from saleor.cart import decorators
 from saleor.cart.models import Cart
 from saleor.product.models import Product, ProductVariant, Stock
 from saleor.shipping.models import ShippingMethod
-from saleor.userprofile.models import Address
+from saleor.userprofile.models import Address, User
 
 
 @pytest.fixture
@@ -32,20 +32,15 @@ def request_cart(cart, monkeypatch):
 
 
 @pytest.fixture
-def normal_user(django_user_model):
-    return django_user_model.objects.create_user('test@example.com',
-                                                 'password', is_active=True)
+def normal_user(db):
+    return User.objects.create_user('test@example.com', 'password')
 
 
 @pytest.fixture()
-def admin_user(django_user_model):
+def admin_user(db):
     """A Django admin user.
-
-    This uses an existing user with username "admin", or creates a new one with
-    password "password".
     """
-    return django_user_model.objects.create_superuser('test@example.com',
-                                                      'password', is_active=True)
+    return User.objects.create_superuser('admin@example.com', 'password')
 
 
 @pytest.fixture()
@@ -75,7 +70,7 @@ def billing_address(db):  # pylint: disable=W0613
 
 
 @pytest.fixture
-def shipping_method():
+def shipping_method(db):
     shipping_method = ShippingMethod.objects.create(name='DHL')
     shipping_method.price_per_country.create(price=10)
     return shipping_method

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,11 +16,8 @@ def cart(db):  # pylint: disable=W0613
 
 
 @pytest.fixture
-def cart_with_item(product_in_stock, request_cart):
-    variant = product_in_stock.variants.get()
-    # Prepare some data
-    request_cart.add(variant)
-    return request_cart
+def normal_user(db):
+    return User.objects.create_user('test@example.com', 'password')
 
 
 @pytest.fixture
@@ -32,8 +29,11 @@ def request_cart(cart, monkeypatch):
 
 
 @pytest.fixture
-def normal_user(db):
-    return User.objects.create_user('test@example.com', 'password')
+def request_cart_with_item(product_in_stock, request_cart):
+    variant = product_in_stock.variants.get()
+    # Prepare some data
+    request_cart.add(variant)
+    return request_cart
 
 
 @pytest.fixture()

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -3,7 +3,7 @@ from django.core.urlresolvers import reverse
 from tests.utils import get_redirect_location
 
 
-def test_checkout_flow(cart_with_item, client, shipping_method):  # pylint: disable=W0613
+def test_checkout_flow(request_cart_with_item, client, shipping_method):  # pylint: disable=W0613
     """
     Basic test case that confirms if core checkout flow works
     """
@@ -62,15 +62,15 @@ def test_checkout_flow(cart_with_item, client, shipping_method):  # pylint: disa
     assert get_redirect_location(payment_response) == order_details
 
 
-def test_checkout_flow_authenticated_user(authorized_client, billing_address, cart_with_item,
+def test_checkout_flow_authenticated_user(authorized_client, billing_address, request_cart_with_item,
                                           normal_user, shipping_method):
     """
     Checkout with authenticated user and previously saved address
     """
     # Prepare some data
     normal_user.addresses.add(billing_address)
-    cart_with_item.user = normal_user
-    cart_with_item.save()
+    request_cart_with_item.user = normal_user
+    request_cart_with_item.save()
 
     # Enter checkout
     # Checkout index redirects directly to shipping address step
@@ -112,7 +112,7 @@ def test_checkout_flow_authenticated_user(authorized_client, billing_address, ca
     assert get_redirect_location(payment_response) == order_details
 
 
-def test_address_without_shipping(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
+def test_address_without_shipping(request_cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get shipping address step in checkout without shipping -
      if is redirected to summary step
@@ -126,7 +126,7 @@ def test_address_without_shipping(cart_with_item, client, monkeypatch):  # pylin
     assert get_redirect_location(response) == reverse('checkout:summary')
 
 
-def test_shipping_method_without_shipping(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
+def test_shipping_method_without_shipping(request_cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get shipping method step in checkout without shipping -
      if is redirected to summary step
@@ -140,7 +140,7 @@ def test_shipping_method_without_shipping(cart_with_item, client, monkeypatch): 
     assert get_redirect_location(response) == reverse('checkout:summary')
 
 
-def test_shipping_method_without_address(cart_with_item, client):  # pylint: disable=W0613
+def test_shipping_method_without_address(request_cart_with_item, client):  # pylint: disable=W0613
     """
     user tries to get shipping method step without saved shipping address -
      if is redirected to shipping address step
@@ -151,7 +151,7 @@ def test_shipping_method_without_address(cart_with_item, client):  # pylint: dis
     assert get_redirect_location(response) == reverse('checkout:shipping-address')
 
 
-def test_summary_without_address(cart_with_item, client):  # pylint: disable=W0613
+def test_summary_without_address(request_cart_with_item, client):  # pylint: disable=W0613
     """
     user tries to get summary step without saved shipping method -
      if is redirected to shipping method step
@@ -162,7 +162,7 @@ def test_summary_without_address(cart_with_item, client):  # pylint: disable=W06
     assert get_redirect_location(response) == reverse('checkout:shipping-method')
 
 
-def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
+def test_summary_without_shipping_method(request_cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get summary step without saved shipping method -
      if is redirected to shipping method step
@@ -176,7 +176,7 @@ def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):  
     assert get_redirect_location(response) == reverse('checkout:shipping-method')
 
 
-def test_client_login(cart_with_item, client, admin_user):
+def test_client_login(request_cart_with_item, client, admin_user):
     data = {
         'username': admin_user.email,
         'password': 'password'
@@ -185,4 +185,4 @@ def test_client_login(cart_with_item, client, admin_user):
     assert response.status_code == 302
     assert get_redirect_location(response) == '/'
     response = client.get(reverse('checkout:shipping-address'))
-    assert response.context['checkout'].cart.token == cart_with_item.token
+    assert response.context['checkout'].cart.token == request_cart_with_item.token

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -8,6 +8,8 @@ from saleor.order import Status as OrderStatus
 from saleor.order.models import Order
 from saleor.shipping.models import ShippingMethod
 
+from saleor.userprofile.models import Address
+
 
 @pytest.fixture
 def cart_with_item(product_in_stock, request_cart):
@@ -112,6 +114,109 @@ def test_checkout_flow(product_in_stock, client):
     payment = order.payments.latest('pk')
     assert payment.status == 'preauth'
     assert order.status == OrderStatus.NEW
+
+
+def test_checkout_flow_authenticated_user(product_in_stock, client,
+                                          django_user_model):
+    """
+    Checkout with authenticated user and previously saved address
+    """
+    variant = product_in_stock.variants.get()
+    # Prepare some data
+    shipping_method = ShippingMethod.objects.create(name='DHL')
+    shipping_variant = shipping_method.price_per_country.create(price=10)
+    user = django_user_model.objects.create(
+        email='test@example.com', is_active=True)
+    user.set_password('test')
+    user.save()
+
+    shipping_data = {
+        'first_name': 'John',
+        'last_name': 'Doe',
+        'street_address_1': 'Some street',
+        'street_address_2': '',
+        'city': 'Somewhere',
+        'city_area': '',
+        'country_area': '',
+        'postal_code': '50-123',
+        'country': 'PL'}
+
+    user_shipping_address = Address.objects.create(**shipping_data)
+    user.addresses.add(user_shipping_address)
+
+    client.login(username=user.email, password='test')
+    cart = Cart.objects.create(user=user)
+    cart.add(variant)
+
+    # This is anonymous checkout, so cart token in stored in signed cookie
+    value = signing.get_cookie_signer(salt=Cart.COOKIE_NAME).sign(cart.token)
+    client.cookies[Cart.COOKIE_NAME] = value
+
+    # Go to cart page
+    cart_page = client.get(reverse('cart:index'))
+    cart_lines = cart_page.context['cart_lines']
+    assert len(cart_lines) == cart.lines.count()
+    assert cart_lines[0]['variant'] == variant
+    # Enter checkout
+    checkout_index = client.get(reverse('checkout:index'))
+    # Checkout index redirects directly to shipping address step
+    assert_redirect(checkout_index, reverse('checkout:shipping-address'))
+    shipping_address = client.get(reverse('checkout:shipping-address'))
+    assert shipping_address.status_code == 200
+    # Enter shipping address data
+    shipping_data = {'address': user_shipping_address.pk}
+    shipping_response = client.post(
+        reverse('checkout:shipping-address'), data=shipping_data)
+    # Select shipping method
+    assert_redirect(shipping_response, reverse('checkout:shipping-method'))
+    shipping_method_page = client.get(reverse('checkout:shipping-method'))
+    assert shipping_method_page.status_code == 200
+    # Redirect to summary after shipping method selection
+    shipping_method_response = client.post(
+        reverse('checkout:shipping-method'), data={'method': shipping_method.pk})
+    assert_redirect(shipping_method_response, reverse('checkout:summary'))
+    # Summary page asks for Billing address, default is the same as shipping
+    summary_response = client.post(reverse('checkout:summary'),
+                                   data={'address': 'shipping_address'})
+    # After summary step, order is created and it waits for payment
+    order = Order.objects.latest('pk')
+    order_payment_url = reverse('order:payment', kwargs={'token': order.token})
+    assert_redirect(summary_response, order_payment_url)
+    payment_method_page = client.get(order_payment_url)
+    assert payment_method_page.status_code == 200
+    # Select payment method
+    payment_page = client.post(order_payment_url, data={'method': 'default'},
+                               follow=True)
+    assert len(payment_page.redirect_chain) == 1
+    assert payment_page.status_code == 200
+    # Go to payment details page, enter payment data
+    payment_page_url = payment_page.redirect_chain[0][0]
+    payment_data = {
+        'status': 'preauth',
+        'fraud_status': 'unknown',
+        'gateway_response': '3ds-disabled',
+        'verification_result': 'waiting'}
+    payment_response = client.post(payment_page_url, data=payment_data)
+    assert payment_response.status_code == 302
+    # Target page contains full URL with domain from Site object
+    site = Site.objects.get_current()
+    order_details = reverse('order:details', kwargs={'token': order.token})
+    expected_url = 'http://%s%s' % (site, order_details)
+    assert payment_response['Location'] == expected_url
+    order_details_page = client.get(order_details)
+    assert order_details_page.status_code == 200
+    # Check if order has correct totals and payments
+    expected_total = variant.get_price() + shipping_variant.price
+    assert order.total == expected_total
+    assert order.payments.exists()
+    payment = order.payments.latest('pk')
+    assert payment.status == 'preauth'
+    assert order.status == OrderStatus.NEW
+    assert Address.objects.are_identical(
+        order.shipping_address, user_shipping_address)
+    assert order.user == user
+    # Address should be copied to new object
+    assert order.shipping_address.pk != user_shipping_address.pk
 
 
 def test_address_without_shipping(cart_with_item, client, monkeypatch):

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -114,6 +114,8 @@ def test_checkout_flow(product_in_stock, client):
     payment = order.payments.latest('pk')
     assert payment.status == 'preauth'
     assert order.status == OrderStatus.NEW
+    latest_address = Address.objects.latest('pk')
+    assert Address.objects.are_identical(order.shipping_address, latest_address)
 
 
 def test_checkout_flow_authenticated_user(product_in_stock, client,

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -1,4 +1,3 @@
-from django.contrib.sites.models import Site
 from django.core.urlresolvers import reverse
 
 from tests.utils import get_redirect_location
@@ -67,11 +66,8 @@ def test_checkout_flow(cart_with_item, product_in_stock, client, shipping_method
         'verification_result': 'waiting'}
     payment_response = client.post(payment_page_url, data=payment_data)
     assert payment_response.status_code == 302
-    # Target page contains full URL with domain from Site object
     order_details = reverse('order:details', kwargs={'token': order.token})
-    site = Site.objects.get_current()
-    expected_url = 'http://%s%s' % (site, order_details)
-    assert payment_response['Location'] == expected_url
+    assert get_redirect_location(payment_response) == order_details
 
 
 def test_checkout_flow_authenticated_user(authorized_client, billing_address, cart_with_item,
@@ -126,11 +122,8 @@ def test_checkout_flow_authenticated_user(authorized_client, billing_address, ca
                                               data=payment_data)
 
     assert payment_response.status_code == 302
-    # Target page contains full URL with domain from Site object
     order_details = reverse('order:details', kwargs={'token': order.token})
-    site = Site.objects.get_current()
-    expected_url = 'http://%s%s' % (site, order_details)
-    assert payment_response['Location'] == expected_url
+    assert get_redirect_location(payment_response) == order_details
 
 
 def test_address_without_shipping(cart_with_item, client, monkeypatch):  # pylint: disable=W0613

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -190,7 +190,7 @@ def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):  
     assert get_redirect_location(response) == reverse('checkout:shipping-method')
 
 
-def test_client_login(cart_with_item, client, admin_user):  # pylint: disable=W0613
+def test_client_login(cart_with_item, client, admin_user):
     data = {
         'username': admin_user.email,
         'password': 'password'

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -3,18 +3,10 @@ from django.core.urlresolvers import reverse
 from tests.utils import get_redirect_location
 
 
-def test_checkout_flow(cart_with_item, product_in_stock, client, shipping_method):
+def test_checkout_flow(cart_with_item, client, shipping_method):  # pylint: disable=W0613
     """
     Basic test case that confirms if core checkout flow works
     """
-    # Prepare some data
-    variant = product_in_stock.variants.get()
-
-    # Go to cart page
-    cart_page = client.get(reverse('cart:index'))
-    cart_lines = cart_page.context['cart_lines']
-    assert len(cart_lines) == cart_with_item.lines.count()
-    assert cart_lines[0]['variant'] == variant
 
     # Enter checkout
     checkout_index = client.get(reverse('checkout:index'), follow=True)
@@ -71,21 +63,15 @@ def test_checkout_flow(cart_with_item, product_in_stock, client, shipping_method
 
 
 def test_checkout_flow_authenticated_user(authorized_client, billing_address, cart_with_item,
-                                          normal_user, product_in_stock, shipping_method):
+                                          normal_user, shipping_method):
     """
     Checkout with authenticated user and previously saved address
     """
-    variant = product_in_stock.variants.get()
     # Prepare some data
     normal_user.addresses.add(billing_address)
     cart_with_item.user = normal_user
     cart_with_item.save()
 
-    # Go to cart page
-    cart_page = authorized_client.get(reverse('cart:index'))
-    cart_lines = cart_page.context['cart_lines']
-    assert len(cart_lines) == cart_with_item.lines.count()
-    assert cart_lines[0]['variant'] == variant
     # Enter checkout
     # Checkout index redirects directly to shipping address step
     shipping_address = authorized_client.get(reverse('checkout:index'), follow=True)

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -1,94 +1,61 @@
-import pytest
 from django.contrib.sites.models import Site
-from django.core import signing
 from django.core.urlresolvers import reverse
 
-from saleor.cart.models import Cart
-from saleor.order import Status as OrderStatus
-from saleor.order.models import Order
-from saleor.shipping.models import ShippingMethod
-
-from saleor.userprofile.models import Address
+from tests.utils import get_redirect_location
 
 
-@pytest.fixture
-def cart_with_item(product_in_stock, request_cart):
-    variant = product_in_stock.variants.get()
-    # Prepare some data
-    request_cart.add(variant)
-    return request_cart
-
-
-def assert_redirect(response, expected_url):
-    assert response.status_code == 302
-    # Due to Django 1.8 compatibility, we have to handle both cases
-    location = response['Location']
-    if location.startswith('http'):
-        location = location.split('http://testserver')[1]
-    assert location == expected_url
-
-
-def test_checkout_flow(product_in_stock, client):
+def test_checkout_flow(cart_with_item, product_in_stock, client, shipping_method):
     """
     Basic test case that confirms if core checkout flow works
     """
-    variant = product_in_stock.variants.get()
     # Prepare some data
-    cart = Cart.objects.create()
-    cart.add(variant)
-    shipping_method = ShippingMethod.objects.create(name='DHL')
-    shipping_variant = shipping_method.price_per_country.create(price=10)
-
-
-    # This is anonymous checkout, so cart token in stored in signed cookie
-    value = signing.get_cookie_signer(salt=Cart.COOKIE_NAME).sign(cart.token)
-    client.cookies[Cart.COOKIE_NAME] = value
+    variant = product_in_stock.variants.get()
 
     # Go to cart page
     cart_page = client.get(reverse('cart:index'))
     cart_lines = cart_page.context['cart_lines']
-    assert len(cart_lines) == cart.lines.count()
+    assert len(cart_lines) == cart_with_item.lines.count()
     assert cart_lines[0]['variant'] == variant
+
     # Enter checkout
-    checkout_index = client.get(reverse('checkout:index'))
+    checkout_index = client.get(reverse('checkout:index'), follow=True)
     # Checkout index redirects directly to shipping address step
-    assert_redirect(checkout_index, reverse('checkout:shipping-address'))
-    shipping_address = client.get(reverse('checkout:shipping-address'))
-    assert shipping_address.status_code == 200
+    shipping_address = client.get(checkout_index.request['PATH_INFO'])
+
     # Enter shipping address data
     shipping_data = {
         'email': 'test@example.com',
         'first_name': 'John',
         'last_name': 'Doe',
-        'street_address_1': 'Some street',
+        'street_address_1': 'Aleje Jerozolimskie 2',
         'street_address_2': '',
-        'city': 'Somewhere',
+        'city': 'Warszawa',
         'city_area': '',
         'country_area': '',
-        'postal_code': '50-123',
+        'postal_code': '00-374',
         'country': 'PL'}
-    shipping_response = client.post(
-        reverse('checkout:shipping-address'), data=shipping_data)
+    shipping_response = client.post(shipping_address.request['PATH_INFO'],
+                                    data=shipping_data, follow=True)
+
     # Select shipping method
-    assert_redirect(shipping_response, reverse('checkout:shipping-method'))
-    shipping_method_page = client.get(reverse('checkout:shipping-method'))
-    assert shipping_method_page.status_code == 200
+    shipping_method_page = client.get(shipping_response.request['PATH_INFO'])
+
     # Redirect to summary after shipping method selection
-    shipping_method_response = client.post(
-        reverse('checkout:shipping-method'), data={'method': shipping_method.pk})
-    assert_redirect(shipping_method_response, reverse('checkout:summary'))
+    shipping_method_data = {'method': shipping_method.pk}
+    shipping_method_response = client.post(shipping_method_page.request['PATH_INFO'],
+                                           data=shipping_method_data, follow=True)
+
     # Summary page asks for Billing address, default is the same as shipping
-    summary_response = client.post(reverse('checkout:summary'),
-                                   data={'address': 'shipping_address'})
+    address_data = {'address': 'shipping_address'}
+    summary_response = client.post(shipping_method_response.request['PATH_INFO'],
+                                   data=address_data, follow=True)
+
     # After summary step, order is created and it waits for payment
-    order = Order.objects.latest('pk')
-    order_payment_url = reverse('order:payment', kwargs={'token': order.token})
-    assert_redirect(summary_response, order_payment_url)
-    payment_method_page = client.get(order_payment_url)
-    assert payment_method_page.status_code == 200
+    order = summary_response.context['order']
+
     # Select payment method
-    payment_page = client.post(order_payment_url, data={'method': 'default'},
-                               follow=True)
+    payment_page = client.post(summary_response.request['PATH_INFO'],
+                               data={'method': 'default'}, follow=True)
     assert len(payment_page.redirect_chain) == 1
     assert payment_page.status_code == 200
     # Go to payment details page, enter payment data
@@ -101,127 +68,72 @@ def test_checkout_flow(product_in_stock, client):
     payment_response = client.post(payment_page_url, data=payment_data)
     assert payment_response.status_code == 302
     # Target page contains full URL with domain from Site object
-    site = Site.objects.get_current()
     order_details = reverse('order:details', kwargs={'token': order.token})
+    site = Site.objects.get_current()
     expected_url = 'http://%s%s' % (site, order_details)
     assert payment_response['Location'] == expected_url
-    order_details_page = client.get(order_details)
-    assert order_details_page.status_code == 200
-    # Check if order has correct totals and payments
-    expected_total = variant.get_price() + shipping_variant.price
-    assert order.total == expected_total
-    assert order.payments.exists()
-    payment = order.payments.latest('pk')
-    assert payment.status == 'preauth'
-    assert order.status == OrderStatus.NEW
-    latest_address = Address.objects.latest('pk')
-    assert Address.objects.are_identical(order.shipping_address, latest_address)
 
 
-def test_checkout_flow_authenticated_user(product_in_stock, client,
-                                          django_user_model):
+def test_checkout_flow_authenticated_user(authorized_client, billing_address, cart_with_item,
+                                          normal_user, product_in_stock, shipping_method):
     """
     Checkout with authenticated user and previously saved address
     """
     variant = product_in_stock.variants.get()
     # Prepare some data
-    shipping_method = ShippingMethod.objects.create(name='DHL')
-    shipping_variant = shipping_method.price_per_country.create(price=10)
-    user = django_user_model.objects.create(
-        email='test@example.com', is_active=True)
-    user.set_password('test')
-    user.save()
-
-    shipping_data = {
-        'first_name': 'John',
-        'last_name': 'Doe',
-        'street_address_1': 'Some street',
-        'street_address_2': '',
-        'city': 'Somewhere',
-        'city_area': '',
-        'country_area': '',
-        'postal_code': '50-123',
-        'country': 'PL'}
-
-    user_shipping_address = Address.objects.create(**shipping_data)
-    user.addresses.add(user_shipping_address)
-
-    client.login(username=user.email, password='test')
-    cart = Cart.objects.create(user=user)
-    cart.add(variant)
-
-    # This is anonymous checkout, so cart token in stored in signed cookie
-    value = signing.get_cookie_signer(salt=Cart.COOKIE_NAME).sign(cart.token)
-    client.cookies[Cart.COOKIE_NAME] = value
+    normal_user.addresses.add(billing_address)
+    cart_with_item.user = normal_user
+    cart_with_item.save()
 
     # Go to cart page
-    cart_page = client.get(reverse('cart:index'))
+    cart_page = authorized_client.get(reverse('cart:index'))
     cart_lines = cart_page.context['cart_lines']
-    assert len(cart_lines) == cart.lines.count()
+    assert len(cart_lines) == cart_with_item.lines.count()
     assert cart_lines[0]['variant'] == variant
     # Enter checkout
-    checkout_index = client.get(reverse('checkout:index'))
     # Checkout index redirects directly to shipping address step
-    assert_redirect(checkout_index, reverse('checkout:shipping-address'))
-    shipping_address = client.get(reverse('checkout:shipping-address'))
-    assert shipping_address.status_code == 200
+    shipping_address = authorized_client.get(reverse('checkout:index'), follow=True)
+
     # Enter shipping address data
-    shipping_data = {'address': user_shipping_address.pk}
-    shipping_response = client.post(
-        reverse('checkout:shipping-address'), data=shipping_data)
+    shipping_data = {'address': billing_address.pk}
+    shipping_method_page = authorized_client.post(shipping_address.request['PATH_INFO'],
+                                                  data=shipping_data, follow=True)
+
     # Select shipping method
-    assert_redirect(shipping_response, reverse('checkout:shipping-method'))
-    shipping_method_page = client.get(reverse('checkout:shipping-method'))
-    assert shipping_method_page.status_code == 200
-    # Redirect to summary after shipping method selection
-    shipping_method_response = client.post(
-        reverse('checkout:shipping-method'), data={'method': shipping_method.pk})
-    assert_redirect(shipping_method_response, reverse('checkout:summary'))
+    shipping_method_data = {'method': shipping_method.pk}
+    shipping_method_response = authorized_client.post(shipping_method_page.request['PATH_INFO'],
+                                                      data=shipping_method_data, follow=True)
+
     # Summary page asks for Billing address, default is the same as shipping
-    summary_response = client.post(reverse('checkout:summary'),
-                                   data={'address': 'shipping_address'})
+    payment_method_data = {'address': 'shipping_address'}
+    payment_method_page = authorized_client.post(shipping_method_response.request['PATH_INFO'],
+                                                 data=payment_method_data, follow=True)
+
     # After summary step, order is created and it waits for payment
-    order = Order.objects.latest('pk')
-    order_payment_url = reverse('order:payment', kwargs={'token': order.token})
-    assert_redirect(summary_response, order_payment_url)
-    payment_method_page = client.get(order_payment_url)
-    assert payment_method_page.status_code == 200
+    order = payment_method_page.context['order']
+
     # Select payment method
-    payment_page = client.post(order_payment_url, data={'method': 'default'},
-                               follow=True)
-    assert len(payment_page.redirect_chain) == 1
-    assert payment_page.status_code == 200
+    payment_page = authorized_client.post(payment_method_page.request['PATH_INFO'],
+                                          data={'method': 'default'}, follow=True)
+
     # Go to payment details page, enter payment data
-    payment_page_url = payment_page.redirect_chain[0][0]
     payment_data = {
         'status': 'preauth',
         'fraud_status': 'unknown',
         'gateway_response': '3ds-disabled',
         'verification_result': 'waiting'}
-    payment_response = client.post(payment_page_url, data=payment_data)
+    payment_response = authorized_client.post(payment_page.request['PATH_INFO'],
+                                              data=payment_data)
+
     assert payment_response.status_code == 302
     # Target page contains full URL with domain from Site object
-    site = Site.objects.get_current()
     order_details = reverse('order:details', kwargs={'token': order.token})
+    site = Site.objects.get_current()
     expected_url = 'http://%s%s' % (site, order_details)
     assert payment_response['Location'] == expected_url
-    order_details_page = client.get(order_details)
-    assert order_details_page.status_code == 200
-    # Check if order has correct totals and payments
-    expected_total = variant.get_price() + shipping_variant.price
-    assert order.total == expected_total
-    assert order.payments.exists()
-    payment = order.payments.latest('pk')
-    assert payment.status == 'preauth'
-    assert order.status == OrderStatus.NEW
-    assert Address.objects.are_identical(
-        order.shipping_address, user_shipping_address)
-    assert order.user == user
-    # Address should be copied to new object
-    assert order.shipping_address.pk != user_shipping_address.pk
 
 
-def test_address_without_shipping(cart_with_item, client, monkeypatch):
+def test_address_without_shipping(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get shipping address step in checkout without shipping -
      if is redirected to summary step
@@ -231,10 +143,11 @@ def test_address_without_shipping(cart_with_item, client, monkeypatch):
                         False)
 
     response = client.get(reverse('checkout:shipping-address'))
-    assert_redirect(response, reverse('checkout:summary'))
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse('checkout:summary')
 
 
-def test_shipping_method_without_shipping(cart_with_item, client, monkeypatch):
+def test_shipping_method_without_shipping(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get shipping method step in checkout without shipping -
      if is redirected to summary step
@@ -244,30 +157,33 @@ def test_shipping_method_without_shipping(cart_with_item, client, monkeypatch):
                         False)
 
     response = client.get(reverse('checkout:shipping-method'))
-    assert_redirect(response, reverse('checkout:summary'))
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse('checkout:summary')
 
 
-def test_shipping_method_without_address(cart_with_item, client):
+def test_shipping_method_without_address(cart_with_item, client):  # pylint: disable=W0613
     """
     user tries to get shipping method step without saved shipping address -
      if is redirected to shipping address step
     """
 
     response = client.get(reverse('checkout:shipping-method'))
-    assert_redirect(response, reverse('checkout:shipping-address'))
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse('checkout:shipping-address')
 
 
-def test_summary_without_address(cart_with_item, client):
+def test_summary_without_address(cart_with_item, client):  # pylint: disable=W0613
     """
     user tries to get summary step without saved shipping method -
      if is redirected to shipping method step
     """
 
     response = client.get(reverse('checkout:summary'))
-    assert_redirect(response, reverse('checkout:shipping-method'))
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse('checkout:shipping-method')
 
 
-def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):
+def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):  # pylint: disable=W0613
     """
     user tries to get summary step without saved shipping method -
      if is redirected to shipping method step
@@ -277,15 +193,17 @@ def test_summary_without_shipping_method(cart_with_item, client, monkeypatch):
                         True)
 
     response = client.get(reverse('checkout:summary'))
-    assert_redirect(response, reverse('checkout:shipping-method'))
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse('checkout:shipping-method')
 
 
-def test_client_login(cart_with_item, client, admin_user):
+def test_client_login(cart_with_item, client, admin_user):  # pylint: disable=W0613
     data = {
         'username': admin_user.email,
         'password': 'password'
     }
     response = client.post(reverse('registration:login'), data=data)
-    assert_redirect(response, '/')
+    assert response.status_code == 302
+    assert get_redirect_location(response) == '/'
     response = client.get(reverse('checkout:shipping-address'))
     assert response.context['checkout'].cart.token == cart_with_item.token

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,6 @@
+def get_redirect_location(response):
+    # Due to Django 1.8 compatibility, we have to handle both cases
+    location = response['Location']
+    if location.startswith('http'):
+        location = location.split('http://testserver')[1]
+    return location

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,10 @@
+from urlparse import urlparse
+
+
 def get_redirect_location(response):
     # Due to Django 1.8 compatibility, we have to handle both cases
     location = response['Location']
     if location.startswith('http'):
-        location = location.split('http://testserver')[1]
+        url = urlparse(location)
+        location = url.path
     return location

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,7 @@
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 
 def get_redirect_location(response):


### PR DESCRIPTION
Each order instance should have separated copy of `Address` object.
Test case is a bit ugly and redundant, but a major tests refactoring is already planned, so tests will be cleaned up as soon as we'll have better tests architecture.
Closes #503