### PR TITLE
Improve generating prices in the populatedb script

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -77,7 +77,6 @@ DEFAULT_SCHEMA = {
             'Candy Box Size': ['100g', '250g', '500g']
         },
         'images_dir': 'candy/',
-        'different_variant_prices': True,
         'is_shipping_required': True
     },
     'E-books': {
@@ -102,7 +101,6 @@ DEFAULT_SCHEMA = {
             'Cover': ['Soft', 'Hard']
         },
         'images_dir': 'books/',
-        'different_variant_prices': True,
         'is_shipping_required': True
     }
 }


### PR DESCRIPTION
I want to merge this change because it improves generating prices in the populatedb script by keeping different variant prices only for coffee. Variants for other products do not override price.

Closes #1659 