### PR TITLE
Let javascript cope with Saleor not at root of site

### DIFF
--- a/saleor/static/js/components/cart.js
+++ b/saleor/static/js/components/cart.js
@@ -1,6 +1,6 @@
 import {getAjaxError} from './misc';
 
-export const summaryLink = '/cart/summary/';
+export var summaryLink = '/cart/summary/';  /* overriden in base.html to url 'cart:cart-summary' */
 export const $cartDropdown = $('.cart-dropdown');
 export const $cartIcon = $('.cart__icon');
 export const $addToCartError = $('.product__info__form-error small');
@@ -28,7 +28,7 @@ export const onAddToCartSuccess = () => {
 
 export default $(document).ready((e) => {
   // Cart dropdown
-
+  summaryLink = cartURL;	// override from base.html 
   $.get(summaryLink, (data) => {
     $cartDropdown.html(data);
   });
@@ -133,7 +133,7 @@ export default $(document).ready((e) => {
   let deliveryAjax = (e) => {
     let newCountry = $(countrySelect).val();
     $.ajax({
-      url: '/cart/shipingoptions/',
+      url: shippingOptionsURL,			// this is set in base.html to cart:shipping-options
       type: 'POST',
       data: {
         'csrfmiddlewaretoken': crsfToken,

--- a/saleor/static/js/components/cart.js
+++ b/saleor/static/js/components/cart.js
@@ -1,6 +1,6 @@
 import {getAjaxError} from './misc';
 
-export var summaryLink = '/cart/summary/';  /* overriden in base.html to url 'cart:cart-summary' */
+export const summaryLink = $('html').data('cart-summary-url');
 export const $cartDropdown = $('.cart-dropdown');
 export const $cartIcon = $('.cart__icon');
 export const $addToCartError = $('.product__info__form-error small');
@@ -28,7 +28,6 @@ export const onAddToCartSuccess = () => {
 
 export default $(document).ready((e) => {
   // Cart dropdown
-  summaryLink = cartURL;	// override from base.html 
   $.get(summaryLink, (data) => {
     $cartDropdown.html(data);
   });
@@ -133,7 +132,7 @@ export default $(document).ready((e) => {
   let deliveryAjax = (e) => {
     let newCountry = $(countrySelect).val();
     $.ajax({
-      url: shippingOptionsURL,			// this is set in base.html to cart:shipping-options
+      url: $('html').data('shipping-options-url'),
       type: 'POST',
       data: {
         'csrfmiddlewaretoken': crsfToken,

--- a/templates/base.html
+++ b/templates/base.html
@@ -266,6 +266,10 @@
 {% endblock %}
 {% block footer_scripts %}
   <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
+  <script type="text/javascript">
+	var cartURL = "{% url 'cart:cart-summary'%}";
+	var shippingOptionsURL = "{% url 'cart:shipping-options' %}";
+  </script>
   {% render_bundle 'vendor' 'js' %}
   {% render_bundle 'storefront' 'js' %}
 {% endblock footer_scripts %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 {% load staticfiles %}
 {% load render_bundle from webpack_loader %}
 
-<html lang="{{ LANGUAGE_CODE }}" class="no-js">
+<html lang="{{ LANGUAGE_CODE }}" class="no-js" data-shipping-options-url="{% url 'cart:shipping-options' %}" data-cart-summary-url="{% url 'cart:cart-summary' %}">
 <head>
   <title>{% block title %}{{ site.name }}{% endblock %}</title>
   {% block meta %}
@@ -266,10 +266,6 @@
 {% endblock %}
 {% block footer_scripts %}
   <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
-  <script type="text/javascript">
-	var cartURL = "{% url 'cart:cart-summary'%}";
-	var shippingOptionsURL = "{% url 'cart:shipping-options' %}";
-  </script>
   {% render_bundle 'vendor' 'js' %}
   {% render_bundle 'storefront' 'js' %}
 {% endblock footer_scripts %}


### PR DESCRIPTION
I want to merge this change because...

I needed to run saleor at a non-root URL, and the hardcoded URLs in cart.js break this. This change uses base.html to set the relevant URLs into two javascript variables which are then used in cart.js. 

I appreciate that there may be more optimal ways to achieve this outcome, but I couldn't immediately think of what they might be! Very happy to take suggestions as to better ways to achieve this...

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [X] The changes are tested.
1. [X] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.