### PR TITLE
Remove unused cart status

### DIFF
--- a/saleor/cart/__init__.py
+++ b/saleor/cart/__init__.py
@@ -9,22 +9,10 @@ class CartStatus:
     """Enum of possible cart statuses."""
 
     OPEN = 'open'
-    SAVED = 'saved'
-    WAITING_FOR_PAYMENT = 'payment'
-    ORDERED = 'ordered'
-    CHECKOUT = 'checkout'
     CANCELED = 'canceled'
 
     CHOICES = [
         (OPEN, pgettext_lazy(
             'cart status', 'Open - currently active')),
-        (WAITING_FOR_PAYMENT, pgettext_lazy(
-            'cart status', 'Waiting for payment')),
-        (SAVED, pgettext_lazy(
-            'cart status', 'Saved - for items to be purchased later')),
-        (ORDERED, pgettext_lazy(
-            'cart status', 'Submitted - an order was placed')),
-        (CHECKOUT, pgettext_lazy(
-            'cart status', 'Checkout - processed in checkout')),
         (CANCELED, pgettext_lazy(
             'cart status', 'Canceled - canceled by user'))]

--- a/saleor/cart/models.py
+++ b/saleor/cart/models.py
@@ -55,18 +55,6 @@ class CartQueryset(models.QuerySet):
         """Return `OPEN` carts."""
         return self.filter(status=CartStatus.OPEN)
 
-    def saved(self):
-        """Return `SAVED` carts."""
-        return self.filter(status=CartStatus.SAVED)
-
-    def waiting_for_payment(self):
-        """Return `SAVED_FOR_PAYMENT` carts."""
-        return self.filter(status=CartStatus.WAITING_FOR_PAYMENT)
-
-    def checkout(self):
-        """Return carts in `CHECKOUT` state."""
-        return self.filter(status=CartStatus.CHECKOUT)
-
     def canceled(self):
         """Return `CANCELED` carts."""
         return self.filter(status=CartStatus.CANCELED)

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -614,23 +614,7 @@ def test_product_group():
 
 
 def test_cart_queryset(customer_user):
-    saved_cart = Cart.objects.create(status=CartStatus.SAVED)
-    waiting_cart = Cart.objects.create(status=CartStatus.WAITING_FOR_PAYMENT)
-    checkout_cart = Cart.objects.create(status=CartStatus.CHECKOUT)
     canceled_cart = Cart.objects.create(status=CartStatus.CANCELED)
-
-    anonymous_carts = Cart.objects.anonymous()
-    assert anonymous_carts.filter(pk=saved_cart.pk).exists()
-
-    saved = Cart.objects.saved()
-    assert saved.filter(pk=saved_cart.pk).exists()
-
-    waiting_for_payment = Cart.objects.waiting_for_payment()
-    assert waiting_for_payment.filter(pk=waiting_cart.pk).exists()
-
-    checkout = Cart.objects.checkout()
-    assert checkout.filter(pk=checkout_cart.pk).exists()
-
     canceled = Cart.objects.canceled()
     assert canceled.filter(pk=canceled_cart.pk).exists()
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -288,7 +288,6 @@ def test_adding_to_cart_with_closed_cart_token(
     cart = Cart.objects.create(user=admin_user)
     variant = product_in_stock.variants.first()
     cart.add(variant, 1)
-    cart.change_status(CartStatus.ORDERED)
 
     response = client.get('/cart/')
     utils.set_cart_cookie(cart, response)
@@ -302,8 +301,6 @@ def test_adding_to_cart_with_closed_cart_token(
 
     assert Cart.objects.filter(
         user=admin_user, status=CartStatus.OPEN).count() == 1
-    assert Cart.objects.filter(
-        user=admin_user, status=CartStatus.ORDERED).count() == 1
 
 
 def test_get_attributes_display_map(product_in_stock):
@@ -514,7 +511,7 @@ def test_render_product_page_with_no_variant(
     status = get_product_availability_status(product)
     assert status == ProductAvailabilityStatus.VARIANTS_MISSSING
     url = reverse(
-            'product:details',
-            kwargs={'product_id': product.pk, 'slug': product.get_slug()})
+        'product:details',
+        kwargs={'product_id': product.pk, 'slug': product.get_slug()})
     response = admin_client.get(url)
     assert response.status_code == 200


### PR DESCRIPTION
It is a part of #1764. It seems that we do not use cart status other than `OPEN` or `CANCEL` in the flow.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
