### PR TITLE
Force to install elastic 5.4 on heroku

### DIFF
--- a/docs/deploy.rst
+++ b/docs/deploy.rst
@@ -35,7 +35,7 @@ First steps
  $ heroku addons:create heroku-postgresql:hobby-dev
  $ heroku addons:create heroku-redis:hobby-dev
  $ heroku addons:create sendgrid:starter
- $ heroku addons:create bonsai:sandbox-6 
+ $ heroku addons:create bonsai:sandbox-6 --version=5.4
  $ heroku config:set ALLOWED_HOSTS='<your hosts here>'
  $ heroku config:set NODE_MODULES_CACHE=false
  $ heroku config:set NPM_CONFIG_PRODUCTION=false


### PR DESCRIPTION
By default elastic 6 will be install and this is not
supported by django-elasticsearch-dsl

I want to merge this change because it fixes #1691

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [X] Privileged views and APIs are guarded by proper permission checks.
1. [X] All visible strings are translated with proper context.
1. [X] All data-formatting is locale-aware (dates, numbers, and so on).
1. [X] Database queries are optimized and the number of queries is constant.
1. [X] The changes are tested.
1. [X] The code is documented (docstrings, project documentation).
1. [X] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [X] JavaScript code quality checks pass: `eslint`.
