### PR TITLE
Use dropdown menu for country area choices

### DIFF
--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -9,44 +9,6 @@ export default $(document).ready((e) => {
         $previewField.val('on');
         $form.submit();
       });
-      const $countryAreaList = $form.find('#country_area_list');
-      if ($countryAreaList) {
-        const $countryAreaField = $form.find('input[name=country_area]');
-        const countryAreaOptions = $countryAreaList.find('option').toArray().reduce((options, option) => {
-          option = $(option);
-          let value = option.val();
-          let text = option.text();
-          options.push(value);
-          if (option !== text) {
-            options.push(text);
-          }
-          return options;
-        }, []);
-        let countryAreaTimeout = null;
-        $countryAreaField.on('change', () => {
-          clearTimeout(countryAreaTimeout);
-          countryAreaTimeout = setTimeout(() => {
-            let lowerCaseValue = $countryAreaField.val().toLowerCase();
-            if (lowerCaseValue) {
-              let value = countryAreaOptions.find(val => val.toLowerCase() === lowerCaseValue);
-              if (value) {
-                $countryAreaField.val(value);
-              } else {
-                let value = countryAreaOptions.find(val => val.toLowerCase().startsWith(lowerCaseValue));
-                if (value) {
-                  $countryAreaField.val(value);
-                } else {
-                  let value = countryAreaOptions.find(val => val.toLowerCase().includes(lowerCaseValue));
-                  if (value) {
-                    $countryAreaField.val(value);
-                  }
-                }
-              }
-            }
-          }, 500);
-        });
-        $countryAreaField.trigger('change');
-      };
     });
   });
 

--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -1,5 +1,4 @@
-export default $(document).ready((e) => {
-  $(function () {
+export default $(document).ready((e) => {  $(function () {
     const $i18nAddresses = $('.i18n-address');
     $i18nAddresses.each(function () {
       const $form = $(this).closest('form');
@@ -9,6 +8,39 @@ export default $(document).ready((e) => {
         $previewField.val('on');
         $form.submit();
       });
+      const $countryAreaList = $form.find('#country_area_list');
+      if ($countryAreaList){
+          const $countryAreaField = $form.find('input[name=country_area]');
+          const countryAreaOptions = $countryAreaList.find('option').toArray().reduce((options, option) => {
+              option = $(option);
+              let value = option.val();
+              let text = option.text();
+              options.push(value);
+              if (option != text) options.push(text);
+              return options;
+        }, []);
+        let countryAreaTimeout = null;
+        $countryAreaField.on('change', () => {
+            clearTimeout(countryAreaTimeout);
+            countryAreaTimeout = setTimeout(() => {
+                let lowerCaseValue = $countryAreaField.val().toLowerCase();
+                console.log($countryField.val());
+                if (lowerCaseValue){
+                    let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
+                    if (value) $countryAreaField.val(value);
+                    else {
+                        let value = countryAreaOptions.find(val => val.toLowerCase().startsWith(lowerCaseValue));
+                        if (value) $countryAreaField.val(value);
+                        else {
+                            let value = countryAreaOptions.find(val => val.toLowerCase().includes(lowerCaseValue));
+                            if (value) $countryAreaField.val(value);
+                        }
+                    }
+                }
+            }, 500)
+        })
+        $countryAreaField.trigger('change');
+      }
     });
   });
 

--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -28,7 +28,7 @@ export default $(document).ready((e) => {
           countryAreaTimeout = setTimeout(() => {
             let lowerCaseValue = $countryAreaField.val().toLowerCase();
             if (lowerCaseValue) {
-              let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
+              let value = countryAreaOptions.find(val => val.toLowerCase() === lowerCaseValue);
               if (value) {
                 $countryAreaField.val(value);
               } else {

--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -1,4 +1,5 @@
-export default $(document).ready((e) => {  $(function () {
+export default $(document).ready((e) => {
+  $(function () {
     const $i18nAddresses = $('.i18n-address');
     $i18nAddresses.each(function () {
       const $form = $(this).closest('form');
@@ -10,36 +11,42 @@ export default $(document).ready((e) => {  $(function () {
       });
       const $countryAreaList = $form.find('#country_area_list');
       if ($countryAreaList){
-          const $countryAreaField = $form.find('input[name=country_area]');
-          const countryAreaOptions = $countryAreaList.find('option').toArray().reduce((options, option) => {
-              option = $(option);
-              let value = option.val();
-              let text = option.text();
-              options.push(value);
-              if (option != text) options.push(text);
-              return options;
+        const $countryAreaField = $form.find('input[name=country_area]');
+        const countryAreaOptions = $countryAreaList.find('option').toArray().reduce((options, option) => {
+          option = $(option);
+          let value = option.val();
+          let text = option.text();
+          options.push(value);
+          if (option != text) {
+            options.push(text);
+          }
+          return options;
         }, []);
         let countryAreaTimeout = null;
         $countryAreaField.on('change', () => {
-            clearTimeout(countryAreaTimeout);
-            countryAreaTimeout = setTimeout(() => {
-                let lowerCaseValue = $countryAreaField.val().toLowerCase();
-                if (lowerCaseValue){
-                    let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
-                    if (value) $countryAreaField.val(value);
-                    else {
-                        let value = countryAreaOptions.find(val => val.toLowerCase().startsWith(lowerCaseValue));
-                        if (value) $countryAreaField.val(value);
-                        else {
-                            let value = countryAreaOptions.find(val => val.toLowerCase().includes(lowerCaseValue));
-                            if (value) $countryAreaField.val(value);
-                        }
-                    }
+          clearTimeout(countryAreaTimeout);
+          countryAreaTimeout = setTimeout(() => {
+            let lowerCaseValue = $countryAreaField.val().toLowerCase();
+            if (lowerCaseValue){
+              let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
+              if (value) {
+                $countryAreaField.val(value);
+              }else {
+                let value = countryAreaOptions.find(val => val.toLowerCase().startsWith(lowerCaseValue));
+                if (value) {
+                  $countryAreaField.val(value);
+                }else {
+                  let value = countryAreaOptions.find(val => val.toLowerCase().includes(lowerCaseValue));
+                  if (value) {
+                    $countryAreaField.val(value);
+                  }
                 }
-            }, 500)
+              }
+            }
+           }, 500)
         })
         $countryAreaField.trigger('change');
-      }
+      };
     });
   });
 

--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -10,14 +10,14 @@ export default $(document).ready((e) => {
         $form.submit();
       });
       const $countryAreaList = $form.find('#country_area_list');
-      if ($countryAreaList){
+      if ($countryAreaList) {
         const $countryAreaField = $form.find('input[name=country_area]');
         const countryAreaOptions = $countryAreaList.find('option').toArray().reduce((options, option) => {
           option = $(option);
           let value = option.val();
           let text = option.text();
           options.push(value);
-          if (option != text) {
+          if (option !== text) {
             options.push(text);
           }
           return options;
@@ -27,15 +27,15 @@ export default $(document).ready((e) => {
           clearTimeout(countryAreaTimeout);
           countryAreaTimeout = setTimeout(() => {
             let lowerCaseValue = $countryAreaField.val().toLowerCase();
-            if (lowerCaseValue){
+            if (lowerCaseValue) {
               let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
               if (value) {
                 $countryAreaField.val(value);
-              }else {
+              } else {
                 let value = countryAreaOptions.find(val => val.toLowerCase().startsWith(lowerCaseValue));
                 if (value) {
                   $countryAreaField.val(value);
-                }else {
+                } else {
                   let value = countryAreaOptions.find(val => val.toLowerCase().includes(lowerCaseValue));
                   if (value) {
                     $countryAreaField.val(value);
@@ -43,8 +43,8 @@ export default $(document).ready((e) => {
                 }
               }
             }
-           }, 500)
-        })
+          }, 500);
+        });
         $countryAreaField.trigger('change');
       };
     });

--- a/saleor/static/js/components/address-form.js
+++ b/saleor/static/js/components/address-form.js
@@ -24,7 +24,6 @@ export default $(document).ready((e) => {  $(function () {
             clearTimeout(countryAreaTimeout);
             countryAreaTimeout = setTimeout(() => {
                 let lowerCaseValue = $countryAreaField.val().toLowerCase();
-                console.log($countryField.val());
                 if (lowerCaseValue){
                     let value = countryAreaOptions.find(val => val.toLowerCase() == lowerCaseValue);
                     if (value) $countryAreaField.val(value);

--- a/saleor/userprofile/i18n.py
+++ b/saleor/userprofile/i18n.py
@@ -9,7 +9,7 @@ from phonenumber_field.formfields import PhoneNumberField
 
 from .models import Address
 from .validators import validate_possible_number
-from .widgets import PhonePrefixWidget
+from .widgets import PhonePrefixWidget, DatalistTextWidget
 
 COUNTRY_FORMS = {}
 UNKNOWN_COUNTRIES = set()
@@ -50,6 +50,9 @@ class PossiblePhoneNumberFormField(PhoneNumberField):
 
     def to_python(self, value):
         return value
+
+class CountryAreaChoiceField(forms.ChoiceField):
+    widget = DatalistTextWidget
 
 
 class AddressMetaForm(forms.ModelForm):
@@ -183,7 +186,7 @@ def get_form_i18n_lines(form_instance):
 
 def update_base_fields(form_class, i18n_rules):
     if i18n_rules.country_area_choices:
-        form_class.base_fields['country_area'] = forms.ChoiceField(choices=i18n_rules.country_area_choices)
+        form_class.base_fields['country_area'] = CountryAreaChoiceField(choices=i18n_rules.country_area_choices)
 
     labels_map = {
         'country_area': i18n_rules.country_area_type,

--- a/saleor/userprofile/i18n.py
+++ b/saleor/userprofile/i18n.py
@@ -51,6 +51,7 @@ class PossiblePhoneNumberFormField(PhoneNumberField):
     def to_python(self, value):
         return value
 
+
 class CountryAreaChoiceField(forms.ChoiceField):
     widget = DatalistTextWidget
 

--- a/saleor/userprofile/i18n.py
+++ b/saleor/userprofile/i18n.py
@@ -182,6 +182,9 @@ def get_form_i18n_lines(form_instance):
 
 
 def update_base_fields(form_class, i18n_rules):
+    if i18n_rules.country_area_choices:
+        form_class.base_fields['country_area'] = forms.ChoiceField(choices=i18n_rules.country_area_choices)
+
     labels_map = {
         'country_area': i18n_rules.country_area_type,
         'postal_code': i18n_rules.postal_code_type,

--- a/saleor/userprofile/i18n.py
+++ b/saleor/userprofile/i18n.py
@@ -54,6 +54,9 @@ class PossiblePhoneNumberFormField(PhoneNumberField):
 class CountryAreaChoiceField(forms.ChoiceField):
     widget = DatalistTextWidget
 
+    def valid_value(self, value):
+        return True
+
 
 class AddressMetaForm(forms.ModelForm):
     # This field is never visible in UI

--- a/saleor/userprofile/widgets.py
+++ b/saleor/userprofile/widgets.py
@@ -22,3 +22,30 @@ class PhonePrefixWidget(PhoneNumberPrefixWidget):
     def __init__(self, attrs=None):
         widgets = (Select(attrs=attrs, choices=phone_prefixes), TextInput())
         super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
+
+class DatalistTextWidget(Select):
+    template_name = "userprofile/snippets/datalist.html"
+    input_type = "text"
+
+    def render(self, *args, **kwargs):
+        return super(DatalistTextWidget, self).render(*args, **kwargs)
+
+    def get_context(self, name, value, attrs):
+        context = super(DatalistTextWidget, self).get_context(name, value, attrs)
+        context['widget']['type'] = self.input_type
+        return context
+
+    def format_value(self, value):
+        value = super(DatalistTextWidget, self).format_value(value)
+        value = value[0]
+        if value:
+            for choice in self.choices:
+                if any(c.lower() == value.lower() for c in choice):
+                    return choice[0]
+            for choice in self.choices:
+                if any(c.lower().startswith(value.lower()) for c in choice):
+                    return choice[0]
+            for choice in self.choices:
+                if any(value.lower() in c.lower() for c in choice):
+                    return choice[0]
+        return value

--- a/saleor/userprofile/widgets.py
+++ b/saleor/userprofile/widgets.py
@@ -23,6 +23,7 @@ class PhonePrefixWidget(PhoneNumberPrefixWidget):
         widgets = (Select(attrs=attrs, choices=phone_prefixes), TextInput())
         super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
 
+
 class DatalistTextWidget(Select):
     template_name = "userprofile/snippets/datalist.html"
     input_type = "text"
@@ -30,8 +31,8 @@ class DatalistTextWidget(Select):
     def render(self, *args, **kwargs):
         return super(DatalistTextWidget, self).render(*args, **kwargs)
 
-    def get_context(self, name, value, attrs):
-        context = super(DatalistTextWidget, self).get_context(name, value, attrs)
+    def get_context(self, *args):
+        context = super(DatalistTextWidget, self).get_context(*args)
         context['widget']['type'] = self.input_type
         return context
 

--- a/saleor/userprofile/widgets.py
+++ b/saleor/userprofile/widgets.py
@@ -28,9 +28,6 @@ class DatalistTextWidget(Select):
     template_name = "userprofile/snippets/datalist.html"
     input_type = "text"
 
-    def render(self, *args, **kwargs):
-        return super(DatalistTextWidget, self).render(*args, **kwargs)
-
     def get_context(self, *args):
         context = super(DatalistTextWidget, self).get_context(*args)
         context['widget']['type'] = self.input_type

--- a/saleor/userprofile/widgets.py
+++ b/saleor/userprofile/widgets.py
@@ -37,15 +37,4 @@ class DatalistTextWidget(Select):
 
     def format_value(self, value):
         value = super(DatalistTextWidget, self).format_value(value)
-        value = value[0]
-        if value:
-            for choice in self.choices:
-                if any(c.lower() == value.lower() for c in choice):
-                    return choice[0]
-            for choice in self.choices:
-                if any(c.lower().startswith(value.lower()) for c in choice):
-                    return choice[0]
-            for choice in self.choices:
-                if any(value.lower() in c.lower() for c in choice):
-                    return choice[0]
-        return value
+        return value[0]

--- a/templates/userprofile/snippets/datalist.html
+++ b/templates/userprofile/snippets/datalist.html
@@ -1,0 +1,8 @@
+<input type="{{ widget.type }}" name="{{ widget.name }}" list="{{widget.name}}_list" {% if widget.value != None and widget.value != "" %} value="{{ widget.value }}"{% endif %}{% include "django/forms/widgets/attrs.html" %} />
+
+<datalist id="{{widget.name}}_list">
+{% for group_name, group_choices, group_index in widget.optgroups %}{% if group_name %}
+  <optgroup label="{{ group_name }}">{% endif %}{% for option in group_choices %}
+  {% include option.template_name with widget=option %}{% endfor %}{% if group_name %}
+  </optgroup>{% endif %}{% endfor %}
+</datalist>


### PR DESCRIPTION
I want to merge this change because...

It provides a fix for issue #1335 and improves usability.
In the CountryAwareAddressForm, currently country area (states, counties, provinces, etc) is a regular input field for all countries. Validation will fail if the user doesn't type one of the listed country area values exactly, if that country has country area choices.  Expecting endusers to enter country area values exactly (especially for Irish counties where it is necessary to enter Co. before the county name) is inconvenient. So it makes sense to provide the choices as a dropdown field, but only for countries that have country area choices. The others will still use a regular input field.

Here's examples for US and Ireland after the change:

![capture_usa](https://user-images.githubusercontent.com/6353787/34621401-e41ea40a-f240-11e7-9f32-67f1210c2afc.png)
![capture_ireland](https://user-images.githubusercontent.com/6353787/34621402-e43d6c96-f240-11e7-85e8-fb5bf6a22514.png)

Here's an example for Colombia, which does not have country area choices and thus, still uses an input field:

![capture_colombia](https://user-images.githubusercontent.com/6353787/34621931-eeb99b84-f242-11e7-8cda-2016b290e5db.png)


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
