### PR TITLE
Hide 'Clear filters' on storefront when filters are not applied

### DIFF
--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -10,8 +10,10 @@ class SortedFilterSet(FilterSet):
     '''
     def __init__(self, data, *args, **kwargs):
         data_copy = data.copy() if data else None
+        print data
         if data:
-            del data_copy['sort_by']
+            if data_copy.get('sort_by', None):
+                del data_copy['sort_by']
             if data_copy:
                 self.is_bound_unsorted = True
         else:

--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -10,11 +10,14 @@ class SortedFilterSet(FilterSet):
     '''
     def __init__(self, data, *args, **kwargs):
         data_copy = data.copy() if data else None
-        if data:
+        self.is_bound_unsorted = self.set_is_bound_unsorted(data_copy)
+        super(SortedFilterSet, self).__init__(data, *args, **kwargs)
+
+    def set_is_bound_unsorted(self, data_copy):
+        if data_copy:
             if data_copy.get('sort_by', None):
                 del data_copy['sort_by']
             if data_copy:
-                self.is_bound_unsorted = True
+                return True
         else:
-            self.is_bound_unsorted = False
-        super(SortedFilterSet, self).__init__(data, *args, **kwargs)
+            return False

--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -10,7 +10,6 @@ class SortedFilterSet(FilterSet):
     '''
     def __init__(self, data, *args, **kwargs):
         data_copy = data.copy() if data else None
-        print data
         if data:
             if data_copy.get('sort_by', None):
                 del data_copy['sort_by']

--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -14,10 +14,8 @@ class SortedFilterSet(FilterSet):
         super(SortedFilterSet, self).__init__(data, *args, **kwargs)
 
     def set_is_bound_unsorted(self, data_copy):
+        if data_copy and data_copy.get('sort_by', None):
+            del data_copy['sort_by']
         if data_copy:
-            if data_copy.get('sort_by', None):
-                del data_copy['sort_by']
-            if data_copy:
-                return True
-        else:
-            return False
+            return True
+        return False

--- a/saleor/dashboard/category/filters.py
+++ b/saleor/dashboard/category/filters.py
@@ -1,11 +1,10 @@
 from __future__ import unicode_literals
 
-from django_filters import OrderingFilter
 from django.utils.translation import pgettext_lazy
+from django_filters import OrderingFilter
 
+from ...core.filters import SortedFilterSet
 from ...product.models import Category
-from ..filters import SortedFilterSet
-
 
 SORT_BY_FIELDS = {
     'name': pgettext_lazy('Category list sorting option', 'name'),

--- a/saleor/dashboard/customer/filters.py
+++ b/saleor/dashboard/customer/filters.py
@@ -1,14 +1,13 @@
 from __future__ import unicode_literals
 
+from django import forms
+from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ChoiceFilter, OrderingFilter)
+
+from ...core.filters import SortedFilterSet
 from ...core.utils.filters import filter_by_customer, filter_by_location
-from django.utils.translation import pgettext_lazy
-from django import forms
-
 from ...userprofile.models import User
-from ..filters import SortedFilterSet
-
 
 SORT_BY_FIELDS = (
     ('email', 'email'),

--- a/saleor/dashboard/discount/filters.py
+++ b/saleor/dashboard/discount/filters.py
@@ -1,17 +1,16 @@
 from __future__ import unicode_literals
 
+from django import forms
+from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ChoiceFilter, DateFromToRangeFilter, ModelMultipleChoiceFilter,
     OrderingFilter, RangeFilter)
-from django.utils.translation import pgettext_lazy
-from django import forms
 
+from ...core.filters import SortedFilterSet
+from ..widgets import DateRangeWidget
 from ...core.utils.filters import filter_by_date_range
 from ...discount.models import Sale, Voucher
 from ...product.models import Category
-from ..filters import SortedFilterSet
-from ..widgets import DateRangeWidget
-
 
 SORT_BY_FIELDS_SALE = {
     'name': pgettext_lazy('Sale list sorting option', 'name'),

--- a/saleor/dashboard/group/filters.py
+++ b/saleor/dashboard/group/filters.py
@@ -1,13 +1,12 @@
 from __future__ import unicode_literals
 
 from django.contrib.auth.models import Group
+from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ModelMultipleChoiceFilter, OrderingFilter)
-from django.utils.translation import pgettext_lazy
 
+from ...core.filters import SortedFilterSet
 from ...core.permissions import get_permissions
-from ..filters import SortedFilterSet
-
 
 SORT_BY_FIELDS = {
     'name': pgettext_lazy('Group list sorting option', 'name')}

--- a/saleor/dashboard/order/filters.py
+++ b/saleor/dashboard/order/filters.py
@@ -1,18 +1,17 @@
 from __future__ import unicode_literals
 
+from django import forms
+from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ChoiceFilter, DateFromToRangeFilter, NumberFilter, RangeFilter,
     OrderingFilter)
-from django import forms
-from django.utils.translation import pgettext_lazy
 from payments import PaymentStatus
 
-from ...core.utils.filters import filter_by_order_customer
-from ...order.models import Order
-from ...order import OrderStatus
-from ..filters import SortedFilterSet
+from ...core.filters import SortedFilterSet
 from ..widgets import DateRangeWidget, PriceRangeWidget
-
+from ...core.utils.filters import filter_by_order_customer
+from ...order import OrderStatus
+from ...order.models import Order
 
 SORT_BY_FIELDS = (
     ('pk', 'pk'),

--- a/saleor/dashboard/product/filters.py
+++ b/saleor/dashboard/product/filters.py
@@ -6,10 +6,10 @@ from django_filters import (
     CharFilter, ChoiceFilter, ModelMultipleChoiceFilter, RangeFilter,
     OrderingFilter)
 
+from ...core.filters import SortedFilterSet
+from ..widgets import PriceRangeWidget
 from ...product.models import (
     Category, Product, ProductAttribute, ProductClass, StockLocation)
-from ..filters import SortedFilterSet
-from ..widgets import PriceRangeWidget
 
 PRODUCT_SORT_BY_FIELDS = {
     'name': pgettext_lazy('Product list sorting option', 'name'),

--- a/saleor/dashboard/shipping/filters.py
+++ b/saleor/dashboard/shipping/filters.py
@@ -1,12 +1,11 @@
 from __future__ import unicode_literals
 
+from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ChoiceFilter, OrderingFilter, RangeFilter)
-from django.utils.translation import pgettext_lazy
 
+from ...core.filters import SortedFilterSet
 from ...shipping.models import COUNTRY_CODE_CHOICES, ShippingMethod
-from ..filters import SortedFilterSet
-
 
 SORT_BY_FIELDS = {
     'name': pgettext_lazy('Group list sorting option', 'name')}

--- a/saleor/dashboard/staff/filters.py
+++ b/saleor/dashboard/staff/filters.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals
 
-from django_filters import (
-    CharFilter, ChoiceFilter, ModelMultipleChoiceFilter, OrderingFilter)
+from django import forms
 from django.contrib.auth.models import Group
 from django.utils.translation import pgettext_lazy
-from django import forms
+from django_filters import (
+    CharFilter, ChoiceFilter, ModelMultipleChoiceFilter, OrderingFilter)
 
+from ...core.filters import SortedFilterSet
 from ...core.utils.filters import filter_by_customer, filter_by_location
 from ...userprofile.models import User
-from ..filters import SortedFilterSet
-
 
 SORT_BY_FIELDS = (
     ('email', 'email'),

--- a/saleor/product/filters.py
+++ b/saleor/product/filters.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 from collections import OrderedDict
 
-from django_filters import (FilterSet, MultipleChoiceFilter, RangeFilter,
+from django_filters import (MultipleChoiceFilter, RangeFilter,
                             OrderingFilter)
 from django.forms import CheckboxSelectMultiple, ValidationError
 from django.utils.translation import pgettext_lazy

--- a/saleor/product/filters.py
+++ b/saleor/product/filters.py
@@ -8,6 +8,7 @@ from django.utils.translation import pgettext_lazy
 
 from django_prices.models import PriceField
 
+from ..core.filters import SortedFilterSet
 from .models import Product, ProductAttribute
 
 
@@ -16,7 +17,7 @@ SORT_BY_FIELDS = {'name': pgettext_lazy('Product list sorting option', 'name'),
                       'Product list sorting option', 'price')}
 
 
-class ProductFilter(FilterSet):
+class ProductFilter(SortedFilterSet):
     def __init__(self, *args, **kwargs):
         self.category = kwargs.pop('category')
         super(ProductFilter, self).__init__(*args, **kwargs)

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -114,7 +114,7 @@
           <h2>
             {% trans 'Filters' context 'Filter heading title' %}
             {% if filter.is_bound_unsorted %}
-              <a href="?">
+              <a href=".">
                 <span class="clear-filters float-right">{% trans 'Clear filters' context 'Category page filters' %}</span>
               </a>
             {% endif %}

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -113,9 +113,11 @@
         <div class="filters-menu__body d-none d-md-block">
           <h2>
             {% trans 'Filters' context 'Filter heading title' %}
-            <a href="?">
-              <span class="clear-filters float-right">{% trans 'Clear filters' context 'Category page filters' %}</span>
-            </a>
+            {% if filter.is_bound_unsorted %}
+              <a href="?">
+                <span class="clear-filters float-right">{% trans 'Clear filters' context 'Category page filters' %}</span>
+              </a>
+            {% endif %}
           </h2>
           <div class="product-filters">
             <div class="product-filters__attributes" data-icon-up="{% static "images/chevron_up.svg" %}"

--- a/templates/dashboard/includes/_filters.html
+++ b/templates/dashboard/includes/_filters.html
@@ -40,7 +40,7 @@
         <div class="right-align">
           <div class="col s12">
               {% if filter.is_bound_unsorted %}
-                <a href="?" class="clear-filters btn btn-flat">
+                <a href="." class="clear-filters btn btn-flat">
                   {% trans 'Clear' context 'Category page filters' %}
                 </a>
               {% endif %}

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -5,6 +5,7 @@ import json
 from io import BytesIO
 
 import pytest
+from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils.encoding import smart_text
@@ -588,8 +589,14 @@ def test_product_list_filters_no_results(admin_client, product_list):
     assert list(response.context['filter'].qs) == []
 
 
-def tets_product_list_filters_with_pagination(admin_client, product_list):
+def test_product_list_pagination(admin_client, product_list):
+    settings.DASHBOARD_PAGINATE_BY = 1
     data = {'page': '1'}
+    url = reverse('dashboard:product-list')
+    response = admin_client.get(url, data)
+    assert response.status_code == 200
+
+    data = {'page': '2'}
     url = reverse('dashboard:product-list')
     response = admin_client.get(url, data)
     assert response.status_code == 200

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -586,3 +586,10 @@ def test_product_list_filters_no_results(admin_client, product_list):
     response = admin_client.get(url, data)
     assert response.status_code == 200
     assert list(response.context['filter'].qs) == []
+
+
+def tets_product_list_filters_with_pagination(admin_client, product_list):
+    data = {'page': '1'}
+    url = reverse('dashboard:product-list')
+    response = admin_client.get(url, data)
+    assert response.status_code == 200

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -600,3 +600,20 @@ def test_product_list_pagination(admin_client, product_list):
     url = reverse('dashboard:product-list')
     response = admin_client.get(url, data)
     assert response.status_code == 200
+
+
+def test_product_list_pagination_with_filters(admin_client, product_list):
+    settings.DASHBOARD_PAGINATE_BY = 1
+    data = {'page': '1', 'price_1': [''], 'price_0': [''], 'is_featured': [''],
+            'name': ['Test'], 'sort_by': ['name'], 'is_published': ['']}
+    url = reverse('dashboard:product-list')
+    response = admin_client.get(url, data)
+    assert response.status_code == 200
+    assert list(response.context['products'])[0] == product_list[0]
+
+    data = {'page': '2', 'price_1': [''], 'price_0': [''], 'is_featured': [''],
+            'name': ['Test'], 'sort_by': ['name'], 'is_published': ['']}
+    url = reverse('dashboard:product-list')
+    response = admin_client.get(url, data)
+    assert response.status_code == 200
+    assert list(response.context['products'])[0] == product_list[1]


### PR DESCRIPTION
I want to merge this change because...

'Clear filter' link should be visible only when some filtering is applied on products.
Fixes #1376 
Fixes #1406

![screenshot from 2017-12-04 09-47-30](https://user-images.githubusercontent.com/11785371/33543673-3493602e-d8d8-11e7-902c-faee876e7c8c.png)
![screenshot from 2017-12-04 09-47-41](https://user-images.githubusercontent.com/11785371/33543680-38728080-d8d8-11e7-9663-b57f94ed2cba.png)


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
