### PR TITLE
Fix thread-safety of get_country_by_ip

### DIFF
--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -17,6 +17,8 @@ try:
 except ImportError:
     from urlparse import urljoin
 
+georeader = geolite2.reader()
+
 
 class CategoryChoiceField(forms.ModelChoiceField):
     def label_from_instance(self, obj):
@@ -50,9 +52,7 @@ def get_client_ip(request):
 
 
 def get_country_by_ip(ip_address):
-    reader = geolite2.reader()
-    geo_data = reader.get(ip_address)
-    geolite2.close()
+    geo_data = georeader.get(ip_address)
     if geo_data and 'country' in geo_data and 'iso_code' in geo_data['country']:
         country_iso_code = geo_data['country']['iso_code']
         if country_iso_code in countries:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,8 +13,8 @@ from saleor.core.utils import (
     ({'country': {}}, None)])
 def test_get_country_by_ip(ip_data, expected_country, monkeypatch):
     monkeypatch.setattr(
-        'saleor.core.utils.geolite2.reader',
-        Mock(return_value=Mock(get=Mock(return_value=ip_data))))
+        'saleor.core.utils.georeader.get',
+        Mock(return_value=ip_data))
     country = get_country_by_ip('127.0.0.1')
     assert country == expected_country
 


### PR DESCRIPTION
This fixes the case where two threads call `geolite2.reader()` and then one of them calls `reader.close()` before the other has a chance to access the file. By avoiding reopening/closing it also mitigates two unnecessary thread lock acquisitions per request (a performance bottleneck).