### PR TITLE
Fix editor

### DIFF
--- a/saleor/static/dashboard/js/components/editor.js
+++ b/saleor/static/dashboard/js/components/editor.js
@@ -1,6 +1,7 @@
 import MediumEditor from 'medium-editor';
 
-MediumEditor('.rich-text-editor', {
+// eslint-disable
+const editor = new MediumEditor('.rich-text-editor', {
   toolbar: {
     buttons: [
       {


### PR DESCRIPTION
Fixes following error:

```
dashboard.js:82 Uncaught TypeError: Cannot read property 'init' of undefined
    at e (dashboard.js:82)
    at Object.<anonymous> (dashboard.js:80)
    at e (vendor.js:1)
    at Object.<anonymous> (dashboard.js:69)
    at e (vendor.js:1)
    at Object.<anonymous> (dashboard.js:13)
    at e (vendor.js:1)
    at window.webpackJsonp (vendor.js:1)
    at dashboard.js:1
```