### PR TITLE
Unify button style

### DIFF
--- a/saleor/static/dashboard/js/components/modal.js
+++ b/saleor/static/dashboard/js/components/modal.js
@@ -1,4 +1,4 @@
-import {initSelects} from './utils';
+import { initSelects } from './utils';
 import SVGInjector from 'svg-injector-2';
 
 // List of input types that can be autofocused after opening modal
@@ -19,7 +19,10 @@ export default $(document).ready((e) => {
         $modal.html(response);
         initSelects();
         $modal.modal('open');
-        $modal.find(focusInputs.join(','))[0].focus();
+        const inputs = $modal.find(focusInputs.join(','));
+        if (inputs.length) {
+          $modal.find(focusInputs.join(','))[0].focus();
+        }
         // Image checkbox selector
         $('.image_select-item-overlay').on('click', function (e) {
           let id = $(e.target).attr('id');

--- a/saleor/static/dashboard/scss/components/_buttons.scss
+++ b/saleor/static/dashboard/scss/components/_buttons.scss
@@ -1,15 +1,24 @@
+.card .card-action {
+  a:not(.btn):not(.btn-large):not(.btn-large):not(.btn-floating) {
+    @extend .btn-flat;
+    &:hover {
+      color: $secondary-color;
+    }
+  }
+}
+
 .btn {
   &:not(.btn-floating) {
     box-shadow: none;
   }
   &-flat {
-    @extend .btn;
+    @extend .waves-lightgray;
     color: $secondary-color;
     &:hover {
-      background: transparentize(#cccccc, .6);
+      background: unset;
     }
     &:focus, &:active {
-      background: transparentize(#000000, .88);
+      background: unset;
     }
   }
   &-fab {

--- a/saleor/static/dashboard/scss/components/_buttons.scss
+++ b/saleor/static/dashboard/scss/components/_buttons.scss
@@ -1,61 +1,33 @@
-.btn-flat {
-  color: $secondary-color;
-  &.btn:hover {
-    color: #fff;
-  }
-}
-
 .btn {
   &:not(.btn-floating) {
     box-shadow: none;
   }
-  &-danger {
-    color: $error-color;
+  &-flat {
+    @extend .btn;
+    color: $secondary-color;
     &:hover {
-      background: $error-color;
-      color: #fff;
+      background: transparentize(#cccccc, .6);
+    }
+    &:focus, &:active {
+      background: transparentize(#000000, .88);
     }
   }
-  &-action {
-    &-primary {
-      @extend  .btn;
-      @extend .btn-flat;
+  &-fab {
+    &-fixed {
+      @extend .fixed-action-btn;
+      @media (min-width: $medium-screen) {
+        position: absolute;
+        top: 4px;
+        right: 25%;
+      }
+      @media (min-width: $large-screen) {
+        right: calc(25% - 60px);
+      }
     }
-    &-secondary {
-      @extend .btn;
-      @extend .btn-flat;
+    &-default {
+      @extend .btn-fab;
+      @extend .btn-floating;
+      @extend .btn-large;
     }
-  }
-}
-
-.btn-fab, .btn-floating {
-  svg {
-    vertical-align: middle;
-  }
-  &.btn-fab-hidden {
-    transform: scaleX(0) scaleY(0);
-  }
-}
-
-.bulk-submit {
-  margin-top: 25px;
-}
-
-.btn-fab {
-  &-fixed {
-    @extend .fixed-action-btn;
-    @media (min-width: $medium-screen) {
-      position: absolute;
-      top: 4px;
-      right: 25%;
-    }
-    @media (min-width: $large-screen) {
-      right: calc(25% - 60px);
-    }
-  }
-  &-default {
-    @extend .btn-fab;
-    @extend .btn-floating;
-    @extend .btn-large;
   }
 }

--- a/saleor/static/dashboard/scss/components/_buttons.scss
+++ b/saleor/static/dashboard/scss/components/_buttons.scss
@@ -18,7 +18,7 @@
       background: unset;
     }
     &:focus, &:active {
-      background: unset;
+      background: rgba(0,0,0,0.05);
     }
   }
   &-fab, &-floating {

--- a/saleor/static/dashboard/scss/components/_buttons.scss
+++ b/saleor/static/dashboard/scss/components/_buttons.scss
@@ -17,7 +17,7 @@
     &:hover {
       background: unset;
     }
-    &:focus, &:active {
+    &:focus {
       background: rgba(0,0,0,0.05);
     }
   }

--- a/saleor/static/dashboard/scss/components/_buttons.scss
+++ b/saleor/static/dashboard/scss/components/_buttons.scss
@@ -21,6 +21,14 @@
       background: unset;
     }
   }
+  &-fab, &-floating {
+    svg {
+      vertical-align: middle;
+    }
+    &.btn-fab-hidden {
+      transform: scaleX(0) scaleY(0);
+    }
+  }
   &-fab {
     &-fixed {
       @extend .fixed-action-btn;

--- a/saleor/static/dashboard/scss/components/_global.scss
+++ b/saleor/static/dashboard/scss/components/_global.scss
@@ -164,3 +164,7 @@ svg {
     color: #999;
   }
 }
+
+.waves-effect.waves-lightgray .waves-ripple {
+  background-color: rgba(0, 0, 0, 0.05);
+}

--- a/templates/dashboard/base_modal_confirm_delete.html
+++ b/templates/dashboard/base_modal_confirm_delete.html
@@ -18,10 +18,10 @@
   </div>
   <div class="modal-footer">
   {% block footer %}
-    <a href="#!" class="modal-action modal-close btn-flat">
+    <a href="#!" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Remove" context "Dashboard delete action" %}
     </button>
   {% endblock footer %}

--- a/templates/dashboard/category/detail.html
+++ b/templates/dashboard/category/detail.html
@@ -107,10 +107,10 @@
           </div>
           {% if perms.product.edit_category %}
           <div class="card-action">
-            <a class="btn btn-flat" href="{% url 'dashboard:category-edit' root_pk=root.pk %}">
+            <a class="btn-flat waves-effect" href="{% url 'dashboard:category-edit' root_pk=root.pk %}">
               {% trans "Edit category" context "Category detail view action" %}
             </a>
-            <a class="btn btn-flat modal-trigger-custom"
+            <a class="btn-flat waves-effect modal-trigger-custom"
              data-href="{% url 'dashboard:category-delete' pk=root.pk %}"
              href="#base-modal">
               {% trans "Remove category" context "Category detail view action" %}
@@ -125,7 +125,7 @@
             </span>
           </div>
           <div class="data-table-header-action">
-            <a href="{% if root%}{% url 'dashboard:category-add' root_pk=root.pk %}{% else %}{% url 'dashboard:category-add' %}{% endif %}" class="btn-data-table btn btn-flat">
+            <a href="{% if root%}{% url 'dashboard:category-add' root_pk=root.pk %}{% else %}{% url 'dashboard:category-add' %}{% endif %}" class="btn-data-table btn-flat waves-effect">
               {% trans "Add" %}
             </a>
           </div>
@@ -165,10 +165,10 @@
                     </td>
                     {% if perms.product.edit_category %}
                       <td class="right-align ignore-link">
-                        <a href="{% url 'dashboard:category-edit' root_pk=node.pk %}" class="btn btn-flat">
+                        <a href="{% url 'dashboard:category-edit' root_pk=node.pk %}" class="btn-flat waves-effect">
                           {% trans 'Edit' context 'Category edit action' %}
                         </a>
-                        <a class="btn btn-flat modal-trigger-custom"
+                        <a class="btn-flat waves-effect modal-trigger-custom"
                          data-href="{% url 'dashboard:category-delete' pk=node.pk %}"
                          href="#base-modal">
                           {% trans "Remove" context "Category list action link" %}

--- a/templates/dashboard/category/form.html
+++ b/templates/dashboard/category/form.html
@@ -119,11 +119,11 @@
               </a>
             {% endif %}
             {% if category.pk %}
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/customer/modal/confirm_promote.html
+++ b/templates/dashboard/customer/modal/confirm_promote.html
@@ -13,10 +13,10 @@
     {% trans "Are you sure?" context "Dashboard confirmation modal" %}
   </div>
   <div class="modal-footer">
-    <a href="#!" class="modal-action modal-close btn-flat">
+    <a href="#!" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Promote" context "Dashboard promote action" %}
     </button>
   </div>

--- a/templates/dashboard/discount/sale/form.html
+++ b/templates/dashboard/discount/sale/form.html
@@ -8,7 +8,7 @@
     {{ sale }}
   {% else %}
     {% trans "Add new sale"  context "Sale (discount) page title" %}
-  {% endif %} 
+  {% endif %}
   - {% trans "Sales" context "Dashboard sales (discounts) list." %} - {{ block.super }}
 {% endblock %}
 
@@ -94,17 +94,17 @@
 
           <div class="card-action right-align">
             {% if sale.pk %}
-              <a href="{% url 'dashboard:sale-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:sale-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/discount/sale/form.html
+++ b/templates/dashboard/discount/sale/form.html
@@ -97,14 +97,14 @@
               <a href="{% url 'dashboard:sale-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:sale-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/discount/sale/form.html
+++ b/templates/dashboard/discount/sale/form.html
@@ -94,14 +94,14 @@
 
           <div class="card-action right-align">
             {% if sale.pk %}
-              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:sale-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/discount/voucher/form.html
+++ b/templates/dashboard/discount/voucher/form.html
@@ -123,14 +123,14 @@
           </div>
           <div class="card-action right-align">
             {% if voucher.pk %}
-              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/discount/voucher/form.html
+++ b/templates/dashboard/discount/voucher/form.html
@@ -123,17 +123,17 @@
           </div>
           <div class="card-action right-align">
             {% if voucher.pk %}
-              <a href="{% url 'dashboard:voucher-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:voucher-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/discount/voucher/form.html
+++ b/templates/dashboard/discount/voucher/form.html
@@ -126,14 +126,14 @@
               <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:voucher-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/group/detail.html
+++ b/templates/dashboard/group/detail.html
@@ -81,7 +81,7 @@
             </div>
             {% if perms.userprofile.edit_group %}
             <div class="card-action right-align">
-              <a href="{% url 'dashboard:group-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:group-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/group/detail.html
+++ b/templates/dashboard/group/detail.html
@@ -81,10 +81,10 @@
             </div>
             {% if perms.userprofile.edit_group %}
             <div class="card-action right-align">
-              <a href="{% url 'dashboard:group-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:group-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% if group.name %}
                   {% trans 'Update' context 'Dashboard update action' %}
                 {% else %}

--- a/templates/dashboard/group/detail.html
+++ b/templates/dashboard/group/detail.html
@@ -84,7 +84,7 @@
               <a href="{% url 'dashboard:group-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% if group.name %}
                   {% trans 'Update' context 'Dashboard update action' %}
                 {% else %}

--- a/templates/dashboard/includes/_filters.html
+++ b/templates/dashboard/includes/_filters.html
@@ -40,11 +40,11 @@
         <div class="right-align">
           <div class="col s12">
               {% if filter.is_bound_unsorted %}
-                <a href="." class="clear-filters btn btn-flat">
+                <a href="." class="clear-filters btn-flat">
                   {% trans 'Clear' context 'Category page filters' %}
                 </a>
               {% endif %}
-            <button class="btn btn-flat" type="submit">
+            <button class="btn-flat" type="submit">
               {% trans 'Filter' context 'Category price filter' %}
             </button>
           </div>

--- a/templates/dashboard/includes/_filters.html
+++ b/templates/dashboard/includes/_filters.html
@@ -40,11 +40,11 @@
         <div class="right-align">
           <div class="col s12">
               {% if filter.is_bound_unsorted %}
-                <a href="." class="clear-filters btn-flat">
+                <a href="." class="clear-filters btn-flat waves-effect">
                   {% trans 'Clear' context 'Category page filters' %}
                 </a>
               {% endif %}
-            <button class="btn-flat" type="submit">
+            <button class="btn-flat waves-effect" type="submit">
               {% trans 'Filter' context 'Category price filter' %}
             </button>
           </div>

--- a/templates/dashboard/order/address_form.html
+++ b/templates/dashboard/order/address_form.html
@@ -57,7 +57,7 @@
             </div>
           </div>
           <div class="card-action right-align">
-            <a href="{% url "dashboard:order-details" order_pk=order.pk %}" class="btn-flat">
+            <a href="{% url "dashboard:order-details" order_pk=order.pk %}" class="btn-flat waves-effect">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
             <button type="submit" class="btn">

--- a/templates/dashboard/order/address_form.html
+++ b/templates/dashboard/order/address_form.html
@@ -57,10 +57,10 @@
             </div>
           </div>
           <div class="card-action right-align">
-            <a href="{% url "dashboard:order-details" order_pk=order.pk %}" class="btn btn-flat">
+            <a href="{% url "dashboard:order-details" order_pk=order.pk %}" class="btn-flat">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn waves-effect waves-light">
+            <button type="submit" class="btn">
               {% trans "Update" context "Dashboard update action" %}
             </button>
           </div>

--- a/templates/dashboard/order/address_form.html
+++ b/templates/dashboard/order/address_form.html
@@ -60,7 +60,7 @@
             <a href="{% url "dashboard:order-details" order_pk=order.pk %}" class="btn-flat waves-effect">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn">
+            <button type="submit" class="btn waves-effect">
               {% trans "Update" context "Dashboard update action" %}
             </button>
           </div>

--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -188,22 +188,22 @@
             <div class="data-table-action">
               {% if can_capture %}
                 <a href="#base-modal" data-href="{% url 'dashboard:capture-payment' order_pk=order.pk payment_pk=payment.pk %}"
-              class="btn btn-flat modal-trigger-custom">
+              class="btn-flat modal-trigger-custom waves-effect">
                   {% trans "Capture" context "Order summary card action" %}
                 </a>
               {% elif can_refund %}
                 <a href="#base-modal" data-href="{% url 'dashboard:refund-payment' order_pk=order.pk payment_pk=payment.pk %}"
-              class="btn btn-flat modal-trigger-custom">
+              class="btn-flat modal-trigger-custom waves-effect">
                   {% trans "Refund" context "Order summary card action" %}
                 </a>
               {% endif %}
               {% if can_release %}
                 <a href="#base-modal" data-href="{% url 'dashboard:release-payment' order_pk=order.pk payment_pk=payment.pk %}"
-              class="btn btn-flat modal-trigger-custom">
+              class="btn-flat modal-trigger-custom waves-effect">
                   {% trans "Release" context "Order summary card action" %}
                 </a>
               {% endif %}
-              <a href="{% url 'dashboard:order-invoice' order_pk=order.pk %}" data-href="" class="btn btn-flat" target="_blank">
+              <a href="{% url 'dashboard:order-invoice' order_pk=order.pk %}" data-href="" class="btn-flat waves-effect" target="_blank">
                   {% trans "Invoice" context "Order detail action" %}
               </a>
             </div>
@@ -223,7 +223,7 @@
                 </div>
                 {% if perms.order.edit_order %}
                   <div class="card-action">
-                    <a class="btn btn-flat" href="{% url "dashboard:address-edit" order_pk=order.pk address_type="shipping" %}">
+                    <a class="btn-flat waves-effect" href="{% url "dashboard:address-edit" order_pk=order.pk address_type="shipping" %}">
                       {% trans "Edit" context "Dashboard edit action" %}
                     </a>
                   </div>
@@ -243,7 +243,7 @@
               </div>
               {% if perms.order.edit_order %}
                 <div class="card-action">
-                  <a href="{% url "dashboard:address-edit" order_pk=order.pk address_type="billing" %}" class="btn btn-flat">
+                  <a href="{% url "dashboard:address-edit" order_pk=order.pk address_type="billing" %}" class="btn-flat waves-effect">
                     {% trans "Edit" context "Dashboard edit action" %}</a>
                 </div>
               {% endif %}
@@ -340,19 +340,19 @@
             {% if group.can_ship or group.can_cancel %}
               <div class="data-table-action">
                 {% if group.can_ship %}
-                  <a href="#base-modal" data-href="{% url 'dashboard:ship-delivery-group' order_pk=order.pk group_pk=group.pk %}" class="btn btn-flat modal-trigger-custom">
+                  <a href="#base-modal" data-href="{% url 'dashboard:ship-delivery-group' order_pk=order.pk group_pk=group.pk %}" class="btn-flat waves-effect modal-trigger-custom">
                     {% trans "Dispatch" context "Shipment group table action" %}
                   </a>
                 {% endif %}
                 {% if group.can_cancel %}
-                  <a href="#base-modal" data-href="{% url 'dashboard:cancel-delivery-group' order_pk=order.pk group_pk=group.pk %}" class="btn btn-flat modal-trigger-custom" title="{% trans 'Cancel group' context 'Shipment group table action' %}">
+                  <a href="#base-modal" data-href="{% url 'dashboard:cancel-delivery-group' order_pk=order.pk group_pk=group.pk %}" class="btn-flat waves-effect modal-trigger-custom" title="{% trans 'Cancel group' context 'Shipment group table action' %}">
                     {% trans "Cancel shipment" context "Shipment group table action" %}
                   </a>
                 {% endif %}
-                <a href="#base-modal" data-href="{% url 'dashboard:add-variant-to-group' order_pk=order.pk group_pk=group.pk %}" class="btn btn-flat modal-trigger-custom" title="{% trans "Add product to order" context "Order summary card action title" %}">
+                <a href="#base-modal" data-href="{% url 'dashboard:add-variant-to-group' order_pk=order.pk group_pk=group.pk %}" class="btn-flat waves-effect modal-trigger-custom" title="{% trans "Add product to order" context "Order summary card action title" %}">
                   {% trans "Add product" context "Order summary card action" %}
                 </a>
-                <a href="{% url 'dashboard:order-packing-slips' group_pk=group.pk %}" data-href="" class="btn btn-flat" target="_blank">
+                <a href="{% url 'dashboard:order-packing-slips' group_pk=group.pk %}" data-href="" class="btn-flat waves-effect" target="_blank">
                   {% trans "Packing Slips" context "Order detail action" %}
                 </a>
               </div>
@@ -455,7 +455,7 @@
         </div>
         {% if perms.order.edit_order %}
           <div class="card-action">
-            <a data-href="{% url "dashboard:order-add-note" order_pk=order.pk %}" class="modal-trigger-custom btn btn-flat" href="#base-modal">
+            <a data-href="{% url "dashboard:order-add-note" order_pk=order.pk %}" class="modal-trigger-custom btn-flat waves-effect" href="#base-modal">
               {% trans "Add note" context "Order notes card action" %}
             </a>
           </div>

--- a/templates/dashboard/order/modal/add_note.html
+++ b/templates/dashboard/order/modal/add_note.html
@@ -16,10 +16,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" class="modal-action modal-close btn-flat">
+    <a href="#!" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Save note" context "Modal add note primary action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/add_variant_to_group.html
+++ b/templates/dashboard/order/modal/add_variant_to_group.html
@@ -21,10 +21,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Add" context "Modal group add variant primary action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/cancel_line.html
+++ b/templates/dashboard/order/modal/cancel_line.html
@@ -56,10 +56,10 @@
     </table>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Remove" context "Dashboard remove action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/cancel_order.html
+++ b/templates/dashboard/order/modal/cancel_order.html
@@ -16,10 +16,10 @@
   <form id="release-form" method="post" role="form" class="form-async"
   action="{% url 'dashboard:order-cancel' order_pk=order.pk %}" novalidate>
     {% csrf_token %}
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Abort" context "Dashboard abort action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Cancel Order" context "Modal cancel order primary action" %}
     </button>
   </form>

--- a/templates/dashboard/order/modal/capture.html
+++ b/templates/dashboard/order/modal/capture.html
@@ -25,10 +25,10 @@
     </ul>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Capture" context "Modal capture payment primary action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/change_quantity.html
+++ b/templates/dashboard/order/modal/change_quantity.html
@@ -12,10 +12,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Update" context "Dashboard update action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/order_remove_voucher.html
+++ b/templates/dashboard/order/modal/order_remove_voucher.html
@@ -15,10 +15,10 @@
   <form id="release-form" method="post" role="form" class="form-async"
   action="{% url 'dashboard:order-remove-voucher' order_pk=order.pk %}" novalidate>
     {% csrf_token %}
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Abort" context "Dashboard abort action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Remove voucher" context "Modal remove voucher from order primary action" %}
     </button>
   </form>

--- a/templates/dashboard/order/modal/refund.html
+++ b/templates/dashboard/order/modal/refund.html
@@ -25,10 +25,10 @@
     </ul>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Refund" context "Modal refund payment primary action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/release.html
+++ b/templates/dashboard/order/modal/release.html
@@ -12,10 +12,10 @@
 <div class="modal-footer">
   <form id="release-form" method="post" role="form" class="form-async" action="{% url 'dashboard:release-payment' order_pk=order.pk payment_pk=payment.pk %}" novalidate>
     {% csrf_token %}
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Release" context "Modal release payment primary action" %}
     </button>
   </form>

--- a/templates/dashboard/order/modal/ship_shipment_group.html
+++ b/templates/dashboard/order/modal/ship_shipment_group.html
@@ -16,10 +16,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Ship" context "Modal ship shipment group primary action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/shipment_group_stock.html
+++ b/templates/dashboard/order/modal/shipment_group_stock.html
@@ -16,10 +16,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Save" context "Dashboard update action" %}
     </button>
   </div>

--- a/templates/dashboard/order/modal/split_order_line.html
+++ b/templates/dashboard/order/modal/split_order_line.html
@@ -12,10 +12,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat">
+    <a href="#!" aria-hidden="true" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Split" context "Modal split order line primary action" %}
     </button>
   </div>

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -72,14 +72,14 @@
         </div>
         <div class="card-action">
           {% if perms.product.edit_product %}
-            <a href="{% url "dashboard:product-update" product.pk %}" class="btn-flat">
+            <a href="{% url "dashboard:product-update" product.pk %}" class="btn-flat waves-effect">
               {% trans "Edit product" context "Product action" %}
             </a>
-            <a href="#base-modal" data-href="{% url 'dashboard:product-delete' pk=product.pk %}" class="modal-trigger-custom btn-flat">
+            <a href="#base-modal" data-href="{% url 'dashboard:product-delete' pk=product.pk %}" class="modal-trigger-custom btn-flat waves-effect">
                 {% trans "Remove product" context "Product action" %}
             </a>
           {% endif %}
-          <a href="{{ product.get_absolute_url }}" target="_blank" class="btn-flat">
+          <a href="{{ product.get_absolute_url }}" target="_blank" class="btn-flat waves-effect">
             {% trans "View on site" context "Product action" %}
           </a>
         </div>
@@ -91,7 +91,7 @@
           </div>
           {% if perms.product.edit_product %}
             <div class="data-table-header-action">
-                <a href="{% url 'dashboard:variant-add' product_pk=product.pk %}" class="btn-flat">{% trans "Add" %}</a>
+                <a href="{% url 'dashboard:variant-add' product_pk=product.pk %}" class="btn-flat waves-effect">{% trans "Add" %}</a>
             </div>
           {% endif %}
           <div class="data-table-container">
@@ -126,7 +126,7 @@
                       {% endif %}
                     </td>
                     {% if perms.product.edit_product %}
-                      <td><a href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">{% trans "Edit" %}</a></td>
+                      <td><a href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat waves-effect">{% trans "Edit" %}</a></td>
                     {% endif %}
                   </tr>
                 {% empty %}
@@ -145,7 +145,7 @@
             <span class="card-title">{% trans "Stock" context "Dashboard variant details view" %}</span>
           </div>
           <div class="data-table-header-action">
-            <a class="btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=only_variant.pk %}">
+            <a class="btn-flat waves-effect" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=only_variant.pk %}">
               {% trans "Add" context "Dashboard action" %}
             </a>
           </div>
@@ -203,7 +203,7 @@
               </div>
               {% if perms.product.edit_product %}
                 <div class="card-action">
-                  <a href="{% url 'dashboard:product-image-list' product.pk %}" class="btn-flat">{% trans "Edit images" %}</a>
+                  <a href="{% url 'dashboard:product-image-list' product.pk %}" class="btn-flat waves-effect">{% trans "Edit images" %}</a>
                 </div>
               {% endif %}
             </div>

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -72,14 +72,14 @@
         </div>
         <div class="card-action">
           {% if perms.product.edit_product %}
-            <a href="{% url "dashboard:product-update" product.pk %}" class="btn btn-flat">
+            <a href="{% url "dashboard:product-update" product.pk %}" class="btn-flat">
               {% trans "Edit product" context "Product action" %}
             </a>
-            <a href="#base-modal" data-href="{% url 'dashboard:product-delete' pk=product.pk %}" class="modal-trigger-custom btn btn-flat">
+            <a href="#base-modal" data-href="{% url 'dashboard:product-delete' pk=product.pk %}" class="modal-trigger-custom btn-flat">
                 {% trans "Remove product" context "Product action" %}
             </a>
           {% endif %}
-          <a href="{{ product.get_absolute_url }}" target="_blank" class="btn btn-flat">
+          <a href="{{ product.get_absolute_url }}" target="_blank" class="btn-flat">
             {% trans "View on site" context "Product action" %}
           </a>
         </div>
@@ -91,7 +91,7 @@
           </div>
           {% if perms.product.edit_product %}
             <div class="data-table-header-action">
-                <a href="{% url 'dashboard:variant-add' product_pk=product.pk %}" class="btn-data-table btn btn-flat">{% trans "Add" %}</a>
+                <a href="{% url 'dashboard:variant-add' product_pk=product.pk %}" class="btn-flat">{% trans "Add" %}</a>
             </div>
           {% endif %}
           <div class="data-table-container">
@@ -126,7 +126,7 @@
                       {% endif %}
                     </td>
                     {% if perms.product.edit_product %}
-                      <td><a href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}" class="btn btn-flat">{% trans "Edit" %}</a></td>
+                      <td><a href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">{% trans "Edit" %}</a></td>
                     {% endif %}
                   </tr>
                 {% empty %}
@@ -145,7 +145,7 @@
             <span class="card-title">{% trans "Stock" context "Dashboard variant details view" %}</span>
           </div>
           <div class="data-table-header-action">
-            <a class="btn btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=only_variant.pk %}">
+            <a class="btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=only_variant.pk %}">
               {% trans "Add" context "Dashboard action" %}
             </a>
           </div>
@@ -203,7 +203,7 @@
               </div>
               {% if perms.product.edit_product %}
                 <div class="card-action">
-                  <a href="{% url 'dashboard:product-image-list' product.pk %}" class="btn btn-flat">{% trans "Edit images" %}</a>
+                  <a href="{% url 'dashboard:product-image-list' product.pk %}" class="btn-flat">{% trans "Edit images" %}</a>
                 </div>
               {% endif %}
             </div>

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -108,14 +108,14 @@
           </div>
           <div class="card-action right-align">
             {% if product.pk %}
-              <a href="{% url 'dashboard:product-detail' product.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-detail' product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -111,14 +111,14 @@
               <a href="{% url 'dashboard:product-detail' product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:product-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -108,17 +108,17 @@
           </div>
           <div class="card-action right-align">
             {% if product.pk %}
-              <a href="{% url 'dashboard:product-detail' product.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-detail' product.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/list.html
+++ b/templates/dashboard/product/list.html
@@ -59,7 +59,7 @@
               <ul class="right">
                 {% for action, label in bulk_action_form.action.field.widget.choices %}
                   <li>
-                    <a href="" data-action="{{ action }}" class="btn-flat">{{ label|upper }}</a>
+                    <a href="" data-action="{{ action }}" class="btn-flat waves-effect">{{ label|upper }}</a>
                   </li>
                 {% endfor %}
               </ul>
@@ -144,10 +144,10 @@
         </div>
       </div>
       <div class="modal-footer">
-        <a href="#!" class="modal-action modal-close btn-flat">
+        <a href="#!" class="modal-action modal-close btn-flat waves-effect">
           {% trans "Cancel" context "Dashboard cancel action" %}
         </a>
-        <button type="submit" class="modal-action btn-flat">
+        <button type="submit" class="modal-action btn-flat waves-effect">
           {% trans "Create new" context "Dashboard add action" %}
         </button>
       </div>

--- a/templates/dashboard/product/list.html
+++ b/templates/dashboard/product/list.html
@@ -144,10 +144,10 @@
         </div>
       </div>
       <div class="modal-footer">
-        <a href="#!" class="modal-action modal-close btn-action-secondary">
+        <a href="#!" class="modal-action modal-close btn-flat">
           {% trans "Cancel" context "Dashboard cancel action" %}
         </a>
-        <button type="submit" class="modal-action btn-action-primary">
+        <button type="submit" class="modal-action btn-flat">
           {% trans "Create new" context "Dashboard add action" %}
         </button>
       </div>

--- a/templates/dashboard/product/product_attribute/detail.html
+++ b/templates/dashboard/product/product_attribute/detail.html
@@ -45,10 +45,10 @@
         </div>
         {% if perms.product.edit_properties %}
         <div class="card-action">
-          <a class="btn-flat" href="{% url "dashboard:product-attribute-update" attribute.pk %}">
+          <a class="btn-flat waves-effect" href="{% url "dashboard:product-attribute-update" attribute.pk %}">
             {% trans "Edit attribute" context "Attribute detail action" %}
           </a>
-          <a class="btn-flat modal-trigger-custom" href="#base-modal"
+          <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal"
             data-href="{% url 'dashboard:product-attribute-delete' pk=attribute.pk %}">
               {% trans "Remove attribute" context "Attribute detail action" %}
           </a>
@@ -63,7 +63,7 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="data-table-header-action">
-              <a href="{% url 'dashboard:product-attribute-value-add' attribute_pk=attribute.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-attribute-value-add' attribute_pk=attribute.pk %}" class="btn-flat waves-effect">
                 {% trans "Add" %}
               </a>
           </div>
@@ -94,10 +94,10 @@
                   </td>
                   {% if perms.product.edit_product %}
                     <td class="right-align">
-                      <a href="{% url 'dashboard:product-attribute-value-update' attribute_pk=attribute.pk value_pk=value.pk %}" class="btn-flat">
+                      <a href="{% url 'dashboard:product-attribute-value-update' attribute_pk=attribute.pk value_pk=value.pk %}" class="btn-flat waves-effect">
                         {% trans 'Edit' context 'Attribute choice value edit action' %}
                       </a>
-                      <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:product-attribute-value-delete' attribute_pk=attribute.pk value_pk=value.pk %}">
+                      <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:product-attribute-value-delete' attribute_pk=attribute.pk value_pk=value.pk %}">
                         {% trans 'Remove' context 'Attribute choice value edit action' %}
                       </a>
                     </td>

--- a/templates/dashboard/product/product_attribute/detail.html
+++ b/templates/dashboard/product/product_attribute/detail.html
@@ -45,10 +45,10 @@
         </div>
         {% if perms.product.edit_properties %}
         <div class="card-action">
-          <a class="btn btn-flat" href="{% url "dashboard:product-attribute-update" attribute.pk %}">
+          <a class="btn-flat" href="{% url "dashboard:product-attribute-update" attribute.pk %}">
             {% trans "Edit attribute" context "Attribute detail action" %}
           </a>
-          <a class="btn btn-flat modal-trigger-custom" href="#base-modal"
+          <a class="btn-flat modal-trigger-custom" href="#base-modal"
             data-href="{% url 'dashboard:product-attribute-delete' pk=attribute.pk %}">
               {% trans "Remove attribute" context "Attribute detail action" %}
           </a>
@@ -63,7 +63,7 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="data-table-header-action">
-              <a href="{% url 'dashboard:product-attribute-value-add' attribute_pk=attribute.pk %}" class="btn-data-table btn btn-flat">
+              <a href="{% url 'dashboard:product-attribute-value-add' attribute_pk=attribute.pk %}" class="btn-flat">
                 {% trans "Add" %}
               </a>
           </div>
@@ -94,10 +94,10 @@
                   </td>
                   {% if perms.product.edit_product %}
                     <td class="right-align">
-                      <a href="{% url 'dashboard:product-attribute-value-update' attribute_pk=attribute.pk value_pk=value.pk %}" class="btn btn-flat">
+                      <a href="{% url 'dashboard:product-attribute-value-update' attribute_pk=attribute.pk value_pk=value.pk %}" class="btn-flat">
                         {% trans 'Edit' context 'Attribute choice value edit action' %}
                       </a>
-                      <a class="btn btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:product-attribute-value-delete' attribute_pk=attribute.pk value_pk=value.pk %}">
+                      <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:product-attribute-value-delete' attribute_pk=attribute.pk value_pk=value.pk %}">
                         {% trans 'Remove' context 'Attribute choice value edit action' %}
                       </a>
                     </td>

--- a/templates/dashboard/product/product_attribute/form.html
+++ b/templates/dashboard/product/product_attribute/form.html
@@ -73,17 +73,17 @@
           </div>
           <div class="card-action right-align">
             {% if attribute.pk %}
-              <a href="{% url 'dashboard:product-attribute-detail' attribute.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' attribute.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-attributes' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-attributes' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_attribute/form.html
+++ b/templates/dashboard/product/product_attribute/form.html
@@ -73,14 +73,14 @@
           </div>
           <div class="card-action right-align">
             {% if attribute.pk %}
-              <a href="{% url 'dashboard:product-attribute-detail' attribute.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' attribute.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-attributes' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-attributes' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/product_attribute/form.html
+++ b/templates/dashboard/product/product_attribute/form.html
@@ -76,14 +76,14 @@
               <a href="{% url 'dashboard:product-attribute-detail' attribute.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:product-attributes' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_attribute/values/form.html
+++ b/templates/dashboard/product/product_attribute/values/form.html
@@ -75,14 +75,14 @@
           </div>
           <div class="card-action right-align">
             {% if value.pk %}
-              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk%}" class="btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk%}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/product_attribute/values/form.html
+++ b/templates/dashboard/product/product_attribute/values/form.html
@@ -78,14 +78,14 @@
               <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk%}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_attribute/values/form.html
+++ b/templates/dashboard/product/product_attribute/values/form.html
@@ -75,17 +75,17 @@
           </div>
           <div class="card-action right-align">
             {% if value.pk %}
-              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk%}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-attribute-detail' pk=attribute.pk%}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_class/form.html
+++ b/templates/dashboard/product/product_class/form.html
@@ -100,14 +100,14 @@
               <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_class/form.html
+++ b/templates/dashboard/product/product_class/form.html
@@ -10,7 +10,7 @@
     {{ product_class }}
   {% else %}
     {% trans "Add new product type" context "Product class page title" %}
-  {% endif %} 
+  {% endif %}
   - {% trans "Products" context "Dashboard products list" %} - {{ block.super }}
 {% endblock %}
 
@@ -97,17 +97,17 @@
           {% if perms.product.edit_properties %}
           <div class="card-action right-align">
             {% if product_class.pk %}
-              <a href="{% url 'dashboard:product-class-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-class-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_class/form.html
+++ b/templates/dashboard/product/product_class/form.html
@@ -97,14 +97,14 @@
           {% if perms.product.edit_properties %}
           <div class="card-action right-align">
             {% if product_class.pk %}
-              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-class-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/product_class/list.html
+++ b/templates/dashboard/product/product_class/list.html
@@ -106,7 +106,7 @@
         </div>
         <div class="row">
           <div class="col s12">
-            <button class="btn" type="submit">
+            <button class="btn waves-effect" type="submit">
               {% trans "Create new" context "Dashboard create new action"  %}
             </button>
           </div>

--- a/templates/dashboard/product/product_image/form.html
+++ b/templates/dashboard/product/product_image/form.html
@@ -76,17 +76,17 @@
           </div>
           <div class="card-action right-align">
             {% if product_image.pk %}
-              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_image/form.html
+++ b/templates/dashboard/product/product_image/form.html
@@ -79,14 +79,14 @@
               <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_image/form.html
+++ b/templates/dashboard/product/product_image/form.html
@@ -76,14 +76,14 @@
           </div>
           <div class="card-action right-align">
             {% if product_image.pk %}
-              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:product-image-list" product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/product_image/list.html
+++ b/templates/dashboard/product/product_image/list.html
@@ -65,10 +65,10 @@
                       </div>
                       <div class="sortable__drag-area"></div>
                       <div class="card-action">
-                        <a class="btn btn-flat" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=image.pk %}">
+                        <a class="btn-flat" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=image.pk %}">
                           {% trans "Edit" context "Dashboard edit action" %}
                         </a>
-                        <a href="#base-modal" class="btn btn-flat modal-trigger-custom" data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=image.pk %}">
+                        <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=image.pk %}">
                           {% trans "Remove" context "Dashboard remove action" %}
                         </a>
                       </div>
@@ -110,10 +110,10 @@
               </div>
               <div class="sortable__drag-area"></div>
               <div class="card-action">
-                <a class="btn btn-flat card-action-edit" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=0 %}">
+                <a class="btn-flat card-action-edit" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=0 %}">
                   {% trans "Edit" context "Dashboard edit action" %}
                 </a>
-                <a href="#base-modal" class="btn btn-flat card-action-delete modal-trigger-custom"
+                <a href="#base-modal" class="btn-flat card-action-delete modal-trigger-custom"
                 data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=0 %}">
                   {% trans "Remove" context "Dashboard remove action" %}
                 </a>

--- a/templates/dashboard/product/product_image/list.html
+++ b/templates/dashboard/product/product_image/list.html
@@ -65,10 +65,10 @@
                       </div>
                       <div class="sortable__drag-area"></div>
                       <div class="card-action">
-                        <a class="btn-flat" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=image.pk %}">
+                        <a class="btn-flat waves-effect" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=image.pk %}">
                           {% trans "Edit" context "Dashboard edit action" %}
                         </a>
-                        <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=image.pk %}">
+                        <a href="#base-modal" class="btn-flat waves-effect modal-trigger-custom" data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=image.pk %}">
                           {% trans "Remove" context "Dashboard remove action" %}
                         </a>
                       </div>
@@ -110,10 +110,10 @@
               </div>
               <div class="sortable__drag-area"></div>
               <div class="card-action">
-                <a class="btn-flat card-action-edit" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=0 %}">
+                <a class="btn-flat waves-effect card-action-edit" href="{% url 'dashboard:product-image-update' product_pk=product.pk img_pk=0 %}">
                   {% trans "Edit" context "Dashboard edit action" %}
                 </a>
-                <a href="#base-modal" class="btn-flat card-action-delete modal-trigger-custom"
+                <a href="#base-modal" class="btn-flat waves-effect card-action-delete modal-trigger-custom"
                 data-href="{% url 'dashboard:product-image-delete' product_pk=product.pk img_pk=0 %}">
                   {% trans "Remove" context "Dashboard remove action" %}
                 </a>

--- a/templates/dashboard/product/product_variant/detail.html
+++ b/templates/dashboard/product/product_variant/detail.html
@@ -89,10 +89,10 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="card-action">
-            <a class="btn-flat" href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}">
+            <a class="btn-flat waves-effect" href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Edit variant" context "Dashboard action" %}
             </a>
-            <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-delete' product_pk=product.pk variant_pk=variant.pk %}">
+            <a href="#base-modal" class="btn-flat waves-effect modal-trigger-custom" data-href="{% url 'dashboard:variant-delete' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Remove variant" context "Dashboard action" %}
             </a>
           </div>
@@ -105,7 +105,7 @@
           </div>
           {% if perms.product.edit_stock_location %}
             <div class="data-table-header-action">
-              <a class="btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=variant.pk %}">
+              <a class="btn-flat waves-effect" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=variant.pk %}">
                 {% trans "Add" context "Dashboard action" %}
               </a>
             </div>
@@ -135,7 +135,7 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="card-action">
-            <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:variant-images' product_pk=product.pk variant_pk=variant.pk %}">
+            <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:variant-images' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Select images" context "Dashboard action" %}
             </a>
           </div>

--- a/templates/dashboard/product/product_variant/detail.html
+++ b/templates/dashboard/product/product_variant/detail.html
@@ -89,10 +89,10 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="card-action">
-            <a class="btn btn-flat" href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}">
+            <a class="btn-flat" href="{% url 'dashboard:variant-update' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Edit variant" context "Dashboard action" %}
             </a>
-            <a href="#base-modal" class="btn btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-delete' product_pk=product.pk variant_pk=variant.pk %}">
+            <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-delete' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Remove variant" context "Dashboard action" %}
             </a>
           </div>
@@ -105,7 +105,7 @@
           </div>
           {% if perms.product.edit_stock_location %}
             <div class="data-table-header-action">
-              <a class="btn btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=variant.pk %}">
+              <a class="btn-flat" href="{% url "dashboard:variant-stock-add" product_pk=product.pk variant_pk=variant.pk %}">
                 {% trans "Add" context "Dashboard action" %}
               </a>
             </div>
@@ -135,7 +135,7 @@
         </div>
         {% if perms.product.edit_product %}
           <div class="card-action">
-            <a class="btn btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:variant-images' product_pk=product.pk variant_pk=variant.pk %}">
+            <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:variant-images' product_pk=product.pk variant_pk=variant.pk %}">
               {% trans "Select images" context "Dashboard action" %}
             </a>
           </div>

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -103,14 +103,14 @@
               <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url "dashboard:product-detail" pk=product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -100,14 +100,14 @@
           </div>
           <div class="card-action right-align">
             {% if variant.pk %}
-              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:product-detail" pk=product.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:product-detail" pk=product.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -100,17 +100,17 @@
           </div>
           <div class="card-action right-align">
             {% if variant.pk %}
-              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:product-detail" pk=product.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:product-detail" pk=product.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -66,7 +66,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col s12 m9">
+    <div class="col s12 l9">
       <div class="card">
         <form method="post" id="form-variant" enctype="multipart/form-data">
           <div class="card-content">

--- a/templates/dashboard/product/product_variant/modal/select_images.html
+++ b/templates/dashboard/product/product_variant/modal/select_images.html
@@ -13,10 +13,10 @@
     </div>
   </div>
   <div class="modal-footer">
-    <a href="#!" class="modal-action modal-close btn-flat">
+    <a href="#!" class="modal-action modal-close btn-flat waves-effect">
       {% trans "Cancel" context "Dashboard cancel action" %}
     </a>
-    <button type="submit" class="modal-action btn-flat">
+    <button type="submit" class="modal-action btn-flat waves-effect">
       {% trans "Save" context "Dashboard modal action" %}
     </button>
   </div>

--- a/templates/dashboard/product/stock/detail.html
+++ b/templates/dashboard/product/stock/detail.html
@@ -62,10 +62,10 @@
         </div>
         {% if perms.product.edit_stock_location %}
           <div class="card-action">
-            <a class="btn-flat" href="{% url "dashboard:variant-stock-update" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
+            <a class="btn-flat waves-effect" href="{% url "dashboard:variant-stock-update" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
               {% trans "Edit stock" context "Dashboard action" %}
             </a>
-            <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-stock-delete' product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
+            <a href="#base-modal" class="btn-flat waves-effect modal-trigger-custom" data-href="{% url 'dashboard:variant-stock-delete' product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
               {% trans "Remove stock" context "Dashboard action" %}
             </a>
           </div>

--- a/templates/dashboard/product/stock/detail.html
+++ b/templates/dashboard/product/stock/detail.html
@@ -62,10 +62,10 @@
         </div>
         {% if perms.product.edit_stock_location %}
           <div class="card-action">
-            <a class="btn btn-flat" href="{% url "dashboard:variant-stock-update" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
+            <a class="btn-flat" href="{% url "dashboard:variant-stock-update" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
               {% trans "Edit stock" context "Dashboard action" %}
             </a>
-            <a href="#base-modal" class="btn btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-stock-delete' product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
+            <a href="#base-modal" class="btn-flat modal-trigger-custom" data-href="{% url 'dashboard:variant-stock-delete' product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}">
               {% trans "Remove stock" context "Dashboard action" %}
             </a>
           </div>

--- a/templates/dashboard/product/stock/form.html
+++ b/templates/dashboard/product/stock/form.html
@@ -95,17 +95,17 @@
           </div>
           <div class="card-action right-align">
             {% if stock.pk %}
-              <a href="{% url "dashboard:variant-stock-details" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:variant-stock-details" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn btn-flat">
+              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/stock/form.html
+++ b/templates/dashboard/product/stock/form.html
@@ -72,7 +72,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col s12 m9">
+    <div class="col s12 l9">
       <div class="card">
         <form method="post" id="form-stock" enctype="multipart/form-data">
           <div class="card-content">

--- a/templates/dashboard/product/stock/form.html
+++ b/templates/dashboard/product/stock/form.html
@@ -98,14 +98,14 @@
               <a href="{% url "dashboard:variant-stock-details" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/stock/form.html
+++ b/templates/dashboard/product/stock/form.html
@@ -95,14 +95,14 @@
           </div>
           <div class="card-action right-align">
             {% if stock.pk %}
-              <a href="{% url "dashboard:variant-stock-details" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:variant-stock-details" product_pk=product.pk variant_pk=variant.pk stock_pk=stock.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat">
+              <a href="{% url "dashboard:variant-details" product_pk=product.pk variant_pk=variant.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/stock_location/form.html
+++ b/templates/dashboard/product/stock_location/form.html
@@ -70,17 +70,17 @@
           </div>
           <div class="card-action right-align">
             {% if location.pk %}
-              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/product/stock_location/form.html
+++ b/templates/dashboard/product/stock_location/form.html
@@ -70,14 +70,14 @@
           </div>
           <div class="card-action right-align">
             {% if location.pk %}
-              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat">
+              <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/product/stock_location/form.html
+++ b/templates/dashboard/product/stock_location/form.html
@@ -73,14 +73,14 @@
               <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Update" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:product-stock-location-list' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/search/results.html
+++ b/templates/dashboard/search/results.html
@@ -26,7 +26,7 @@
           <input id="icon_prefix" type="text" class="validate left"
                  placeholder="{% trans "Search" context "Dashboard search" %}"
                  name="q" value="{% if query %}{{ query }}{% endif %}">
-          <button class="btn-flat" type="submit">
+          <button class="btn-flat waves-effect" type="submit">
             <svg data-src="{% static "dashboard/images/search.svg" %}"
                  width="20" height="20" fill="#E57373"/>
           </button>

--- a/templates/dashboard/shipping/country/form.html
+++ b/templates/dashboard/shipping/country/form.html
@@ -77,14 +77,14 @@
           </div>
           <div class="card-action right-align">
             {% if country.pk %}
-              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/shipping/country/form.html
+++ b/templates/dashboard/shipping/country/form.html
@@ -77,17 +77,17 @@
           </div>
           <div class="card-action right-align">
             {% if country.pk %}
-              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/shipping/country/form.html
+++ b/templates/dashboard/shipping/country/form.html
@@ -80,14 +80,14 @@
               <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:shipping-method-detail' pk=shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/shipping/detail.html
+++ b/templates/dashboard/shipping/detail.html
@@ -55,10 +55,10 @@
         </div>
         {% if perms.shipping.edit_shipping %}
         <div class="card-action">
-          <a class="btn btn-flat" href="{% url 'dashboard:shipping-method-update' shipping_method.pk %}">
+          <a class="btn-flat waves-effect" href="{% url 'dashboard:shipping-method-update' shipping_method.pk %}">
             {% trans "Edit shipping method" context "Shipping method action" %}
           </a>
-          <a class="btn btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:shipping-method-delete' shipping_method.pk %}">
+          <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:shipping-method-delete' shipping_method.pk %}">
             {% trans "Remove shipping method" context "Shipping method action" %}
           </a>
         </div>
@@ -74,7 +74,7 @@
           </span>
         </div>
         <div class="data-table-header-action">
-            <a href="{% url 'dashboard:shipping-method-country-add' shipping_method_pk=shipping_method.pk %}" class="btn-data-table btn btn-flat">
+            <a href="{% url 'dashboard:shipping-method-country-add' shipping_method_pk=shipping_method.pk %}" class="btn-data-table btn-flat waves-effect">
               {% trans "Add" %}
             </a>
         </div>
@@ -96,10 +96,10 @@
                   <td>{{ country.get_country_code_display }}</td>
                   <td>{% gross country.price %}</td>
                   <td class="right-align">
-                    <a href="{% url 'dashboard:shipping-method-country-edit' shipping_method_pk=shipping_method.pk country_pk=country.pk %}" class="btn btn-flat">
+                    <a href="{% url 'dashboard:shipping-method-country-edit' shipping_method_pk=shipping_method.pk country_pk=country.pk %}" class="btn-flat waves-effect">
                       {% trans 'Edit' context 'Attribute choice value edit action' %}
                     </a>
-                    <a class="btn btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:shipping-method-country-delete' shipping_method_pk=shipping_method.pk country_pk=country.pk %}">
+                    <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:shipping-method-country-delete' shipping_method_pk=shipping_method.pk country_pk=country.pk %}">
                       {% trans 'Remove' context 'Attribute choice value remove action' %}
                     </a>
                   </td>

--- a/templates/dashboard/shipping/form.html
+++ b/templates/dashboard/shipping/form.html
@@ -74,14 +74,14 @@
           </div>
           <div class="card-action right-align">
             {% if shipping_method.pk %}
-              <a href="{% url 'dashboard:shipping-method-detail' shipping_method.pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:shipping-methods' %}" class="btn-flat">
+              <a href="{% url 'dashboard:shipping-methods' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/shipping/form.html
+++ b/templates/dashboard/shipping/form.html
@@ -74,17 +74,17 @@
           </div>
           <div class="card-action right-align">
             {% if shipping_method.pk %}
-              <a href="{% url 'dashboard:shipping-method-detail' shipping_method.pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:shipping-method-detail' shipping_method.pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:shipping-methods' %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:shipping-methods' %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/shipping/form.html
+++ b/templates/dashboard/shipping/form.html
@@ -77,14 +77,14 @@
               <a href="{% url 'dashboard:shipping-method-detail' shipping_method.pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:shipping-methods' %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/sites/authorization_keys/form.html
+++ b/templates/dashboard/sites/authorization_keys/form.html
@@ -71,14 +71,14 @@
               <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
               <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn">
+              <button type="submit" class="btn waves-effect">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/sites/authorization_keys/form.html
+++ b/templates/dashboard/sites/authorization_keys/form.html
@@ -68,14 +68,14 @@
           </div>
           <div class="card-action right-align">
             {% if value.pk %}
-              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat">
+              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat waves-effect">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
               <button type="submit" class="btn">

--- a/templates/dashboard/sites/authorization_keys/form.html
+++ b/templates/dashboard/sites/authorization_keys/form.html
@@ -68,17 +68,17 @@
           </div>
           <div class="card-action right-align">
             {% if value.pk %}
-              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Save" context "Dashboard update action" %}
               </button>
             {% else %}
-              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn btn-flat">
+              <a href="{% url 'dashboard:site-detail' pk=site_settings_pk %}" class="btn-flat">
                 {% trans "Cancel" context "Dashboard cancel action" %}
               </a>
-              <button type="submit" class="btn waves-effect waves-light">
+              <button type="submit" class="btn">
                 {% trans "Create" context "Dashboard create action" %}
               </button>
             {% endif %}

--- a/templates/dashboard/sites/detail.html
+++ b/templates/dashboard/sites/detail.html
@@ -64,7 +64,7 @@
           </div>
         </div>
         <div class="card-action">
-          <a class="btn-flat" href="{% url 'dashboard:site-update' pk=site.pk %}">
+          <a class="btn-flat waves-effect" href="{% url 'dashboard:site-update' pk=site.pk %}">
             {% trans "Edit site settings" context "Shipping method action" %}
           </a>
         </div>
@@ -78,7 +78,7 @@
           </span>
         </div>
         <div class="data-table-header-action">
-            <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site.pk %}" class="btn-flat">
+            <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site.pk %}" class="btn-flat waves-effect">
               {% trans "Add" %}
             </a>
         </div>
@@ -100,10 +100,10 @@
                   <td>{{ key.name }}</td>
                   <td>{{ key.key }}</td>
                   <td class="right-align">
-                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site.pk key_pk=key.pk %}" class="btn-flat">
+                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site.pk key_pk=key.pk %}" class="btn-flat waves-effect">
                       {% trans 'Edit' context 'Authorization key edit action' %}
                     </a>
-                    <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site.pk key_pk=key.pk %}">
+                    <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site.pk key_pk=key.pk %}">
                       {% trans 'Remove' context 'Authorization key remove action' %}
                     </a>
                   </td>

--- a/templates/dashboard/sites/detail.html
+++ b/templates/dashboard/sites/detail.html
@@ -64,7 +64,7 @@
           </div>
         </div>
         <div class="card-action">
-          <a class="btn btn-flat" href="{% url 'dashboard:site-update' pk=site.pk %}">
+          <a class="btn-flat" href="{% url 'dashboard:site-update' pk=site.pk %}">
             {% trans "Edit site settings" context "Shipping method action" %}
           </a>
         </div>
@@ -78,7 +78,7 @@
           </span>
         </div>
         <div class="data-table-header-action">
-            <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site.pk %}" class="btn-data-table btn btn-flat">
+            <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site.pk %}" class="btn-flat">
               {% trans "Add" %}
             </a>
         </div>
@@ -100,10 +100,10 @@
                   <td>{{ key.name }}</td>
                   <td>{{ key.key }}</td>
                   <td class="right-align">
-                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site.pk key_pk=key.pk %}" class="btn btn-flat">
+                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site.pk key_pk=key.pk %}" class="btn-flat">
                       {% trans 'Edit' context 'Authorization key edit action' %}
                     </a>
-                    <a class="btn btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site.pk key_pk=key.pk %}">
+                    <a class="btn-flat modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site.pk key_pk=key.pk %}">
                       {% trans 'Remove' context 'Authorization key remove action' %}
                     </a>
                   </td>

--- a/templates/dashboard/sites/form.html
+++ b/templates/dashboard/sites/form.html
@@ -51,7 +51,7 @@
             </div>
           </div>
           <div class="card-action right-align">
-            <a class="btn-flat" href="{% url 'dashboard:site-detail' pk=site.pk %}" target="_blank">
+            <a class="btn-flat waves-effect" href="{% url 'dashboard:site-detail' pk=site.pk %}" target="_blank">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
             <button type="submit" class="btn">

--- a/templates/dashboard/sites/form.html
+++ b/templates/dashboard/sites/form.html
@@ -51,10 +51,10 @@
             </div>
           </div>
           <div class="card-action right-align">
-            <a class="btn btn-flat" href="{% url 'dashboard:site-detail' pk=site.pk %}" traget="_blank">
+            <a class="btn-flat" href="{% url 'dashboard:site-detail' pk=site.pk %}" target="_blank">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn waves-effect waves-light">
+            <button type="submit" class="btn">
               {% trans "Update" context "Dashboard update action" %}
             </button>
           </div>

--- a/templates/dashboard/sites/form.html
+++ b/templates/dashboard/sites/form.html
@@ -54,7 +54,7 @@
             <a class="btn-flat waves-effect" href="{% url 'dashboard:site-detail' pk=site.pk %}" target="_blank">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn">
+            <button type="submit" class="btn waves-effect">
               {% trans "Update" context "Dashboard update action" %}
             </button>
           </div>

--- a/templates/dashboard/staff/detail.html
+++ b/templates/dashboard/staff/detail.html
@@ -73,7 +73,7 @@
           </div>
           {% if perms.userprofile.edit_staff %}
           <div class="card-action right-align">
-            <a href="{% url 'dashboard:staff-list' %}" class="btn-flat">
+            <a href="{% url 'dashboard:staff-list' %}" class="btn-flat waves-effect">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
             <button type="submit" class="btn">

--- a/templates/dashboard/staff/detail.html
+++ b/templates/dashboard/staff/detail.html
@@ -76,7 +76,7 @@
             <a href="{% url 'dashboard:staff-list' %}" class="btn-flat waves-effect">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn">
+            <button type="submit" class="btn waves-effect">
               {% if staff_member %}
                 {% trans 'Update' context 'Dashboard update action' %}
               {% else %}

--- a/templates/dashboard/staff/detail.html
+++ b/templates/dashboard/staff/detail.html
@@ -73,10 +73,10 @@
           </div>
           {% if perms.userprofile.edit_staff %}
           <div class="card-action right-align">
-            <a href="{% url 'dashboard:staff-list' %}" class="btn btn-flat">
+            <a href="{% url 'dashboard:staff-list' %}" class="btn-flat">
               {% trans "Cancel" context "Dashboard cancel action" %}
             </a>
-            <button type="submit" class="btn waves-effect waves-light">
+            <button type="submit" class="btn">
               {% if staff_member %}
                 {% trans 'Update' context 'Dashboard update action' %}
               {% else %}

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -405,7 +405,7 @@
                   <div class="card-content">
                     <div class="row section">
                       <div class="col m4 s12">
-                        <a class="btn" contenteditable="true">
+                        <a class="btn waves-effect" contenteditable="true">
                           Primary
                         </a>
                       </div>
@@ -785,7 +785,7 @@
                       </h4>
                       <form>
                         <div class="file-field input-field">
-                          <div class="btn">
+                          <div class="btn waves-effect">
                             <span contenteditable="true">File</span>
                             <input type="file">
                           </div>
@@ -1566,7 +1566,7 @@
                 </h3>
                 <div class="card">
                   <div class="card-content">
-                    <a class="btn" onclick="Materialize.toast('Example toast text', 4000)"> Toast</a>
+                    <a class="btn waves-effect" onclick="Materialize.toast('Example toast text', 4000)"> Toast</a>
                   </div>
                 </div>
               </div>

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -410,7 +410,7 @@
                         </a>
                       </div>
                        <div class="col m4 s12">
-                        <a class="btn-flat" contenteditable="true">
+                        <a class="btn-flat waves-effect" contenteditable="true">
                           Secondary
                         </a>
                       </div>
@@ -427,7 +427,7 @@
                         </a>
                       </div>
                       <div class="col m4 s12">
-                        <a class="btn-flat disabled" contenteditable="true">
+                        <a class="btn-flat waves-effect disabled" contenteditable="true">
                           Secondary disabled
                         </a>
                       </div>
@@ -1029,7 +1029,7 @@
                   </h4>
                   <div class="card">
                     <div class="data-table-header-action">
-                      <a href="" class="btn btn-data-table btn-flat" contenteditable="true">
+                      <a href="" class="btn btn-data-table btn-flat waves-effect" contenteditable="true">
                         Add
                       </a>
                     </div>
@@ -1120,10 +1120,10 @@
                   <div class="card">
                     <form>
                       <div class="data-table-header-action">
-                        <a href="" class="btn btn-data-table btn-show-when-unchecked btn-flat" contenteditable="true">
+                        <a href="" class="btn btn-data-table btn-show-when-unchecked btn-flat waves-effect" contenteditable="true">
                           Add
                         </a>
-                        <a href="" class="btn btn-data-table btn-show-when-checked btn-flat" style="display:none" hidden contenteditable="true">
+                        <a href="" class="btn btn-data-table btn-show-when-checked btn-flat waves-effect" style="display:none" hidden contenteditable="true">
                           Remove
                         </a>
                       </div>
@@ -1461,7 +1461,7 @@
                         </p>
                       </div>
                       <div class="card-action">
-                        <a href="#" class="btn-flat" contenteditable="true">
+                        <a href="#" class="btn-flat waves-effect" contenteditable="true">
                           This is a link
                         </a>
                       </div>
@@ -1549,10 +1549,10 @@
                         </p>
                       </div>
                       <div class="modal-footer">
-                        <a href="#!" class=" modal-action modal-close waves-effect waves-green btn-flat" contenteditable="true">
+                        <a href="#!" class=" modal-action modal-close waves-effect waves-green btn-flat waves-effect" contenteditable="true">
                           Agree
                         </a>
-                        <a href="#!" class=" modal-action modal-close btn-flat" contenteditable="true">
+                        <a href="#!" class=" modal-action modal-close btn-flat waves-effect" contenteditable="true">
                           Cancel
                         </a>
                       </div>

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -405,12 +405,12 @@
                   <div class="card-content">
                     <div class="row section">
                       <div class="col m4 s12">
-                        <a class="btn waves-effect waves-light" contenteditable="true">
+                        <a class="btn" contenteditable="true">
                           Primary
                         </a>
                       </div>
                        <div class="col m4 s12">
-                        <a class="btn btn-flat" contenteditable="true">
+                        <a class="btn-flat" contenteditable="true">
                           Secondary
                         </a>
                       </div>
@@ -422,12 +422,12 @@
                     </div>
                     <div class="row section">
                       <div class="col m4 s12">
-                        <a class="btn waves-effect waves-light disabled" contenteditable="true">
+                        <a class="btn disabled" contenteditable="true">
                           Primary disabled
                         </a>
                       </div>
                       <div class="col m4 s12">
-                        <a class="btn btn-flat disabled" contenteditable="true">
+                        <a class="btn-flat disabled" contenteditable="true">
                           Secondary disabled
                         </a>
                       </div>
@@ -1461,7 +1461,7 @@
                         </p>
                       </div>
                       <div class="card-action">
-                        <a href="#" class="btn btn-flat" contenteditable="true">
+                        <a href="#" class="btn-flat" contenteditable="true">
                           This is a link
                         </a>
                       </div>


### PR DESCRIPTION
This PR unifies button style in dashboard. Changes flat button's background to gray (when focused), so it doesn't look like primary button when hovered over. Also applies minor hotfixes to UI.

<img width="424" alt="zrzut ekranu 2017-12-05 o 14 35 55" src="https://user-images.githubusercontent.com/6833443/33609880-10451a58-d9ca-11e7-99e0-1727111e3ce8.png">
<img width="489" alt="zrzut ekranu 2017-12-05 o 14 36 11" src="https://user-images.githubusercontent.com/6833443/33609881-10b38998-d9ca-11e7-987e-37917767e5d6.png">
<img width="1242" alt="zrzut ekranu 2017-12-05 o 14 36 36" src="https://user-images.githubusercontent.com/6833443/33609882-10d284d8-d9ca-11e7-9ade-d9fa76e60688.png">
<img width="815" alt="zrzut ekranu 2017-12-05 o 14 36 59" src="https://user-images.githubusercontent.com/6833443/33609883-10f036d6-d9ca-11e7-81f9-dc49d7b56600.png">