### PR TITLE
Explictly define impersonate and impersonate-stop urls

### DIFF
--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -5,6 +5,7 @@ from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.views import serve
 from django.views.i18n import JavaScriptCatalog
 from graphene_django.views import GraphQLView
+from impersonate.views import impersonate, stop_impersonate
 
 from .cart.urls import urlpatterns as cart_urls
 from .checkout.urls import urlpatterns as checkout_urls
@@ -27,7 +28,8 @@ urlpatterns = [
     url(r'^dashboard/',
         include((dashboard_urls, 'dashboard'), namespace='dashboard')),
     url(r'^graphql', GraphQLView.as_view(graphiql=settings.DEBUG)),
-    url(r'^impersonate/', include('impersonate.urls')),
+    url(r'^impersonate/stop/$', stop_impersonate, name='impersonate-stop'),
+    url(r'^impersonate/(?P<uid>\d+)/$', impersonate, name='impersonate-start'),
     url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^order/', include((order_urls, 'order'), namespace='order')),
     url(r'^products/',

--- a/tests/test_impersonation.py
+++ b/tests/test_impersonation.py
@@ -1,4 +1,6 @@
+import pytest
 from django.core.urlresolvers import reverse
+from django.urls.exceptions import NoReverseMatch
 
 from saleor.userprofile.models import User
 
@@ -14,3 +16,19 @@ def test_staff_with_permission_can_impersonate(
     assert response.context['user'] == customer_user
     assert response.context['user'].is_impersonate
     assert response.context['request'].impersonator == staff_user
+
+    response = staff_client.get(reverse('impersonate-stop'), follow=True)
+    assert response.context['user'] == staff_user
+    assert response.context['user'].is_impersonate is False
+
+
+def test_impersonate_list_search_urls_are_disabled():
+    with pytest.raises(NoReverseMatch):
+        reverse('impersonate-list')
+    with pytest.raises(NoReverseMatch):
+        reverse('impersonate-search')
+
+
+def test_impersonate_start_url_uid_arg_is_number():
+    with pytest.raises(NoReverseMatch):
+        reverse('impersonate', args=['string'])


### PR DESCRIPTION
Fixes #1564 by removing the `url(r'^impersonate/', include('impersonate.urls'))` from our urlconf and explicitly defining the urls for `impersonate` and `impersonate-stop`.

I've also noticed that original `impersonate` url allowed user's ID to be any string, thus producing 500 if value couldn't be coerced to `int` in python. This is also fixed in this PR.

Updated our tests suite to test following cases:

- `test_staff_with_permission_can_impersonate` also tests if impersonation can be stopped, so test will fail if either `impersonate` or `impersonate-stop` urls are undefined
- `reverse()` for `impersonate-list` and `impersonate-search` throws with undefined
- `/impersonate/string/` will 404 instead of calling the view and thus throwing with 500