### PR TITLE
Changed assets root to relative in production mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,7 +15,7 @@ if (process.env.NODE_ENV === 'production') {
   output = {
     path: resolve('saleor/static/assets/'),
     filename: '[name].[chunkhash].js',
-    publicPath: 'https://saleor-demo.s3.amazonaws.com/assets/'
+    publicPath: '/static/assets/'
   };
   fileLoaderPath = 'file?name=[name].[hash].[ext]';
   extractTextPlugin = new ExtractTextPlugin('[name].[contenthash].css');


### PR DESCRIPTION
The less places to change config values we have the better would be. All works fine with relative path to assets so why not use it.

Personally I've spent at least some hours trying to figure out why SVGs weren't showing. Had to open dev console, see that some scripts are trying to be searched on saleor-demo aws cloud, grep the thing. Hopefully, I found what was wrong, but someone may not. 