### PR TITLE
Incorrect parent category query while having subcategory(children)

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -121,7 +121,10 @@ class CategoryType(DjangoObjectType):
             return [obj for obj in queryset if operator(get_availability(
                 obj, context.discounts).price_range.min_price.gross, value)]
 
-        tree = self.get_descendants(include_self=True)
+        if self.is_root_node():
+            tree = self.get_ancestors(include_self=True)
+        else:
+            tree = self.get_descendants(include_self=True)
         qs = products_for_api(context.user)
         qs = qs.filter(categories__in=tree)
         attributes_filter = args.get('attributes')


### PR DESCRIPTION
When selecting category the products are supplied and filtered with query:
```
tree = self.get_descendants(include_self=True)
qs = products_for_api(context.user)
qs = qs.filter(categories__in=tree)
```
However, if you add a level of subcategories, the above query would produce a correct data ONLY for a subcategory and won't display all products in parent category.
