### PR TITLE
Fix send password reset mail with celery

### DIFF
--- a/saleor/account/forms.py
+++ b/saleor/account/forms.py
@@ -108,4 +108,5 @@ class PasswordResetForm(django_forms.PasswordResetForm):
     def send_mail(
             self, subject_template_name, email_template_name, context,
             from_email, to_email, html_email_template_name=None):
+        del context['user']
         emails.send_password_reset_email.delay(context, to_email)


### PR DESCRIPTION
I want to merge this change because...

Sending the password reset mail asyncronously with celery fails, due to "User object not JSON serializable" error. This pull request removes the user object from context before providing it to the delay method, as the user is not needed. This allows the arguments to be serialized to JSON.

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ x] Privileged views and APIs are guarded by proper permission checks.
1. [ x] All visible strings are translated with proper context.
1. [ x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ x] Database queries are optimized and the number of queries is constant.
1. [x ] The changes are tested.
1. [ x] The code is documented (docstrings, project documentation).
1. [x ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ x] JavaScript code quality checks pass: `eslint`.
