### PR TITLE
Fix search URL in Schema.org markup

### DIFF
--- a/saleor/core/context_processors.py
+++ b/saleor/core/context_processors.py
@@ -52,6 +52,6 @@ def webpage_schema(request):
         search_url = urljoin(url, reverse('search:search'))
         data['potentialAction'] = {
             '@type': 'SearchAction',
-            'target': '%s?q={search_term}' % search_url,
-            'query-input': 'required name=search_term'}
+            'target': '%s?q={q}' % search_url,
+            'query-input': 'required name=q'}
     return {'webpage_schema': json.dumps(data)}

--- a/saleor/core/context_processors.py
+++ b/saleor/core/context_processors.py
@@ -9,6 +9,11 @@ from django.urls import reverse
 from ..core.utils import build_absolute_uri
 from ..product.models import Category
 
+try:
+    from urllib.parse import urljoin
+except ImportError:
+    from urlparse import urljoin
+
 
 def get_setting_as_dict(name, short_name=None):
     short_name = short_name or name
@@ -44,8 +49,9 @@ def webpage_schema(request):
         'name': site.name,
         'description': site.settings.description}
     if settings.ENABLE_SEARCH:
+        search_url = urljoin(url, reverse('search:search'))
         data['potentialAction'] = {
             '@type': 'SearchAction',
-            'target': '%s%s?q={search_term}' % (url, reverse('search:search')),
+            'target': '%s?q={search_term}' % search_url,
             'query-input': 'required name=search_term'}
     return {'webpage_schema': json.dumps(data)}

--- a/templates/base.html
+++ b/templates/base.html
@@ -100,7 +100,8 @@
                 </div>
                 <input class="form-control" type="text" name="q"
                        value="{% if query %}{{ query }}{% endif %}"
-                       placeholder="{% trans "Search for product" %}">
+                       placeholder="{% trans "Search for product" %}"
+                       required>
                 <button class="btn btn-link" type="submit">
                   <svg data-src="{% static "images/search.svg" %}" width="30" height="30"/>
                 </button>

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -75,8 +75,8 @@
                 <form method="get" action="{% url "dashboard:search" %}">
                   <a class="hide-on-med-and-up" id="btn-search-close"></a>
                   <div class="input-field d-inline">
-                    <input id="search" type="search" placeholder="{% trans "Search" context "Dashboard search" %}" name="q" value="{% if query %}{{ query }}{% endif %}">
-                    <label class="hide-on-small-only">
+                    <input id="search" type="search" placeholder="{% trans "Search" context "Dashboard search" %}" name="q" required value="{% if query %}{{ query }}{% endif %}">
+                    <label>
                       <svg data-src="{% static "dashboard/images/search.svg" %}" width="24" height="24" fill="#fff" />
                     </label>
                   </div>

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -76,7 +76,7 @@
                   <a class="hide-on-med-and-up" id="btn-search-close"></a>
                   <div class="input-field d-inline">
                     <input id="search" type="search" placeholder="{% trans "Search" context "Dashboard search" %}" name="q" required value="{% if query %}{{ query }}{% endif %}">
-                    <label>
+                    <label class="hide-on-small-only">
                       <svg data-src="{% static "dashboard/images/search.svg" %}" width="24" height="24" fill="#fff" />
                     </label>
                   </div>

--- a/templates/styleguide.html
+++ b/templates/styleguide.html
@@ -483,7 +483,7 @@
           <div class="row">
             <div class="col-md-6">
               <form class="form-inline search-form" action="{% url "search:search" %}">
-                <input class="form-control" type="text" name="q" value="{% if query %}{{ query }}{% endif %}" placeholder="Search for product">
+                <input class="form-control" type="text" name="q" required value="{% if query %}{{ query }}{% endif %}" placeholder="Search for product">
                 <button class="btn btn-link" type="submit">
                   <svg data-src="{% static "images/search.svg" %}" width="19" height="19" />
                 </button>


### PR DESCRIPTION
Close #1455 
Search URL was incorrect, containing double slash
Before: http://demo.getsaleor.com//search/?q={search_term}
After: http://demo.getsaleor.com/search/?q={search_term}

Also fixed `query-input` name to match input field name
If user clicks 'search' without providing query we display empty search page, so I set input field to required
