### PR TITLE
Cast max_age of cart cookie to int

### DIFF
--- a/saleor/cart/utils.py
+++ b/saleor/cart/utils.py
@@ -24,7 +24,7 @@ def set_cart_cookie(simple_cart, response):
     # FIXME: document why session is not used
     ten_years = timedelta(days=(365 * 10))
     response.set_signed_cookie(
-        COOKIE_NAME, simple_cart.token, max_age=ten_years.total_seconds())
+        COOKIE_NAME, simple_cart.token, max_age=int(ten_years.total_seconds()))
 
 
 def contains_unavailable_variants(cart):


### PR DESCRIPTION
I want to merge this change because...

Without this fix some clients (ex python Requests lib) skips cart cookie as invalid.
`timedelta.total_seconds()` return float value, where max_age should be an int.

Big thanks to @patrys for great help and stubbornness in debugging this.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
