### PR TITLE
Fix order details fails for not logged in user and order open

### DIFF
--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -33,7 +33,8 @@ def details(request, token):
     notes = order.notes.filter(is_public=True)
     ctx = {'order': order, 'groups': groups, 'notes': notes}
     if order.status == OrderStatus.OPEN:
-        note = OrderNote(order=order, user=request.user)
+        user = request.user if request.user.is_authenticated else None
+        note = OrderNote(order=order, user=user)
         note_form = OrderNoteForm(request.POST or None, instance=note)
         ctx.update({'note_form': note_form})
         if request.method == 'POST':


### PR DESCRIPTION
I want to merge this change because...

Fixes an issue where when the user is not logged in and the order is still open and so an exception is raised due to trying to add an OrderNote related to an anonymous user. Sets user to None if the request.user is an anonymous user.

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ x] Privileged views and APIs are guarded by proper permission checks.
1. [ x] All visible strings are translated with proper context.
1. [ x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ x] Database queries are optimized and the number of queries is constant.
1. [ x] The changes are tested.
1. [ x] The code is documented (docstrings, project documentation).
1. [ x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x ] JavaScript code quality checks pass: `eslint`.
