### PR TITLE
Upgrade BabelDjango to django-babel

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,10 +1,10 @@
 Babel>=2.5
-BabelDjango>=0.2
 boto3
 cairosvg==1.0.22
 Django>=1.11
 dj_database_url>=0.3.0
 dj_email_url>=0.0.4
+django-babel>=0.6.1
 django-bootstrap3>=8.2.1
 django-cache-url>=1.0.0
 django-countries>=4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@
 amqp==2.2.2               # via kombu
 asn1crypto==0.22.0        # via cryptography
 babel==2.5.1
-babeldjango==0.2.2        # via django-prices
 billiard==3.5.0.3         # via celery
 boto3==1.4.7
 botocore==1.7.14          # via boto3, s3transfer
@@ -32,7 +31,7 @@ django-filter==1.0.4
 django-mptt==0.8.7
 django-payments==0.12.0
 django-prices-openexchangerates==0.1.15
-django-prices==0.6.2
+django-prices==0.7.0
 django-redis==4.8.0
 django-render-block==0.5  # via django-templated-email
 django-storages==1.6.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 amqp==2.2.2               # via kombu
 asn1crypto==0.22.0        # via cryptography
 babel==2.5.1
-babeldjango==0.2.2
+babeldjango==0.2.2        # via django-prices
 billiard==3.5.0.3         # via celery
 boto3==1.4.7
 botocore==1.7.14          # via boto3, s3transfer
@@ -23,6 +23,7 @@ cssselect2==0.2.1         # via weasyprint
 defusedxml==0.5.0         # via python3-openid, social-auth-core
 dj-database-url==0.4.2
 dj-email-url==0.0.10
+django-babel==0.6.1
 django-bootstrap3==9.0.0
 django-cache-url==1.3.1
 django-celery-results==1.0.1

--- a/saleor/cart/views.py
+++ b/saleor/cart/views.py
@@ -1,7 +1,7 @@
 """Cart-related views."""
 from __future__ import unicode_literals
 
-from babeldjango.templatetags.babel import currencyfmt
+from django_babel.templatetags.babel import currencyfmt
 from django.core.urlresolvers import reverse
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -134,7 +134,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.locale.LocaleMiddleware',
-    'babeldjango.middleware.LocaleMiddleware',
+    'django_babel.middleware.LocaleMiddleware',
     'saleor.core.middleware.DiscountMiddleware',
     'saleor.core.middleware.GoogleAnalytics',
     'saleor.core.middleware.CountryMiddleware',
@@ -175,7 +175,7 @@ INSTALLED_APPS = [
 
     # External apps
     'versatileimagefield',
-    'babeldjango',
+    'django_babel',
     'bootstrap3',
     'django_prices',
     'django_prices_openexchangerates',

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -4,12 +4,12 @@ import json
 from uuid import uuid4
 
 import pytest
-from babeldjango.templatetags.babel import currencyfmt
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
+from django_babel.templatetags.babel import currencyfmt
 from mock import MagicMock, Mock
 from prices import Price
 from satchless.item import InsufficientStock


### PR DESCRIPTION
The package was renamed around version 0.2.

Fixes #1227 

Todo:
* [x] upgrade django-prices to a version that used django-babel