### PR TITLE
Move all impersonate urls to single place

### DIFF
--- a/saleor/core/urls.py
+++ b/saleor/core/urls.py
@@ -8,4 +8,6 @@ urlpatterns = [
     url(r'^style-guide/', views.styleguide, name='styleguide'),
     url(r'^impersonate/(?P<uid>\d+)/', views.impersonate,
         name='impersonate-start'),
+    url(r'^impersonate/stop/$', views.stop_impersonate,
+        name='impersonate-stop'),
 ]

--- a/saleor/core/views.py
+++ b/saleor/core/views.py
@@ -1,7 +1,7 @@
 from django.template.response import TemplateResponse
 from django.contrib import messages
 from django.utils.translation import pgettext_lazy
-from impersonate.views import impersonate as orig_impersonate
+from impersonate.views import impersonate as orig_impersonate, stop_impersonate
 
 from ..dashboard.views import staff_member_required
 from ..product.utils import products_with_availability, products_for_homepage

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -5,7 +5,6 @@ from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.views import serve
 from django.views.i18n import JavaScriptCatalog
 from graphene_django.views import GraphQLView
-from impersonate.views import impersonate, stop_impersonate
 
 from .cart.urls import urlpatterns as cart_urls
 from .checkout.urls import urlpatterns as checkout_urls
@@ -28,8 +27,6 @@ urlpatterns = [
     url(r'^dashboard/',
         include((dashboard_urls, 'dashboard'), namespace='dashboard')),
     url(r'^graphql', GraphQLView.as_view(graphiql=settings.DEBUG)),
-    url(r'^impersonate/stop/$', stop_impersonate, name='impersonate-stop'),
-    url(r'^impersonate/(?P<uid>\d+)/$', impersonate, name='impersonate-start'),
     url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^order/', include((order_urls, 'order'), namespace='order')),
     url(r'^products/',


### PR DESCRIPTION
This is the sequel to #1567

Looks like in addition to `include()` with impersonate urls, we've been defining redefining `impersonate-start` url in `saleor.core.urls`.

This PR removes impersonate's urls from our root urlconf and moves `impersonate-stop` to `saleor.core.urls`, so both start and stop urls are in single spot.