### PR TITLE
Drop Python 2 from master, add Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ cache:
   directories:
     - node_modules
 sudo: false
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
 install:
   - pip install -U pip setuptools wheel
   - pip install tox codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,16 +31,12 @@ env:
     - TOXENV=py35-django_master
 matrix:
   allow_failures:
+    - env: TOXENV=py27-django111
+    - env: TOXENV=py34-django111
+    - env: TOXENV=py35-django111
     - env: TOXENV=py34-django_master
     - env: TOXENV=py35-django_master
 after_success:
   - codecov
-addons:
-  apt:
-    sources:
-      - deadsnakes
-    packages:
-      - python3.5
-      - python3.5-dev
 services:
   - postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,16 +20,17 @@ env:
   matrix:
     - TOXENV=py27-django18
     - TOXENV=py27-django110
-    - TOXENV=py27-django_master
+    - TOXENV=py27-django111
     - TOXENV=py34-django18
     - TOXENV=py34-django110
+    - TOXENV=py34-django111
     - TOXENV=py34-django_master
     - TOXENV=py35-django18
     - TOXENV=py35-django110
+    - TOXENV=py35-django111
     - TOXENV=py35-django_master
 matrix:
   allow_failures:
-    - env: TOXENV=py27-django_master
     - env: TOXENV=py34-django_master
     - env: TOXENV=py35-django_master
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,13 @@ cache:
   directories:
     - node_modules
 sudo: false
-python:
-  - "2.7"
-  - "3.4"
-  - "3.5"
+addons:
+  apt:
+    sources:
+      - deadsnakes
+    packages:
+      - python3.5
+      - python3.5-dev
 install:
   - pip install -U pip setuptools wheel
   - pip install tox codecov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35}-django{18,110,_master}
+envlist = py{27,34,35}-django{18,110,111} py{34,35}-django_master
 skipsdist = True
 
 [testenv]
@@ -8,8 +8,9 @@ deps =
     -rrequirements.txt
     pytest-cov
 commands =
-    django18: pip install "django>=1.8,!=1.8.6,<1.9a0" --upgrade
-    django110: pip install "django>=1.10a1,<1.11a0" --upgrade --pre
+    django18: pip install "django>=1.8,!=1.8.6,<1.9" --upgrade
+    django110: pip install "django>=1.10a1,<1.11" --upgrade
+    django111: pip install "django>=1.11a1,<1.12" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput
     pytest --cov --cov-report=


### PR DESCRIPTION
1.11 alpha is out, `master` is going to become 2.0.