### PR TITLE
Fix to make signal on payment change actually be registered

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -22,6 +22,7 @@ from ..core.utils import build_absolute_uri
 from ..discount.models import Voucher
 from ..product.models import Product
 from ..userprofile.models import Address
+from .signals import order_status_change
 
 
 class OrderQuerySet(models.QuerySet):

--- a/saleor/order/signals.py
+++ b/saleor/order/signals.py
@@ -1,11 +1,11 @@
 import logging
 from django.dispatch import receiver
 from payments.signals import status_changed
+from django.utils.translation import pgettext_lazy
 
 from ..core import analytics
 
 logger = logging.getLogger(__name__)
-
 
 @receiver(status_changed)
 def order_status_change(sender, instance, **kwargs):


### PR DESCRIPTION

I think that https://github.com/mirumee/saleor/commit/413ec31a1280b677da37a5ae8d6cb1080ffe302e has introduced a problem in which the status_changed signal is not processed, because order_status_change() is not registered as a received, because the code in signals.py is not loaded / referenced.

I've added an import of order_status_change() to the models.py file; I'm not sure is the best way to achieve the need, but it does cause the signal receiver registration to occur.
