### PR TITLE
issues/1053 - list of choices for the variant picker is wrong

### DIFF
--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -198,19 +198,17 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
                 int(variant_value))
 
     for attribute in variant_attributes:
-        availabel_variants = filter_available_variants.get(attribute.pk, None)
+        available_variants = filter_available_variants.get(attribute.pk, None)
 
-        if not availabel_variants:
-            continue
-
-        data['variantAttributes'].append({
-            'pk': attribute.pk,
-            'name': attribute.name,
-            'slug': attribute.slug,
-            'values': [
-                {'pk': value.pk, 'name': value.name, 'slug': value.slug}
-                for value in attribute.values.filter(
-                    pk__in=availabel_variants)]})
+        if available_variants:
+            data['variantAttributes'].append({
+                'pk': attribute.pk,
+                'name': attribute.name,
+                'slug': attribute.slug,
+                'values': [
+                    {'pk': value.pk, 'name': value.name, 'slug': value.slug}
+                    for value in attribute.values.filter(
+                        pk__in=available_variants)]})
 
     data['availability'] = {
         'discount': price_as_dict(availability.discount),

--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -1,4 +1,6 @@
-from collections import namedtuple
+from collections import defaultdict, namedtuple
+
+from six import iteritems
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -160,13 +162,9 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
     data = {'variantAttributes': [], 'variants': []}
 
     variant_attributes = product.product_class.variant_attributes.all()
-    for attribute in variant_attributes:
-        data['variantAttributes'].append({
-            'pk': attribute.pk,
-            'name': attribute.name,
-            'slug': attribute.slug,
-            'values': [{'pk': value.pk, 'name': value.name, 'slug': value.slug}
-                       for value in attribute.values.all()]})
+
+    # Collect only available variants
+    filter_available_variants = defaultdict(list)
 
     for variant in variants:
         price = variant.get_price_per_item(discounts)
@@ -194,6 +192,25 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
             'priceLocalCurrency': price_as_dict(price_local_currency),
             'schemaData': schema_data}
         data['variants'].append(variant_data)
+
+        for variant_key, variant_value in iteritems(variant.attributes):
+            filter_available_variants[int(variant_key)].append(
+                int(variant_value))
+
+    for attribute in variant_attributes:
+        availabel_variants = filter_available_variants.get(attribute.pk, None)
+
+        if not availabel_variants:
+            continue
+
+        data['variantAttributes'].append({
+            'pk': attribute.pk,
+            'name': attribute.name,
+            'slug': attribute.slug,
+            'values': [
+                {'pk': value.pk, 'name': value.name, 'slug': value.slug}
+                for value in attribute.values.filter(
+                    pk__in=availabel_variants)]})
 
     data['availability'] = {
         'discount': price_as_dict(availability.discount),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -240,7 +240,14 @@ def product_in_stock(product_class, default_category):
         product_class=product_class, attributes=attributes)
     product.categories.add(default_category)
 
-    variant = ProductVariant.objects.create(product=product, sku='123')
+    variant_attr = product_class.variant_attributes.first()
+    variant_attr_value = variant_attr.values.first()
+    variant_attributes = {
+        smart_text(variant_attr.pk): smart_text(variant_attr_value.pk)
+    }
+
+    variant = ProductVariant.objects.create(
+        product=product, sku='123', attributes=variant_attributes)
     warehouse_1 = StockLocation.objects.create(name='Warehouse 1')
     warehouse_2 = StockLocation.objects.create(name='Warehouse 2')
     warehouse_3 = StockLocation.objects.create(name='Warehouse 3')

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -8,12 +8,13 @@ from django.utils.encoding import smart_text
 
 from saleor.cart.models import Cart
 from saleor.cart import CartStatus, utils
+
 from saleor.product import (
     models, ProductAvailabilityStatus, VariantAvailabilityStatus)
 from saleor.product.utils import (
-    get_attributes_display_map, get_availability,
-    get_product_availability_status,
-    get_variant_availability_status)
+    get_attributes_display_map, get_availability, get_variant_picker_data,
+    get_product_availability_status, get_variant_availability_status)
+from saleor.product.utils import get_availability
 from tests.utils import filter_products_by_attribute
 
 
@@ -442,3 +443,16 @@ def test_product_filter_sorted_by_wrong_parameter(
     data = {'sort_by': 'aaa'}
     response = authorized_client.get(url, data)
     assert not list(response.context['filter'].qs)
+
+
+def test_get_variant_picker_data_proper_variant_count(product_in_stock):
+    """
+    test checks if get_variant_picker_data provide proper count of
+    variant information from available product variants and not count
+    of variant attributes from product class
+    """
+    data = get_variant_picker_data(
+        product_in_stock, discounts=None, local_currency=None)
+
+    assert len(data['variantAttributes'][0]['values']) == 1
+

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -14,7 +14,6 @@ from saleor.product import (
 from saleor.product.utils import (
     get_attributes_display_map, get_availability, get_variant_picker_data,
     get_product_availability_status, get_variant_availability_status)
-from saleor.product.utils import get_availability
 from tests.utils import filter_products_by_attribute
 
 


### PR DESCRIPTION
Issue #1053:
https://github.com/mirumee/saleor/issues/1053

Additional questions:
I would like to ask about the situation when we don't have some product variants in storehouse. Do we show that option to clients? On the one hand we don't need information about variants we can't buy, but on the other hand this is also a vital information for clients - we can't buy that variant now, but in general our store have that variant available.