### PR TITLE
Fix missing import and filters in dashboard

### DIFF
--- a/saleor/dashboard/product/filters.py
+++ b/saleor/dashboard/product/filters.py
@@ -123,6 +123,9 @@ class StockLocationFilter(SortedFilterSet):
             'Stock location list filter label', 'Sort by'),
         fields=STOCK_LOCATION_SORT_BY_FIELDS.keys(),
         field_labels=STOCK_LOCATION_SORT_BY_FIELDS)
+    name = CharFilter(
+        label=pgettext_lazy('Stock location list filter label', 'Name'),
+        lookup_expr='icontains')
 
     class Meta:
         model = StockLocation

--- a/templates/dashboard/includes/_orders_table.html
+++ b/templates/dashboard/includes/_orders_table.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load prices_i18n %}
 {% load status %}
+{% load sorting_header from utils %}
 
 <div class="data-table-container">
   <table class="bordered highlight responsive data-table last-right-align">

--- a/templates/dashboard/product/stock_location/list.html
+++ b/templates/dashboard/product/stock_location/list.html
@@ -69,5 +69,8 @@
         {% endif %}
       {% endif %}
     </div>
+    <div class="col s12 l3" id="filters">
+      {% if not is_empty %}{% filters filter_set %}{% endif %}
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
This changes fix missing ```sorting_header``` import in ```_orders_table.html``` template and add missing filters in stock locations tab.