### PR TITLE
Use Python 3.6 on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@ machine:
   node:
     version: "8.7.0"
   python:
-    version: "3.5.1"
+    version: "3.6.2"
   environment:
     DATABASE_URL: postgres://ubuntu:@127.0.0.1:5432/circle_test
     DJANGO_SETTINGS_MODULE: saleor.settings


### PR DESCRIPTION
Currently CircleCI is still using 3.5 which among other things includes an old version of the `typing` library.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
