### PR TITLE
Block modal submissions in demo's dashboard

### DIFF
--- a/saleor/static/dashboard/js/components/async-form.js
+++ b/saleor/static/dashboard/js/components/async-form.js
@@ -1,28 +1,8 @@
 import {initSelects} from './utils';
 
 export default $(document).on('submit', '.form-async', function (e) {
-  let that = this;
-  $.ajax({
-    url: $(that).attr('action'),
-    method: 'post',
-    data: $(that).serialize(),
-    complete: function (response) {
-      if (response.status === 400) {
-        $(that).parent().html(response.responseText);
-        initSelects();
-      } else {
-        $('.modal-close').click();
-      }
-    },
-    success: function (response) {
-      if (response.redirectUrl) {
-        window.location.href = response.redirectUrl;
-      } else {
-        location.reload();
-      }
-    }
-  });
   e.preventDefault();
+  alert("Be aware admin pirate! Dashboard runs in read only mode!");
 }).on('click', '.modal-close', function () {
   $('.modal').modal('close');
 });

--- a/saleor/static/dashboard/js/components/async-form.js
+++ b/saleor/static/dashboard/js/components/async-form.js
@@ -1,8 +1,21 @@
 import {initSelects} from './utils';
 
 export default $(document).on('submit', '.form-async', function (e) {
+  let that = this;
+  $.ajax({
+    url: $(that).attr('action'),
+    method: 'post',
+    data: $(that).serialize(),
+    success: function (data) {
+      let $message = $(data).find('div');
+      $message.find('a').remove();
+      $(that).find('.row').last().html($message);
+      $(that).find('.row').last().css('text-align', 'center');
+      $(that).find('svg').height('160px');
+      $(that).find('button').remove();
+    }
+  });
   e.preventDefault();
-  alert("Be aware admin pirate! Dashboard runs in read only mode!");
 }).on('click', '.modal-close', function () {
   $('.modal').modal('close');
 });

--- a/saleor/static/dashboard/js/components/async-form.js
+++ b/saleor/static/dashboard/js/components/async-form.js
@@ -1,17 +1,17 @@
-import {initSelects} from './utils';
-
 export default $(document).on('submit', '.form-async', function (e) {
+  const $target = $(e.currentTarget);
   $.ajax({
-    url: $(e.currentTarget).attr('action'),
+    url: $target.attr('action'),
     method: 'post',
-    data: $(e.currentTarget).serialize(),
+    data: $target.serialize(),
     success: function (data) {
       const $message = $(data).find('div');
       $message.find('a').remove();
-      $(e.currentTarget).find('.row').last().html($message);
-      $(e.currentTarget).find('.row').last().css('text-align', 'center');
-      $(e.currentTarget).find('svg').height('160px');
-      $(e.currentTarget).find('button').remove();
+      const $lastRow = $target.find('.row').last();
+      $lastRow.html($message);
+      $lastRow.css('text-align', 'center');
+      $lastRow.find('svg').height('160px');
+      $target.find('button').remove();
     }
   });
   e.preventDefault();

--- a/saleor/static/dashboard/js/components/async-form.js
+++ b/saleor/static/dashboard/js/components/async-form.js
@@ -1,18 +1,17 @@
 import {initSelects} from './utils';
 
 export default $(document).on('submit', '.form-async', function (e) {
-  let that = this;
   $.ajax({
-    url: $(that).attr('action'),
+    url: $(e.currentTarget).attr('action'),
     method: 'post',
-    data: $(that).serialize(),
+    data: $(e.currentTarget).serialize(),
     success: function (data) {
-      let $message = $(data).find('div');
+      const $message = $(data).find('div');
       $message.find('a').remove();
-      $(that).find('.row').last().html($message);
-      $(that).find('.row').last().css('text-align', 'center');
-      $(that).find('svg').height('160px');
-      $(that).find('button').remove();
+      $(e.currentTarget).find('.row').last().html($message);
+      $(e.currentTarget).find('.row').last().css('text-align', 'center');
+      $(e.currentTarget).find('svg').height('160px');
+      $(e.currentTarget).find('button').remove();
     }
   });
   e.preventDefault();


### PR DESCRIPTION
This PR replaces JS handling submissions in dashboard's modals with one that extracts message and svg image from blocked request's page and replaces modal's content with it:

<img width="694" alt="zrzut ekranu 2018-01-24 o 14 59 49" src="https://user-images.githubusercontent.com/750553/35337561-d7f13a32-011b-11e8-9731-5dbf7bdba389.png">

This fixes the edge case that dashboard's modals fall into, where our demo WSGI middleware intercepts the form's submission and replies with status 200, fooling our JS into thinking that form submitted successfully and reloading page, leaving user confused why nothing changed.