### PR TITLE
Use 2 spaces to indent HTML files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -23,3 +23,6 @@ indent_size = 2
 
 [*.yml]
 indent_size = 2
+
+[*.html]
+indent_size = 2


### PR DESCRIPTION
Use 2 spaces for indent in HTML files, following Google Styleguide (https://google.github.io/styleguide/htmlcssguide.xml?showone=Indentation#Indentation)