### PR TITLE
Opengraph, canonical URLs, 'next' and 'prev'

### DIFF
--- a/saleor/core/templatetags/shop.py
+++ b/saleor/core/templatetags/shop.py
@@ -7,13 +7,6 @@ from django.utils.http import urlencode
 register = Library()
 
 
-@register.filter
-def slice(items, group_size=1):
-    args = [iter(items)] * group_size
-    return (filter(None, group)
-            for group in zip_longest(*args, fillvalue=None))
-
-
 @register.simple_tag(takes_context=True)
 def get_sort_by_url(context, field, descending=False):
     request = context['request']

--- a/saleor/core/templatetags/shop.py
+++ b/saleor/core/templatetags/shop.py
@@ -1,5 +1,3 @@
-from itertools import zip_longest
-
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template import Library
 from django.utils.http import urlencode

--- a/saleor/core/templatetags/status.py
+++ b/saleor/core/templatetags/status.py
@@ -2,8 +2,7 @@ from django.template import Library
 from payments import PaymentStatus
 
 from ...order import OrderStatus
-from ...product import (
-    ProductAvailabilityStatus, VariantAvailabilityStatus)
+from ...product import ProductAvailabilityStatus, VariantAvailabilityStatus
 from ...product.utils import (
     get_product_availability_status, get_variant_availability_status)
 

--- a/saleor/core/templatetags/urls.py
+++ b/saleor/core/templatetags/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import template
 
 register = template.Library()

--- a/saleor/core/templatetags/urls.py
+++ b/saleor/core/templatetags/urls.py
@@ -8,4 +8,3 @@ register = template.Library()
 @register.simple_tag
 def build_absolute_uri(request, location):
     return request.build_absolute_uri(location)
-

--- a/saleor/core/templatetags/urls.py
+++ b/saleor/core/templatetags/urls.py
@@ -1,0 +1,11 @@
+from __future__ import unicode_literals
+
+from django import template
+
+register = template.Library()
+
+
+@register.simple_tag
+def build_absolute_uri(request, location):
+    return request.build_absolute_uri(location)
+

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -35,7 +35,7 @@ class CategoryChoiceField(forms.ModelChoiceField):
         return '%s%s' % (indent, smart_text(obj))
 
 
-def build_absolute_uri(location, is_secure=False):
+def build_absolute_uri(location, is_secure=settings.ENABLE_SSL):
     # type: (str, bool, saleor.site.models.SiteSettings) -> str
     host = Site.objects.get_current().domain
     current_uri = '%s://%s' % ('https' if is_secure else 'http', host)

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -35,10 +35,10 @@ class CategoryChoiceField(forms.ModelChoiceField):
         return '%s%s' % (indent, smart_text(obj))
 
 
-def build_absolute_uri(location, is_secure=settings.ENABLE_SSL):
+def build_absolute_uri(location):
     # type: (str, bool, saleor.site.models.SiteSettings) -> str
     host = Site.objects.get_current().domain
-    current_uri = '%s://%s' % ('https' if is_secure else 'http', host)
+    current_uri = '%s://%s' % ('https' if settings.ENABLE_SSL else 'http', host)
     location = urljoin(current_uri, location)
     return iri_to_uri(location)
 

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -38,7 +38,8 @@ class CategoryChoiceField(forms.ModelChoiceField):
 def build_absolute_uri(location):
     # type: (str, bool, saleor.site.models.SiteSettings) -> str
     host = Site.objects.get_current().domain
-    current_uri = '%s://%s' % ('https' if settings.ENABLE_SSL else 'http', host)
+    protocol = 'https' if settings.ENABLE_SSL else 'http'
+    current_uri = '%s://%s' % (protocol, host)
     location = urljoin(current_uri, location)
     return iri_to_uri(location)
 

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -20,7 +20,6 @@ from versatileimagefield.fields import PPOIField, VersatileImageField
 
 from ..discount.models import calculate_discounted_price
 from .utils import get_attributes_display_map
-from ..core.utils import build_absolute_uri
 
 
 class Category(MPTTModel):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -20,6 +20,7 @@ from versatileimagefield.fields import PPOIField, VersatileImageField
 
 from ..discount.models import calculate_discounted_price
 from .utils import get_attributes_display_map
+from ..core.utils import build_absolute_uri
 
 
 class Category(MPTTModel):
@@ -54,6 +55,11 @@ class Category(MPTTModel):
         return reverse('product:category',
                        kwargs={'path': self.get_full_path(ancestors),
                                'category_id': self.id})
+
+    def get_full_absolute_url(self, ancestors=None):
+        return build_absolute_uri(
+            self.get_absolute_url(ancestors=ancestors)
+        )
 
     def get_full_path(self, ancestors=None):
         if not self.parent_id:
@@ -163,6 +169,9 @@ class Product(models.Model, ItemRange):
         return reverse(
             'product:details',
             kwargs={'slug': self.get_slug(), 'product_id': self.id})
+
+    def get_full_absolute_url(self):
+        return build_absolute_uri(self.get_absolute_url())
 
     def get_slug(self):
         return slugify(smart_text(unidecode(self.name)))

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -56,11 +56,6 @@ class Category(MPTTModel):
                        kwargs={'path': self.get_full_path(ancestors),
                                'category_id': self.id})
 
-    def get_full_absolute_url(self, ancestors=None):
-        return build_absolute_uri(
-            self.get_absolute_url(ancestors=ancestors)
-        )
-
     def get_full_path(self, ancestors=None):
         if not self.parent_id:
             return self.slug
@@ -169,9 +164,6 @@ class Product(models.Model, ItemRange):
         return reverse(
             'product:details',
             kwargs={'slug': self.get_slug(), 'product_id': self.id})
-
-    def get_full_absolute_url(self):
-        return build_absolute_uri(self.get_absolute_url())
 
     def get_slug(self):
         return slugify(smart_text(unidecode(self.name)))

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -67,6 +67,9 @@ EMAIL_BACKEND = email_config['EMAIL_BACKEND']
 EMAIL_USE_TLS = email_config['EMAIL_USE_TLS']
 EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
 
+ENABLE_SSL = ast.literal_eval(
+    os.environ.get('ENABLE_SSL', 'False'))
+
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,6 +20,7 @@
   {% block stylesheet %}{% endblock stylesheet %}
   {% block meta_tags %}{% endblock meta_tags %}
 
+  {% block meta_tags %}{% endblock meta_tags %}
   <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
   <!--[if lt IE 9]>
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -20,7 +20,6 @@
   {% render_bundle 'storefront' 'css' %}
 
   {% block stylesheet %}{% endblock stylesheet %}
-  {% block meta_tags %}{% endblock meta_tags %}
 
   {% block meta_tags %}
     <meta property="og:title" content="{{ site.name }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
 
   {% block meta_tags %}
     <meta property="og:title" content="{{ site.name }}">
-    <meta property="og:url" content="{{ request.get_full_path }}">
+    <meta property="og:url" content="{{ request.build_absolute_uri }}">
     <meta property="og:image" content="{% static "images/block1.png" %}">
   {% endblock meta_tags %}
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,8 +11,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{% block meta_description %}{% endblock %}">
     <meta name="author" content="{% trans "Mirumee Software" context "Meta author text" %}">
-    <meta name="theme-color" content="#21915a" />
+    <meta name="theme-color" content="#21915a">
+    <meta name="og:type" content="website">
   {% endblock meta %}
+
   {% include 'favicon.html' %}
   {% render_bundle 'vendor' 'css' %}
   {% render_bundle 'storefront' 'css' %}
@@ -20,7 +22,12 @@
   {% block stylesheet %}{% endblock stylesheet %}
   {% block meta_tags %}{% endblock meta_tags %}
 
-  {% block meta_tags %}{% endblock meta_tags %}
+  {% block meta_tags %}
+    <meta property="og:title" content="{{ site.name }}">
+    <meta property="og:url" content="{{ request.get_full_path }}">
+    <meta property="og:image" content="{% static "images/logo.png" %}">
+  {% endblock meta_tags %}
+
   <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->
   <!--[if lt IE 9]>
     <script src="//html5shim.googlecode.com/svn/trunk/html5.js"></script>

--- a/templates/base.html
+++ b/templates/base.html
@@ -25,7 +25,7 @@
   {% block meta_tags %}
     <meta property="og:title" content="{{ site.name }}">
     <meta property="og:url" content="{{ request.get_full_path }}">
-    <meta property="og:image" content="{% static "images/logo.png" %}">
+    <meta property="og:image" content="{% static "images/block1.png" %}">
   {% endblock meta_tags %}
 
   <!-- Le HTML5 shim, for IE6-8 support of HTML5 elements -->

--- a/templates/cart/index.html
+++ b/templates/cart/index.html
@@ -2,7 +2,6 @@
 {% load gross from prices_i18n %}
 {% load i18n %}
 {% load staticfiles %}
-{% load render_bundle from webpack_loader %}
 {% load get_thumbnail from product_images %}
 
 {% block title %}{% trans "Your cart" context "Cart page title" %} — {{ block.super }}{% endblock %}

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -3,8 +3,8 @@
 {% load i18n %}
 {% load shop %}
 {% load staticfiles %}
-{% load render_bundle from webpack_loader %}
 {% load prices_i18n %}
+{% load build_absolute_uri from urls %}
 
 {% block footer_scripts %}
   {{ block.super }}
@@ -17,18 +17,17 @@
     <meta property="og:description" content="{{ category.description }}">
     <meta property="og:image" content="{% static "images/block1.png" %}">
 
-    {% with category_url=category.get_full_absolute_url %}
-      <meta property="og:url" content="{{ category_url }}">
-      <link rel="canonical" href="{{ category_url }}?page={{ products_paginated.number }}">
+    {% build_absolute_uri request=request location=category.get_absolute_url as category_url %}
+    <meta property="og:url" content="{{ category_url }}">
+    <link rel="canonical" href="{{ category_url }}?page={{ products_paginated.number }}">
 
-      {% if products_paginated.has_previous %}
-        <link rel="prev" href="{{ category_url }}?page={{ products_paginated.previous_page_number }}">
-      {% endif %}
+    {% if products_paginated.has_previous %}
+      <link rel="prev" href="{{ category_url }}?page={{ products_paginated.previous_page_number }}">
+    {% endif %}
 
-      {% if products_paginated.has_next %}
-        <link rel="next" href="{{ category_url }}?page={{ products_paginated.next_page_number }}">
-      {% endif %}
-    {% endwith %}
+    {% if products_paginated.has_next %}
+      <link rel="next" href="{{ category_url }}?page={{ products_paginated.next_page_number }}">
+    {% endif %}
 {% endblock meta_tags %}
 
 {% block breadcrumb %}

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -15,7 +15,7 @@
 {% block meta_tags %}
     <meta property="og:title" content="{{ category }} — {{ block.super }}">
     <meta property="og:description" content="{{ category.description }}">
-    <meta property="og:image" content="{% static "images/logo.png" %}">
+    <meta property="og:image" content="{% static "images/block1.png" %}">
 
     {% with category_url=category.get_absolute_url %}
       <meta property="og:url" content="{{ category_url }}">

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -14,19 +14,19 @@
 
 {% block meta_tags %}
     <meta property="og:title" content="{{ category }} — {{ block.super }}">
-    <meta name="og:description" content="{{ category.description }}">
-    <meta property="og:image" content="{% static "images/logo.png" %}" />
+    <meta property="og:description" content="{{ category.description }}">
+    <meta property="og:image" content="{% static "images/logo.png" %}">
 
     {% with category_url=category.get_absolute_url %}
       <meta property="og:url" content="{{ category_url }}">
       <link rel="canonical" href="{{ category_url }}?page={{ products_paginated.number }}">
 
       {% if products_paginated.has_previous %}
-        <link rel="prev" href="{{ category_url }}?page={{ products_paginated.previous_page_number }}" />
+        <link rel="prev" href="{{ category_url }}?page={{ products_paginated.previous_page_number }}">
       {% endif %}
 
       {% if products_paginated.has_next %}
-        <link rel="next" href="{{ category_url }}?page={{ products_paginated.next_page_number }}" />
+        <link rel="next" href="{{ category_url }}?page={{ products_paginated.next_page_number }}">
       {% endif %}
     {% endwith %}
 {% endblock meta_tags %}

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -13,8 +13,7 @@
 {% block title %}{{ category }} — {{ block.super }}{% endblock %}
 
 {% block meta_tags %}
-    <meta name="title" content="{{ category }}">
-    <meta property="og:title" content="{{ category }}">
+    <meta property="og:title" content="{{ category }} — {{ block.super }}">
     <meta name="og:description" content="{{ category.description }}">
     <meta property="og:image" content="{% static "images/logo.png" %}" />
 

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -13,11 +13,11 @@
 {% block title %}{{ category }} — {{ block.super }}{% endblock %}
 
 {% block meta_tags %}
-    <meta property="og:title" content="{{ category }} — {{ block.super }}">
+    <meta property="og:title" content="{{ category }}">
     <meta property="og:description" content="{{ category.description }}">
     <meta property="og:image" content="{% static "images/block1.png" %}">
 
-    {% with category_url=category.get_absolute_url %}
+    {% with category_url=category.get_full_absolute_url %}
       <meta property="og:url" content="{{ category_url }}">
       <link rel="canonical" href="{{ category_url }}?page={{ products_paginated.number }}">
 

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -12,6 +12,26 @@
 
 {% block title %}{{ category }} — {{ block.super }}{% endblock %}
 
+{% block meta_tags %}
+    <meta name="title" content="{{ category }}">
+    <meta property="og:title" content="{{ category }}">
+    <meta name="og:description" content="{{ category.description }}">
+    <meta property="og:image" content="{% static "images/logo.png" %}" />
+
+    {% with category_url=category.get_absolute_url %}
+      <meta property="og:url" content="{{ category_url }}">
+      <link rel="canonical" href="{{ category_url }}?page={{ products_paginated.number }}">
+
+      {% if products_paginated.has_previous %}
+        <link rel="prev" href="{{ category_url }}?page={{ products_paginated.previous_page_number }}" />
+      {% endif %}
+
+      {% if products_paginated.has_next %}
+        <link rel="next" href="{{ category_url }}?page={{ products_paginated.next_page_number }}" />
+      {% endif %}
+    {% endwith %}
+{% endblock meta_tags %}
+
 {% block breadcrumb %}
   {{ block.super }}
   {% for breadcrumb in breadcrumbs %}

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% load materializecss %}
 {% load staticfiles %}
-{% load attributes %}
 
 {% block title %}
   {% if product.pk %}

--- a/templates/dashboard/product/product_class/form.html
+++ b/templates/dashboard/product/product_class/form.html
@@ -3,7 +3,6 @@
 {% load i18n %}
 {% load materializecss %}
 {% load staticfiles %}
-{% load attributes %}
 
 {% block title %}
   {% if product_class.pk %}

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -1,7 +1,6 @@
 <!DOCTYPE html>
 {% load staticfiles i18n %}
 {% load render_bundle from webpack_loader %}
-{% load version %}
 
 <html lang="{{ LANGUAGE_CODE }}" class="no-js">
   <head>

--- a/templates/favicon.html
+++ b/templates/favicon.html
@@ -1,7 +1,6 @@
 {% load webpack_static from webpack_loader %}
 
 <meta name="mobile-web-app-capable" content="yes">
-<meta name="theme-color" content="#fff">
 <meta name="application-name" content="favicons-webpack-plugin">
 <link rel="apple-touch-icon" sizes="57x57" href="{% webpack_static "favicons/apple-touch-icon-57x57.png" %}">
 <link rel="apple-touch-icon" sizes="60x60" href="{% webpack_static "favicons/apple-touch-icon-60x60.png" %}">

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -12,6 +12,23 @@
 
 {% block meta_description %}{{ product.description }}{% endblock %}
 
+{% block meta_tags %}
+  <meta property="og:title" content="{{ product }} — {{ block.super }}">
+  <meta name="description" content="{{ product.description }}">
+
+  {% with product_url=product.get_absolute_url %}
+    <meta property="og:url" content="{{ product_url }}">
+    <link rel="canonical" href="{{ product_url }}">
+  {% endwith %}
+
+  {% product_first_image product size="510x510" as product_image %}
+  {% if product_image %}
+    <meta property="og:image" content="{{ product_image }}" />
+    <meta property="og:image:width" content="510">
+    <meta property="og:image:height" content="510">
+  {% endif %}
+{% endblock meta_tags %}
+
 {% block breadcrumb %}
   <ul class="breadcrumbs list-unstyled">
     <li><a href="/">

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -14,7 +14,7 @@
 
 {% block meta_tags %}
   <meta property="og:title" content="{{ product }} — {{ block.super }}">
-  <meta name="description" content="{{ product.description }}">
+  <meta property="og:description" content="{{ product.description }}">
 
   {% with product_url=product.get_absolute_url %}
     <meta property="og:url" content="{{ product_url }}">
@@ -26,6 +26,8 @@
     <meta property="og:image" content="{{ product_image }}" />
     <meta property="og:image:width" content="510">
     <meta property="og:image:height" content="510">
+  {% else %}
+    <meta property="og:image" content="{% static "images/logo.png" %}">
   {% endif %}
 {% endblock meta_tags %}
 

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -6,7 +6,8 @@
 {% load markdown from markdown %}
 {% load price_range from price_ranges %}
 {% load staticfiles %}
-{% load get_thumbnail from product_images %}
+{% load get_thumbnail product_first_image from product_images %}
+{% load build_absolute_uri from urls %}
 
 {% block title %}{{ product }} — {{ block.super }}{% endblock %}
 
@@ -16,10 +17,9 @@
   <meta property="og:title" content="{{ product }} — {{ block.super }}">
   <meta property="og:description" content="{{ product.description }}">
 
-  {% with product_url=product.get_full_absolute_url %}
-    <meta property="og:url" content="{{ product_url }}">
-    <link rel="canonical" href="{{ product_url }}">
-  {% endwith %}
+  {% build_absolute_uri request=request location=product.get_absolute_url as product_url %}
+  <meta property="og:url" content="{{ product_url }}">
+  <link rel="canonical" href="{{ product_url }}">
 
   {% product_first_image product size="510x510" as product_image %}
   {% if product_image %}

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -27,7 +27,7 @@
     <meta property="og:image:width" content="510">
     <meta property="og:image:height" content="510">
   {% else %}
-    <meta property="og:image" content="{% static "images/logo.png" %}">
+    <meta property="og:image" content="{% static "images/block1.png" %}">
   {% endif %}
 {% endblock meta_tags %}
 

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -16,7 +16,7 @@
   <meta property="og:title" content="{{ product }} — {{ block.super }}">
   <meta property="og:description" content="{{ product.description }}">
 
-  {% with product_url=product.get_absolute_url %}
+  {% with product_url=product.get_full_absolute_url %}
     <meta property="og:url" content="{{ product_url }}">
     <link rel="canonical" href="{{ product_url }}">
   {% endwith %}

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load slice from shop %}
 {% load staticfiles %}
 {% load bootstrap_pagination from bootstrap3 %}
 


### PR DESCRIPTION
Close #1403 
Close #1345 
- Added Opengraph for Product, Category pages  + Default
- Set `canonical` for `Product` and `Category` pages
- Added `next` and `prev` tags for `Category` and `Search` pages

TODO:
- [x] Add OpenGraph on Category/Product/Default page
- [x] Add Canonical on Category/Product page
- [x] Add `next` and `prev` tags for `Category` page
- [x] Make `og:url` links absolute