### PR TITLE
Add Transifex commands to customization docs

### DIFF
--- a/docs/customization.rst
+++ b/docs/customization.rst
@@ -9,6 +9,7 @@ Customizing Saleor
    customization/emails
    customization/frontend
    customization/backend
+   customization/i18n
    customization/tests
    customization/ci
    customization/pypy

--- a/docs/customization/i18n.rst
+++ b/docs/customization/i18n.rst
@@ -1,0 +1,49 @@
+Internationalization
+====================
+
+Pulling Translations From Transifex
+-----------------------------------
+
+First make sure you have the Transifex command-line client installed:
+
+.. code-block:: console
+
+ $ pip install transifex-client
+
+Then use the ``pull`` command to pull translations:
+
+.. code-block:: console
+
+ $ tx pull
+
+.. note::
+
+    To create locale directories for newly created translations you will need to call ``tx pull`` with the ``--all`` flag.
+
+
+Compiling Message Catalogs
+--------------------------
+
+This is required for Django to see the translations.
+
+.. code-block:: console
+
+ $ python manage.py compilemessages
+
+
+Extracting Messages to Translate
+--------------------------------
+
+This will update the English language files with messages that appear in your code.
+
+For the backend code and templates:
+
+.. code-block:: console
+
+ $ python manage.py makemessages -l en --extension=email,html,py,txt --ignore="templates/templated_email/compiled/*"
+
+For JavaScript code:
+
+.. code-block:: console
+
+ $ python manage.py makemessages -l en -d djangojs --ignore="_build/*" --ignore="node_modules/*" --ignore="saleor/static/assets/*"


### PR DESCRIPTION
This should allow anyone to do the Transifex sync in the unlikely case that I get hit by a bus.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
