### PR TITLE
Show customer email in the order details dashboard

### DIFF
--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -119,6 +119,8 @@
               <p>
                 {% if order.user %}
                   <a href="{% url "dashboard:customer-details" pk=order.user.pk %}">{{ order.user }}</a>
+                {% elif order.user_email %}
+                  {{ order.user_email }}
                 {% else %}
                   {% trans "Guest" context "Anonymous user account value" %}
                 {% endif %}


### PR DESCRIPTION
Currently, when a user associated with an order is deleted, order details page shows "Customer: guest". This PR adds small improvement by trying to render the customer's email which is stored in a separate field.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
