### PR TITLE
Cart is incorrectly referencing productId rather than variantId

### DIFF
--- a/saleor/cart/views.py
+++ b/saleor/cart/views.py
@@ -55,7 +55,7 @@ def update(request, cart, variant_id):
                                discounts=discounts)
     if form.is_valid():
         form.save()
-        response = {'productId': variant_id,
+        response = {'variantId': variant_id,
                     'subtotal': 0,
                     'total': 0}
         updated_line = cart.get_line(form.cart_line.variant)

--- a/saleor/static/js/cart.js
+++ b/saleor/static/js/cart.js
@@ -56,9 +56,9 @@ if ($cartTotal.length) {
 }
 
 $('.cart-item-subtotal').each(function() {
-  let productId = $(this).data('product-id')
+  let variantId = $(this).data('variant-id')
   let props = {
-    productId,
+    variantId,
     subtotal: $(this).text()
   }
   store.dispatch({
@@ -67,7 +67,7 @@ $('.cart-item-subtotal').each(function() {
   })
   render(
     <Provider store={store}>
-      <CartItemSubtotal productId={productId} />
+      <CartItemSubtotal variantId={variantId} />
     </Provider>,
     this
   )

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -93,7 +93,7 @@
                         </div>
                     </td>
                     <td class="text-right hidden-xs">{% gross line.get_price_per_item html=True %}</td>
-                    <td class="text-right cart-item-subtotal" data-product-id="{{ line.variant.pk }}">{% gross line.get_total html=True %}</td>
+                    <td class="text-right cart-item-subtotal" data-variant-id="{{ line.variant.pk }}">{% gross line.get_total html=True %}</td>
                 </tr>
             {% endfor %}
         </tbody>


### PR DESCRIPTION
Subtotals are accurate on pageload but get overwritten with the final subtotal by JS otherwise. I'm not 100% sure on my fix, but it seems to work here. 