### PR TITLE
Use JavaScriptCatalog instead of javascript_catalog

### DIFF
--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url, include
 from django.conf.urls.static import static
 from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.views import serve
-from django.views.i18n import javascript_catalog
+from django.views.i18n import JavaScriptCatalog
 from graphene_django.views import GraphQLView
 
 from .cart.urls import urlpatterns as cart_urls
@@ -27,7 +27,7 @@ urlpatterns = [
     url(r'^dashboard/',
         include((dashboard_urls, 'dashboard'), namespace='dashboard')),
     url(r'^graphql', GraphQLView.as_view(graphiql=settings.DEBUG)),
-    url(r'^jsi18n/$', javascript_catalog, name='javascript-catalog'),
+    url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^order/', include((order_urls, 'order'), namespace='order')),
     url(r'^products/',
         include((product_urls, 'product'), namespace='product')),


### PR DESCRIPTION
`javascript_catalog` was deprecated since 1.10 and was replaced by the `JavaScriptCatalog` class-based view.