### PR TITLE
Support 404 for "Packing slips" and "Invoice" views

### DIFF
--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -25,10 +25,7 @@ def _create_pdf(rendered_template, absolute_url):
     return pdf_file
 
 
-def create_invoice_pdf(order_pk, absolute_url):
-    order = (Order.objects.prefetch_related(
-        'user', 'shipping_address', 'billing_address', 'voucher',
-        'groups').get(pk=order_pk))
+def create_invoice_pdf(order, absolute_url):
     shipping_methods = [
         {'name': d.shipping_method_name} for d in order.groups.all()]
     ctx = {'order': order, 'shipping_methods': shipping_methods}

--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -2,8 +2,6 @@ from django.conf import settings
 from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import get_template
 
-from ...order.models import DeliveryGroup, Order
-
 INVOICE_TEMPLATE = 'dashboard/order/pdf/invoice.html'
 PACKING_SLIP_TEMPLATE = 'dashboard/order/pdf/packing_slip.html'
 
@@ -34,10 +32,7 @@ def create_invoice_pdf(order, absolute_url):
     return pdf_file, order
 
 
-def create_packing_slip_pdf(group_pk, absolute_url):
-    group = (DeliveryGroup.objects.prefetch_related(
-        'lines', 'order', 'order__user', 'order__shipping_address',
-        'order__billing_address').get(pk=group_pk))
+def create_packing_slip_pdf(group, absolute_url):
     ctx = {'group': group}
     rendered_template = get_template(PACKING_SLIP_TEMPLATE).render(ctx)
     pdf_file = _create_pdf(rendered_template, absolute_url)

--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -406,8 +406,11 @@ def remove_order_voucher(request, order_pk):
 @staff_member_required
 @permission_required('order.edit_order')
 def order_invoice(request, order_pk):
+    orders = Order.objects.prefetch_related(
+        'user', 'shipping_address', 'billing_address', 'voucher', 'groups')
+    order = get_object_or_404(orders, pk=order_pk)
     absolute_url = get_statics_absolute_url(request)
-    pdf_file, order = create_invoice_pdf(order_pk, absolute_url)
+    pdf_file, order = create_invoice_pdf(order, absolute_url)
     response = HttpResponse(pdf_file, content_type='application/pdf')
     name = "invoice-%s" % order.id
     response['Content-Disposition'] = 'filename=%s' % name

--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -24,7 +24,7 @@ from .utils import (
 from ..views import staff_member_required
 from ...core.utils import get_paginator_items
 from ...order import GroupStatus
-from ...order.models import Order, OrderLine, OrderNote
+from ...order.models import DeliveryGroup, Order, OrderLine, OrderNote
 
 
 @staff_member_required
@@ -420,8 +420,12 @@ def order_invoice(request, order_pk):
 @staff_member_required
 @permission_required('order.edit_order')
 def order_packing_slip(request, group_pk):
+    groups = DeliveryGroup.objects.prefetch_related(
+        'lines', 'order', 'order__user', 'order__shipping_address',
+        'order__billing_address')
+    group = get_object_or_404(groups, pk=group_pk)
     absolute_url = get_statics_absolute_url(request)
-    pdf_file, group = create_packing_slip_pdf(group_pk, absolute_url)
+    pdf_file, group = create_packing_slip_pdf(group, absolute_url)
     response = HttpResponse(pdf_file, content_type='application/pdf')
     name = "packing-slip-%s-%s" % (group.order.id, group.id)
     response['Content-Disposition'] = 'filename=%s' % name


### PR DESCRIPTION
This changes add ```get_object_or_404``` method in packing slips and invoice view for DeliveryGroup and Order access respectively.

Fixes #1616 