### PR TITLE
Update storefront.js reference error

### DIFF
--- a/saleor/static/js/storefront.js
+++ b/saleor/static/js/storefront.js
@@ -60,7 +60,7 @@ $(document).ready((e) => {
 
   $toogleIcon.click((e) => {
     $mobileNav.toggleClass('open');
-    event.stopPropagation();
+    e.stopPropagation();
   });
   $(document).click((e) => {
     $mobileNav.removeClass('open');


### PR DESCRIPTION
event in event.stopPropagation() caused a reference error. It prevented the mobile nav menu of displaying.