### PR TITLE
Tweak to filters to operate on QuerySet not Model

### DIFF
--- a/saleor/dashboard/order/filters.py
+++ b/saleor/dashboard/order/filters.py
@@ -71,6 +71,6 @@ class OrderFilter(SortedFilterSet):
     def filter_by_status(self, queryset, name, value):
         """Filter by status using custom querysets."""
         return (
-            Order.objects.open() if value == OrderStatus.OPEN
-            else Order.objects.closed()
+            queryset.open() if value == OrderStatus.OPEN
+            else queryset.closed()
         )


### PR DESCRIPTION
I want to merge this change because...

...the filter was operating on the base Order model, not on the Queryset that the filter has been initialised with.

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [X] The changes are tested.
1. [X] The code is documented (docstrings, project documentation).
1. [X] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
