### PR TITLE
[WIP] Add pypy3.5 to the test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "pypy3.5-5.9.0"
 cache:
   pip: true
   directories:
@@ -35,6 +36,10 @@ matrix:
     - python: "3.6"
       env: DJANGO="2.0"
     - python: "3.6"
+      env: DJANGO="master"
+    - python: "pypy3.5-5.9.0"
+      env: DJANGO="2.0"
+    - python: "pypy3.5-5.9.0"
       env: DJANGO="master"
   exclude:
     - python: "3.4"

--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,7 @@ Markdown>=2.4
 maxminddb
 maxminddb-geolite2
 prices>=0.5.7
-psycopg2>=2.6
+psycopg2cffi>=2.7.6
 purl>=0.4.1
 pytest
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ cairocffi==0.8.0          # via cairosvg, weasyprint
 cairosvg==1.0.22
 celery[redis]==4.1.0
 certifi==2017.7.27.1      # via requests
-cffi==1.10.0              # via cairocffi, cryptography, weasyprint
+cffi==1.10.0              # via cairocffi, cryptography, psycopg2cffi, weasyprint
 chardet==3.0.4            # via requests
 cryptography==2.0.3       # via django-payments
 cssselect2==0.2.1         # via weasyprint
@@ -71,7 +71,7 @@ phonenumberslite==8.8.5   # via django-phonenumber-field
 pillow==4.0.0             # via django-versatileimagefield
 prices==0.5.9
 promise==2.0.2            # via graphene, graphql-core, graphql-relay
-psycopg2==2.7.3.1
+psycopg2cffi==2.7.7
 purl==1.3.1
 py==1.4.34                # via pytest
 pycparser==2.18           # via cffi
@@ -91,7 +91,7 @@ requests==2.18.4
 s3transfer==0.1.10        # via boto3
 satchless==1.1.3
 singledispatch==3.4.0.3   # via graphene-django
-six==1.11.0               # via cryptography, django-templated-email, elasticsearch-dsl, faker, freezegun, graphene, graphene-django, graphql-core, graphql-relay, html5lib, promise, purl, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, vcrpy
+six==1.11.0               # via cryptography, django-templated-email, elasticsearch-dsl, faker, freezegun, graphene, graphene-django, graphql-core, graphql-relay, html5lib, promise, psycopg2cffi, purl, python-dateutil, singledispatch, social-auth-app-django, social-auth-core, vcrpy
 social-auth-app-django==2.0.0
 social-auth-core==1.4.0   # via social-auth-app-django
 stripe==1.65.0            # via django-payments

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -6,6 +6,9 @@ import dj_email_url
 from django.contrib.messages import constants as messages
 import django_cache_url
 
+from psycopg2cffi import compat
+compat.register()
+
 
 def get_list(text):
     return [item.strip() for item in text.split(',')]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{34,35,36}-django{111,20,_master}
+envlist = py{34,35,36,py35}-django{111,20,_master}
 skipsdist = True
 
 [testenv]
@@ -19,6 +19,7 @@ python =
     3.4: py34
     3.5: py35
     3.6: py36
+    pypy3.5-5.9.0: pypy35
 unignore_outcomes = True
 
 [travis:env]


### PR DESCRIPTION
This adds pypy3.5 to the test matrix.

Important changes:
* `psycopg2cffi` instead of `psycopg2`; very fast under PyPy but does not come with wheel packages for Windows