### PR TITLE
Comma-separated list of values

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -10,6 +10,8 @@ Environment variables
 ``ALLOWED_HOSTS``
   Controls `Django's allowed hosts <https://docs.djangoproject.com/en/1.10/ref/settings/#allowed-hosts>`_ setting. Defaults to ``localhost``.
 
+  Separate multiple values with comma.
+
 ``CACHE_URL`` or ``REDIS_URL``
   The URL of a cache database. Defaults to local process memory.
 
@@ -44,7 +46,7 @@ Environment variables
 ``INTERNAL_IPS``
   Controls `Django's internal IPs <https://docs.djangoproject.com/en/1.10/ref/settings/#internal-ips>`_ setting. Defaults to ``127.0.0.1``.
 
-  Separate multiple values with whitespace.
+  Separate multiple values with comma.
 
 ``SECRET_KEY``
   Controls `Django's secret key <https://docs.djangoproject.com/en/1.10/ref/settings/#secret-key>`_ setting.

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -9,6 +9,10 @@ from django.contrib.messages import constants as messages
 import django_cache_url
 
 
+def get_list(text):
+    return map(str.strip, text.split(','))
+
+
 DEBUG = ast.literal_eval(os.environ.get('DEBUG', 'True'))
 
 SITE_ID = 1
@@ -23,7 +27,8 @@ ADMINS = (
     # ('Your Name', 'your_email@example.com'),
 )
 MANAGERS = ADMINS
-INTERNAL_IPS = os.environ.get('INTERNAL_IPS', '127.0.0.1').split()
+
+INTERNAL_IPS = get_list(os.environ.get('INTERNAL_IPS', '127.0.0.1'))
 
 CACHES = {'default': django_cache_url.config()}
 
@@ -284,8 +289,7 @@ BOOTSTRAP3 = {
 
 TEST_RUNNER = ''
 
-ALLOWED_HOSTS = map(
-    str.strip, os.environ.get('ALLOWED_HOSTS', 'localhost').split(','))
+ALLOWED_HOSTS = get_list(os.environ.get('ALLOWED_HOSTS', 'localhost'))
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -10,7 +10,7 @@ import django_cache_url
 
 
 def get_list(text):
-    return map(str.strip, text.split(','))
+    return [item.strip() for item in text.split(',')]
 
 
 DEBUG = ast.literal_eval(os.environ.get('DEBUG', 'True'))

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -284,7 +284,8 @@ BOOTSTRAP3 = {
 
 TEST_RUNNER = ''
 
-ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost').split()
+ALLOWED_HOSTS = map(
+    str.strip, os.environ.get('ALLOWED_HOSTS', 'localhost').split(','))
 
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 


### PR DESCRIPTION
This PR sets comma (which better fits here) as a separator to `ALLOWED_HOSTS` and `INTERNAL_IPS` env variables and makes [heroku doc](https://github.com/mirumee/saleor/blob/master/app.json#L19)  consistent with the code.