### PR TITLE
Fix failing attribute lookups

### DIFF
--- a/saleor/product/models/utils.py
+++ b/saleor/product/models/utils.py
@@ -1,7 +1,6 @@
 from django.utils.encoding import smart_text
 
 def get_attributes_display_map(variant, attributes):
-    print "in get_attributes_display_map with " + str(variant) + " and " + str(attributes)
     display = {}
     for attribute in attributes:
         value = variant.get_attribute(attribute.pk)

--- a/saleor/product/models/utils.py
+++ b/saleor/product/models/utils.py
@@ -1,9 +1,12 @@
+from django.utils.encoding import smart_text
+
 def get_attributes_display_map(variant, attributes):
+    print "in get_attributes_display_map with " + str(variant) + " and " + str(attributes)
     display = {}
     for attribute in attributes:
         value = variant.get_attribute(attribute.pk)
         if value:
-            choices = {a.pk: a for a in attribute.values.all()}
+            choices = {smart_text(a.pk): a for a in attribute.values.all()}
             attr = choices.get(value)
             if attr:
                 display[attribute.pk] = attr


### PR DESCRIPTION
get_attributes_display_map() was returning IDs rather than attributes; it appears get_attribute() returns a smart_text, whereas a.pk is an int, so the dict get() would always return None. 