### PR TITLE
Make GraphQL connections countable

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -5,7 +5,8 @@ from graphene_django.filter import DjangoFilterConnectionField
 from .product.types import (
     Category, ProductAttribute, Product, resolve_attributes, resolve_category,
     resolve_product, resolve_products)
-from .product.filters import DistinctFilterSet, ProductFilterSet
+from .core.filters import DistinctFilterSet
+from .product.filters import ProductFilterSet
 
 
 class Query(graphene.ObjectType):

--- a/saleor/graphql/core/filters.py
+++ b/saleor/graphql/core/filters.py
@@ -1,0 +1,33 @@
+from django import forms
+from django_filters.constants import STRICTNESS
+from graphene_django.filter.filterset import FilterSet
+
+
+class DistinctFilterSet(FilterSet):
+    # workaround for https://github.com/graphql-python/graphene-django/pull/290
+    @property
+    def qs(self):
+        if not hasattr(self, '_qs'):
+            if not self.is_bound:
+                self._qs = self.queryset.all().distinct()
+                return self._qs
+
+            if not self.form.is_valid():
+                if self.strict == STRICTNESS.RAISE_VALIDATION_ERROR:
+                    raise forms.ValidationError(self.form.errors)
+                elif self.strict == STRICTNESS.RETURN_NO_RESULTS:
+                    self._qs = self.queryset.none()
+                    return self._qs
+                # else STRICTNESS.IGNORE...  ignoring
+
+            # start with all the results and filter from there
+            qs = self.queryset.all().distinct()
+            for name, filter_ in self.filters.items():
+                value = self.form.cleaned_data.get(name)
+
+                if value is not None:  # valid & clean data
+                    qs = filter_.filter(qs, value).distinct()
+
+            self._qs = qs
+
+        return self._qs

--- a/saleor/graphql/core/types.py
+++ b/saleor/graphql/core/types.py
@@ -1,5 +1,31 @@
 import graphene
 from django_prices.templatetags import prices_i18n
+from graphene_django import DjangoObjectType
+
+
+class CountableConnection(graphene.relay.Connection):
+    class Meta:
+        abstract = True
+
+    total_count = graphene.Int()
+
+    @staticmethod
+    def resolve_total_count(root, info, *args, **kwargs):
+        return root.length
+
+
+class CountableDjangoObjectType(DjangoObjectType):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def __init_subclass_with_meta__(cls, *args, **kwargs):
+        # Force it to use the countable connection
+        countable_conn = CountableConnection.create_type(
+            "{}CountableConnection".format(cls.__name__),
+            node=cls)
+        super().__init_subclass_with_meta__(
+            *args, connection=countable_conn, **kwargs)
 
 
 class Price(graphene.ObjectType):

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -2,44 +2,13 @@ import functools
 import operator
 from collections import defaultdict
 
-from django import forms
 from django.db.models import Q
-from django_filters.constants import STRICTNESS
 from django_filters.fields import Lookup
-from graphene_django.filter.filterset import Filter, FilterSet
+from graphene_django.filter.filterset import Filter
 
+from ..core.filters import DistinctFilterSet
 from ..fields import AttributeField
 from ...product.models import Product, ProductAttribute
-
-
-class DistinctFilterSet(FilterSet):
-    # workaround for https://github.com/graphql-python/graphene-django/pull/290
-    @property
-    def qs(self):
-        if not hasattr(self, '_qs'):
-            if not self.is_bound:
-                self._qs = self.queryset.all().distinct()
-                return self._qs
-
-            if not self.form.is_valid():
-                if self.strict == STRICTNESS.RAISE_VALIDATION_ERROR:
-                    raise forms.ValidationError(self.form.errors)
-                elif self.strict == STRICTNESS.RETURN_NO_RESULTS:
-                    self._qs = self.queryset.none()
-                    return self._qs
-                # else STRICTNESS.IGNORE...  ignoring
-
-            # start with all the results and filter from there
-            qs = self.queryset.all().distinct()
-            for name, filter_ in self.filters.items():
-                value = self.form.cleaned_data.get(name)
-
-                if value is not None:  # valid & clean data
-                    qs = filter_.filter(qs, value).distinct()
-
-            self._qs = qs
-
-        return self._qs
 
 
 class ProduductAttributeFilter(Filter):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -7,9 +7,10 @@ from graphene_django.filter import DjangoFilterConnectionField
 from ...product import models
 from ...product.templatetags.product_images import product_first_image
 from ...product.utils import get_availability
-from ..core.types import Price, PriceRange
+from ..core.filters import DistinctFilterSet
+from ..core.types import CountableDjangoObjectType, Price, PriceRange
 from ..utils import CategoryAncestorsCache
-from .filters import DistinctFilterSet, ProductFilterSet
+from .filters import ProductFilterSet
 
 CONTEXT_CACHE_NAME = '__cache__'
 CACHE_ANCESTORS = 'ancestors'
@@ -32,7 +33,7 @@ class ProductAvailability(graphene.ObjectType):
     price_range_local_currency = graphene.Field(PriceRange)
 
 
-class Product(DjangoObjectType):
+class Product(CountableDjangoObjectType):
     url = graphene.String()
     thumbnail_url = graphene.String(
         size=graphene.Argument(
@@ -68,7 +69,7 @@ class Product(DjangoObjectType):
         return ProductAvailability(**availability._asdict())
 
 
-class Category(DjangoObjectType):
+class Category(CountableDjangoObjectType):
     products = DjangoFilterConnectionField(
         Product, filterset_class=ProductFilterSet)
     products_count = graphene.Int()
@@ -107,7 +108,7 @@ class Category(DjangoObjectType):
         return qs.distinct()
 
 
-class ProductVariant(DjangoObjectType):
+class ProductVariant(CountableDjangoObjectType):
     stock_quantity = graphene.Int()
     price_override = graphene.Field(Price)
 
@@ -119,7 +120,7 @@ class ProductVariant(DjangoObjectType):
         return self.get_stock_quantity()
 
 
-class ProductImage(DjangoObjectType):
+class ProductImage(CountableDjangoObjectType):
     url = graphene.String(size=graphene.String())
 
     class Meta:
@@ -132,13 +133,13 @@ class ProductImage(DjangoObjectType):
         return self.image.url
 
 
-class ProductAttributeValue(DjangoObjectType):
+class ProductAttributeValue(CountableDjangoObjectType):
     class Meta:
         model = models.AttributeChoiceValue
         interfaces = [relay.Node]
 
 
-class ProductAttribute(DjangoObjectType):
+class ProductAttribute(CountableDjangoObjectType):
     values = graphene.List(ProductAttributeValue)
 
     class Meta:

--- a/tests/test_graphql.py
+++ b/tests/test_graphql.py
@@ -64,6 +64,7 @@ def test_fetch_all_products(client, product_in_stock):
     query = '''
     query {
         products {
+            totalCount
             edges {
                 node {
                     id
@@ -75,8 +76,9 @@ def test_fetch_all_products(client, product_in_stock):
     response = client.post('/graphql/', {'query': query})
     content = get_content(response)
     assert 'errors' not in content
-    assert (
-        len(content['data']['products']['edges']) == Product.objects.count())
+    num_products = Product.objects.count()
+    assert content['data']['products']['totalCount'] == num_products
+    assert len(content['data']['products']['edges']) == num_products
 
 
 @pytest.mark.djangodb
@@ -85,6 +87,7 @@ def test_fetch_unavailable_products(client, product_in_stock):
     query = '''
     query {
         products {
+            totalCount
             edges {
                 node {
                     id
@@ -96,6 +99,7 @@ def test_fetch_unavailable_products(client, product_in_stock):
     response = client.post('/graphql/', {'query': query})
     content = get_content(response)
     assert 'errors' not in content
+    assert content['data']['products']['totalCount'] == 0
     assert not content['data']['products']['edges']
 
 


### PR DESCRIPTION
Have all ORM-backed connection fields support `totalCount`.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
