### PR TITLE
Replaced `float: right` on category filter labels by a flexbox

### DIFF
--- a/saleor/static/scss/components/_filters.scss
+++ b/saleor/static/scss/components/_filters.scss
@@ -10,6 +10,11 @@
     cursor: pointer;
     display: flex;
     align-items: center;
+    flex-wrap: wrap;
+    span {
+      max-width: calc(100% - 30px);
+      word-wrap: break-word;
+    }
     .collapse-filters-icon {
       margin: 0 0 0 auto;
       img {
@@ -43,22 +48,24 @@
     }
   }
   &__price-range {
-    h3 {
-      margin-bottom: $global-margin;
-      span {
-        width: 100%;
-        margin: 0;
-        display: inline;
+    div:first-child {
+      h3 {
+        margin-bottom: $global-margin;
+        span {
+          width: 100%;
+          margin: 0;
+          display: inline;
+        }
       }
-    }
-    input {
-      width: 40%;
-      display: inline-block;
-    }
-    span {
-      width: 20%;
-      text-align: center;
-      display: inline-block;
+      input {
+        width: 40%;
+        display: inline-block;
+      }
+      span {
+        width: 20%;
+        text-align: center;
+        display: inline-block;
+      }
     }
   }
   &__title {

--- a/saleor/static/scss/components/_filters.scss
+++ b/saleor/static/scss/components/_filters.scss
@@ -8,10 +8,13 @@
     padding: $global-padding;
     font-weight: bold;
     cursor: pointer;
+    display: flex;
+    align-items: center;
     .collapse-filters-icon {
-      float: right !important;
-      width: 20px;
-      height: 20px;
+      margin: 0 0 0 auto;
+      img {
+        width: 20px;
+      }
     }
   }
   ul {

--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -31,7 +31,7 @@
           {% elif field.name == 'price' %}
             <div class="toggle-filter product-filters__price-range">
               <h3 class="filter-label">
-                {{ field.label }}
+                <span>{{ field.label }}</span>
                 <div class="collapse-filters-icon">
                   <img class="lazyload lazypreload" data-src="{% static "images/chevron-up.svg" %}">
                 </div>
@@ -50,7 +50,7 @@
           {% else %}
             <div class="toggle-filter">
               <h3 class="filter-label">
-                {{ field.label }}
+                <span>{{ field.label }}</span>
                 <div class="collapse-filters-icon">
                   <img class="lazyload lazypreload" data-src="{% static "images/chevron-up.svg" %}">
                 </div>


### PR DESCRIPTION
After a lot of "fun" recovering those changes from the hypervisor that had a critical failure... I want to merge this change because... It improves the visual rendering of the frontstore. :smile: 

When the filter name is too long, it makes the filter label's arrow ugly on the frontstore.

To explain the changes, here is two screenshots.

#### Before
![](https://i.imgur.com/OvBlh25.png)

#### After
![](https://i.imgur.com/tcbBkrl.png)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
