### PR TITLE
Add phonenumberslite to requirements.in

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,6 +34,7 @@ jsonfield>=2.0.2
 Markdown>=2.4
 maxminddb
 maxminddb-geolite2
+phonenumberslite>=8.8.8
 prices>=0.5.7
 psycopg2>=2.6
 purl>=0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -68,6 +68,7 @@ maxminddb==1.3.0
 oauthlib==2.0.4           # via requests-oauthlib, social-auth-core
 olefile==0.44             # via pillow
 pdfrw==0.4                # via weasyprint
+phonenumberslite==8.8.8
 pillow==4.0.0             # via django-versatileimagefield
 prices==0.5.9
 promise==2.1              # via graphene, graphene-django, graphql-core, graphql-relay


### PR DESCRIPTION
Package ```phonenumberslite``` was removed with PR #1556 as a side-effect of recompiling ```requirements.in``` file. This PR fixes problem with missing package by adding it explicitly to ```requirements.in```.