### PR TITLE
Pass variant.attributes only available in product_type.variant_attributes

### DIFF
--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -155,7 +155,7 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
     variants = product.variants.all()
     data = {'variantAttributes': [], 'variants': []}
 
-    product_class_variant_attributes = product.product_type.variant_attributes.all()
+    product_type_variant_attributes = product.product_type.variant_attributes.all()
 
     # Collect only available variants
     filter_available_variants = defaultdict(list)
@@ -197,7 +197,7 @@ def get_variant_picker_data(product, discounts=None, local_currency=None):
             'schemaData': schema_data}
         data['variants'].append(variant_data)
 
-    for attribute in product_class_variant_attributes:
+    for attribute in product_type_variant_attributes:
         available_variants = filter_available_variants.get(attribute.pk, None)
 
         if available_variants:


### PR DESCRIPTION
In some cases product variant has more attributes then product type. It affects interface - variant picker can't find and select variant because filter contain less attributes then any product variant (js error on product page). This fix filter unavailable attributes.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
