### PR TITLE
Fix Facebook and Google oauth login

### DIFF
--- a/templates/account/partials/login_form.html
+++ b/templates/account/partials/login_form.html
@@ -19,7 +19,7 @@
       <a rel="nofollow" class="link--styled" href="{% url 'account_reset_password' %}">
         {% trans "Forgot password?" context "Login form secondary link" %}
       </a>
-      {% with available_backends=settings.available_backends %}
+      {% with available_backends=site.settings.available_backends %}
         {% if available_backends %}
           <hr>
           <div class="row">


### PR DESCRIPTION
Currenctly, Facebook and Google oauth login don't appear due to an incorrect reference to site settings in the login_form.html template. It uses settings which is not provided as context but site.settings is.

This pull request fixes the issue. Now the keys simply need to be added in the Site Settings section of the dashboard and it works!
