### PR TITLE
Fix missing variable in category form template

### DIFF
--- a/templates/dashboard/category/detail.html
+++ b/templates/dashboard/category/detail.html
@@ -78,7 +78,7 @@
             </span>
             <div class="row">
               {% if root.description %}
-                <div class="col s12 l8">
+                <div class="col s12">
                   <h4>
                     {% trans "Description" context "Category field" %}
                   </h4>
@@ -88,18 +88,6 @@
                 </div>
               {% endif %}
             </div>
-            {% if root.is_hidden %}
-              <div class="row">
-                <div class="col s12 l8">
-                  <h4>
-                    {% trans "Hidden" context "Category field" %}
-                  </h4>
-                  {% blocktrans trimmed context "Category detail is hidden text" %}
-                    This category is hidden on storefront
-                  {% endblocktrans %}
-                </div>
-              </div>
-            {% endif %}
           </div>
           {% if perms.product.edit_category %}
           <div class="card-action">

--- a/templates/dashboard/category/form.html
+++ b/templates/dashboard/category/form.html
@@ -94,14 +94,9 @@
               {{ form.name|materializecss }}
             </div>
             <div class="row">
-              <div class="col s12 m8">
+              <div class="col s12">
                 <div class="row">
                   {{ form.description|materializecss }}
-                </div>
-              </div>
-              <div class="col s12 m4">
-                <div class="row">
-                  {{ form.is_hidden|materializecss:"input-field s12" }}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
I want to merge this change because it fixes #1637 with missing ```is_hidden``` variable in templates.