### PR TITLE
Drop python2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 sudo: false
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
@@ -29,8 +28,6 @@ matrix:
   allow_failures:
     - python: "3.4"
       env: DJANGO="2.0"
-    - python: "3.4"
-      env: DJANGO="master"
     - python: "3.5"
       env: DJANGO="2.0"
     - python: "3.5"
@@ -40,9 +37,7 @@ matrix:
     - python: "3.6"
       env: DJANGO="master"
   exclude:
-    - python: "2.7"
-      env: DJANGO="2.0"
-    - python: "2.7"
+    - python: "3.4"
       env: DJANGO="master"
 after_success:
   - codecov

--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-from __future__ import unicode_literals
-
+#!/usr/bin/env python3
 import os
 import sys
 

--- a/requirements.in
+++ b/requirements.in
@@ -33,7 +33,6 @@ jsonfield>=2.0.2
 Markdown>=2.4
 maxminddb
 maxminddb-geolite2
-mock>=1.3.0
 prices>=0.5.7
 psycopg2>=2.6
 purl>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -64,10 +64,8 @@ kombu==4.1.0              # via celery
 markdown==2.6.9
 maxminddb-geolite2==2017.803
 maxminddb==1.3.0
-mock==2.0.0
 oauthlib==2.0.4           # via requests-oauthlib, social-auth-core
 olefile==0.44             # via pillow
-pbr==3.1.1                # via mock
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.8.5   # via django-phonenumber-field
 pillow==4.0.0             # via django-versatileimagefield
@@ -93,7 +91,7 @@ requests==2.18.4
 s3transfer==0.1.10        # via boto3
 satchless==1.1.3
 singledispatch==3.4.0.3   # via graphene-django
-six==1.11.0               # via cryptography, django-templated-email, elasticsearch-dsl, faker, freezegun, graphene, graphene-django, graphql-core, graphql-relay, html5lib, mock, promise, purl, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, vcrpy
+six==1.11.0               # via cryptography, django-templated-email, elasticsearch-dsl, faker, freezegun, graphene, graphene-django, graphql-core, graphql-relay, html5lib, promise, purl, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, vcrpy
 social-auth-app-django==2.0.0
 social-auth-core==1.4.0   # via social-auth-app-django
 stripe==1.65.0            # via django-payments

--- a/saleor/__init__.py
+++ b/saleor/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import, unicode_literals
 from .celeryconf import app as celery_app
 
 __all__ = ['celery_app']

--- a/saleor/cart/__init__.py
+++ b/saleor/cart/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from django.utils.translation import pgettext_lazy

--- a/saleor/cart/context_processors.py
+++ b/saleor/cart/context_processors.py
@@ -1,6 +1,4 @@
 """Cart-related context processors."""
-from __future__ import unicode_literals
-
 from .utils import get_cart_from_request
 
 

--- a/saleor/cart/forms.py
+++ b/saleor/cart/forms.py
@@ -1,6 +1,4 @@
 """Cart-related forms and fields."""
-from __future__ import unicode_literals
-
 from django import forms
 from django.conf import settings
 from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist

--- a/saleor/cart/models.py
+++ b/saleor/cart/models.py
@@ -1,6 +1,4 @@
 """Cart-related ORM models."""
-from __future__ import unicode_literals
-
 from collections import namedtuple
 from decimal import Decimal
 from uuid import uuid4
@@ -8,7 +6,7 @@ from uuid import uuid4
 from django.conf import settings
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible, smart_str
+from django.utils.encoding import smart_str
 from django.utils.timezone import now
 from django.utils.translation import pgettext_lazy
 from django_prices.models import PriceField
@@ -243,7 +241,6 @@ class Cart(models.Model):
         return partition(self.lines.all(), grouper, ProductGroup)
 
 
-@python_2_unicode_compatible
 class CartLine(models.Model, ItemLine):
     """A single cart line.
 

--- a/saleor/cart/urls.py
+++ b/saleor/cart/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/cart/utils.py
+++ b/saleor/cart/utils.py
@@ -1,6 +1,4 @@
 """Cart-related utility functions."""
-from __future__ import unicode_literals
-
 from datetime import timedelta
 from functools import wraps
 from uuid import UUID

--- a/saleor/cart/views.py
+++ b/saleor/cart/views.py
@@ -1,6 +1,4 @@
 """Cart-related views."""
-from __future__ import unicode_literals
-
 from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.response import TemplateResponse

--- a/saleor/celeryconf.py
+++ b/saleor/celeryconf.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import os
 from celery import Celery
 from django.conf import settings

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -1,6 +1,4 @@
 """Checkout session state management."""
-from __future__ import unicode_literals
-
 from datetime import date
 from functools import wraps
 
@@ -26,7 +24,7 @@ from phonenumber_field.phonenumber import PhoneNumber
 STORAGE_SESSION_KEY = 'checkout_storage'
 
 
-class Checkout(object):
+class Checkout:
     """Represents a checkout session.
 
     This object acts a temporary storage for the entire checkout session. An

--- a/saleor/checkout/forms.py
+++ b/saleor/checkout/forms.py
@@ -1,6 +1,4 @@
 """Checkout-related forms."""
-from __future__ import unicode_literals
-
 from django import forms
 from django.utils.safestring import mark_safe
 from django.utils.translation import pgettext_lazy

--- a/saleor/checkout/urls.py
+++ b/saleor/checkout/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/checkout/views/__init__.py
+++ b/saleor/checkout/views/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 

--- a/saleor/checkout/views/discount.py
+++ b/saleor/checkout/views/discount.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from datetime import date
 from functools import wraps
 

--- a/saleor/checkout/views/shipping.py
+++ b/saleor/checkout/views/shipping.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 

--- a/saleor/checkout/views/summary.py
+++ b/saleor/checkout/views/summary.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse

--- a/saleor/checkout/views/validators.py
+++ b/saleor/checkout/views/validators.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from functools import wraps
 
 from django.core.exceptions import ValidationError

--- a/saleor/core/__init__.py
+++ b/saleor/core/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.core.checks import register, Warning
 

--- a/saleor/core/analytics.py
+++ b/saleor/core/analytics.py
@@ -1,10 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 import uuid
 
 import google_measurement_protocol as ga
-import six
 from django.conf import settings
 
 FINGERPRINT_PARTS = [
@@ -20,10 +16,6 @@ UUID_NAMESPACE = uuid.UUID('fb4abc05-e2fb-4e3e-8b78-28037ef7d07f')
 def get_client_id(request):
     parts = [request.META.get(key, '') for key in FINGERPRINT_PARTS]
     name = '_'.join(parts)
-    # In Python2 name is unicode type
-    # We encode it to avoid UnicodeDecodeError in uuid package
-    if six.PY2:
-        name = name.encode('utf-8')
     return uuid.uuid5(UUID_NAMESPACE, name)
 
 

--- a/saleor/core/context_processors.py
+++ b/saleor/core/context_processors.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 
 from django.conf import settings

--- a/saleor/core/context_processors.py
+++ b/saleor/core/context_processors.py
@@ -1,4 +1,5 @@
 import json
+from urllib.parse import urljoin
 
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
@@ -6,11 +7,6 @@ from django.urls import reverse
 
 from ..core.utils import build_absolute_uri
 from ..product.models import Category
-
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
 
 
 def get_setting_as_dict(name, short_name=None):

--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django_filters import FilterSet
 
 

--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
 from django.conf import settings

--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from django.conf import settings

--- a/saleor/core/permissions.py
+++ b/saleor/core/permissions.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from django.contrib.auth.models import Permission
 
 

--- a/saleor/core/sitemaps.py
+++ b/saleor/core/sitemaps.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.sitemaps import Sitemap
 
 from ..product.models import Category, Product

--- a/saleor/core/storages.py
+++ b/saleor/core/storages.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
 

--- a/saleor/core/templatetags/attributes.py
+++ b/saleor/core/templatetags/attributes.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.template import Library
 
 from ...product.utils import get_attributes_display_map

--- a/saleor/core/templatetags/jsonld.py
+++ b/saleor/core/templatetags/jsonld.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 
 from django.template import Library

--- a/saleor/core/templatetags/markdown.py
+++ b/saleor/core/templatetags/markdown.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 from django import template
 from django.utils.safestring import mark_safe
 from markdown import markdown as format_markdown

--- a/saleor/core/templatetags/materializecss.py
+++ b/saleor/core/templatetags/materializecss.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.template.loader import get_template
 from django import template

--- a/saleor/core/templatetags/shop.py
+++ b/saleor/core/templatetags/shop.py
@@ -1,12 +1,8 @@
-try:
-    from itertools import zip_longest
-except ImportError:
-    from itertools import izip_longest as zip_longest
+from itertools import zip_longest
 
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.template import Library
 from django.utils.http import urlencode
-
 
 register = Library()
 

--- a/saleor/core/templatetags/shop.py
+++ b/saleor/core/templatetags/shop.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 try:
     from itertools import zip_longest
 except ImportError:
@@ -50,7 +49,7 @@ def get_sort_by_toggle(context, field):
             # enable ascending sort
             # new_sort_by is used to construct a link with already toggled
             # sort_by value
-            new_sort_by = u'-%s' % field
+            new_sort_by = '-%s' % field
             sorting_icon = static('/images/arrow_up_icon.svg')
             is_active = True
         else:

--- a/saleor/core/templatetags/status.py
+++ b/saleor/core/templatetags/status.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.template import Library
 from payments import PaymentStatus
 

--- a/saleor/core/templatetags/version.py
+++ b/saleor/core/templatetags/version.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.template import Library
 from saleor import __version__
 

--- a/saleor/core/urls.py
+++ b/saleor/core/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -1,5 +1,6 @@
 import decimal
 from json import JSONEncoder
+from urllib.parse import urljoin
 
 from babel.numbers import get_territory_currencies
 from django import forms
@@ -15,11 +16,6 @@ from geolite2 import geolite2
 from prices import PriceRange
 
 from ...userprofile.models import User
-
-try:
-    from urllib.parse import urljoin
-except ImportError:
-    from urlparse import urljoin
 
 georeader = geolite2.reader()
 

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -1,6 +1,3 @@
-# coding: utf-8
-from __future__ import unicode_literals
-
 import decimal
 from json import JSONEncoder
 

--- a/saleor/core/utils/filters.py
+++ b/saleor/core/utils/filters.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 def get_sort_by_choices(filter_set):
     return [(choice[0], choice[1].lower()) for choice in
             filter_set.filters['sort_by'].field.choices[1::2]]

--- a/saleor/core/utils/form_renderer.py
+++ b/saleor/core/utils/form_renderer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from bootstrap3.renderers import FormRenderer as BaseFormRenderer
 
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import itertools
 import os
 import random
@@ -10,7 +8,6 @@ from django.conf import settings
 from django.contrib.auth.models import Group, Permission
 from django.core.files import File
 from django.template.defaultfilters import slugify
-from django.utils.six import moves
 from faker import Factory
 from faker.providers import BaseProvider
 from payments import PaymentStatus
@@ -19,13 +16,12 @@ from prices import Price
 from ...discount.models import Sale, Voucher
 from ...order import OrderStatus
 from ...order.models import DeliveryGroup, Order, OrderLine, Payment
-from ...product.models import (AttributeChoiceValue, Category, Product,
-                               ProductAttribute, ProductClass, ProductImage,
-                               ProductVariant, Stock, StockLocation)
+from ...product.models import (
+    AttributeChoiceValue, Category, Product, ProductAttribute, ProductClass,
+    ProductImage, ProductVariant, Stock, StockLocation)
 from ...shipping.models import ANY_COUNTRY, ShippingMethod
 from ...userprofile.models import Address, User
 from ...userprofile.utils import store_user_address
-
 
 fake = Factory.create()
 STOCK_LOCATION = 'default'
@@ -188,9 +184,10 @@ def get_variant_combinations(product):
                         for attr
                         in product.product_class.variant_attributes.all()}
     all_combinations = itertools.product(*variant_attr_map.values())
-    return [{str(attr_value.attribute.pk): str(attr_value.pk)
-            for attr_value in combination}
-            for combination in all_combinations]
+    return [
+        {str(attr_value.attribute.pk): str(attr_value.pk)
+         for attr_value in combination}
+        for combination in all_combinations]
 
 
 def get_price_override(schema, combinations_num, current_price):
@@ -221,7 +218,7 @@ def create_products_by_class(product_class, schema,
 
         prices = get_price_override(
             schema, len(variant_combinations), product.price)
-        variants_with_prices = moves.zip_longest(
+        variants_with_prices = itertools.zip_longest(
             variant_combinations, prices)
 
         for i, variant_price in enumerate(variants_with_prices, start=1337):

--- a/saleor/core/views.py
+++ b/saleor/core/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.template.response import TemplateResponse
 from django.contrib import messages
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/category/filters.py
+++ b/saleor/dashboard/category/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.utils.translation import pgettext_lazy
 from django_filters import CharFilter, OrderingFilter
 

--- a/saleor/dashboard/category/forms.py
+++ b/saleor/dashboard/category/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.shortcuts import get_object_or_404
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/category/urls.py
+++ b/saleor/dashboard/category/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/category/views.py
+++ b/saleor/dashboard/category/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/customer/filters.py
+++ b/saleor/dashboard/customer/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.db.models import Q
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/customer/urls.py
+++ b/saleor/dashboard/customer/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/customer/views.py
+++ b/saleor/dashboard/customer/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/discount/filters.py
+++ b/saleor/dashboard/discount/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.db.models import Q
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/discount/forms.py
+++ b/saleor/dashboard/discount/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import uuid
 
 from django import forms

--- a/saleor/dashboard/discount/urls.py
+++ b/saleor/dashboard/discount/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/discount/views.py
+++ b/saleor/dashboard/discount/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/group/filters.py
+++ b/saleor/dashboard/group/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.models import Group
 from django.utils.translation import pgettext_lazy
 from django_filters import (

--- a/saleor/dashboard/group/forms.py
+++ b/saleor/dashboard/group/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.contrib.auth.models import Group
 

--- a/saleor/dashboard/group/urls.py
+++ b/saleor/dashboard/group/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/group/views.py
+++ b/saleor/dashboard/group/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/order/filters.py
+++ b/saleor/dashboard/order/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.db.models import Q
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/order/forms.py
+++ b/saleor/dashboard/order/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.conf import settings
 from django.core.validators import MinValueValidator, MaxValueValidator

--- a/saleor/dashboard/order/urls.py
+++ b/saleor/dashboard/order/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import get_template

--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/product/__init__.py
+++ b/saleor/dashboard/product/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.utils.translation import pgettext_lazy
 
 

--- a/saleor/dashboard/product/filters.py
+++ b/saleor/dashboard/product/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.utils.translation import pgettext_lazy
 from django_filters import (

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.db.models import Count
 from django.forms.models import ModelChoiceIterator

--- a/saleor/dashboard/product/urls.py
+++ b/saleor/dashboard/product/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/product/widgets.py
+++ b/saleor/dashboard/product/widgets.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.forms import MultiWidget, HiddenInput
 from versatileimagefield.widgets import (ClearableFileInputWithImagePreview,
                                          SizedImageCenterpointWidgetMixIn)

--- a/saleor/dashboard/search/forms.py
+++ b/saleor/dashboard/search/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from ...search.backends import picker
 from ...search.forms import SearchForm
 

--- a/saleor/dashboard/search/urls.py
+++ b/saleor/dashboard/search/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/search/views.py
+++ b/saleor/dashboard/search/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import render

--- a/saleor/dashboard/shipping/filters.py
+++ b/saleor/dashboard/shipping/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.utils.translation import pgettext_lazy
 from django_filters import (
     CharFilter, ChoiceFilter, OrderingFilter, RangeFilter)

--- a/saleor/dashboard/shipping/forms.py
+++ b/saleor/dashboard/shipping/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 
 from ...shipping.models import ShippingMethod, ShippingMethodCountry

--- a/saleor/dashboard/shipping/urls.py
+++ b/saleor/dashboard/shipping/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/shipping/views.py
+++ b/saleor/dashboard/shipping/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/sites/forms.py
+++ b/saleor/dashboard/sites/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.contrib.sites.models import Site
 

--- a/saleor/dashboard/sites/urls.py
+++ b/saleor/dashboard/sites/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/sites/views.py
+++ b/saleor/dashboard/sites/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
 from django.contrib.sites.models import Site

--- a/saleor/dashboard/staff/emails.py
+++ b/saleor/dashboard/staff/emails.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from celery import shared_task
 from django.conf import settings
 from django.contrib.auth.tokens import default_token_generator

--- a/saleor/dashboard/staff/filters.py
+++ b/saleor/dashboard/staff/filters.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.contrib.auth.models import Group
 from django.utils.translation import pgettext_lazy

--- a/saleor/dashboard/staff/forms.py
+++ b/saleor/dashboard/staff/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 
 from ...userprofile.models import User

--- a/saleor/dashboard/staff/urls.py
+++ b/saleor/dashboard/staff/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/dashboard/staff/views.py
+++ b/saleor/dashboard/staff/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required

--- a/saleor/dashboard/templatetags/chips.py
+++ b/saleor/dashboard/templatetags/chips.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.template.defaultfilters import yesno
 from django.utils.translation import pgettext_lazy
 

--- a/saleor/dashboard/templatetags/chips.py
+++ b/saleor/dashboard/templatetags/chips.py
@@ -1,11 +1,7 @@
+from urllib.parse import urlencode
+
 from django.template.defaultfilters import yesno
 from django.utils.translation import pgettext_lazy
-
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
-
 
 CHIPS_PATTERN = '%s: %s'
 

--- a/saleor/dashboard/templatetags/utils.py
+++ b/saleor/dashboard/templatetags/utils.py
@@ -1,19 +1,16 @@
+from urllib.parse import urlencode
+
 from django import forms
 from django.template import Library
 from django_filters.fields import RangeField
 from versatileimagefield.widgets import VersatileImagePPOIClickWidget
 
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
-
 from ...product.utils import get_margin_for_variant, get_variant_costs_data
+from ..product.widgets import ImagePreviewWidget
 from .chips import (
     handle_default, handle_multiple_choice, handle_multiple_model_choice,
     handle_nullboolean, handle_range, handle_single_choice,
     handle_single_model_choice)
-from ..product.widgets import ImagePreviewWidget
 
 register = Library()
 

--- a/saleor/dashboard/templatetags/utils.py
+++ b/saleor/dashboard/templatetags/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.template import Library
 from django_filters.fields import RangeField

--- a/saleor/dashboard/urls.py
+++ b/saleor/dashboard/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url, include
 
 from . import views as core_views

--- a/saleor/dashboard/views.py
+++ b/saleor/dashboard/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib.admin.views.decorators import \
     staff_member_required as _staff_member_required

--- a/saleor/dashboard/widgets.py
+++ b/saleor/dashboard/widgets.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-from django_filters.widgets import RangeWidget
-from django_prices.widgets import PriceInput
-
 from django import forms
 from django.conf import settings
+from django_filters.widgets import RangeWidget
+from django_prices.widgets import PriceInput
 
 
 class DateRangeWidget(RangeWidget):

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import gzip
 import csv
 
@@ -7,7 +5,6 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.contrib.syndication.views import add_domain
 from django.core.files.storage import default_storage
-from django.utils import six
 from django.utils.encoding import smart_text
 
 from ..discount.models import Sale
@@ -221,9 +218,6 @@ def update_feed(file_path=FILE_PATH):
     module as FILE_PATH.
     """
     with default_storage.open(file_path, 'wb') as output_file:
-        if six.PY3:
-            output = gzip.open(output_file, 'wt')
-        else:
-            output = gzip.GzipFile(fileobj=output_file, mode='w')
+        output = gzip.open(output_file, 'wt')
         write_feed(output)
         output.close()

--- a/saleor/data_feeds/management/commands/update_feeds.py
+++ b/saleor/data_feeds/management/commands/update_feeds.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.core.management import BaseCommand
 
 from ...google_merchant import update_feed

--- a/saleor/data_feeds/urls.py
+++ b/saleor/data_feeds/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 from django.views.generic.base import RedirectView
 

--- a/saleor/discount/forms.py
+++ b/saleor/discount/forms.py
@@ -1,11 +1,10 @@
-from __future__ import unicode_literals
-
 from datetime import date
+
 from django import forms
 from django.utils.encoding import smart_text
 from django.utils.translation import pgettext_lazy
 
-from .models import Voucher, NotApplicable
+from .models import NotApplicable, Voucher
 
 
 class VoucherField(forms.ModelChoiceField):

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -1,12 +1,10 @@
-from __future__ import unicode_literals
-
 from datetime import date
 from decimal import Decimal
 
 from django.conf import settings
 from django.db import models
 from django.db.models import F
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import smart_text
 from django.utils.translation import pgettext, pgettext_lazy
 from django_countries import countries
 from django_prices.models import PriceField
@@ -49,7 +47,6 @@ class VoucherQueryset(models.QuerySet):
         voucher.save(update_fields=['used'])
 
 
-@python_2_unicode_compatible
 class Voucher(models.Model):
 
     APPLY_TO_ONE_PRODUCT = 'one'
@@ -264,7 +261,6 @@ class Voucher(models.Model):
             raise NotImplementedError('Unknown discount type')
 
 
-@python_2_unicode_compatible
 class Sale(models.Model):
     FIXED = 'fixed'
     PERCENTAGE = 'percentage'

--- a/saleor/discount/templatetags/voucher.py
+++ b/saleor/discount/templatetags/voucher.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import template
 from django_prices.templatetags.prices_i18n import gross
 from prices import Price

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -1,22 +1,20 @@
-from __future__ import unicode_literals
-
 import functools
-import graphene
 import operator
 
 from django.db.models import Q
-from graphene import relay
-from graphene_django import DjangoObjectType, DjangoConnectionField
-from graphene_django.debug import DjangoDebug
 from django_prices.templatetags import prices_i18n
+import graphene
+from graphene import relay
+from graphene_django import DjangoConnectionField, DjangoObjectType
+from graphene_django.debug import DjangoDebug
 
-from ..product.models import (AttributeChoiceValue, Category, Product,
-                              ProductAttribute, ProductImage, ProductVariant)
-from ..product.utils import get_availability, products_for_api
+from ..product.models import (
+    AttributeChoiceValue, Category, Product, ProductAttribute, ProductImage,
+    ProductVariant)
 from ..product.templatetags.product_images import product_first_image
+from ..product.utils import get_availability, products_for_api
 from .scalars import AttributesFilterScalar
-from .utils import (CategoryAncestorsCache, DjangoPkInterface)
-
+from .utils import CategoryAncestorsCache, DjangoPkInterface
 
 CONTEXT_CACHE_NAME = '__cache__'
 CACHE_ANCESTORS = 'ancestors'

--- a/saleor/graphql/scalars.py
+++ b/saleor/graphql/scalars.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-from django.utils import six
 from graphene.types import Scalar
 from graphql.language import ast
 
@@ -16,7 +13,7 @@ class AttributesFilterScalar(Scalar):
 
     @staticmethod
     def parse_value(value):
-        if isinstance(value, six.string_types):
+        if isinstance(value, str):
             splitted = value.split(":")
             if len(splitted) == 2:
                 return tuple(splitted)

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -1,11 +1,8 @@
-from __future__ import unicode_literals
-
+from django.shortcuts import _get_queryset
 import graphene
 
-from django.shortcuts import _get_queryset
 
-
-class CategoryAncestorsCache(object):
+class CategoryAncestorsCache:
     """
     Cache used to store ancestors of a category in GraphQL context in order to
     reduce number of database queries. Categories of the same tree depth level

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.utils.translation import pgettext_lazy
 
 

--- a/saleor/order/emails.py
+++ b/saleor/order/emails.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-
-from templated_email import send_templated_mail
+from celery import shared_task
 from django.conf import settings
 from django.contrib.sites.models import Site
-from celery import shared_task
+from templated_email import send_templated_mail
 
 CONFIRM_ORDER_TEMPLATE = 'order/confirm_order'
 CONFIRM_PAYMENT_TEMPLATE = 'order/payment/confirm_payment'

--- a/saleor/order/forms.py
+++ b/saleor/order/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.conf import settings
 from django.utils.translation import pgettext_lazy

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from decimal import Decimal
 from uuid import uuid4
 
@@ -8,7 +6,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.urls import reverse
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now
 from django.utils.translation import pgettext_lazy
 from django_prices.models import PriceField
@@ -24,7 +21,6 @@ from ..product.models import Product
 from ..userprofile.models import Address
 
 
-@python_2_unicode_compatible
 class Order(models.Model, ItemSet):
     status = models.CharField(
         pgettext_lazy('Order field', 'order status'),
@@ -247,7 +243,6 @@ class DeliveryGroup(models.Model, ItemSet):
         return self.status not in {OrderStatus.CANCELLED, OrderStatus.SHIPPED}
 
 
-@python_2_unicode_compatible
 class OrderLine(models.Model, ItemLine):
     delivery_group = models.ForeignKey(
         DeliveryGroup, related_name='lines', editable=False,
@@ -262,7 +257,7 @@ class OrderLine(models.Model, ItemLine):
     product_sku = models.CharField(
         pgettext_lazy('Ordered line field', 'sku'), max_length=32)
     stock_location = models.CharField(
-        pgettext_lazy('OrderLine field', 'stock location'), max_length=100,
+        pgettext_lazy('Ordered line field', 'stock location'), max_length=100,
         default='')
     stock = models.ForeignKey(
         'product.Stock', on_delete=models.SET_NULL, null=True,
@@ -276,11 +271,6 @@ class OrderLine(models.Model, ItemLine):
     unit_price_gross = models.DecimalField(
         pgettext_lazy('Ordered line field', 'unit price (gross)'),
         max_digits=12, decimal_places=4)
-
-    class Meta:
-        verbose_name = pgettext_lazy('Ordered line model', 'Ordered line')
-        verbose_name_plural = pgettext_lazy(
-            'Ordered line model', 'Ordered lines')
 
     def __str__(self):
         return self.product_name
@@ -353,7 +343,6 @@ class Payment(BasePayment):
         return Price(self.captured_amount, currency=self.currency)
 
 
-@python_2_unicode_compatible
 class OrderHistoryEntry(models.Model):
     date = models.DateTimeField(
         pgettext_lazy('Order history entry field', 'last history change'),
@@ -382,7 +371,6 @@ class OrderHistoryEntry(models.Model):
             'OrderHistoryEntry for Order #%d') % self.order.pk
 
 
-@python_2_unicode_compatible
 class OrderNote(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL, on_delete=models.CASCADE)

--- a/saleor/order/urls.py
+++ b/saleor/order/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from ..core import TOKEN_PATTERN

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from functools import wraps
 
 from django.conf import settings

--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 
 from django.conf import settings

--- a/saleor/product/__init__.py
+++ b/saleor/product/__init__.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-
 from django.utils.translation import pgettext_lazy
 
 
-class ProductAvailabilityStatus(object):
+class ProductAvailabilityStatus:
     NOT_PUBLISHED = 'not-published'
     VARIANTS_MISSSING = 'variants-missing'
     NOT_CARRIED = 'not-carried'
@@ -32,7 +30,7 @@ class ProductAvailabilityStatus(object):
             raise NotImplementedError('Unknown status: %s' % status)
 
 
-class VariantAvailabilityStatus(object):
+class VariantAvailabilityStatus:
     AVAILABLE = 'available'
     NOT_CARRIED = 'not-carried'
     OUT_OF_STOCK = 'out-of-stock'

--- a/saleor/product/filters.py
+++ b/saleor/product/filters.py
@@ -1,16 +1,12 @@
-from __future__ import unicode_literals
 from collections import OrderedDict
 
-from django_filters import (
-    MultipleChoiceFilter, RangeFilter, OrderingFilter)
 from django.forms import CheckboxSelectMultiple, ValidationError
 from django.utils.translation import pgettext_lazy
-
+from django_filters import MultipleChoiceFilter, OrderingFilter, RangeFilter
 from django_prices.models import PriceField
 
 from ..core.filters import SortedFilterSet
 from .models import Product, ProductAttribute
-
 
 SORT_BY_FIELDS = {
     'name': pgettext_lazy('Product list sorting option', 'name'),

--- a/saleor/product/forms.py
+++ b/saleor/product/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import json
 
 from django import forms

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import datetime
 from decimal import Decimal
 
@@ -9,8 +7,7 @@ from django.core.validators import MinValueValidator, RegexValidator
 from django.db import models
 from django.db.models import F, Max, Q
 from django.urls import reverse
-from django.utils import six
-from django.utils.encoding import python_2_unicode_compatible, smart_text
+from django.utils.encoding import smart_text
 from django.utils.text import slugify
 from django.utils.translation import pgettext_lazy
 from django_prices.models import Price, PriceField
@@ -25,7 +22,6 @@ from ..discount.models import calculate_discounted_price
 from .utils import get_attributes_display_map
 
 
-@python_2_unicode_compatible
 class Category(MPTTModel):
     name = models.CharField(
         pgettext_lazy('Category field', 'name'), max_length=128)
@@ -71,7 +67,6 @@ class Category(MPTTModel):
         self.get_descendants().update(is_hidden=is_hidden)
 
 
-@python_2_unicode_compatible
 class ProductClass(models.Model):
     name = models.CharField(
         pgettext_lazy('Product class field', 'name'), max_length=128)
@@ -109,7 +104,6 @@ class ProductManager(models.Manager):
                 is_published=True)
 
 
-@python_2_unicode_compatible
 class Product(models.Model, ItemRange):
     product_class = models.ForeignKey(
         ProductClass, related_name='products',
@@ -216,7 +210,6 @@ class Product(models.Model, ItemRange):
         return PriceRange(min(grosses), max(grosses))
 
 
-@python_2_unicode_compatible
 class ProductVariant(models.Model, Item):
     sku = models.CharField(
         pgettext_lazy('Product variant field', 'SKU'), max_length=32,
@@ -290,7 +283,7 @@ class ProductVariant(models.Model, Item):
             return ', '.join(
                 ['%s: %s' % (smart_text(attributes.get(id=int(key))),
                              smart_text(value))
-                 for (key, value) in six.iteritems(values)])
+                 for (key, value) in values.items()])
         else:
             return smart_text(self.sku)
 
@@ -318,7 +311,6 @@ class ProductVariant(models.Model, Item):
             return stock.cost_price
 
 
-@python_2_unicode_compatible
 class StockLocation(models.Model):
     name = models.CharField(
         pgettext_lazy('Stock location field', 'location'), max_length=100)
@@ -351,7 +343,6 @@ class StockManager(models.Manager):
         stock.save(update_fields=['quantity', 'quantity_allocated'])
 
 
-@python_2_unicode_compatible
 class Stock(models.Model):
     variant = models.ForeignKey(
         ProductVariant, related_name='stock',
@@ -384,7 +375,6 @@ class Stock(models.Model):
         return max(self.quantity - self.quantity_allocated, 0)
 
 
-@python_2_unicode_compatible
 class ProductAttribute(models.Model):
     slug = models.SlugField(
         pgettext_lazy('Product attribute field', 'internal name'),
@@ -406,7 +396,6 @@ class ProductAttribute(models.Model):
         return self.values.exists()
 
 
-@python_2_unicode_compatible
 class AttributeChoiceValue(models.Model):
     name = models.CharField(
         pgettext_lazy('Attribute choice value field', 'display name'),

--- a/saleor/product/templatetags/discount.py
+++ b/saleor/product/templatetags/discount.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import template
 
 register = template.Library()

--- a/saleor/product/templatetags/price_ranges.py
+++ b/saleor/product/templatetags/price_ranges.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import template
 
 register = template.Library()

--- a/saleor/product/templatetags/product_images.py
+++ b/saleor/product/templatetags/product_images.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import logging
 import re
 import warnings

--- a/saleor/product/urls.py
+++ b/saleor/product/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -1,21 +1,16 @@
 from collections import defaultdict, namedtuple
-
-from prices import Price, PriceRange
+from urllib.parse import urlencode
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.encoding import smart_text
 from django_prices.templatetags import prices_i18n
+from prices import Price, PriceRange
 
+from . import ProductAvailabilityStatus, VariantAvailabilityStatus
 from ..cart.utils import get_cart_from_request, get_or_create_cart_from_request
 from ..core.utils import to_local_currency
 from .forms import ProductForm
-from . import ProductAvailabilityStatus, VariantAvailabilityStatus
-
-try:
-    from urllib.parse import urlencode
-except ImportError:
-    from urllib import urlencode
 
 
 def products_visible_to_user(user):

--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
-
 from collections import defaultdict, namedtuple
 
 from prices import Price, PriceRange
-from six import iteritems
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
@@ -195,7 +192,7 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
             'schemaData': schema_data}
         data['variants'].append(variant_data)
 
-        for variant_key, variant_value in iteritems(variant.attributes):
+        for variant_key, variant_value in variant.attributes.items():
             filter_available_variants[int(variant_key)].append(
                 int(variant_value))
 

--- a/saleor/product/views.py
+++ b/saleor/product/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import datetime
 import json
 

--- a/saleor/registration/backends/__init__.py
+++ b/saleor/registration/backends/__init__.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-
 from ...site.utils import get_authorization_key_for_backend
 
 
-class BaseBackend(object):
+class BaseBackend:
     def get_key_and_secret(self):
         """Return tuple with Consumer Key and Consumer Secret for current
         service provider. Must return (key, secret), order *must* be respected.

--- a/saleor/registration/backends/facebook.py
+++ b/saleor/registration/backends/facebook.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from social_core.backends.facebook import FacebookOAuth2
 
 from . import BaseBackend

--- a/saleor/registration/backends/google.py
+++ b/saleor/registration/backends/google.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from social_core.backends.google import GoogleOAuth2
 
 from . import BaseBackend

--- a/saleor/registration/forms.py
+++ b/saleor/registration/forms.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.contrib.auth import forms as django_forms
 from django.http.request import HttpRequest

--- a/saleor/registration/urls.py
+++ b/saleor/registration/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 from django.contrib.auth import views as django_views
 

--- a/saleor/registration/views.py
+++ b/saleor/registration/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib import auth, messages
 from django.contrib.auth import views as django_views

--- a/saleor/search/backends/elasticsearch.py
+++ b/saleor/search/backends/elasticsearch.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from . import elasticsearch_dashboard, elasticsearch_storefront
 
 

--- a/saleor/search/backends/elasticsearch_dashboard.py
+++ b/saleor/search/backends/elasticsearch_dashboard.py
@@ -1,7 +1,6 @@
-from __future__ import unicode_literals
-
-from ..documents import ProductDocument, OrderDocument, UserDocument
 from elasticsearch_dsl.query import MultiMatch
+
+from ..documents import OrderDocument, ProductDocument, UserDocument
 
 
 def _search_products(phrase):

--- a/saleor/search/backends/elasticsearch_storefront.py
+++ b/saleor/search/backends/elasticsearch_storefront.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
-
 from elasticsearch_dsl.query import MultiMatch
+
 from ..documents import ProductDocument
 
 

--- a/saleor/search/backends/picker.py
+++ b/saleor/search/backends/picker.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals
-
-from django.utils.module_loading import import_module
 from django.conf import settings
+from django.utils.module_loading import import_module
 
 
 def pick_backend():

--- a/saleor/search/backends/postgresql.py
+++ b/saleor/search/backends/postgresql.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
 from . import postgresql_dashboard, postgresql_storefront
 
 

--- a/saleor/search/backends/test_elasticsearch_dashboard.py
+++ b/saleor/search/backends/test_elasticsearch_dashboard.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from . import elasticsearch_dashboard
 
 PHRASE = 'You can go to the west'

--- a/saleor/search/backends/test_elasticsearch_storefront.py
+++ b/saleor/search/backends/test_elasticsearch_storefront.py
@@ -1,4 +1,3 @@
-from __future__ import unicode_literals
 from . import elasticsearch_storefront
 
 PHRASE = 'How fortunate man with none'

--- a/saleor/search/documents.py
+++ b/saleor/search/documents.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
-
 from django_elasticsearch_dsl import DocType, Index, fields
 from elasticsearch_dsl import analyzer, token_filter
+
+from ..order.models import Order
 from ..product.models import Product
 from ..userprofile.models import User
-from ..order.models import Order
-
 
 storefront = Index('storefront')
 storefront.settings(number_of_shards=1, number_of_replicas=0)

--- a/saleor/search/forms.py
+++ b/saleor/search/forms.py
@@ -1,7 +1,6 @@
-from __future__ import unicode_literals
-
 from django import forms
 from django.utils.translation import pgettext
+
 from .backends import picker
 
 

--- a/saleor/search/urls.py
+++ b/saleor/search/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/search/views.py
+++ b/saleor/search/views.py
@@ -1,11 +1,10 @@
-from __future__ import unicode_literals
-
-from django.core.paginator import Paginator, InvalidPage
 from django.conf import settings
+from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404
 from django.shortcuts import render
+
+from ..product.utils import products_with_availability, products_with_details
 from .forms import SearchForm
-from ..product.utils import products_with_details, products_with_availability
 
 
 def paginate_results(results, get_data, paginate_by=settings.PAGINATE_BY):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,12 +1,10 @@
-from __future__ import unicode_literals
-
 import ast
 import os.path
 
 import dj_database_url
 import dj_email_url
-import django_cache_url
 from django.contrib.messages import constants as messages
+import django_cache_url
 
 
 def get_list(text):

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -1,23 +1,19 @@
-from __future__ import absolute_import, unicode_literals
 from itertools import groupby
 from operator import itemgetter
 
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import pgettext_lazy
+from django_countries import countries
 from django_prices.models import PriceField
 from prices import PriceRange
-from django_countries import countries
-
 
 ANY_COUNTRY = ''
 ANY_COUNTRY_DISPLAY = pgettext_lazy('Country choice', 'Rest of World')
 COUNTRY_CODE_CHOICES = [(ANY_COUNTRY, ANY_COUNTRY_DISPLAY)] + list(countries)
 
 
-@python_2_unicode_compatible
 class ShippingMethod(models.Model):
 
     name = models.CharField(
@@ -77,7 +73,6 @@ class ShippingMethodCountryQueryset(models.QuerySet):
         return self.filter(id__in=ids)
 
 
-@python_2_unicode_compatible
 class ShippingMethodCountry(models.Model):
 
     country_code = models.CharField(

--- a/saleor/shipping/utils.py
+++ b/saleor/shipping/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prices import PriceRange
 
 from .models import ShippingMethodCountry

--- a/saleor/site/__init__.py
+++ b/saleor/site/__init__.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 class AuthenticationBackends:
     GOOGLE = 'google-oauth2'
     FACEBOOK = 'facebook'

--- a/saleor/site/context_processors.py
+++ b/saleor/site/context_processors.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.sites.shortcuts import get_current_site
 
 

--- a/saleor/site/models.py
+++ b/saleor/site/models.py
@@ -1,8 +1,5 @@
-from __future__ import unicode_literals
-
 from django.contrib.sites.models import Site
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import pgettext_lazy
 
 from . import AuthenticationBackends
@@ -11,7 +8,6 @@ from .patch_sites import patch_contrib_sites
 patch_contrib_sites()
 
 
-@python_2_unicode_compatible
 class SiteSettings(models.Model):
     site = models.OneToOneField(
         Site, related_name='settings', on_delete=models.CASCADE)
@@ -37,7 +33,6 @@ class SiteSettings(models.Model):
         return self.authorizationkey_set.values_list('name', flat=True)
 
 
-@python_2_unicode_compatible
 class AuthorizationKey(models.Model):
     site_settings = models.ForeignKey(SiteSettings, on_delete=models.CASCADE)
     name = models.CharField(

--- a/saleor/site/patch_sites.py
+++ b/saleor/site/patch_sites.py
@@ -3,8 +3,6 @@ Since django.contrib.sites may not be thread-safe when there are
 multiple instances of the application server, we're patching it with
 a thread-safe structure and methods that use it underneath.
 '''
-from __future__ import unicode_literals
-
 import threading
 
 from django.contrib.sites.models import Site, SiteManager

--- a/saleor/site/utils.py
+++ b/saleor/site/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 
 from .models import AuthorizationKey

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.conf.urls import url, include
 from django.conf.urls.static import static

--- a/saleor/userprofile/forms.py
+++ b/saleor/userprofile/forms.py
@@ -1,6 +1,3 @@
-# encoding: utf-8
-from __future__ import unicode_literals
-
 from django.conf import settings
 from django.contrib.auth import forms as django_forms, update_session_auth_hash
 from phonenumbers.phonenumberutil import country_code_for_region

--- a/saleor/userprofile/i18n.py
+++ b/saleor/userprofile/i18n.py
@@ -1,18 +1,15 @@
-from __future__ import unicode_literals
-
 from collections import defaultdict
 
-import i18naddress
 from django import forms
 from django.forms.forms import BoundField
-from django_countries.data import COUNTRIES
 from django.utils.translation import pgettext_lazy
+from django_countries.data import COUNTRIES
+import i18naddress
 from phonenumber_field.formfields import PhoneNumberField
 
 from .models import Address
-from .widgets import PhonePrefixWidget
 from .validators import validate_possible_number
-
+from .widgets import PhonePrefixWidget
 
 COUNTRY_FORMS = {}
 UNKNOWN_COUNTRIES = set()

--- a/saleor/userprofile/impersonate.py
+++ b/saleor/userprofile/impersonate.py
@@ -1,6 +1,4 @@
 # Module used to config django-impersonate app
-from __future__ import unicode_literals
-
 from .models import User
 
 

--- a/saleor/userprofile/management/commands/changepassword.py
+++ b/saleor/userprofile/management/commands/changepassword.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.management.commands.changepassword import Command
 
 __all__ = ['Command']

--- a/saleor/userprofile/management/commands/createsuperuser.py
+++ b/saleor/userprofile/management/commands/createsuperuser.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.management.commands.createsuperuser import Command
 
 __all__ = ['Command']

--- a/saleor/userprofile/models.py
+++ b/saleor/userprofile/models.py
@@ -1,11 +1,8 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.models import (
     AbstractBaseUser, BaseUserManager, PermissionsMixin)
 from django.db import models
 from django.forms.models import model_to_dict
 from django.utils import timezone
-from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import pgettext_lazy
 from django_countries.fields import Country, CountryField
 from phonenumber_field.modelfields import PhoneNumberField
@@ -50,7 +47,6 @@ class AddressManager(models.Manager):
         return address
 
 
-@python_2_unicode_compatible
 class Address(models.Model):
     first_name = models.CharField(
         pgettext_lazy('Address field', 'given name'),

--- a/saleor/userprofile/templatetags/i18n_address_tags.py
+++ b/saleor/userprofile/templatetags/i18n_address_tags.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django import template
 from django.utils.safestring import mark_safe
 from django.utils.translation import pgettext

--- a/saleor/userprofile/urls.py
+++ b/saleor/userprofile/urls.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.conf.urls import url
 
 from . import views

--- a/saleor/userprofile/utils.py
+++ b/saleor/userprofile/utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from .models import Address
 
 

--- a/saleor/userprofile/views.py
+++ b/saleor/userprofile/views.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseRedirect

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -13,8 +13,6 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
-from __future__ import unicode_literals
-
 import os
 os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'saleor.settings')
 

--- a/saleor/wsgi/health_check.py
+++ b/saleor/wsgi/health_check.py
@@ -1,6 +1,3 @@
-from __future__ import unicode_literals
-
-
 def health_check(application, health_url):
     def health_check_wrapper(environ, start_response):
         if environ.get('PATH_INFO') == health_url:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from io import BytesIO
+from unittest.mock import MagicMock
 
 import pytest
 from django.contrib.auth.models import AnonymousUser, Group, Permission
@@ -9,7 +10,6 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.encoding import smart_text
 from PIL import Image
 
-from mock import MagicMock
 from saleor.cart import utils
 from saleor.cart.models import Cart
 from saleor.checkout.core import Checkout

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,26 @@
-# coding: utf-8
-from __future__ import unicode_literals
-
 from decimal import Decimal
-import pytest
-
 from io import BytesIO
+
+import pytest
+from django.contrib.auth.models import AnonymousUser, Group, Permission
+from django.contrib.sites.models import Site
+from django.core.files import File
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils.encoding import smart_text
 from PIL import Image
 
-from django.contrib.sites.models import Site
-from django.core.files.uploadedfile import SimpleUploadedFile
-from django.contrib.auth.models import AnonymousUser, Group, Permission
-from django.core.files import File
-from django.utils.encoding import smart_text
-
 from mock import MagicMock
-
 from saleor.cart import utils
 from saleor.cart.models import Cart
 from saleor.checkout.core import Checkout
-from saleor.discount.models import Voucher, Sale
-from saleor.order.models import Order, OrderLine, DeliveryGroup
+from saleor.discount.models import Sale, Voucher
+from saleor.order.models import DeliveryGroup, Order, OrderLine
 from saleor.order.utils import recalculate_order
 from saleor.product.models import (
     AttributeChoiceValue, Category, Product, ProductAttribute, ProductClass,
-    ProductVariant, ProductImage, Stock, StockLocation)
+    ProductImage, ProductVariant, Stock, StockLocation)
 from saleor.shipping.models import ShippingMethod
-from saleor.site.models import SiteSettings, AuthorizationKey
+from saleor.site.models import AuthorizationKey, SiteSettings
 from saleor.userprofile.models import Address, User
 
 

--- a/tests/dashboard/test_customer.py
+++ b/tests/dashboard/test_customer.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.urls import reverse
 
 from saleor.userprofile.models import User

--- a/tests/dashboard/test_group.py
+++ b/tests/dashboard/test_group.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.models import Group
 from django.urls import reverse
 

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -1,19 +1,17 @@
-from __future__ import unicode_literals
-
 from decimal import Decimal
 
-import pytest
 from django.urls import reverse
+import pytest
+from tests.utils import get_redirect_location, get_url_path
 
 from saleor.dashboard.order.forms import ChangeQuantityForm, MoveLinesForm
 from saleor.order import OrderStatus
 from saleor.order.models import (
-    DeliveryGroup, Order, OrderLine, OrderHistoryEntry)
+    DeliveryGroup, Order, OrderHistoryEntry, OrderLine)
 from saleor.order.utils import (
     add_variant_to_existing_lines, change_order_line_quantity,
     fill_group_with_partition, remove_empty_groups)
 from saleor.product.models import ProductVariant, Stock, StockLocation
-from tests.utils import get_redirect_location, get_url_path
 
 
 @pytest.mark.integration

--- a/tests/dashboard/test_permissions.py
+++ b/tests/dashboard/test_permissions.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.urls import reverse
 
 from saleor.userprofile.models import User

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -1,15 +1,12 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
-import json
 from io import BytesIO
+import json
 
-import pytest
+from PIL import Image
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 from django.utils.encoding import smart_text
-from PIL import Image
+import pytest
 
 from saleor.dashboard.product import ProductBulkAction
 from saleor.dashboard.product.forms import (
@@ -261,7 +258,7 @@ def test_attribute_choice_value_delete(color_attribute, admin_client):
 
 def test_get_formfield_name_with_unicode_characters(db):
     text_attribute = ProductAttribute.objects.create(
-        slug=u'ąęαβδηθλμπ', name=u'ąęαβδηθλμπ')
+        slug='ąęαβδηθλμπ', name='ąęαβδηθλμπ')
     assert text_attribute.get_formfield_name() == 'attribute-ąęαβδηθλμπ'
 
 
@@ -579,7 +576,7 @@ def test_product_list_filters_is_published(
 
 
 def test_product_list_filters_no_results(admin_client, product_list):
-    data = {'price_1': [u''], 'price_0': [''], 'is_featured': [''],
+    data = {'price_1': [''], 'price_0': [''], 'is_featured': [''],
             'name': ['BADTest'], 'sort_by': [''],
             'is_published': ['']}
     url = reverse('dashboard:product-list')

--- a/tests/dashboard/test_shipping.py
+++ b/tests/dashboard/test_shipping.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.urls import reverse
 
 from saleor.shipping.models import ShippingMethod, ShippingMethodCountry

--- a/tests/dashboard/test_site_settings.py
+++ b/tests/dashboard/test_site_settings.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
-
-import pytest
 from django.contrib.sites.models import Site
 from django.db.utils import IntegrityError
 from django.test.client import RequestFactory
 from django.urls import reverse
 from django.utils.encoding import smart_text
+import pytest
 
 from saleor.dashboard.sites.forms import SiteForm, SiteSettingsForm
 from saleor.site import utils

--- a/tests/dashboard/test_staff.py
+++ b/tests/dashboard/test_staff.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.auth.tokens import default_token_generator
 from django.contrib.sites.models import Site
 from django.core import mail

--- a/tests/dashboard/test_utils.py
+++ b/tests/dashboard/test_utils.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.test.client import RequestFactory
 from django.urls import reverse
 

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 # pylint: disable=W0401, W0614
 from saleor.settings import *  # noqa
 

--- a/tests/test_asynchronous_tasks.py
+++ b/tests/test_asynchronous_tasks.py
@@ -1,10 +1,9 @@
-from __future__ import unicode_literals
-
 import celery
-import pytest
 import mock
-from saleor.order.emails import (send_order_confirmation,
-                                 send_payment_confirmation)
+import pytest
+
+from saleor.order.emails import (
+    send_order_confirmation, send_payment_confirmation)
 
 
 @celery.shared_task

--- a/tests/test_asynchronous_tasks.py
+++ b/tests/test_asynchronous_tasks.py
@@ -1,26 +1,13 @@
-import celery
-import mock
 import pytest
 
 from saleor.order.emails import (
     send_order_confirmation, send_payment_confirmation)
 
 
-@celery.shared_task
-def dummy_task(x):
-    return x+1
-
-
-@pytest.mark.integration
-def test_task_running_asynchronously_on_worker(celery_worker):
-    assert dummy_task.delay(42).get(timeout=10) == 43
-
-
 @pytest.mark.django_db
 @pytest.mark.integration
-@mock.patch('saleor.order.emails.send_templated_mail')
-def test_email_sending_asynchronously(email_send, transactional_db, celery_app,
-                                      celery_worker):
+def test_email_sending_asynchronously(
+        transactional_db, celery_app, celery_worker):
     order = send_order_confirmation.delay('joe.doe@foo.com', '/nowhere/to/go')
     payment = send_payment_confirmation.delay('joe.doe@foo.com', '/nowhere/')
     order.get()

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -1,5 +1,6 @@
 import json
 from uuid import uuid4
+from unittest.mock import MagicMock, Mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
@@ -7,7 +8,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.http import HttpResponse
 from django.urls import reverse
 from django_babel.templatetags.babel import currencyfmt
-from mock import MagicMock, Mock
 from prices import Price
 import pytest
 from satchless.item import InsufficientStock

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -1,9 +1,6 @@
-from __future__ import unicode_literals
-
 import json
 from uuid import uuid4
 
-import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
 from django.core.exceptions import ObjectDoesNotExist
@@ -12,6 +9,7 @@ from django.urls import reverse
 from django_babel.templatetags.babel import currencyfmt
 from mock import MagicMock, Mock
 from prices import Price
+import pytest
 from satchless.item import InsufficientStock
 
 from saleor.cart import CartStatus, forms, utils

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,6 +1,7 @@
+from unittest.mock import MagicMock, Mock
+
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from mock import MagicMock, Mock
 from prices import Price
 import pytest
 from satchless.item import InsufficientStock

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -1,10 +1,8 @@
-from __future__ import unicode_literals
-
-import pytest
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from mock import MagicMock, Mock
 from prices import Price
+import pytest
 from satchless.item import InsufficientStock
 
 from saleor.checkout import views
@@ -123,9 +121,9 @@ def test_checkout_shipping_address_setter():
     checkout.shipping_address = address
     assert checkout._shipping_address == address
     assert checkout.storage['shipping_address'] == {
-        'city': u'', 'city_area': u'', 'company_name': u'', 'country': '', 'phone': u'',
-        'country_area': u'', 'first_name': 'Jan', 'id': None, 'last_name': 'Kowalski',
-        'postal_code': u'', 'street_address_1': u'', 'street_address_2': u''}
+        'city': '', 'city_area': '', 'company_name': '', 'country': '', 'phone': '',
+        'country_area': '', 'first_name': 'Jan', 'id': None, 'last_name': 'Kowalski',
+        'postal_code': '', 'street_address_1': '', 'street_address_2': ''}
 
 
 @pytest.mark.parametrize('shipping_address, shipping_method, value', [

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.urls import reverse
 from payments import FraudStatus, PaymentStatus
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,5 @@
-from mock import Mock
+from unittest.mock import Mock
+
 import pytest
 
 from saleor.core.utils import (

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,7 +1,5 @@
-from __future__ import unicode_literals
-
-import pytest
 from mock import Mock
+import pytest
 
 from saleor.core.utils import (
     Country, create_superuser, get_country_by_ip, get_currency_for_country,

--- a/tests/test_data_feeds.py
+++ b/tests/test_data_feeds.py
@@ -1,23 +1,13 @@
-from __future__ import unicode_literals
-
 import csv
-
-from mock import Mock, patch
-
-from django.utils import six
-from django.utils.encoding import smart_text
-if six.PY3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from io import StringIO
 
 from django.contrib.sites.models import Site
+from django.utils.encoding import smart_text
+from mock import Mock, patch
 
+from saleor.data_feeds.google_merchant import (
+    get_feed_items, item_attributes, item_google_product_category, write_feed)
 from saleor.product.models import AttributeChoiceValue, Category
-from saleor.data_feeds.google_merchant import (get_feed_items,
-                                               item_attributes,
-                                               item_google_product_category,
-                                               write_feed)
 
 
 def test_saleor_feed_items(product_in_stock):

--- a/tests/test_data_feeds.py
+++ b/tests/test_data_feeds.py
@@ -1,9 +1,9 @@
 import csv
 from io import StringIO
+from unittest.mock import Mock, patch
 
 from django.contrib.sites.models import Site
 from django.utils.encoding import smart_text
-from mock import Mock, patch
 
 from saleor.data_feeds.google_merchant import (
     get_feed_items, item_attributes, item_google_product_category, write_feed)

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,10 +1,10 @@
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from unittest.mock import Mock
 
-from freezegun import freeze_time
-from mock import Mock
-from prices import FixedDiscount, FractionalDiscount, Price
 import pytest
+from freezegun import freeze_time
+from prices import FixedDiscount, FractionalDiscount, Price
 
 from saleor.cart.utils import get_category_variants_and_prices
 from saleor.checkout.core import Checkout

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -1,18 +1,16 @@
-from __future__ import unicode_literals
-
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+
 from freezegun import freeze_time
-import pytest
 from mock import Mock
 from prices import FixedDiscount, FractionalDiscount, Price
+import pytest
 
 from saleor.cart.utils import get_category_variants_and_prices
 from saleor.checkout.core import Checkout
 from saleor.discount.forms import CheckoutDiscountForm
 from saleor.discount.models import NotApplicable, Sale, Voucher
-from saleor.product.models import Category
-from saleor.product.models import Product, ProductVariant
+from saleor.product.models import Category, Product, ProductVariant
 
 
 @pytest.mark.parametrize('limit, value', [

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -1,11 +1,9 @@
-from __future__ import unicode_literals
-
 from decimal import Decimal
 
 from django.core.urlresolvers import reverse
+from elasticsearch_dsl.connections import connections
 import pytest
 
-from elasticsearch_dsl.connections import connections
 from saleor.order.models import Order
 from saleor.product.models import Product
 from saleor.userprofile.models import User

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,5 +1,6 @@
+from unittest import mock
+
 from django.conf import settings
-import mock
 
 import saleor.order.emails as emails
 

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,8 +1,7 @@
-from __future__ import unicode_literals
 from django.conf import settings
+import mock
 
 import saleor.order.emails as emails
-import mock
 
 EMAIL = "foo@bar.com"
 SITE_NAME = 'mirumee.com'

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -1,6 +1,5 @@
-from __future__ import unicode_literals
-
 import json
+
 import pytest
 
 from saleor.product.models import Category, ProductAttribute

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.core.urlresolvers import reverse
 
 from saleor.userprofile.models import User

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prices import Price
 
 from saleor.cart.models import Cart

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from prices import Price
 
 from saleor.order.models import Payment

--- a/tests/test_postgresql_search.py
+++ b/tests/test_postgresql_search.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals
-
 from saleor.product.models import Product
 from saleor.order.models import Order
 from saleor.userprofile.models import Address, User

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,12 +1,11 @@
-from __future__ import unicode_literals
-
 import datetime
 import json
 
-import pytest
 from django.urls import reverse
 from django.utils.encoding import smart_text
 from mock import Mock
+import pytest
+from tests.utils import filter_products_by_attribute
 
 from saleor.cart import CartStatus, utils
 from saleor.cart.models import Cart
@@ -16,7 +15,6 @@ from saleor.product.utils import (
     get_attributes_display_map, get_availability,
     get_product_availability_status, get_variant_availability_status,
     get_variant_picker_data)
-from tests.utils import filter_products_by_attribute
 
 
 @pytest.fixture()

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -1,10 +1,10 @@
 import datetime
 import json
+from unittest.mock import Mock
 
+import pytest
 from django.urls import reverse
 from django.utils.encoding import smart_text
-from mock import Mock
-import pytest
 from tests.utils import filter_products_by_attribute
 
 from saleor.cart import CartStatus, utils

--- a/tests/test_product_tags.py
+++ b/tests/test_product_tags.py
@@ -1,9 +1,9 @@
-from __future__ import unicode_literals
-
 from django.contrib.staticfiles.templatetags.staticfiles import static
 from mock import Mock
+
 from saleor.product.templatetags.product_images import (
-    choose_placeholder, get_thumbnail,product_first_image)
+    choose_placeholder, get_thumbnail, product_first_image)
+
 
 def test_get_thumbnail():
     instance = Mock()

--- a/tests/test_product_tags.py
+++ b/tests/test_product_tags.py
@@ -1,5 +1,6 @@
+from unittest.mock import Mock
+
 from django.contrib.staticfiles.templatetags.staticfiles import static
-from mock import Mock
 
 from saleor.product.templatetags.product_images import (
     choose_placeholder, get_thumbnail, product_first_image)

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,9 +1,7 @@
-from __future__ import unicode_literals
-
-import pytest
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
+import pytest
 
 from saleor.registration.backends import BaseBackend
 from saleor.registration.forms import LoginForm, SignupForm

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from django.contrib.sites.models import Site
 from django.urls import reverse
 

--- a/tests/test_userprofile.py
+++ b/tests/test_userprofile.py
@@ -1,20 +1,13 @@
-# encoding: utf-8
-from __future__ import unicode_literals
-
-try:
-    # Python 3
-    from urllib.parse import urlencode
-except ImportError:
-    # Python 2
-    from urllib import urlencode
+from urllib.parse import urlencode
 
 import i18naddress
 import pytest
 from django.core.exceptions import ValidationError
 from django.http import QueryDict
 
-from saleor.userprofile import forms, models, i18n
+from saleor.userprofile import forms, i18n, models
 from saleor.userprofile.validators import validate_possible_number
+
 
 @pytest.fixture
 def billing_address(db):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,9 +1,4 @@
-from __future__ import unicode_literals
-
-try:
-    from urllib.parse import urlparse
-except ImportError:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 from django.db.models import Q
 from django.utils.encoding import smart_text

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{111}, py{34,35,36}-django{20,_master}
+envlist = py{34,35,36}-django{111,20,_master}
 skipsdist = True
 
 [testenv]
@@ -16,7 +16,6 @@ commands =
 
 [travis]
 python =
-    2.7: py27
     3.4: py34
     3.5: py35
     3.6: py36


### PR DESCRIPTION
This removes Python 2-specific features:

* encoding declaration (Python 3 defaults to UTF-8)
* `__future__` feature imports
* `u`-prefixed unicode literals
* `six` library
* conditional imports in `try`/`except`
* `mock` library as it's now part of the standard library

Fixes #1421 

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
