### PR TITLE
Use text-unidecode instead of unidecode

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -37,5 +37,5 @@ pytest>=2.8.0
 pytest-django
 requests>=1.2.0
 satchless>=1.1.2,<1.2a0
-unidecode
+text-unidecode
 uwsgi>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ six==1.10.0               # via cryptography, fake-factory, graphene, graphene-d
 typing==3.5.2.2           # via promise
 stripe==1.46.0            # via django-payments
 suds-jurko==0.6           # via django-payments
-unidecode==0.4.20
+text-unidecode==1.0
 urllib3==1.19.1           # via elasticsearch
 uwsgi==2.0.14
 xmltodict==0.10.2         # via django-payments

--- a/saleor/dashboard/category/forms.py
+++ b/saleor/dashboard/category/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.shortcuts import get_object_or_404
 from django.utils.text import slugify
-from unidecode import unidecode
+from text_unidecode import unidecode
 
 from ...product.models import Category
 

--- a/saleor/product/models/base.py
+++ b/saleor/product/models/base.py
@@ -17,7 +17,7 @@ from django_prices.models import PriceField
 from mptt.managers import TreeManager
 from mptt.models import MPTTModel
 from satchless.item import InsufficientStock, Item, ItemRange
-from unidecode import unidecode
+from text_unidecode import unidecode
 
 from ...discount.models import get_variant_discounts
 from .fields import WeightField


### PR DESCRIPTION
This PR replaces `unidecode` in favour of `text-unidecode`  licensed under *Artistic License*.