### PR TITLE
Fix getting cart for logged user

### DIFF
--- a/saleor/cart/decorators.py
+++ b/saleor/cart/decorators.py
@@ -40,9 +40,7 @@ def get_cart_from_request(request, cart_queryset=Cart.objects.all(),
         cart = queryset.open().get(token=token)
     except Cart.DoesNotExist:
         if create:
-            cart = Cart.objects.create(
-                user=user,
-                token=cookie_token)
+            cart = Cart.objects.create(user=user, token=token)
         else:
             cart = Cart()
 


### PR DESCRIPTION
There was the typo (_cookie_token_ instead of _token_) causing db error when adding items to cart as logged user.  