### PR TITLE
menu "hamburger" button doesn't respond

### DIFF
--- a/saleor/static/js/storefront.js
+++ b/saleor/static/js/storefront.js
@@ -60,7 +60,7 @@ $(document).ready((e) => {
 
   $toogleIcon.click((e) => {
     $mobileNav.toggleClass('open');
-    event.stopPropagation();
+    e.stopPropagation();
   });
   $(document).click((e) => {
     $mobileNav.removeClass('open');


### PR DESCRIPTION
changed event.stopPropagation() to e.stopPropagation() in saleor/static/js/storefront.js
this is to fix the mobile 'hamburger' icon in top left, which was failing in Firefox with
```
ReferenceError: event is not defined
```

Thanks to @tulsluper for posting the issue and suggested fix in #1070.