### PR TITLE
Replace '0.0.0' version with 'latest'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,7 @@
 {
   "name": "saleor",
-  "version": "0.0.0",
-  "lockfileVersion": 1,
   "requires": true,
+  "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,8 @@
 {
   "name": "saleor",
-  "requires": true,
+  "version": "2017.11.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "abbrev": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "saleor",
-  "version": "0.0.0",
-  "main": "Gruntfile.js",
+  "version": "latest",
   "repository": {
     "type": "git",
     "url": "git://github.com/mirumee/saleor.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "latest",
+  "version": "2017.11.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/mirumee/saleor.git"


### PR DESCRIPTION
Replaced *bad-looking* '0.0.0' version with *awesome* 'latest' in Saleor's `package.json`. Pure cosmetics.