### PR TITLE
Hide clear filters when 'page' in GET parameters

### DIFF
--- a/saleor/core/filters.py
+++ b/saleor/core/filters.py
@@ -5,16 +5,11 @@ class SortedFilterSet(FilterSet):
     '''
     Base class for filtersets used in dashboard views. Adds flag
     is_bound_unsorted to indicate if FilterSet has data from filters other
-    than sort_by.
+    than sort_by or page.
     '''
     def __init__(self, data, *args, **kwargs):
-        data_copy = data.copy() if data else None
-        self.is_bound_unsorted = self.set_is_bound_unsorted(data_copy)
-        super().__init__(data, *args, **kwargs)
+        self.is_bound_unsorted = self.set_is_bound_unsorted(data)
+        super(SortedFilterSet, self).__init__(data, *args, **kwargs)
 
-    def set_is_bound_unsorted(self, data_copy):
-        if data_copy and data_copy.get('sort_by', None):
-            del data_copy['sort_by']
-        if data_copy:
-            return True
-        return False
+    def set_is_bound_unsorted(self, data):
+        return any([key not in {'sort_by', 'page'} for key in data.keys()])

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -591,11 +591,13 @@ def test_product_list_pagination(admin_client, product_list):
     url = reverse('dashboard:product-list')
     response = admin_client.get(url, data)
     assert response.status_code == 200
+    assert not response.context['filter'].is_bound_unsorted
 
     data = {'page': '2'}
     url = reverse('dashboard:product-list')
     response = admin_client.get(url, data)
     assert response.status_code == 200
+    assert not response.context['filter'].is_bound_unsorted
 
 
 def test_product_list_pagination_with_filters(admin_client, product_list):


### PR DESCRIPTION
Hide clear filters button when list view has 'page' in GET parameters by expanding SortedFilterSet functionality.

Fixes #1428

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
