### PR TITLE
Shipping method get initial value

### DIFF
--- a/saleor/checkout/forms.py
+++ b/saleor/checkout/forms.py
@@ -90,8 +90,10 @@ class ShippingMethodForm(forms.Form):
             queryset = method_field.queryset
             method_field.queryset = queryset.unique_for_country_code(
                 country_code)
+
         if self.initial.get('method') is None:
-            method_field.initial = method_field.queryset.first()
+            self.initial['method'] = method_field.queryset.first()
+	 
         method_field.empty_label = None
 
 

--- a/saleor/checkout/forms.py
+++ b/saleor/checkout/forms.py
@@ -93,7 +93,7 @@ class ShippingMethodForm(forms.Form):
 
         if self.initial.get('method') is None:
             self.initial['method'] = method_field.queryset.first()
-	 
+
         method_field.empty_label = None
 
 


### PR DESCRIPTION
On Python 3.6.3 with Django 1.11 the shipping method radioSelect does not get an initial value, and so even if only one shipping method is available the user still has to manually select it during the checkout flow. 