### PR TITLE
Fix/image names in templates

### DIFF
--- a/templates/checkout/login.html
+++ b/templates/checkout/login.html
@@ -10,7 +10,7 @@
       <div class="checkout__login__continue">
         <h3>{% trans "New customer?" context "Checkout login page title" %}</h3>
         <img class="checkout-pirate" src="{% static 'images/pirate_login.png' %}"
-             srcset="{% static 'images/pirate-checkout.png' %} 1x, {% static 'images/pirate-checkout2x.png' %} 2x">
+             srcset="{% static 'images/pirate_login.png' %} 1x, {% static 'images/pirate_login2x.png' %} 2x">
         <p><a href="{% url 'checkout:index' %}" class="btn secondary narrow">
           {% trans "Continue" context "Checkout login page new users action" %}
         </a></p>

--- a/templates/dashboard/category/form.html
+++ b/templates/dashboard/category/form.html
@@ -34,7 +34,7 @@
     </li>
     <li class="back-mobile">
       <a href="{% url 'dashboard:category-list' %}" class="breadcrumbs--ellipsed-item">
-        <svg data-src="{% static "dashboard/images/arrow-left.svg" %}" fill="#fff" width="20px" height="20px" />
+        <svg data-src="{% static "dashboard/images/arrow_left.svg" %}" fill="#fff" width="20px" height="20px" />
       </a>
     </li>
     {% if path %}


### PR DESCRIPTION
I want to merge this change because...

Fix some minor image reference errors in templates. One is arrow_left instead of arrow-left which doesn't exist and was causing errors in the nginx logfile. And the other is to use the login images for srcset instead of checkout.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x ] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
