### PR TITLE
Fix CheckoutDiscountForm voucher queryset

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,6 +21,7 @@ django-webpack-loader>=0.3.0
 django-celery-results
 elasticsearch>=5.4
 faker>=0.7.7
+freezegun>=0.3.9
 google-measurement-protocol
 google-i18n-address>=2.0.1
 graphene-django==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,6 +44,7 @@ docutils==0.14            # via botocore
 elasticsearch==5.4.0
 email-validator==1.0.2    # via faker
 faker==0.8.3
+freezegun==0.3.9
 google-i18n-address==2.0.2
 google-measurement-protocol==0.1.6
 graphene-django==1.2.0

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from datetime import date
 from functools import wraps
 
 from django.conf import settings
@@ -248,7 +249,8 @@ class Checkout(object):
     @transaction.atomic
     def create_order(self):
         voucher = self._get_voucher(
-            vouchers=Voucher.objects.active().select_for_update())
+            vouchers=Voucher.objects.active(today=date.today())
+                            .select_for_update())
         if self.voucher_code is not None and voucher is None:
             # Voucher expired in meantime, abort order placement
             return
@@ -308,7 +310,7 @@ class Checkout(object):
         voucher_code = self.voucher_code
         if voucher_code is not None:
             if vouchers is None:
-                vouchers = Voucher.objects.active()
+                vouchers = Voucher.objects.active(today=date.today())
             try:
                 return vouchers.get(code=self.voucher_code)
             except Voucher.DoesNotExist:

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -249,7 +249,7 @@ class Checkout(object):
     @transaction.atomic
     def create_order(self):
         voucher = self._get_voucher(
-            vouchers=Voucher.objects.active(today=date.today())
+            vouchers=Voucher.objects.active(date=date.today())
                             .select_for_update())
         if self.voucher_code is not None and voucher is None:
             # Voucher expired in meantime, abort order placement
@@ -310,7 +310,7 @@ class Checkout(object):
         voucher_code = self.voucher_code
         if voucher_code is not None:
             if vouchers is None:
-                vouchers = Voucher.objects.active(today=date.today())
+                vouchers = Voucher.objects.active(date=date.today())
             try:
                 return vouchers.get(code=self.voucher_code)
             except Voucher.DoesNotExist:

--- a/saleor/checkout/views/discount.py
+++ b/saleor/checkout/views/discount.py
@@ -1,3 +1,4 @@
+from datetime import date
 from functools import wraps
 
 from django.contrib import messages
@@ -45,7 +46,8 @@ def validate_voucher(view):
     def func(request, checkout, cart):
         if checkout.voucher_code:
             try:
-                Voucher.objects.active().get(code=checkout.voucher_code)
+                Voucher.objects.active(today=date.today()).get(
+                    code=checkout.voucher_code)
             except Voucher.DoesNotExist:
                 del checkout.voucher_code
                 checkout.recalculate_discount()

--- a/saleor/checkout/views/discount.py
+++ b/saleor/checkout/views/discount.py
@@ -46,7 +46,7 @@ def validate_voucher(view):
     def func(request, checkout, cart):
         if checkout.voucher_code:
             try:
-                Voucher.objects.active(today=date.today()).get(
+                Voucher.objects.active(date=date.today()).get(
                     code=checkout.voucher_code)
             except Voucher.DoesNotExist:
                 del checkout.voucher_code

--- a/saleor/discount/forms.py
+++ b/saleor/discount/forms.py
@@ -33,7 +33,7 @@ class CheckoutDiscountForm(forms.Form):
         kwargs['initial'] = initial
         super(CheckoutDiscountForm, self).__init__(*args, **kwargs)
         self.fields['voucher'].queryset = Voucher.objects.active(
-            today=date.today())
+            date=date.today())
 
     def clean(self):
         cleaned_data = super(CheckoutDiscountForm, self).clean()

--- a/saleor/discount/forms.py
+++ b/saleor/discount/forms.py
@@ -1,3 +1,4 @@
+from datetime import date
 from django import forms
 from django.utils.encoding import smart_text
 from django.utils.translation import pgettext_lazy
@@ -17,7 +18,8 @@ class VoucherField(forms.ModelChoiceField):
 class CheckoutDiscountForm(forms.Form):
 
     voucher = VoucherField(
-        queryset=Voucher.objects.active(), to_field_name='code',
+        queryset=Voucher.objects.none(),
+        to_field_name='code',
         label=pgettext_lazy(
             'Checkout discount form label for voucher field',
             'Gift card or discount code'),
@@ -30,6 +32,8 @@ class CheckoutDiscountForm(forms.Form):
             initial['voucher'] = self.checkout.voucher_code
         kwargs['initial'] = initial
         super(CheckoutDiscountForm, self).__init__(*args, **kwargs)
+        self.fields['voucher'].queryset = Voucher.objects.active(
+            today=date.today())
 
     def clean(self):
         cleaned_data = super(CheckoutDiscountForm, self).clean()

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -22,13 +22,13 @@ class NotApplicable(ValueError):
 
 class VoucherQueryset(models.QuerySet):
 
-    def active(self, today):
+    def active(self, date):
         queryset = self.filter(
             models.Q(usage_limit__isnull=True) |
             models.Q(used__lt=models.F('usage_limit')))
         queryset = queryset.filter(
-            models.Q(end_date__isnull=True) | models.Q(end_date__gte=today))
-        queryset = queryset.filter(start_date__lte=today)
+            models.Q(end_date__isnull=True) | models.Q(end_date__gte=date))
+        queryset = queryset.filter(start_date__lte=date)
         return queryset
 
     def increase_usage(self, voucher):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -22,8 +22,7 @@ class NotApplicable(ValueError):
 
 class VoucherQueryset(models.QuerySet):
 
-    def active(self):
-        today = date.today()
+    def active(self, today):
         queryset = self.filter(
             models.Q(usage_limit__isnull=True) |
             models.Q(used__lt=models.F('usage_limit')))

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -209,6 +209,21 @@ def test_voucher_queryset_active(voucher):
     assert len(active_vouchers) == 0
 
 
+@patch('saleor.discount.forms.date')
+def test_checkout_discount_form_active_queryset(date_mock, voucher):
+    assert len(Voucher.objects.all()) == 1
+    checkout = Mock(cart=Mock())
+    date_mock.today.return_value = date.today() - timedelta(days=1)
+    form = CheckoutDiscountForm({'voucher': voucher.code}, checkout=checkout)
+    qs = form.fields['voucher'].queryset
+    assert len(qs) == 0
+
+    date_mock.today.return_value = date.today()
+    form = CheckoutDiscountForm({'voucher': voucher.code}, checkout=checkout)
+    qs = form.fields['voucher'].queryset
+    assert len(qs) == 1
+
+
 @pytest.mark.parametrize(
     'prices, discount_value, discount_type, apply_to, expected_value', [
         ([10], 10, Voucher.DISCOUNT_VALUE_FIXED, Voucher.APPLY_TO_ONE_PRODUCT, 10),  # noqa

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -253,7 +253,6 @@ def test_checkout_discount_form_active_queryset_after_some_time(voucher):
         assert len(form.fields['voucher'].queryset) == 0
 
 
-
 @pytest.mark.parametrize(
     'prices, discount_value, discount_type, apply_to, expected_value', [
         ([10], 10, Voucher.DISCOUNT_VALUE_FIXED, Voucher.APPLY_TO_ONE_PRODUCT, 10),  # noqa

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -241,7 +241,7 @@ def test_checkout_discount_form_active_queryset_after_some_time(voucher):
             {'voucher': voucher.code}, checkout=checkout)
         assert len(form.fields['voucher'].queryset) == 0
 
-    with freeze_time('2016-06-2'):
+    with freeze_time('2016-06-01'):
         form = CheckoutDiscountForm(
             {'voucher': voucher.code}, checkout=checkout)
         qs = form.fields['voucher'].queryset

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -201,17 +201,12 @@ def test_invalid_checkout_discount_form(monkeypatch, voucher):
     assert 'voucher' in form.errors
 
 
-@patch('saleor.discount.models.date')
-def test_checkout_discount_form_active_queryset(date_mock, voucher):
-    date_mock.today.return_value = date.today() - timedelta(days=1)
-    checkout = Mock(cart=Mock())
-    voucher.end_date = date.today() + timedelta(days=1)
-    voucher.save()
-    form = CheckoutDiscountForm({'voucher': voucher.code}, checkout=checkout)
-    qs = form.fields['voucher'].queryset
-    form_qs = list(qs) if qs else []
+def test_voucher_queryset_active(voucher):
     vouchers = Voucher.objects.all()
-    assert not set(form_qs).issubset(vouchers)
+    assert len(vouchers) == 1
+    active_vouchers = Voucher.objects.active(
+        today=date.today() - timedelta(days=1))
+    assert len(active_vouchers) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -234,6 +234,7 @@ def test_checkout_discount_form_active_queryset_after_some_time(voucher):
     assert len(Voucher.objects.all()) == 1
     checkout = Mock(cart=Mock())
     voucher.start_date = date(year=2016, month=6, day=1)
+    voucher.end_date = date(year=2016, month=6, day=2)
     voucher.save()
 
     with freeze_time('2016-05-31'):
@@ -244,8 +245,13 @@ def test_checkout_discount_form_active_queryset_after_some_time(voucher):
     with freeze_time('2016-06-01'):
         form = CheckoutDiscountForm(
             {'voucher': voucher.code}, checkout=checkout)
-        qs = form.fields['voucher'].queryset
-        assert len(qs) == 1
+        assert len(form.fields['voucher'].queryset) == 1
+
+    with freeze_time('2016-06-03'):
+        form = CheckoutDiscountForm(
+            {'voucher': voucher.code}, checkout=checkout)
+        assert len(form.fields['voucher'].queryset) == 0
+
 
 
 @pytest.mark.parametrize(

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 from decimal import Decimal
 import pytest
-from mock import Mock, patch
+from mock import Mock
 from prices import FixedDiscount, FractionalDiscount, Price
 
 from django_prices.templatetags.prices_i18n import net
@@ -209,16 +209,21 @@ def test_voucher_queryset_active(voucher):
     assert len(active_vouchers) == 0
 
 
-@patch('saleor.discount.forms.date')
-def test_checkout_discount_form_active_queryset(date_mock, voucher):
+def test_checkout_discount_form_active_queryset_voucher_not_active(voucher):
     assert len(Voucher.objects.all()) == 1
     checkout = Mock(cart=Mock())
-    date_mock.today.return_value = date.today() - timedelta(days=1)
+    voucher.start_date = date.today() + timedelta(days=1)
+    voucher.save()
     form = CheckoutDiscountForm({'voucher': voucher.code}, checkout=checkout)
     qs = form.fields['voucher'].queryset
     assert len(qs) == 0
 
-    date_mock.today.return_value = date.today()
+
+def test_checkout_discount_form_active_queryset_voucher_active(voucher):
+    assert len(Voucher.objects.all()) == 1
+    checkout = Mock(cart=Mock())
+    voucher.start_date = date.today()
+    voucher.save()
     form = CheckoutDiscountForm({'voucher': voucher.code}, checkout=checkout)
     qs = form.fields['voucher'].queryset
     assert len(qs) == 1

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -205,7 +205,7 @@ def test_voucher_queryset_active(voucher):
     vouchers = Voucher.objects.all()
     assert len(vouchers) == 1
     active_vouchers = Voucher.objects.active(
-        today=date.today() - timedelta(days=1))
+        date=date.today() - timedelta(days=1))
     assert len(active_vouchers) == 0
 
 

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -231,21 +231,21 @@ def test_checkout_discount_form_active_queryset_voucher_active(voucher):
 
 
 def test_checkout_discount_form_active_queryset_after_some_time(voucher):
-    with freeze_time(datetime.now()) as frozen_date:
-        assert len(Voucher.objects.all()) == 1
-        checkout = Mock(cart=Mock())
-        voucher.end_date = datetime.now() + timedelta(days=1)
-        voucher.save()
+    assert len(Voucher.objects.all()) == 1
+    checkout = Mock(cart=Mock())
+    voucher.start_date = date(year=2016, month=6, day=1)
+    voucher.save()
+
+    with freeze_time('2016-05-31'):
+        form = CheckoutDiscountForm(
+            {'voucher': voucher.code}, checkout=checkout)
+        assert len(form.fields['voucher'].queryset) == 0
+
+    with freeze_time('2016-06-2'):
         form = CheckoutDiscountForm(
             {'voucher': voucher.code}, checkout=checkout)
         qs = form.fields['voucher'].queryset
         assert len(qs) == 1
-
-        frozen_date.move_to(datetime.now() + timedelta(days=2))
-        form = CheckoutDiscountForm(
-            {'voucher': voucher.code}, checkout=checkout)
-        qs = form.fields['voucher'].queryset
-        assert len(qs) == 0
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
CheckoutDiscountForm evaluates Voucher.objects.active() only once.

Fixes #1233 