### PR TITLE
Add robots meta tag, set 'nofollow' on links

### DIFF
--- a/saleor/core/views.py
+++ b/saleor/core/views.py
@@ -2,7 +2,6 @@ from __future__ import unicode_literals
 
 from django.template.response import TemplateResponse
 from django.contrib import messages
-from django.conf import settings
 from django.utils.translation import pgettext_lazy
 from impersonate.views import impersonate as orig_impersonate
 

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -4,6 +4,10 @@
 
 {% block title %}{% trans "Log in" context "Login page title" %} — {{ block.super }}{% endblock %}
 
+{% block meta_tags %}
+  <meta name="robots" content="nofollow">
+{% endblock meta_tags %}
+
 {% block content %}
 
   <div class="col-lg-10 col-sm-12 m-auto">

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -17,7 +17,7 @@
           <h3>{% trans "Don't have an account yet?" context "Login form secondary title" %}</h3>
           <img src="{% static 'images/pirate_login.png' %}"
                srcset="{% static 'images/pirate_login.png' %} 1x, {% static 'images/pirate_login2x.png' %} 2x">
-          <a href="{% url 'account_signup' %}" class="btn secondary narrow">
+          <a rel="nofollow" href="{% url 'account_signup' %}" class="btn secondary narrow">
             {% trans "Register" context "Login form secondary action" %}
           </a>
         </div>

--- a/templates/account/partials/login_form.html
+++ b/templates/account/partials/login_form.html
@@ -16,7 +16,7 @@
       <button class="btn primary narrow">
         {% trans "Log in" context "Login form primary action" %}
       </button>
-      <a class="link--styled" href="{% url 'account_reset_password' %}">
+      <a rel="nofollow" class="link--styled" href="{% url 'account_reset_password' %}">
         {% trans "Forgot password?" context "Login form secondary link" %}
       </a>
       {% with available_backends=settings.available_backends %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -5,6 +5,10 @@
 
 {% block title %}{% trans "Password reset" context "Password reset page title" %} — {{ block.super }}{% endblock %}
 
+{% block meta_tags %}
+  <meta name="robots" content="nofollow">
+{% endblock meta_tags %}
+
 {% block content %}
   <div class="row login__forgot-password">
     <div class="col-md-8 m-auto text-center">

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -5,6 +5,10 @@
 
 {% block title %}{% trans "Sign Up" context "Signup page title" %} — {{ block.super }}{% endblock %}
 
+{% block meta_tags %}
+  <meta name="robots" content="nofollow">
+{% endblock meta_tags %}
+
 {% block content %}
   <div class="col-lg-10 offset-lg-1 col-sm-12">
     <div class="row login">

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -17,7 +17,7 @@
           <h3>{% trans "Already have an account?" context "Signup form secondary title" %}</h3>
           <img class="signup-img" src="{% static 'images/pirate_login.png' %}"
                srcset="{% static 'images/pirate_login.png' %} 1x, {% static 'images/pirate_login2x.png' %} 2x">
-          <p><a href="{% url 'account_login' %}" class="btn secondary narrow">
+          <p><a rel="nofollow" href="{% url 'account_login' %}" class="btn secondary narrow">
             {% trans "Log in" context "Signup form secondary action" %}
           </a></p>
         </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -63,11 +63,11 @@
               {% endif %}
             {% else %}
               <li>
-                <a href="{% url "account_signup" %}">
+                <a rel="nofollow" href="{% url "account_signup" %}">
                   {% trans "Register" context "Main navigation item" %}</a>
               </li>
               <li>
-                <a href="{% url "account_login" %}">
+                <a rel="nofollow" href="{% url "account_login" %}">
                   {% trans "Log in" context "Main navigation item" %}
                 </a>
               </li>
@@ -109,7 +109,7 @@
           </div>
           <div class="col-2 col-md-4">
             <div class="navbar__brand__cart float-right">
-              <a class="cart__icon" href="{% url "cart:index" %}">
+              <a rel="nofollow" class="cart__icon" href="{% url "cart:index" %}">
                 <span class="cart-label d-none d-md-inline-block">
                     {% trans "Your Cart" context "Main navigation item" %}
                 </span>
@@ -185,7 +185,7 @@
         <div class="col-md-3 col-sm-6">
           <ul>
             <li>
-              <a href="{% url "cart:index" %}">
+              <a rel="nofollow" href="{% url "cart:index" %}">
                 {% trans "Your Cart" context "Main navigation item" %}
               </a>
             </li>
@@ -221,12 +221,12 @@
               {% endif %}
             {% else %}
               <li>
-                <a href="{% url "account_signup" %}">
+                <a rel="nofollow" href="{% url "account_signup" %}">
                   {% trans "Register" context "Main navigation item" %}
                 </a>
               </li>
               <li>
-                <a href="{% url "account_login" %}">
+                <a rel="nofollow" href="{% url "account_login" %}">
                   {% trans "Log in" context "Main navigation item" %}
                 </a>
               </li>

--- a/templates/base.html
+++ b/templates/base.html
@@ -18,6 +18,7 @@
   {% render_bundle 'storefront' 'css' %}
 
   {% block stylesheet %}{% endblock stylesheet %}
+  {% block meta_tags %}{% endblock meta_tags %}
 
   <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
   <!--[if lt IE 9]>

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -10,9 +10,13 @@
 {% block breadcrumb %}
 <ul class="breadcrumbs list-unstyled">
   <li><a href="/">{% trans "Home" context "Main navigation item" %}</a></li>
-  <li><a href="{% url 'cart:index' %}">{% trans "Cart" context "Cart breadcrumb" %}</a></li>
+  <li><a rel="nofollow" href="{% url 'cart:index' %}">{% trans "Cart" context "Cart breadcrumb" %}</a></li>
 </ul>
 {% endblock breadcrumb %}
+
+{% block meta_tags %}
+  <meta name="robots" content="nofollow">
+{% endblock meta_tags %}
 
 {% block content %}
 <div class="alert alert-success d-block d-sm-none remove-product-alert">

--- a/templates/order/details.html
+++ b/templates/order/details.html
@@ -27,6 +27,10 @@
     {% endif %}
 {% endblock breadcrumb %}
 
+{% block meta_tags %}
+    <meta name="robots" content="noindex, nofollow">
+{% endblock meta_tags %}
+
 {% block content %}
     {# This view is available by just knowing url,          #}
     {# so we don't show all details (like delivery address) #}


### PR DESCRIPTION
Close #1346
- Added robots meta tag on Order confirmation page(noindex, no follow), add nofollow robots meta tag on: signin, singup, cart and password reset pages
- Added 'nofollow' attribute on links pointing to aboves

