### PR TITLE
Heroku postbuild error

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
   },
   "scripts": {
     "build-assets": "node ./node_modules/webpack/bin/webpack.js -p",
-    "heroku-postbuild": "yarn add --force node-sass && yarn run build-assets",
+    "heroku-postbuild": "npm run build-assets",
     "start": "UV_THREADPOOL_SIZE=8 node ./node_modules/webpack/bin/webpack.js -d --watch"
   }
 }


### PR DESCRIPTION
Fixes error when heroku could not build assets beacuse of calling yarn (which was replaced by npm and is no longer needed to build Saleor).