### PR TITLE
Improve tooling config, add automated isort check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,6 +1,9 @@
 engines:
   eslint:
     enabled: true
+  isort:
+    enabled: true
+    channel: beta
   pep8:
     enabled: true
   pylint:
@@ -10,10 +13,13 @@ engines:
     config:
       languages:
         python:
-          mass_threshold: 100 
+          mass_threshold: 100
           python_version: 3
 exclude_patterns:
+- ".*"
+- "**/__pycache__/"
 - "**/migrations/"
+- "node_modules/"
 - "tests/"
 - "**/test_*"
 ratings:

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,8 +1,11 @@
 [MASTER]
-load-plugins=pylint_django
+load-plugins=pylint.extensions.bad_builtin, pylint.extensions.mccabe, pylint_celery, pylint_django
 
 [MESSAGES CONTROL]
-disable=C0103, C0111, I0011, W0621
+disable=C0103, C0111, C0412, I0011, R0903, W0621
+
+[DESIGN]
+max-complexity=5
 
 [SIMILARITIES]
 ignore-imports=yes

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ exclude =
     docs/,
     node_modules/,
     */migrations/
-ignore = H101,H238,H301,H306
+ignore = H101,H238,H301,H306,W503
 
 [pep8]
 exclude =
@@ -33,10 +33,10 @@ exclude =
     docs/,
     node_modules/,
     */migrations/
-ignore = H101,H238,H301,H306
+ignore = H101,H238,H301,H306,W503
 
 [pydocstyle]
-ignore = D100, D104, D105, D106, D107, D203, D213
+ignore = D100, D101, D102, D103, D104, D105, D106, D107, D203, D213
 inherit = false
 match-dir = (?!migrations)[^\.].*
 
@@ -48,3 +48,10 @@ skip =
     docs
     migrations
     node_modules
+
+[yapf]
+based_on_style = pep8
+align_closing_bracket_with_visual_indent = false
+coalesce_brackets = true
+split_before_closing_bracket = false
+split_before_first_argument = true


### PR DESCRIPTION
Our `isort` plugin for Code Climate is now in beta, let's eat our own dog food.

Ignoring W503 makes `pycodestyle` allow splitting both before and after a binary operator (the PEP8 recommendation is now the opposite).

Ingored `pycdestyle` codes make it no longer complain about missing docstrings as at this point in the project it adds lots of noise. We should cosider re-enabling D101-D103 once our docstring coverage is better.

The `yapf` config is not usable yet as it depends on my pull request:
https://github.com/google/yapf/pull/525

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
