### PR TITLE
Tests are tied to USD currency and en-us language

### DIFF
--- a/tests/settings.py
+++ b/tests/settings.py
@@ -5,6 +5,8 @@ SECRET_KEY = 'NOTREALLY'
 
 DEFAULT_CURRENCY = 'USD'
 
+LANGUAGE_CODE = 'en-us'
+
 if 'sqlite' in DATABASES['default']['ENGINE']:
     DATABASES['default']['TEST'] = {  # noqa
         'SERIALIZE': False,

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -535,7 +535,6 @@ def test_cart_page_without_openexchagerates(
 
 def test_cart_page_with_openexchagerates(
         client, monkeypatch, product_in_stock, request_cart, settings):
-    settings.DEFAULT_CURRENCY = 'USD'
     settings.DEFAULT_COUNTRY = 'PL'
     settings.OPENEXCHANGERATES_API_KEY = 'fake-key'
     variant = product_in_stock.variants.get()

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -16,7 +16,6 @@ from saleor.product.models import Product, ProductVariant
         (Price(10, currency='USD'), Price(5, currency='USD'), False),
 ])
 def test_voucher_limit_validation(settings, limit, value, valid):
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.SHIPPING_TYPE,
         discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
@@ -77,7 +76,6 @@ def test_percentage_discounts(product_in_stock):
         ('100.05', 10, Voucher.DISCOUNT_VALUE_PERCENTAGE, 100, 10)])
 def test_value_voucher_checkout_discount(settings, total, discount_value,
                                          discount_type, limit, expected_value):
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.VALUE_TYPE,
         discount_value_type=discount_type,
@@ -90,7 +88,6 @@ def test_value_voucher_checkout_discount(settings, total, discount_value,
 
 
 def test_value_voucher_checkout_discount_not_applicable(settings):
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.VALUE_TYPE,
         discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
@@ -112,7 +109,6 @@ def test_value_voucher_checkout_discount_not_applicable(settings):
 def test_shipping_voucher_checkout_discount(
         settings, shipping_cost, shipping_country_code, discount_value,
         discount_type, apply_to, expected_value):
-    settings.DEFAULT_CURRENCY = 'USD'
     checkout = Mock(
         get_subtotal=Mock(return_value=Price(100, currency='USD')),
         is_shipping_required=True, shipping_method=Mock(
@@ -146,7 +142,6 @@ def test_shipping_voucher_checkout_discount(
 def test_shipping_voucher_checkout_discountnot_applicable(
         settings, is_shipping_required, shipping_method, discount_value,
         discount_type, apply_to, limit, subtotal, error_msg):
-    settings.DEFAULT_CURRENCY = 'USD'
     checkout = Mock(is_shipping_required=is_shipping_required,
                     shipping_method=shipping_method,
                     get_subtotal=Mock(return_value=subtotal))
@@ -166,7 +161,6 @@ def test_product_voucher_checkout_discount_not_applicable(settings,
     monkeypatch.setattr(
         'saleor.discount.models.get_product_variants_and_prices',
         lambda cart, product: [])
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.PRODUCT_TYPE,
         discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
@@ -182,7 +176,6 @@ def test_category_voucher_checkout_discount_not_applicable(settings,
     monkeypatch.setattr(
         'saleor.discount.models.get_category_variants_and_prices',
         lambda cart, product: [])
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.CATEGORY_TYPE,
         discount_value_type=Voucher.DISCOUNT_VALUE_FIXED,
@@ -213,7 +206,6 @@ def test_products_voucher_checkout_discount_not(settings, monkeypatch, prices,
         'saleor.discount.models.get_product_variants_and_prices',
         lambda cart, product: (
             (None, Price(p, currency='USD')) for p in prices))
-    settings.DEFAULT_CURRENCY = 'USD'
     voucher = Voucher(
         code='unique', type=Voucher.PRODUCT_TYPE,
         discount_value_type=discount_type,

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -76,7 +76,6 @@ def test_availability(product_in_stock, monkeypatch, settings):
     monkeypatch.setattr(
         'django_prices_openexchangerates.models.get_rates',
         lambda c: {'PLN': Mock(rate=2)})
-    settings.DEFAULT_CURRENCY = 'USD'
     settings.DEFAULT_COUNTRY = 'PL'
     settings.OPENEXCHANGERATES_API_KEY = 'fake-key'
     availability = get_availability(product_in_stock, local_currency='PLN')


### PR DESCRIPTION
Hello,

Some test fail if I change the `LANGUAGE_CODE` inside the project settings.
This PR only makes explicit that tests expect `en-us` as  `LANGUAGE_CODE`.

Also there is no need to set `DEFAULT_CURRENCY` in every test. It's already inside ```tests/settings.py```