### PR TITLE
Fix storing billing address

### DIFF
--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -227,7 +227,7 @@ class Checkout(object):
             shipping_address = None
         billing_address = self._save_order_billing_address()
         self._add_to_user_address_book(
-            self.shipping_address, is_billing=True)
+            self.billing_address, is_billing=True)
 
         order_data = {
             'billing_address': billing_address,


### PR DESCRIPTION
When anonymous user has no stored addresses and checkout doesn't require shipping - creating an order fails.