### PR TITLE
Fix packaging slip generation to handle order groups without shipping

### DIFF
--- a/templates/dashboard/order/pdf/invoice.html
+++ b/templates/dashboard/order/pdf/invoice.html
@@ -23,9 +23,13 @@
   <thead>
   <tr>
     {% if order.shipping_address %}
-      <th align="left" width="50%">{% trans "Shipping Details" context "Invoice table header" %}</th>
+      <th align="left" width="50%">
+        {% trans "Shipping Details" context "Invoice table header" %}
+      </th>
     {% endif %}
-    <th align="left" width="50%">{% trans "Billing Details" context "Invoice table header" %}</th>
+    <th align="left" {% if order.shipping_address %} width="50%"{% endif %}>
+      {% trans "Billing Details" context "Invoice table header" %}
+    </th>
   </tr>
   </thead>
   <tbody>

--- a/templates/dashboard/order/pdf/packing_slip.html
+++ b/templates/dashboard/order/pdf/packing_slip.html
@@ -22,21 +22,29 @@
 <h2>{% trans "Packing Slips" context "Packing slips header" %}</h2>
 <table width="100%" border="1" cellspacing="0">
   <thead>
-  <tr>
-    <th align="left" width="50%">{% trans "Shipping Details" context "Packing slip shipping details" %}</th>
-    <th align="left" width="50%">{% trans "Billing Details" context "Packing slip shipping details" %}</th>
-  </tr>
-  </thead>
+    <tr>
+      {% if group.order.shipping_address %}
+        <th align="left" width="50%">
+          {% trans "Shipping Details" context "Packing slip shipping details" %}
+        </th>
+      {% endif %}
+      <th align="left"{% if group.order.shipping_address %} width="50%"{% endif %}>
+        {% trans "Billing Details" context "Packing slip shipping details" %}
+      </th>
+    </tr>
+    </thead>
   <tbody>
   <tr>
-    <td valign="top">
-      {% with group.order.shipping_address as address %}
-        <h2>
-          {% trans "Shipping address" context "Packing slip shipping address" %}
-        </h2>
-        {% include 'dashboard/includes/_address.html' with address=address only %}
-      {% endwith %}
-    </td>
+    {% if group.order.shipping_address %}
+      <td valign="top">
+        {% with group.order.shipping_address as address %}
+          <h2>
+            {% trans "Shipping address" context "Packing slip shipping address" %}
+          </h2>
+          {% include 'dashboard/includes/_address.html' with address=address only %}
+        {% endwith %}
+      </td>
+    {% endif %}
     <td valign="top">
       {% with group.order.billing_address as address %}
         <h2>

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -316,6 +316,25 @@ def test_view_order_invoice(
 
 @pytest.mark.integration
 @pytest.mark.django_db
+def test_view_order_invoice_without_shipping(
+        admin_client, order_with_lines_and_stock, billing_address):
+    """
+    Regression test for #1536:
+    user downloads the invoice for order without shipping address
+    """
+    order_with_lines_and_stock.billing_address = billing_address
+    order_with_lines_and_stock.save()
+    url = reverse(
+        'dashboard:order-invoice', kwargs={
+            'order_pk': order_with_lines_and_stock.id
+        })
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    assert response['content-type'] == 'application/pdf'
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
 def test_view_order_packing_slips(
         admin_client, order_with_lines_and_stock, billing_address):
     """
@@ -337,6 +356,24 @@ def test_view_order_packing_slips(
         order_with_lines_and_stock.id,
         order_with_lines_and_stock.groups.all()[0].pk)
     assert response['Content-Disposition'] == 'filename=%s' % name
+
+
+@pytest.mark.integration
+@pytest.mark.django_db
+def test_view_order_packing_slips_without_shipping(
+        admin_client, order_with_lines_and_stock, billing_address):
+    """Regression test for #1536:
+    user downloads the packaging slips for order without shipping address
+    """
+    order_with_lines_and_stock.billing_address = billing_address
+    order_with_lines_and_stock.save()
+    url = reverse(
+        'dashboard:order-packing-slips', kwargs={
+            'group_pk': order_with_lines_and_stock.groups.all()[0].pk
+        })
+    response = admin_client.get(url)
+    assert response.status_code == 200
+    assert response['content-type'] == 'application/pdf'
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Fixes #1536

This PR changes template used to generate PDF for packaging slip to don't crash when order has no  products that require shipping. It also includes regression test to assert that error is no longer present.

This PR extends those changes on invoices too, for consistency and safety sake.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
