### PR TITLE
Fix select input and number input focusing after opening modal

### DIFF
--- a/saleor/static/dashboard/js/components/modal.js
+++ b/saleor/static/dashboard/js/components/modal.js
@@ -1,6 +1,7 @@
 import {initSelects} from './utils';
 import SVGInjector from 'svg-injector-2';
 
+// List of input types that can be autofocused after opening modal
 const focusInputs = [
   'textarea',
   'input[type="text"]:not(.select-dropdown)',

--- a/saleor/static/dashboard/js/components/modal.js
+++ b/saleor/static/dashboard/js/components/modal.js
@@ -1,6 +1,12 @@
 import {initSelects} from './utils';
 import SVGInjector from 'svg-injector-2';
 
+const focusInputs = [
+  'textarea',
+  'input[type="text"]:not(.select-dropdown)',
+  'input[type="number"]'
+];
+
 export default $(document).ready((e) => {
   $('body').on('click', '.modal-trigger-custom', function (e) {
     let that = this;
@@ -12,7 +18,7 @@ export default $(document).ready((e) => {
         $modal.html(response);
         initSelects();
         $modal.modal('open');
-        $modal.find('textarea, input[type="text"]')[0].focus();
+        $modal.find(focusInputs.join(','))[0].focus();
         // Image checkbox selector
         $('.image_select-item-overlay').on('click', function (e) {
           let id = $(e.target).attr('id');


### PR DESCRIPTION
I want to merge this change because...

Currently at master branch there is a bug that causes rendering select input as opened after opening a modal - this PR is an attempt to fix it. Also, adds numeric inputs to the fields that can be autofocused.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
