### PR TITLE
Disable automatic chunk splitting

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -21,8 +21,6 @@
   {% endblock meta %}
 
   {% include 'favicon.html' %}
-  {% render_bundle 'vendors~dashboard~storefront' 'css' attrs='async' %}
-  {% render_bundle 'vendors~storefront' 'css' attrs='async' %}
   {% render_bundle 'storefront' 'css' attrs='async' %}
 
   {% block stylesheet %}{% endblock stylesheet %}
@@ -281,8 +279,6 @@
 {% endblock %}
 {% block footer_scripts %}
   <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
-  {% render_bundle 'vendors~dashboard~storefront' 'js' %}
-  {% render_bundle 'vendors~storefront' 'js' %}
   {% render_bundle 'storefront' 'js' %}
 {% endblock footer_scripts %}
 </body>

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -19,8 +19,6 @@
     {% endblock meta %}
 
     {% include 'favicon.html' %}
-    {% render_bundle 'vendors~dashboard~storefront' 'css' %}
-    {% render_bundle 'vendors~dashboard' 'css' %}
     {% render_bundle 'dashboard' 'css' %}
     <link rel="stylesheet" type="text/css" href="{% static "versatileimagefield/css/versatileimagefield.css" %}">
 
@@ -273,8 +271,6 @@
 
     <!-- Core Scripts - Include with every page -->
     <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
-    {% render_bundle 'vendors~dashboard~storefront' 'js' %}
-    {% render_bundle 'vendors~dashboard' 'js' %}
     {% render_bundle 'dashboard' 'js' %}
     <script src="{% static "versatileimagefield/js/versatileimagefield.js" %}"></script>
 

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -15,8 +15,6 @@
     {% endblock meta %}
 
     {% include 'favicon.html' %}
-    {% render_bundle 'vendors~dashboard~storefront' 'css' %}
-    {% render_bundle 'vendors~dashboard' 'css' %}
     {% render_bundle 'dashboard' 'css' %}
     <link rel="stylesheet" type="text/css" href="{% static "versatileimagefield/css/versatileimagefield.css" %}">
 
@@ -1622,8 +1620,6 @@
 
     <!-- Core Scripts - Include with every page -->
     <script type="text/javascript" src="{% url 'javascript-catalog' %}"></script>
-    {% render_bundle 'vendors~dashboard~storefront' 'js' %}
-    {% render_bundle 'vendors~dashboard' 'js' %}
     {% render_bundle 'dashboard' 'js' %}
     <script src="{% static "versatileimagefield/js/versatileimagefield.js" %}"></script>
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,11 +96,6 @@ var config = {
       }
     ]
   },
-  optimization: {
-    splitChunks: {
-      chunks: 'all'
-    }
-  },
   plugins: [
     bundleTrackerPlugin,
     extractTextPlugin,


### PR DESCRIPTION
This caused some problem on the demo branch and does not help most users as we only have one large entry point for the entire storefront and one for the dashboard. It did limit the total download size for people who visited both the dashboard and the storefront but that's not our main concern (we want to lower the download size for first-time visitors on the storefront side).

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
