### PR TITLE
Don't lose cart after logging in

### DIFF
--- a/saleor/cart/urls.py
+++ b/saleor/cart/urls.py
@@ -7,8 +7,6 @@ urlpatterns = [
     url(r'^$', views.index, name='index'),
     url(r'^update/(?P<variant_id>\d+)/$', views.update, name='update-line'),
     url(r'^summary/$', views.summary, name='cart-summary'),
-    url(r'^assign/$', views.assign_cart_and_redirect_view,
-        name='assign-and-redirect'),
     url(r'^shipingoptions/$', views.get_shipping_options,
         name='shipping-options')
 ]

--- a/saleor/cart/utils.py
+++ b/saleor/cart/utils.py
@@ -73,14 +73,14 @@ def find_and_assign_anonymous_cart(queryset=Cart.objects.all()):
     def get_cart(view):
         @wraps(view)
         def func(request, *args, **kwargs):
+            response = view(request, *args, **kwargs)
             token = request.get_signed_cookie(Cart.COOKIE_NAME, default=None)
             if not token:
-                return
+                return response
             cart = get_anonymous_cart_from_token(
                 token=token, cart_queryset=queryset)
             if cart is None:
-                return
-            response = view(request, *args, **kwargs)
+                return response
             if request.user.is_authenticated():
                 with transaction.atomic():
                     cart.change_user(request.user)

--- a/saleor/cart/utils.py
+++ b/saleor/cart/utils.py
@@ -29,6 +29,8 @@ def contains_unavailable_variants(cart):
 
 
 def token_is_valid(token):
+    if token is None:
+        return False
     if isinstance(token, UUID):
         return True
     try:
@@ -86,7 +88,7 @@ def find_and_assign_anonymous_cart(queryset=Cart.objects.all()):
         def func(request, *args, **kwargs):
             response = view(request, *args, **kwargs)
             token = request.get_signed_cookie(Cart.COOKIE_NAME, default=None)
-            if not token or token is not None and not token_is_valid(token):
+            if not token_is_valid(token):
                 return response
             cart = get_anonymous_cart_from_token(
                 token=token, cart_queryset=queryset)

--- a/saleor/cart/views.py
+++ b/saleor/cart/views.py
@@ -132,13 +132,3 @@ def summary(request, cart):
             'lines': [prepare_line_data(line) for line in cart.lines.all()]}
 
     return render(request, 'cart-dropdown.html', data)
-
-
-def assign_cart_and_redirect_view(request):
-    find_and_assign_anonymous_cart(request)
-    redirect_to = get_request_param(request, "next")
-    if redirect_to is None:
-        redirect_to = '/'
-    response = HttpResponseRedirect(redirect_to)
-    response.delete_cookie(Cart.COOKIE_NAME)
-    return response

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -325,7 +325,6 @@ ACCOUNT_USERNAME_REQUIRED = False
 ACCOUNT_LOGOUT_ON_GET = True
 ACCOUNT_SESSION_REMEMBER = False
 ACCOUNT_SIGNUP_PASSWORD_ENTER_TWICE = False
-ACCOUNT_ADAPTER = 'saleor.userprofile.adapters.AccountAdapter'
 ACCOUNT_FORMS = {
     'reset_password_from_key': 'saleor.userprofile.forms.SetPasswordForm'
 }

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -26,7 +26,7 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^', include(core_urls)),
     url(r'^account/', include('allauth.urls')),
-    url(r'^account/login/', login_view, name="account_login"),
+    url(r'^account/login', login_view, name="account_login"),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^cart/', include(cart_urls, namespace='cart')),
     url(r'^checkout/', include(checkout_urls, namespace='checkout')),

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -15,6 +15,7 @@ from .core.urls import urlpatterns as core_urls
 from .order.urls import urlpatterns as order_urls
 from .product.urls import urlpatterns as product_urls
 from .search.urls import urlpatterns as search_urls
+from .userprofile.views import login as login_view
 from .userprofile.urls import urlpatterns as userprofile_urls
 from .data_feeds.urls import urlpatterns as feed_urls
 from .dashboard.urls import urlpatterns as dashboard_urls
@@ -25,6 +26,7 @@ admin.autodiscover()
 urlpatterns = [
     url(r'^', include(core_urls)),
     url(r'^account/', include('allauth.urls')),
+    url(r'^account/login/', login_view, name="account_login"),
     url(r'^admin/', include(admin.site.urls)),
     url(r'^cart/', include(cart_urls, namespace='cart')),
     url(r'^checkout/', include(checkout_urls, namespace='checkout')),

--- a/saleor/userprofile/adapters.py
+++ b/saleor/userprofile/adapters.py
@@ -1,7 +1,0 @@
-from allauth.account.adapter import DefaultAccountAdapter
-from django.core.urlresolvers import reverse
-
-
-class AccountAdapter(DefaultAccountAdapter):
-    def get_login_redirect_url(self, request):
-        return reverse('cart:assign-and-redirect')

--- a/saleor/userprofile/views.py
+++ b/saleor/userprofile/views.py
@@ -1,4 +1,6 @@
 from allauth.account.adapter import get_adapter
+from allauth.account.views import LoginView as AllauthLoginView
+from allauth.account.forms import ChangePasswordForm
 from allauth.account.utils import logout_on_password_change
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -6,7 +8,9 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
+from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
+from ..cart.utils import find_and_assign_anonymous_cart
 from .forms import ChangePasswordForm, get_address_form
 
 
@@ -56,3 +60,11 @@ def address_delete(request, pk):
         return HttpResponseRedirect(reverse('profile:details') + '#addresses')
     return TemplateResponse(
         request, 'userprofile/address-delete.html', {'address': address})
+
+
+class LoginView(AllauthLoginView):
+    @method_decorator(find_and_assign_anonymous_cart())
+    def dispatch(self, *args, **kwargs):
+        super(LoginView, self).dispatch(*args, **kwargs)
+
+login = LoginView.as_view()

--- a/saleor/userprofile/views.py
+++ b/saleor/userprofile/views.py
@@ -1,5 +1,5 @@
 from allauth.account.adapter import get_adapter
-from allauth.account.views import LoginView as AllauthLoginView
+from allauth.account.views import login as allauth_login
 from allauth.account.forms import ChangePasswordForm
 from allauth.account.utils import logout_on_password_change
 from django.contrib import messages
@@ -8,7 +8,6 @@ from django.core.urlresolvers import reverse
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404
 from django.template.response import TemplateResponse
-from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from ..cart.utils import find_and_assign_anonymous_cart
 from .forms import ChangePasswordForm, get_address_form
@@ -62,9 +61,4 @@ def address_delete(request, pk):
         request, 'userprofile/address-delete.html', {'address': address})
 
 
-class LoginView(AllauthLoginView):
-    @method_decorator(find_and_assign_anonymous_cart())
-    def dispatch(self, *args, **kwargs):
-        super(LoginView, self).dispatch(*args, **kwargs)
-
-login = LoginView.as_view()
+login = find_and_assign_anonymous_cart()(allauth_login)

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -231,7 +231,8 @@ def test_find_and_assign_anonymous_cart_and_close_opened(customer_user,
     token = opened_anonymous_cart.token
     token_user = opened_user_cart.token
     request = cart_request_factory(user=customer_user, token=token)
-    utils.find_and_assign_anonymous_cart(request)
+    mock_view = lambda request: Mock(delete_cookie=lambda name: None)
+    utils.find_and_assign_anonymous_cart()(mock_view)(request)
     token_cart = Cart.objects.filter(token=token).first()
     user_cart = Cart.objects.filter(token=token_user).first()
     assert token_cart.user.pk == customer_user.pk


### PR DESCRIPTION
Scenario:
* Start as an anonymous user
* Add something to cart, proceed to checkout
* Log in using first step of the checkout

Failure: You'll be redirected to cart page showing empty cart
Expected result: Your anonymous cart is now your current cart as logged in user