### PR TITLE
Exclude random_data from coverage reporting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,7 @@ omit =
     */management/*
     */migrations/*
     */test_*.py
+    saleor/core/utils/random_data.py
 source = saleor
 
 [coverage:report]


### PR DESCRIPTION
Because of its random nature there's no way to ensure proper coverage and it causes unrelated pull requests to fail because of subtle changes in execution paths.