### PR TITLE
FIx delivery group deletion on order line removal.

### DIFF
--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -229,12 +229,14 @@ def orderline_cancel(request, order_pk, line_pk):
         with transaction.atomic():
             form.cancel_item()
             order.create_history_entry(comment=msg, user=request.user)
+            messages.success(request, msg)
         return redirect('dashboard:order-details', order_pk=order.pk)
     elif form.errors:
         status = 400
     ctx = {'order': order, 'item': item, 'form': form}
-    return TemplateResponse(request, 'dashboard/order/modal_cancel_line.html',
-                            ctx, status=status)
+    return TemplateResponse(
+        request, 'dashboard/order/modal_cancel_line.html',
+        ctx, status=status)
 
 
 @staff_member_required

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,47 @@ def order_with_items(order, product_class):
 
 
 @pytest.fixture()
+def order_with_items_and_stock(order, product_class):
+    group = DeliveryGroup.objects.create(order=order)
+    product = Product.objects.create(
+        name='Test product', price=Decimal('10.00'),
+        product_class=product_class)
+    variant = ProductVariant.objects.create(product=product, sku='A')
+    warehouse = StockLocation.objects.create(name='Warehouse 1')
+    stock = Stock.objects.create(
+        variant=variant, cost_price=1, quantity=5, quantity_allocated=3,
+        location=warehouse)
+    OrderedItem.objects.create(
+        delivery_group=group,
+        product=product,
+        product_name=product.name,
+        product_sku='SKU_%d' % (product.pk,),
+        quantity=3,
+        unit_price_net=Decimal('30.00'),
+        unit_price_gross=Decimal('30.00'),
+        stock=stock
+    )
+    product = Product.objects.create(
+        name='Test product 2', price=Decimal('20.00'),
+        product_class=product_class)
+    variant = ProductVariant.objects.create(product=product, sku='B')
+    stock = Stock.objects.create(
+        variant=variant, cost_price=2, quantity=2, quantity_allocated=2,
+        location=warehouse)
+    OrderedItem.objects.create(
+        delivery_group=group,
+        product=product,
+        product_name=product.name,
+        product_sku='SKU_%d' % (product.pk,),
+        quantity=2,
+        unit_price_net=Decimal('20.00'),
+        unit_price_gross=Decimal('20.00'),
+        stock=stock
+    )
+    return order
+
+
+@pytest.fixture()
 def sale(db, default_category):
     sale = Sale.objects.create(name="Sale", value=5)
     sale.categories.add(default_category)

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 import pytest
-from django.urls import reverse
+from django.core.urlresolvers import reverse
 from saleor.order.models import Order, OrderHistoryEntry, OrderedItem, DeliveryGroup
 from saleor.product.models import Stock
 from tests.utils import get_redirect_location

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -1,0 +1,49 @@
+from __future__ import unicode_literals
+
+import pytest
+from django.urls import reverse
+from saleor.order.models import Order, OrderHistoryEntry, OrderedItem, DeliveryGroup
+from saleor.product.models import Stock
+from tests.utils import get_redirect_location
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_view_cancel_order_line(admin_client, order_with_items_and_stock):
+    lines_before = order_with_items_and_stock.get_items()
+    lines_before_count = lines_before.count()
+    line = lines_before.first()
+    line_quantity = line.quantity
+    quantity_allocated_before = line.stock.quantity_allocated
+    product = line.product
+
+    url = reverse(
+        'dashboard:orderline-cancel', kwargs={
+            'order_pk': order_with_items_and_stock.pk,
+            'line_pk': line.pk})
+
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    response = admin_client.post(url, {'csrfmiddlewaretoken': 'hello'})
+    assert response.status_code == 302
+    assert get_redirect_location(response) == reverse(
+        'dashboard:order-details', args=[order_with_items_and_stock.pk])
+    # check ordered item removal
+    lines_after = Order.objects.get().get_items()
+    assert lines_before_count - 1 == lines_after.count()
+    # check stock deallocation
+    assert Stock.objects.first().quantity_allocated == quantity_allocated_before - line_quantity
+    # check note in the order's history
+    OrderHistoryEntry.objects.get(
+        order=order_with_items_and_stock).message = 'Cancelled item %s' % product
+    url = reverse(
+        'dashboard:orderline-cancel', kwargs={
+            'order_pk': order_with_items_and_stock.pk,
+            'line_pk': OrderedItem.objects.get().pk})
+    response = admin_client.post(
+        url, {'csrfmiddlewaretoken': 'hello'}, follow=True)
+    # check delivery group removal if it becomes empty
+    assert Order.objects.get().get_items().count() == 0
+    assert DeliveryGroup.objects.count() == 0
+    # check success messages after redirect
+    assert response.context['messages']


### PR DESCRIPTION
Hello,

Steps to reproduce the issue
- Dashboard
- Go to an order details page with more than one line.
- Delete a line

The delivery group is removed even if there are other lines.

I added few tests for this view following #473 directions.

Side note.. a cancelled order without delivery groups doesn't look cancelled.
The only visual reference is the second line in the card to the right 
![schermata del 2017-02-25 14-01-29](https://cloud.githubusercontent.com/assets/650691/23331294/42b1984a-fb63-11e6-96c9-5a77364fb47c.png)