### PR TITLE
Drop meaningless __str__ methods

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -350,11 +350,6 @@ class OrderHistoryEntry(models.Model):
     class Meta:
         ordering = ('date', )
 
-    def __str__(self):
-        return pgettext_lazy(
-            'Order history entry str',
-            'OrderHistoryEntry for Order #%d') % self.order.pk
-
 
 class OrderNote(models.Model):
     user = models.ForeignKey(
@@ -368,8 +363,3 @@ class OrderNote(models.Model):
 
     class Meta:
         ordering = ('date', )
-
-    def __str__(self):
-        return pgettext_lazy(
-            'Order note str',
-            'OrderNote for Order #%d' % self.order.pk)


### PR DESCRIPTION
There's no point in having `__str__` methods that are purely for debug. There's also no point in translating meaningless strings. Let's drop those.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
