### PR TITLE
Load styles in PDF templates using render_bundle

### DIFF
--- a/saleor/static/dashboard/js/document.js
+++ b/saleor/static/dashboard/js/document.js
@@ -1,0 +1,1 @@
+import '../scss/document.scss';

--- a/templates/dashboard/order/pdf/invoice.html
+++ b/templates/dashboard/order/pdf/invoice.html
@@ -1,12 +1,12 @@
 {% load i18n static %}
 {% load prices_i18n %}
 {% load discount_amount_for from prices %}
-{% load static %}
+{% load render_bundle from webpack_loader %}
 
 <html>
 <head>
   <title>{% trans "Invoice for Order" context "Invoice title" %} #{{ order.id }}</title>
-  <link rel="stylesheet" type="text/css" href="{% static '/assets/document.css' %}"/>
+  {% render_bundle 'document' 'css' %}
 </head>
 <body>
 <header>

--- a/templates/dashboard/order/pdf/packing_slip.html
+++ b/templates/dashboard/order/pdf/packing_slip.html
@@ -2,11 +2,12 @@
 {% load i18n static %}
 {% load prices_i18n %}
 {% load shop %}
+{% load render_bundle from webpack_loader %}
 
 <html>
 <head>
   <title>Packing slip</title>
-  <link rel="stylesheet" type="text/css" href="{% static '/assets/document.css' %}" />
+  {% render_bundle 'document' 'css' %}
 </head>
 <body>
 <header>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,8 +61,8 @@ var faviconsWebpackPlugin = new FaviconsWebpackPlugin({
 var config = {
   entry: {
     dashboard: './saleor/static/dashboard/js/dashboard.js',
+    document: './saleor/static/dashboard/js/document.js',
     storefront: './saleor/static/js/storefront.js',
-    document: './saleor/static/dashboard/scss/document.scss',
     vendor: [
       'babel-es6-polyfill',
       'bootstrap',


### PR DESCRIPTION
This PR fixes loading styles in PDF templates. Previously the `static` template tag was used, but it doesn't work in the production environment, where asset file names are hashed and `render_bundle` template tag has to be used.