### PR TITLE
Drop django-admin-related translations

### DIFF
--- a/saleor/cart/models.py
+++ b/saleor/cart/models.py
@@ -118,8 +118,6 @@ class Cart(models.Model):
 
     class Meta:
         ordering = ('-last_status_change',)
-        verbose_name = pgettext_lazy('Cart model', 'Cart')
-        verbose_name_plural = pgettext_lazy('Cart model', 'Carts')
 
     def __init__(self, *args, **kwargs):
         self.discounts = kwargs.pop('discounts', None)
@@ -270,8 +268,6 @@ class CartLine(models.Model, ItemLine):
 
     class Meta:
         unique_together = ('cart', 'variant', 'data')
-        verbose_name = pgettext_lazy('Cart line model', 'Cart line')
-        verbose_name_plural = pgettext_lazy('Cart line model', 'Cart lines')
 
     def __str__(self):
         return smart_str(self.variant)

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -137,8 +137,6 @@ class Voucher(models.Model):
                 self.discount_value_type == Voucher.DISCOUNT_VALUE_PERCENTAGE)
 
     class Meta:
-        verbose_name = pgettext_lazy('Voucher model', 'voucher')
-        verbose_name_plural = pgettext_lazy('Voucher model', 'vouchers')
         permissions = (
             ('view_voucher',
              pgettext_lazy('Permission description', 'Can view vouchers')),
@@ -292,8 +290,6 @@ class Sale(models.Model):
 
     class Meta:
         app_label = 'discount'
-        verbose_name = pgettext_lazy('Sale (discount) model', 'sale')
-        verbose_name_plural = pgettext_lazy('Sales (discounts) model', 'sales')
         permissions = (
             ('view_sale',
              pgettext_lazy('Permission description', 'Can view sales')),

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -98,8 +98,6 @@ class Order(models.Model, ItemSet):
 
     class Meta:
         ordering = ('-last_status_change',)
-        verbose_name = pgettext_lazy('Order model', 'Order')
-        verbose_name_plural = pgettext_lazy('Order model', 'Orders')
         permissions = (
             ('view_order',
              pgettext_lazy('Permission description', 'Can view orders')),
@@ -246,11 +244,6 @@ class DeliveryGroup(models.Model, ItemSet):
         pgettext_lazy('Delivery group field', 'last updated'),
         null=True, auto_now=True)
 
-    class Meta:
-        verbose_name = pgettext_lazy('Delivery group model', 'Delivery Group')
-        verbose_name_plural = pgettext_lazy(
-            'Delivery group model', 'Delivery Groups')
-
     def __str__(self):
         return pgettext_lazy(
             'Delivery group str', 'Shipment #%s') % self.pk
@@ -360,10 +353,6 @@ class OrderedItem(models.Model, ItemLine):
 
     objects = OrderedItemManager()
 
-    class Meta:
-        verbose_name = pgettext_lazy('Ordered item model', 'Ordered item')
-        verbose_name_plural = pgettext_lazy('Ordered item model', 'Ordered items')
-
     def __str__(self):
         return self.product_name
 
@@ -393,8 +382,6 @@ class Payment(BasePayment):
 
     class Meta:
         ordering = ('-pk',)
-        verbose_name = pgettext_lazy('Payment model', 'Payment')
-        verbose_name_plural = pgettext_lazy('Payment model', 'Payments')
 
     def get_failure_url(self):
         return build_absolute_uri(
@@ -459,10 +446,6 @@ class OrderHistoryEntry(models.Model):
 
     class Meta:
         ordering = ('date', )
-        verbose_name = pgettext_lazy(
-            'Order history entry model', 'Order history entry')
-        verbose_name_plural = pgettext_lazy(
-            'Order history entry model', 'Order history entries')
 
     def __str__(self):
         return pgettext_lazy(
@@ -480,10 +463,6 @@ class OrderNote(models.Model):
     content = models.CharField(
         pgettext_lazy('Order note model', 'content'),
         max_length=250)
-
-    class Meta:
-        verbose_name = pgettext_lazy('Order note model', 'Order note')
-        verbose_name_plural = pgettext_lazy('Order note model', 'Order notes')
 
     def __str__(self):
         return pgettext_lazy(

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -44,8 +44,6 @@ class Category(MPTTModel):
     tree = TreeManager()
 
     class Meta:
-        verbose_name = pgettext_lazy('Category model', 'category')
-        verbose_name_plural = pgettext_lazy('Category model', 'categories')
         app_label = 'product'
         permissions = (
             ('view_category',
@@ -92,9 +90,6 @@ class ProductClass(models.Model):
         default=False)
 
     class Meta:
-        verbose_name = pgettext_lazy('Product class model', 'product class')
-        verbose_name_plural = pgettext_lazy(
-            'Product class model', 'product classes')
         app_label = 'product'
 
     def __str__(self):
@@ -145,8 +140,6 @@ class Product(models.Model, ItemRange):
 
     class Meta:
         app_label = 'product'
-        verbose_name = pgettext_lazy('Product model', 'product')
-        verbose_name_plural = pgettext_lazy('Product model', 'products')
         permissions = (
             ('view_product',
              pgettext_lazy('Permission description', 'Can view products')),
@@ -245,10 +238,6 @@ class ProductVariant(models.Model, Item):
 
     class Meta:
         app_label = 'product'
-        verbose_name = pgettext_lazy(
-            'Product variant model', 'product variant')
-        verbose_name_plural = pgettext_lazy(
-            'Product variant model', 'product variants')
 
     def __str__(self):
         return self.name or self.display_variant()
@@ -406,10 +395,6 @@ class ProductAttribute(models.Model):
 
     class Meta:
         ordering = ('slug', )
-        verbose_name = pgettext_lazy(
-            'Product attribute model', 'product attribute')
-        verbose_name_plural = pgettext_lazy(
-            'Product attribute model', 'product attributes')
 
     def __str__(self):
         return self.name
@@ -437,10 +422,6 @@ class AttributeChoiceValue(models.Model):
 
     class Meta:
         unique_together = ('name', 'attribute')
-        verbose_name = pgettext_lazy(
-            'Attribute choice value model', 'attribute choices value')
-        verbose_name_plural = pgettext_lazy(
-            'Attribute choice value model', 'attribute choices values')
 
     def __str__(self):
         return self.name
@@ -474,9 +455,6 @@ class ProductImage(models.Model):
     class Meta:
         ordering = ('order', )
         app_label = 'product'
-        verbose_name = pgettext_lazy('Product image model', 'product image')
-        verbose_name_plural = pgettext_lazy(
-            'Product image model', 'product images')
 
     def get_ordering_queryset(self):
         return self.product.images.all()
@@ -504,8 +482,3 @@ class VariantImage(models.Model):
         ProductImage, related_name='variant_images',
         verbose_name=pgettext_lazy('Variant image field', 'image'),
         on_delete=models.CASCADE)
-
-    class Meta:
-        verbose_name = pgettext_lazy('Variant image model', 'variant image')
-        verbose_name_plural = pgettext_lazy(
-            'Variant image model', 'variant images')

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -28,10 +28,6 @@ class ShippingMethod(models.Model):
         blank=True, default='')
 
     class Meta:
-        verbose_name = pgettext_lazy(
-            'Shipping method model', 'shipping method')
-        verbose_name_plural = pgettext_lazy(
-            'Shipping method model', 'shipping methods')
         permissions = (
             ('view_shipping',
              pgettext_lazy(
@@ -101,10 +97,6 @@ class ShippingMethodCountry(models.Model):
 
     class Meta:
         unique_together = ('country_code', 'shipping_method')
-        verbose_name = pgettext_lazy(
-            'Shipping method country model', 'shipping method country')
-        verbose_name_plural = pgettext_lazy(
-            'Shipping method country model', 'shipping method countries')
 
     def __str__(self):
         # https://docs.djangoproject.com/en/dev/ref/models/instances/#django.db.models.Model.get_FOO_display  # noqa

--- a/saleor/userprofile/models.py
+++ b/saleor/userprofile/models.py
@@ -80,10 +80,6 @@ class Address(models.Model):
     def full_name(self):
         return '%s %s' % (self.first_name, self.last_name)
 
-    class Meta:
-        verbose_name = pgettext_lazy('Address model', 'address')
-        verbose_name_plural = pgettext_lazy('Address model', 'addresses')
-
     def __str__(self):
         if self.company_name:
             return '%s - %s' % (self.company_name, self.full_name)
@@ -149,8 +145,6 @@ class User(PermissionsMixin, AbstractBaseUser):
     objects = UserManager()
 
     class Meta:
-        verbose_name = pgettext_lazy('User model', 'user')
-        verbose_name_plural = pgettext_lazy('User model', 'users')
         permissions = (
             ('view_user',
              pgettext_lazy('Permission description', 'Can view users')),


### PR DESCRIPTION
Saleor does not use django-admin and these add an unnecessary burden on translators who have no way to verify their work.

Related team discussion: https://github.com/orgs/mirumee/teams/open-source/discussions/1

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
