### PR TITLE
Use checkout subtotal for shipping voucher limit

### DIFF
--- a/saleor/dashboard/discount/forms.py
+++ b/saleor/dashboard/discount/forms.py
@@ -62,7 +62,7 @@ class ShippingVoucherForm(forms.ModelForm):
     limit = PriceField(
         min_value=0, required=False, currency=settings.DEFAULT_CURRENCY,
         label=pgettext_lazy(
-            'voucher', 'Only if shipping cost is less than or equal to'))
+            'voucher', 'Only if order is over or equal to'))
     apply_to = forms.ChoiceField(
         label=pgettext_lazy('voucher', 'Country'), choices=country_choices,
         required=False)

--- a/saleor/discount/forms.py
+++ b/saleor/discount/forms.py
@@ -36,7 +36,7 @@ class CheckoutDiscountForm(forms.Form):
                 discount = voucher.get_discount_for_checkout(self.checkout)
                 cleaned_data['discount'] = discount
             except NotApplicable as e:
-                self.add_error('voucher', str(e))
+                self.add_error('voucher', unicode(e))
         return cleaned_data
 
     def apply_discount(self):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -168,7 +168,7 @@ class Voucher(models.Model):
 
     def get_discount_for_checkout(self, checkout):
         if self.type == Voucher.VALUE_TYPE:
-            cart_total = checkout.cart.get_total()
+            cart_total = checkout.get_subtotal()
             self.validate_limit(cart_total)
             return self.get_fixed_discount_for(cart_total)
 
@@ -188,7 +188,7 @@ class Voucher(models.Model):
                     'voucher', 'This offer is only valid in %(country)s.')
                 raise NotApplicable(msg % {
                     'country': self.get_apply_to_display()})
-            cart_total = checkout.cart.get_total()
+            cart_total = checkout.get_subtotal()
             self.validate_limit(cart_total)
             return self.get_fixed_discount_for(shipping_method.price)
 

--- a/templates/checkout/details.html
+++ b/templates/checkout/details.html
@@ -86,8 +86,6 @@
                         </td>
                     </tr>
 
-                    {% include 'checkout/snippets/voucher-form.html' with discount=checkout.discount form=voucher_form %}
-
                     <tr>
                         <td class="noborder">
                             {% trans "Shipping" %}
@@ -100,7 +98,10 @@
                             {% endif %}
                         </td>
                     </tr>
-                    {% if total.tax or True %}
+
+                    {% include 'checkout/snippets/voucher-form.html' with discount=checkout.discount form=voucher_form %}
+
+                    {% if total.tax%}
                         <tr>
                             <td class="noborder">
                                 {% trans "Taxes" %}

--- a/templates/checkout/snippets/voucher-form.html
+++ b/templates/checkout/snippets/voucher-form.html
@@ -1,7 +1,6 @@
 {% load bootstrap_field bootstrap_button bootstrap_icon from bootstrap3 %}
 {% load trans from i18n %}
 {% load gross from prices_i18n %}
-{% load discount_amount_for from prices %}
 
 {% if form %}
     <tr>
@@ -20,7 +19,7 @@
                 </form>
             </td>
             <td class="noborder text-right">
-                {% gross discount|discount_amount_for:total %}
+                -{% gross discount.amount %}
             </td>
         {% else %}
                 <form action="{{ request.path }}?next={{ request.path }}"

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -4,8 +4,32 @@ import pytest
 from mock import Mock
 from prices import FixedDiscount, FractionalDiscount, Price
 
+from django_prices.templatetags.prices_i18n import net
+
 from saleor.discount.models import NotApplicable, Sale, Voucher
 from saleor.product.models import Product, ProductVariant
+
+
+@pytest.mark.parametrize('limit, value, valid', [
+        (Price(5, currency='USD'), Price(10, currency='USD'), True),
+        (Price(10, currency='USD'), Price(10, currency='USD'), True),
+        (Price(10, currency='USD'), Price(5, currency='USD'), False),
+])
+def test_voucher_limit_validation(settings, limit, value, valid):
+    settings.DEFAULT_CURRENCY = 'USD'
+    voucher = Voucher(
+        code='unique', type=Voucher.SHIPPING_TYPE,
+        discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
+        discount_value=Price(10, currency='USD'),
+        limit=limit)
+    if valid:
+        voucher.validate_limit(value)
+    else:
+        with pytest.raises(NotApplicable) as e:
+            voucher.validate_limit(value)
+            msg = 'This offer is only valid for orders over %(amount)s.' % {
+                'amount': net(limit)}
+            assert str(e.value) == msg
 
 
 @pytest.mark.integration
@@ -59,8 +83,8 @@ def test_value_voucher_checkout_discount(settings, total, discount_value,
         discount_value_type=discount_type,
         discount_value=discount_value,
         limit=Price(limit, currency='USD') if limit is not None else None)
-    checkout = Mock(cart=Mock(get_total=Mock(
-        return_value=Price(total, currency='USD'))))
+    checkout = Mock(get_subtotal=Mock(return_value=Price(total,
+                                                         currency='USD')))
     discount = voucher.get_discount_for_checkout(checkout)
     assert discount.amount == Price(expected_value, currency='USD')
 
@@ -72,8 +96,8 @@ def test_value_voucher_checkout_discount_not_applicable(settings):
         discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
         discount_value=10,
         limit=100)
-    checkout = Mock(cart=Mock(get_total=Mock(
-        return_value=Price(10, currency='USD'))))
+    checkout = Mock(get_subtotal=Mock(
+        return_value=Price(10, currency='USD')))
     with pytest.raises(NotApplicable) as e:
         voucher.get_discount_for_checkout(checkout)
     assert str(e.value) == 'This offer is only valid for orders over $100.00.'
@@ -90,6 +114,7 @@ def test_shipping_voucher_checkout_discount(
         discount_type, apply_to, expected_value):
     settings.DEFAULT_CURRENCY = 'USD'
     checkout = Mock(
+        get_subtotal=Mock(return_value=Price(100, currency='USD')),
         is_shipping_required=True, shipping_method=Mock(
             price=Price(shipping_cost, currency='USD'),
             country_code=shipping_country_code))
@@ -97,28 +122,34 @@ def test_shipping_voucher_checkout_discount(
         code='unique', type=Voucher.SHIPPING_TYPE,
         discount_value_type=discount_type,
         discount_value=discount_value,
-        apply_to=apply_to)
+        apply_to=apply_to,
+        limit=None)
     discount = voucher.get_discount_for_checkout(checkout)
     assert discount.amount == Price(expected_value, currency='USD')
 
 
 @pytest.mark.parametrize(
-    'is_shipping_required, shipping_method, discount_value, discount_type, apply_to, limit, error_msg', [  # noqa
-        (True, Mock(country_code='PL'), 10, Voucher.DISCOUNT_VALUE_FIXED, 'US',
-         None, 'This offer is only valid in United States of America.'),
-        (True, None, 10, Voucher.DISCOUNT_VALUE_FIXED, None, None,
+    'is_shipping_required, shipping_method, discount_value, discount_type, '
+    'apply_to, limit, subtotal, error_msg', [
+        (True, Mock(country_code='PL'), 10, Voucher.DISCOUNT_VALUE_FIXED,
+         'US', None, Price(10, currency='USD'),
+         'This offer is only valid in United States of America.'),
+        (True, None, 10, Voucher.DISCOUNT_VALUE_FIXED,
+         None, None, Price(10, currency='USD'),
          'Please select a shipping method first.'),
-        (False, None, 10, Voucher.DISCOUNT_VALUE_FIXED, None, None,
+        (False, None, 10, Voucher.DISCOUNT_VALUE_FIXED,
+         None, None, Price(10, currency='USD'),
          'Your order does not require shipping.'),
         (True, Mock(price=Price(10, currency='USD')), 10,
-         Voucher.DISCOUNT_VALUE_FIXED, None, 5,
-         'This offer is only valid for shipping over $5.00.')])  # noqa
+         Voucher.DISCOUNT_VALUE_FIXED, None, 5, Price(2, currency='USD'),
+         'This offer is only valid for orders over $5.00.')])
 def test_shipping_voucher_checkout_discountnot_applicable(
         settings, is_shipping_required, shipping_method, discount_value,
-        discount_type, apply_to, limit, error_msg):
+        discount_type, apply_to, limit, subtotal, error_msg):
     settings.DEFAULT_CURRENCY = 'USD'
     checkout = Mock(is_shipping_required=is_shipping_required,
-                    shipping_method=shipping_method)
+                    shipping_method=shipping_method,
+                    get_subtotal=Mock(return_value=subtotal))
     voucher = Voucher(
         code='unique', type=Voucher.SHIPPING_TYPE,
         discount_value_type=discount_type,


### PR DESCRIPTION
Instead checking shipping price, apply shipping vouchers on checkouts with subtotal above limit.