### PR TITLE
Set elastic search java and docker runtime memory limits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - '127.0.0.1:6379:6379'
   search:
     image: elasticsearch:5.4.3
-    mem_limit: 1g
+    mem_limit: 512m
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,10 @@ services:
     ports:
       - '127.0.0.1:6379:6379'
   search:
-    image: elasticsearch:5.4
+    image: elasticsearch:5.4.3
+    mem_limit: 1g
+    environment:
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
     ports:
       - '127.0.0.1:9200:9200'
   web:


### PR DESCRIPTION
Due to random memory allocation problems, I've set ES_JAVA_OPTS and docker mem_limit to make its behaviour more deterministic.
ES version is now provided with patch version.