### PR TITLE
Fix selecting variant images

### DIFF
--- a/templates/dashboard/product/product_variant/_image_select.html
+++ b/templates/dashboard/product/product_variant/_image_select.html
@@ -5,10 +5,10 @@
     {% for choice_with_image in choices_with_images %}
       {% with choice=choice_with_image.0 image=choice_with_image.1 %}
         <div class="image_select-item">
-          <input id="{{ choice.id_for_label }}" name="{{ choice.name }}" class="filled-in" type="checkbox" value="{{ choice.choice_value }}" {% if choice.choice_value in choice.value %} checked="checked" {% endif %}>
+          <input id="{{ choice.id_for_label }}" name="{{ choice.data.name }}" class="filled-in" type="checkbox" value="{{ choice.data.value }}" {% if choice.data.selected %}checked{% endif %}>
           <label for="{{ choice.id_for_label }}"></label>
           <img id="{{ choice.id_for_label }}" class="responsive-img" src="{{ image.image.crop.200x200 }}" srcset="{{ image.image.crop.200x200 }} 1x" alt="">
-          <div id="{{ choice.id_for_label }}" class="image_select-item-overlay {% if choice.choice_value in choice.value %}checked{% endif %}"></div>
+          <div id="{{ choice.id_for_label }}" class="image_select-item-overlay{% if choice.data.selected %} checked{% endif %}"></div>
         </div>
       {% endwith %}
     {% endfor %}


### PR DESCRIPTION
This PR fixes selecting variant images that has been broken since introducing Django 1.11 LTS to saleor.

Fixes #1522

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
