### PR TITLE
Remove misleading reference to Python 2

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,7 @@ Prerequisites
 
 Before you are ready to run Saleor you will need certain software installed on your computer.
 
-#. `Python <https://www.python.org/>`_ version 3.5.x or 2.7.x
+#. `Python <https://www.python.org/>`_ version 3.5.x
 
 #. `pip <https://pip.pypa.io/en/stable/installing/>`_ if you're using an older release of Python 2.7
 


### PR DESCRIPTION
https://github.com/mirumee/saleor/pull/1474 should have included a documentation updated.

I want to merge this change because...
... I spent far too long earlier today trying to make Saleor work in a Python 2.7 environment!

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [X] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
