### PR TITLE
Fix get_formfield_name

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -376,8 +376,8 @@ class ProductAttribute(models.Model):
     def __str__(self):
         return self.name
 
-    def get_formfield_name(self, allow_unicode=True):
-        return slugify('attribute-%s' % self.slug, allow_unicode=allow_unicode)
+    def get_formfield_name(self):
+        return slugify('attribute-%s' % self.slug, allow_unicode=True)
 
     def has_values(self):
         return self.values.exists()

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -376,8 +376,8 @@ class ProductAttribute(models.Model):
     def __str__(self):
         return self.name
 
-    def get_formfield_name(self):
-        return slugify('attribute-%s' % self.slug)
+    def get_formfield_name(self, allow_unicode=True):
+        return slugify('attribute-%s' % self.slug, allow_unicode=allow_unicode)
 
     def has_values(self):
         return self.values.exists()

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
 import pytest
@@ -130,9 +131,15 @@ def test_change_attributes_in_product_form(db, product_in_stock,
             'description': 'description',
             'attribute-author': new_author,
             'attribute-color': new_color}
-
     form = ProductForm(data, instance=product)
     assert form.is_valid()
     product = form.save()
     assert product.get_attribute(color_attribute.pk) == smart_text(new_color)
     assert product.get_attribute(text_attribute.pk) == new_author
+
+
+def test_get_formfield_name_with_unicode_characters(db):
+    text_attribute = ProductAttribute.objects.create(slug=u'ąęαβδηθλμπ',
+                                                     name=u'ąęαβδηθλμπ')
+    assert text_attribute.get_formfield_name() == 'attribute-ąęαβδηθλμπ'
+


### PR DESCRIPTION
Add allow_unicode=True in get_formfield_name for correct slugify of attributes.
This closes #1117 