### PR TITLE
Update aws static env name in docs

### DIFF
--- a/docs/integrations.rst
+++ b/docs/integrations.rst
@@ -23,7 +23,7 @@ By default static files (such as CSS and JS files required to display your pages
 
 If you intend to use S3 for your static files as well, set an additional environment variable:
 
-``AWS_STATIC_BUCKET_NAME``
+``AWS_STORAGE_BUCKET_NAME``
   The S3 bucket name to use for static files.
 
 


### PR DESCRIPTION
In settings.py it clearly says this, so AWS_STATIC_BUCKET_NAME is an outdated name.

AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')