### PR TITLE
Dashboard search should not use all indexes

### DIFF
--- a/saleor/search/backends/dashboard.py
+++ b/saleor/search/backends/dashboard.py
@@ -78,6 +78,7 @@ class DashboardSearchResults(DEFAULT_BACKEND_RESULTS_CLASS):
             body=self._get_es_body(),
             _source=False,
             from_=self.start,
+            index='{}*'.format(self.backend.get_index().name)
         )
         params[self.fields_param_name] = 'pk'
 
@@ -127,6 +128,7 @@ class DashboardSearchResults(DEFAULT_BACKEND_RESULTS_CLASS):
         # Get count
         hit_count = self.backend.es.count(
             body=self._get_es_body(for_count=True),
+            index='{}*'.format(self.backend.get_index().name)
         )['count']
         # Add limits
         hit_count -= self.start


### PR DESCRIPTION
Hello! 
I'm looking at the new search feature.
I'm using elasticsearch for other projects on my laptop. So I've other indexes.
```
curl -XGET 'localhost:9200/_cat/indices/*?v&s=index' 
health status index                        pri rep docs.count docs.deleted store.size pri.store.size 
yellow open   haystack-caresa                5   1        393            0      1.9mb          1.9mb 
yellow open   storefront__order_order        5   1         60            0     30.8kb         30.8kb 
yellow open   storefront__userprofile_user   5   1         60            0     27.4kb         27.4kb 
yellow open   storefront__product_product    5   1        120            0    191.5kb        191.5kb
```
The dashboard search is using all indexes. It should use only the ones starting with ```ELASTICSEARCH_INDEX_NAME``` (storefront).
