### PR TITLE
Storefront responsiveness

### DIFF
--- a/saleor/static/js/components/cart.js
+++ b/saleor/static/js/components/cart.js
@@ -86,7 +86,7 @@ export default $(document).ready((e) => {
               $.cookie('alert', 'true', {path: '/cart'});
               location.reload();
             } else {
-              $removeProductSuccess.removeClass('d-sm-none');
+              $removeProductSuccess.removeClass('d-none');
               $(this).fadeOut();
             }
           } else {
@@ -113,7 +113,7 @@ export default $(document).ready((e) => {
             $total.html(response.total);
             $cartBadge.html(response.cart.numItems);
             $cartDropdown.load(summaryLink);
-            $removeProductSuccess.removeClass('d-sm-none');
+            $removeProductSuccess.removeClass('d-none');
           } else {
             $.cookie('alert', 'true', {path: '/cart'});
             location.reload();
@@ -148,7 +148,7 @@ export default $(document).ready((e) => {
   $cartSubtotal.on('change', countrySelect, deliveryAjax);
 
   if ($.cookie('alert') === 'true') {
-    $removeProductSuccess.removeClass('d-sm-none');
+    $removeProductSuccess.removeClass('d-none');
     $.cookie('alert', 'false', {path: '/cart'});
   }
 });

--- a/saleor/static/js/components/cart.js
+++ b/saleor/static/js/components/cart.js
@@ -66,7 +66,7 @@ export default $(document).ready((e) => {
   let $cartBadge = $('.navbar__brand__cart .badge');
   let $closeMsg = $('.close-msg');
   $closeMsg.on('click', (e) => {
-    $removeProductSuccess.addClass('d-sm-none');
+    $removeProductSuccess.addClass('d-none');
   });
   $cartLine.each(function () {
     let $quantityInput = $(this).find('#id_quantity');

--- a/saleor/static/scss/components/_filters.scss
+++ b/saleor/static/scss/components/_filters.scss
@@ -62,6 +62,9 @@
     @include media-breakpoint-down(sm) {
       padding: $global-padding*3 0 $global-padding*2;
     }
+    @media (max-width: 370px) {
+      padding-top: 5rem;
+    }
     h2 {
       font-size: 1.8rem;
       color: $body-color;
@@ -115,6 +118,11 @@
     background: $blue;
     margin-left: $global-margin/2;
     border-radius: 50%;
+  }
+  &__wrapper {
+    @include media-breakpoint-down(sm) {
+      padding-top: 8px;
+    }
   }
 }
 
@@ -172,16 +180,16 @@
       }
     }
     &:before {
-        content: '';
-        display: block;
-        width: 15px;
-        height: 10px;
-        position: absolute;
-        top: -10px;
-        right: 15px;
-        background-color: $light-gray;
-        clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
-      }
+      content: '';
+      display: block;
+      width: 15px;
+      height: 10px;
+      position: absolute;
+      top: -10px;
+      right: 15px;
+      background-color: $light-gray;
+      clip-path: polygon(50% 0%, 0% 100%, 100% 100%);
+    }
   }
   .click-area {
     width: 100%;

--- a/saleor/static/scss/components/_footer.scss
+++ b/saleor/static/scss/components/_footer.scss
@@ -4,6 +4,7 @@
   margin-top: $global-margin * 8;
   @include media-breakpoint-down(xs) {
     text-align: center;
+    margin-top: $global-margin * 2;
   }
   &__logo {
     margin-bottom: $global-margin;

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -31,6 +31,7 @@
     }
   }
 }
+
 .navbar {
   padding: 0;
   @include media-breakpoint-down(sm) {
@@ -41,7 +42,7 @@
   }
   @media (max-width: 370px) {
     svg {
-      max-height: 25px;
+      max-height: 23px;
       width: auto;
     }
   }
@@ -72,18 +73,22 @@
   &__logo {
     padding: $global-padding * 2 0;
     .menu-icon-mobile {
-        position: relative;
-        display: inline-block;
-        span {
-          position: absolute;
-          top: 1.3rem;
-          left: 1.1rem;
-          text-transform: uppercase;
-          font-size: 0.45rem;
-        }
-        svg {
-          vertical-align: top;
-        }
+      position: relative;
+      display: inline-block;
+      top: -5px;
+      span {
+        position: absolute;
+        top: 1.3rem;
+        left: 1.1rem;
+        text-transform: uppercase;
+        font-size: 0.45rem;
+      }
+      svg {
+        vertical-align: top;
+      }
+      @media (max-width: 370px) {
+        top: 0;
+      }
     }
     svg path {
       fill: $body-color;
@@ -131,7 +136,7 @@
         padding: $global-padding * 2;
         position: absolute;
         right: 0;
-        top:0;
+        top: 0;
         z-index: 4;
         @include media-breakpoint-down(sm) {
           position: relative;

--- a/saleor/static/scss/layouts/_cart.scss
+++ b/saleor/static/scss/layouts/_cart.scss
@@ -40,7 +40,7 @@
       form {
         display: inline-block;
         input {
-          width: 40px;
+          width: 62px;
           margin-right: 10px;
         }
       }

--- a/saleor/static/scss/layouts/_cart.scss
+++ b/saleor/static/scss/layouts/_cart.scss
@@ -39,6 +39,10 @@
       }
       form {
         display: inline-block;
+        input {
+          width: 40px;
+          margin-right: 10px;
+        }
       }
       &-error {
         display: block;
@@ -89,6 +93,11 @@
     }
     .btn {
       margin: $global-margin * 2 0 $global-margin * 5;
+    }
+  }
+  &__submit {
+    @media (max-width: 370px) {
+      width: 100%;
     }
   }
 }

--- a/saleor/static/scss/layouts/_home.scss
+++ b/saleor/static/scss/layouts/_home.scss
@@ -4,6 +4,9 @@
   h1 {
     font-weight: 300;
     text-transform: uppercase;
+    @include media-breakpoint-down(sm) {
+      font-size: 2.5rem;
+    }
   }
   .btn {
     margin-top: $global-margin;

--- a/saleor/static/scss/layouts/_product-page.scss
+++ b/saleor/static/scss/layouts/_product-page.scss
@@ -74,6 +74,7 @@
       left: 0;
       display: block;
       text-align: center;
+      z-index: 3;
       li {
         display: inline;
         text-indent: 0;
@@ -83,7 +84,7 @@
         }
         &.active {
           img {
-            opacity: 0.5;  
+            opacity: 0.5;
           }
         }
       }

--- a/saleor/static/scss/layouts/_product-page.scss
+++ b/saleor/static/scss/layouts/_product-page.scss
@@ -4,6 +4,11 @@
     text-decoration: underline;
   }
   &__info {
+    @include media-breakpoint-down(sm) {
+      h1 {
+        font-size: 2rem;
+      }
+    }
     h3 {
       text-transform: uppercase;
     }

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -15,7 +15,7 @@
 {% endblock breadcrumb %}
 
 {% block content %}
-<div class="alert alert-success remove-product-alert">
+<div class="alert alert-success remove-product-alert d-none">
   {% trans "Product has been removed from cart" context "Cart message" %}
   <button type="button" class="close close-msg" aria-hidden="true">&times;</button>
 </div>

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -15,7 +15,7 @@
 {% endblock breadcrumb %}
 
 {% block content %}
-<div class="alert alert-success d-block remove-product-alert">
+<div class="alert alert-success remove-product-alert">
   {% trans "Product has been removed from cart" context "Cart message" %}
   <button type="button" class="close close-msg" aria-hidden="true">&times;</button>
 </div>

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -15,13 +15,13 @@
 {% endblock breadcrumb %}
 
 {% block content %}
-<div class="alert alert-success d-block d-sm-none remove-product-alert">
+<div class="alert alert-success d-block remove-product-alert">
   {% trans "Product has been removed from cart" context "Cart message" %}
   <button type="button" class="close close-msg" aria-hidden="true">&times;</button>
 </div>
 <div class="cart">
   {% if cart_lines %}
-    <div class="table__header hidden-sm-down">
+    <div class="table__header d-none d-md-block">
       <div class="row">
         <div class="col-md-7">
           <small>{% trans "Product" context "Cart table header" %}</small>
@@ -73,7 +73,7 @@
     </div>
     <div class="row">
       <div class="col-md-12">
-        <a href="{% url "checkout:login" %}" class="btn primary float-md-right">
+        <a href="{% url "checkout:login" %}" class="btn primary float-right cart__submit">
           {% trans "Checkout" context "Cart primary action" %}
         </a>
       </div>

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -38,10 +38,10 @@
             <li><a href='{{ category.get_absolute_url }}'>{{ category.name }}</a></li>
           </ul>
         </div>
-        <div class="col-md-5">
+        <div class="col-md-5 filters-menu__wrapper">
           <div class="row">
             <div class="col-6 col-md-2 col-lg-6 filters-menu">
-              <span class="filters-menu__label d-sm-none">Filters</span>
+              <span class="filters-menu__label d-md-none">Filters</span>
             </div>
             <div class="col-6 col-md-10 col-lg-6">
               <div class="sort-by">

--- a/templates/favicon.html
+++ b/templates/favicon.html
@@ -13,8 +13,8 @@
 <link rel="apple-touch-icon" sizes="152x152" href="{% webpack_static "favicons/apple-touch-icon-152x152.png" %}">
 <link rel="apple-touch-icon" sizes="180x180" href="{% webpack_static "favicons/apple-touch-icon-180x180.png" %}">
 <meta name="apple-mobile-web-app-capable" content="yes">
-<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
-<meta name="apple-mobile-web-app-title" content="favicons-webpack-plugin">
+<meta name="apple-mobile-web-app-status-bar-style" content="black">
+<meta name="apple-mobile-web-app-title" content="Saleor">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)" href="{% webpack_static "favicons/apple-touch-startup-image-320x460.png" %}">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)" href="{% webpack_static "favicons/apple-touch-startup-image-640x920.png" %}">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="{% webpack_static "favicons/apple-touch-startup-image-640x1096.png" %}">

--- a/templates/favicon.html
+++ b/templates/favicon.html
@@ -14,7 +14,7 @@
 <link rel="apple-touch-icon" sizes="180x180" href="{% webpack_static "favicons/apple-touch-icon-180x180.png" %}">
 <meta name="apple-mobile-web-app-capable" content="yes">
 <meta name="apple-mobile-web-app-status-bar-style" content="black">
-<meta name="apple-mobile-web-app-title" content="Saleor">
+<meta name="apple-mobile-web-app-title" content="{{ site.name }}">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 1)" href="{% webpack_static "favicons/apple-touch-startup-image-320x460.png" %}">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 480px) and (-webkit-device-pixel-ratio: 2)" href="{% webpack_static "favicons/apple-touch-startup-image-640x920.png" %}">
 <link rel="apple-touch-startup-image" media="(device-width: 320px) and (device-height: 568px) and (-webkit-device-pixel-ratio: 2)" href="{% webpack_static "favicons/apple-touch-startup-image-640x1096.png" %}">

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -60,7 +60,7 @@
                 <svg data-src="{% static "images/gallery_arrow.svg" %}" />
               </a>
             {% endif %}
-            <ol class="carousel-indicators hidden-sm-down">
+            <ol class="carousel-indicators d-none d-md-block">
               {% for image in images %}
                 {% if images|length > 1 %}
                   <li data-target="#carousel-example-generic" data-slide-to="{{ forloop.counter0 }}"{% if forloop.first %} class="active"{% endif %}>


### PR DESCRIPTION
Ref #1401 

Issues:
1. [ ] Block scrolling when sidebar is opened - not going to do
2. [x] Remove empty space on the right in home page
3. [x] Fix displaced logo on screens less than `370px`
4. [x] Shrink footer's top margin
5. [x] Hide cart table header - as it was before updating Bootstrap
6. [x] Cart alert is now closeable
7. [x] Top bar on Apple phones should now render in black color
8. [x] When pinning Saleor site as web app on iPhone, app title now displays properly `site.name`
9. [ ] Shrink navbar height - not going to do
10. [x] Shrink product title on small mobile devices
11. [x] Show filters between `567px` and `576px`
12. [x] Fix carousel miniatures rendering on navbar
13. [ ] Hide (?) subcategories from filters - not going to do