### PR TITLE
Remove variant picker seleted option background

### DIFF
--- a/saleor/static/scss/components/_variant-picker.scss
+++ b/saleor/static/scss/components/_variant-picker.scss
@@ -16,7 +16,6 @@
     border-color: $gray;
     float: left;
     &.active {
-      background-color: $light-gray;
       border-color: $darken-gray;
     }
   }


### PR DESCRIPTION
Background obscured text. Remove in favour of Bootstrap default.

![image](https://user-images.githubusercontent.com/1538480/30599940-6031be32-9da1-11e7-926d-6b1ef08ca7cc.png)

Fixes #1127.