### PR TITLE
Use custom field to allow distinct filtering

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -13,6 +13,7 @@ from ..product.models import (
     ProductVariant)
 from ..product.templatetags.product_images import product_first_image
 from ..product.utils import get_availability, products_visible_to_user
+from .fields import DistinctConnectionField
 from .scalars import AttributesFilterScalar
 from .utils import CategoryAncestorsCache, DjangoPkInterface
 
@@ -74,7 +75,7 @@ class ProductType(DjangoObjectType):
 
 
 class CategoryType(DjangoObjectType):
-    products = DjangoConnectionField(
+    products = DistinctConnectionField(
         ProductType,
         attributes=graphene.Argument(
             graphene.List(AttributesFilterScalar),

--- a/saleor/graphql/fields.py
+++ b/saleor/graphql/fields.py
@@ -1,0 +1,14 @@
+
+from graphene_django.fields import DjangoConnectionField
+
+
+class DistinctConnectionField(DjangoConnectionField):
+    """Connection that allows combining two querysets, by making both of them
+    distinct, if at least one of them is distinct."""
+
+    @classmethod
+    def merge_querysets(cls, default_queryset, queryset):
+        if queryset.query.distinct or default_queryset.query.distinct:
+            queryset = queryset.distinct()
+            default_queryset = default_queryset.distinct()
+        return queryset & default_queryset


### PR DESCRIPTION
This fix allows using `distinct()` in products resolver. Internally, Graphene combines two querysets when resolving a connection. In case one of them is distinct and the other is not, an error is raised. Other solution would be to have a custom manager in the Product model, that would always return distinct results and use that manager in the GraphQL resolver, but to avoid cluttering the model with logic very specific to that case, I found it more elegant to override the field in Graphene.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
