### PR TITLE
Remove `appdirs` from autogenerated requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,6 @@
 #
 #    pip-compile --output-file requirements.txt requirements.in
 #
-appdirs==1.4.0            # via setuptools
 babel==2.3.4
 babeldjango==0.2.2
 boto3==1.4.4


### PR DESCRIPTION
It gave me problems when I tried to install requirements, and by
removing it from requirements.txt file solved the problem.