### PR TITLE
Fix order detail layout

### DIFF
--- a/saleor/static/scss/storefront/components/_order-details.scss
+++ b/saleor/static/scss/storefront/components/_order-details.scss
@@ -7,11 +7,13 @@
   }
   &__table-header {
     color: $gray;
-    border-bottom: 1px solid $light-gray;
     padding-bottom: $global-padding / 2;
     margin-top: $global-margin * 2;
     .col-md-3 {
       text-align: right;
+    }
+    > .row {
+      border-bottom: 1px solid $light-gray;
     }
   }
   &__table {
@@ -32,17 +34,11 @@
         text-decoration: none;
       }
     }
-    .col-3 {
-      padding: 0;
-    }
     .row {
       padding: $global-padding / 2 0;
       &:not(:last-of-type) {
         border-bottom: 1px solid $light-gray;
       }
-    }
-    .total div {
-      padding-right: 0;
     }
   }
 }

--- a/templates/order/order-details.html
+++ b/templates/order/order-details.html
@@ -6,30 +6,35 @@
 
 
 {% if order.user == user %}
-  <div class="row order-details__addresses">
-        {% if order.is_shipping_required %}
-    <div class="col-6">
-      <h3>{% trans "Shipping address" %}</h3>
-            <address>{% include "userprofile/snippets/address-short.html" with address=order.shipping_address %}</address>
-    </div>
-            {% endif %}
-    <div class="col-6">
-      <h3>{% trans "Billing address" %}</h3>
-      <address>{% include "userprofile/snippets/address-short.html" with address=order.billing_address %}</address>
+  <div class="order-details__addresses">
+    <div class="row">
+          {% if order.is_shipping_required %}
+      <div class="col-6">
+        <h3>{% trans "Shipping address" %}</h3>
+              <address>{% include "userprofile/snippets/address-short.html" with address=order.shipping_address %}</address>
+      </div>
+              {% endif %}
+      <div class="col-6">
+        <h3>{% trans "Billing address" %}</h3>
+        <address>{% include "userprofile/snippets/address-short.html" with address=order.billing_address %}</address>
+      </div>
     </div>
   </div>
 {% endif %}
-<div class="row order-details__table-header hidden-sm-down">
-  <div class="col-md-6">
-    <small>{% trans "Product" %}</small>
-  </div>
-  <div class="col-md-3">
-    <small>{% trans "Quantity" %}</small>
-  </div>
-  <div class="col-md-3">
-    <small>{% trans "Price" %}</small>
+<div class="order-details__table-header hidden-sm-down">
+  <div class="row">
+    <div class="col-md-6">
+      <small>{% trans "Product" %}</small>
+    </div>
+    <div class="col-md-3">
+      <small>{% trans "Quantity" %}</small>
+    </div>
+    <div class="col-md-3">
+      <small>{% trans "Price" %}</small>
+    </div>
   </div>
 </div>
+
 <div class="order-details__table">
   {% for item in order %}
     {% for item_line in item %}
@@ -76,12 +81,16 @@
         </div>
       </div>
     {% endif %}
-    <div class="row total">
-      <div class="col-8">
-        <p><strong>{% trans "Total" %}</strong></p>
-      </div>
-      <div class="col-4">
-        <p class="float-right"><strong>{% gross order.total %}</strong></p>
+    <div class="total">
+      <div class="row">
+        <div class="col-8">
+          <div class="total">
+            <p><strong>{% trans "Total" %}</strong></p>
+          </div>
+        </div>
+        <div class="col-4">
+          <p class="float-right"><strong>{% gross order.total %}</strong></p>
+        </div>
       </div>
     </div>
   {% endfor %}


### PR DESCRIPTION
  * fix layout on mobile (horizontal scroll and top navbar)
  * align delivery and shipping to  the other amounts
  * split grid classes from other css classes to avoid unexpected behaviour

**mobile**
before: 
![schermata del 2017-01-28 12-05-55](https://cloud.githubusercontent.com/assets/650691/22396388/d75bdada-e558-11e6-9724-30e26bd03c42.png)

after:
![schermata del 2017-01-28 12-02-44](https://cloud.githubusercontent.com/assets/650691/22396393/f83b01c2-e558-11e6-8b47-3cf25d8466bc.png)

**desktop**
before:
![schermata del 2017-01-28 12-04-20](https://cloud.githubusercontent.com/assets/650691/22396398/11c67306-e559-11e6-86a3-2104329ccdea.png)

after:
![schermata del 2017-01-28 12-07-43](https://cloud.githubusercontent.com/assets/650691/22396409/49cc886c-e559-11e6-83e5-357a877c4681.png)
