### PR TITLE
Fix storefront filters

### DIFF
--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -146,7 +146,7 @@
             <div class="product-filters__attributes" data-icon-up="{% static "images/chevron_up.svg" %}"
                  data-icon-down="{% static "images/chevron_down.svg" %}">
               <form method="get">
-                {% for field in filter.form %}
+                {% for field in filter_set.form %}
                   {% if field.name == 'sort_by' %}
                     {% comment %}
                       Field 'sort_by' is hidden because it is rendered in header.


### PR DESCRIPTION
This PR changes ```filter``` to ```filter_set``` variable name in category index template, which fixes displaying filters in storefront.