### PR TITLE
Fix displaying order history events

### DIFF
--- a/saleor/static/dashboard/scss/components/_timeline.scss
+++ b/saleor/static/dashboard/scss/components/_timeline.scss
@@ -37,7 +37,6 @@
       }
       .content {
         margin-left: 3rem;
-        padding-left: $timeline-status-width;
         min-height: 1.5rem;
         position: relative;
         top: calc(#{$timeline-circle-radius} + #{$timeline-width} + .5px - #{$label-font-size} + .1rem);
@@ -69,7 +68,7 @@
         .content {
           position: relative;
           top: calc(#{$timeline-circle-radius} + #{$timeline-width} + .5px - #{$label-font-size} - .5rem);
-          padding-left: if($timeline-date-width > $timeline-status-width, $timeline-date-width, $timeline-status-width);
+          padding-left: $timeline-date-width;
         }
       }
     }

--- a/saleor/static/dashboard/scss/variables.scss
+++ b/saleor/static/dashboard/scss/variables.scss
@@ -51,7 +51,6 @@ $timeline-width: 3px !default;
 $timeline-circle-radius: 6px !default;
 $timeline-event-margin: 1rem !default;
 $timeline-date-width: 20rem;
-$timeline-status-width: 12rem;
 
 /*** Medium Editor ***/
 $medium-editor-bgcolor: $off-black;

--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -511,18 +511,16 @@
   </div>
   <div class="tab-content" id="order-history">
     <p class="print-show print-tabs">{% trans "History" context "Order detail tab" %}</p>
-  <div class="timeline-outer">
-    <ul class="timeline">
-      {% for event in order.history.all %}
-        <li class="event" data-date="{{ event.date }}">
-          <div class="content">
-            {{ event.comment|default:"" }}{% if event.user %} by {{ event.user }}{% endif %}
-            <div class="status">
-              {% render_status event.status event.get_status_display %}
+    <div class="timeline-outer">
+      <ul class="timeline">
+        {% for event in order.history.all %}
+          <li class="event" data-date="{{ event.date }}">
+            <div class="content">
+              {{ event.content|default:"" }}{% if event.user %} by {{ event.user }}{% endif %}
             </div>
-          </div>
-        </li>
-      {% endfor %}
-    </ul>
+          </li>
+        {% endfor %}
+      </ul>
+    </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
I want to merge this change because it fixes displaying order history events in dashboard. ```comment``` is now replaced by ```content``` keyword and we do not use ```status``` anymore.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
