### PR TITLE
Drop mobx decorators

### DIFF
--- a/saleor/static/js/components/variantPicker/VariantPicker.js
+++ b/saleor/static/js/components/variantPicker/VariantPicker.js
@@ -8,9 +8,7 @@ import AttributeSelectionWidget from './AttributeSelectionWidget';
 import QuantityInput from './QuantityInput';
 import * as queryString from 'query-string';
 
-@observer
-export default class VariantPicker extends Component {
-
+export default observer(class VariantPicker extends Component {
   static propTypes = {
     onAddToCartError: PropTypes.func.isRequired,
     onAddToCartSuccess: PropTypes.func.isRequired,
@@ -172,4 +170,4 @@ export default class VariantPicker extends Component {
       </div>
     );
   }
-}
+});

--- a/saleor/static/js/components/variantPicker/VariantPrice.js
+++ b/saleor/static/js/components/variantPicker/VariantPrice.js
@@ -1,9 +1,7 @@
 import { observer } from 'mobx-react';
 import React, { Component, PropTypes } from 'react';
 
-@observer
-export default class VariantPrice extends Component {
-
+export default observer(class VariantPrice extends Component {
   static propTypes = {
     availability: PropTypes.object.isRequired,
     store: PropTypes.object
@@ -33,14 +31,14 @@ export default class VariantPrice extends Component {
     }
     return (
       <h2 className="product__info__price">
-          <span>{priceText}&nbsp;</span>
-          {isDiscount && (
-            <small className="product__info__price__undiscounted">{priceUndiscountedText}</small>
-          )}
-          {priceLocalCurrency && (
-            <p><small className="text-info">&asymp; {priceLocalCurrency}</small></p>
-          )}
+        <span>{priceText}&nbsp;</span>
+        {isDiscount && (
+          <small className="product__info__price__undiscounted">{priceUndiscountedText}</small>
+        )}
+        {priceLocalCurrency && (
+          <p><small className="text-info">&asymp; {priceLocalCurrency}</small></p>
+        )}
       </h2>
     );
   }
-}
+});

--- a/saleor/static/js/stores/variantPicker.js
+++ b/saleor/static/js/stores/variantPicker.js
@@ -1,14 +1,17 @@
-import { computed, observable } from 'mobx';
+import { extendObservable } from 'mobx';
 
 class VariantPickerStore {
-  @observable variant = {};
+  constructor() {
+    extendObservable(this, {
+      variant: {},
+      get isEmpty() {
+        return !this.variant.id;
+      }
+    });
+  }
 
   setVariant(variant) {
     this.variant = variant || {};
-  }
-
-  @computed get isEmpty() {
-    return !this.variant.id;
   }
 }
 


### PR DESCRIPTION
Switching to Babel 7 broke our MobX state management in the variant picker ([issue in MobX](https://github.com/mobxjs/mobx/issues/1352)). This PR replaces decorators with regular functions which fixes the issue.

Fixes #1849 

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
