### PR TITLE
Drop Python 2 from the site

### DIFF
--- a/index.html
+++ b/index.html
@@ -96,7 +96,7 @@
             <img src="images/modern-development.svg" />
           </div>
           <h4>Modern development</h4>
-          <p>Straighforward local development, service-based architecture, top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL and Docker. Saleor runs on <strong>Python 2.x and&nbsp;3.x</strong>.</p>
+          <p>Straighforward local development, service-based architecture, top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL and Docker. Saleor runs on <strong>Python&nbsp;3.4+</strong>.</p>
         </div>
         <div class="col-sm-6 item">
           <div class="image">

--- a/themes/saleor/layout/_partial/developers.ejs
+++ b/themes/saleor/layout/_partial/developers.ejs
@@ -24,7 +24,7 @@
             <img src="images/modern-development.svg" />
           </div>
           <h4>Modern development</h4>
-          <p>Straighforward local development, service-based architecture, top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL and Docker. Saleor runs on <strong>Python 2.x and&nbsp;3.x</strong>.</p>
+          <p>Straighforward local development, service-based architecture, top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL and Docker. Saleor runs on <strong>Python&nbsp;3.4+</strong>.</p>
         </div>
         <div class="col-sm-6 item">
           <div class="image">


### PR DESCRIPTION
Let's stop advertising Python 2 support now that it's been dropped on master.