### PR TITLE
Display product price in storefront always if available

### DIFF
--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -28,6 +28,7 @@ def get_ancestors_from_cache(category, context):
 
 class ProductAvailabilityType(graphene.ObjectType):
     available = graphene.Boolean()
+    on_sale = graphene.Boolean()
     discount = graphene.Field(lambda: PriceType)
     discount_local_currency = graphene.Field(lambda: PriceType)
     price_range = graphene.Field(lambda: PriceRangeType)

--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -83,8 +83,8 @@ def get_availability(product, discounts=None, local_currency=None):
 
     is_available = product.is_in_stock() and product.is_available()
     is_on_sale = (
-        product.is_available() and discount is not None
-        and undiscounted.min_price != price_range.min_price)
+        product.is_available() and discount is not None and
+        undiscounted.min_price != price_range.min_price)
 
     return ProductAvailability(
         available=is_available,

--- a/saleor/product/utils.py
+++ b/saleor/product/utils.py
@@ -52,8 +52,8 @@ def products_with_availability(products, discounts, local_currency):
 
 ProductAvailability = namedtuple(
     'ProductAvailability', (
-        'available', 'price_range', 'price_range_undiscounted', 'discount',
-        'price_range_local_currency', 'discount_local_currency'))
+        'available', 'on_sale', 'price_range', 'price_range_undiscounted',
+        'discount', 'price_range_local_currency', 'discount_local_currency'))
 
 
 def get_availability(product, discounts=None, local_currency=None):
@@ -82,9 +82,13 @@ def get_availability(product, discounts=None, local_currency=None):
         discount_local_currency = None
 
     is_available = product.is_in_stock() and product.is_available()
+    is_on_sale = (
+        product.is_available() and discount is not None
+        and undiscounted.min_price != price_range.min_price)
 
     return ProductAvailability(
         available=is_available,
+        on_sale=is_on_sale,
         price_range=price_range,
         price_range_undiscounted=undiscounted,
         discount=discount,

--- a/templates/_items.html
+++ b/templates/_items.html
@@ -22,16 +22,14 @@
         {% else %}
           &nbsp;
         {% endif %}
-        {% if availability.available and availability.discount %}
-          {% if availability.price_range_undiscounted.min_price != availability.price_range.min_price %}
-            <div class="product-list__sale">
-              <svg data-src="{% static "images/sale-bg.svg" %}" />
-              <span class="product-list__sale__text">
-                {% comment %}Translators: Layout may break if character length is different than four.{% endcomment %}
-                {% trans "Sale" context "Sale (discount) label for item in product list" %}
-              </span>
-            </div>
-          {% endif %}
+        {% if availability.on_sale %}
+          <div class="product-list__sale">
+            <svg data-src="{% static "images/sale-bg.svg" %}" />
+            <span class="product-list__sale__text">
+              {% comment %}Translators: Layout may break if character length is different than four.{% endcomment %}
+              {% trans "Sale" context "Sale (discount) label for item in product list" %}
+            </span>
+          </div>
         {% endif %}
       </div>
     </div>

--- a/templates/_items.html
+++ b/templates/_items.html
@@ -17,11 +17,8 @@
       </div>
 
       <div class="panel-footer">
-        {% if product.is_available %}
-          {% price_range availability.price_range %}
-        {% else %}
-          &nbsp;
-        {% endif %}
+        {% price_range availability.price_range %}
+
         {% if availability.on_sale %}
           <div class="product-list__sale">
             <svg data-src="{% static "images/sale-bg.svg" %}" />

--- a/templates/_items.html
+++ b/templates/_items.html
@@ -17,21 +17,21 @@
       </div>
 
       <div class="panel-footer">
-        {% if availability.available %}
+        {% if product.is_available %}
           {% price_range availability.price_range %}
-          {% if availability.discount %}
-            {% if availability.price_range_undiscounted.min_price != availability.price_range.min_price %}
-              <div class="product-list__sale">
-                <svg data-src="{% static "images/sale-bg.svg" %}" />
-                <span class="product-list__sale__text">
-                  {% comment %}Translators: Layout may break if character length is different than four.{% endcomment %}
-                  {% trans "Sale" context "Sale (discount) label for item in product list" %}
-                </span>
-              </div>
-            {% endif %}
-          {% endif %}
         {% else %}
           &nbsp;
+        {% endif %}
+        {% if availability.available and availability.discount %}
+          {% if availability.price_range_undiscounted.min_price != availability.price_range.min_price %}
+            <div class="product-list__sale">
+              <svg data-src="{% static "images/sale-bg.svg" %}" />
+              <span class="product-list__sale__text">
+                {% comment %}Translators: Layout may break if character length is different than four.{% endcomment %}
+                {% trans "Sale" context "Sale (discount) label for item in product list" %}
+              </span>
+            </div>
+          {% endif %}
         {% endif %}
       </div>
     </div>


### PR DESCRIPTION
I want to merge this change because it displays product's price in storefront even if all stocks are removed. Price is hidden only if ```available_on``` is a future date.

Closes #1661 

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
