### PR TITLE
exposes aws s3 region

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -294,6 +294,7 @@ AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
 AWS_MEDIA_BUCKET_NAME = os.environ.get('AWS_MEDIA_BUCKET_NAME')
 AWS_QUERYSTRING_AUTH = ast.literal_eval(
     os.environ.get('AWS_QUERYSTRING_AUTH', 'False'))
+AWS_DEFAULT_REGION = os.environ.get('AWS_DEFAULT_REGION')
 
 if AWS_STORAGE_BUCKET_NAME:
     STATICFILES_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'


### PR DESCRIPTION
Some more _recent_ AWS regions like `eu-central-1` only support Signature Version 4 which is not default authorization mechanism for boto3.

In order to authenticate successfuly with those regions you need to pass region you use to boto3 as `AWS_DEFAULT_REGION`

Full details here: https://github.com/boto/botocore/issues/424

This PR fetches AWS_DEFAULT_REGION envinronment variable and exposes it to python code.