### PR TITLE
Fix #1872, add new assertions for payments creation

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -296,7 +296,7 @@ class Payment(BasePayment):
             PurchasedItem(
                 name=line.product_name, sku=line.product_sku,
                 quantity=line.quantity,
-                price=line.unit_price_gross.quantize(Decimal('0.01')),
+                price=line.unit_price_gross.quantize(Decimal('0.01')).amount,
                 currency=settings.DEFAULT_CURRENCY)
             for line in self.order.get_lines()]
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -297,17 +297,18 @@ class Payment(BasePayment):
                 name=line.product_name, sku=line.product_sku,
                 quantity=line.quantity,
                 price=line.unit_price_gross.quantize(Decimal('0.01')).amount,
-                currency=settings.DEFAULT_CURRENCY)
+                currency=line.unit_price.currency)
             for line in self.order.get_lines()]
 
         voucher = self.order.voucher
         if voucher is not None:
-            lines.append(PurchasedItem(
-                name=self.order.discount_name,
-                sku='DISCOUNT',
-                quantity=1,
-                price=-self.order.discount_amount.amount,
-                currency=self.currency))
+            lines.append(
+                PurchasedItem(
+                    name=self.order.discount_name,
+                    sku='DISCOUNT',
+                    quantity=1,
+                    price=-self.order.discount_amount.amount,
+                    currency=self.order.discount_amount.currency))
         return lines
 
     def get_total_price(self):

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -129,6 +129,8 @@ def test_checkout_flow_authenticated_user(
     payment = order.payments.all()[0]
     assert payment.total == order.total.gross.amount
     assert payment.tax == order.total.tax.amount
+    assert payment.currency == order.total.currency
+    assert payment.delivery == order.shipping_price.gross.amount
     assert len(payment.get_purchased_items()) == len(order.get_lines())
 
 

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -125,6 +125,12 @@ def test_checkout_flow_authenticated_user(
         'order:checkout-success', kwargs={'token': order.token})
     assert get_redirect_location(payment_response) == order_password
 
+    # Assert that payment object was created and contains correct data
+    payment = order.payments.all()[0]
+    assert payment.total == order.total.gross.amount
+    assert payment.tax == order.total.tax.amount
+    assert len(payment.get_purchased_items()) == len(order.get_lines())
+
 
 def test_address_without_shipping(request_cart_with_item, client, monkeypatch):
     monkeypatch.setattr(

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -1,10 +1,11 @@
+from decimal import Decimal
+
 from prices import Money
 
 from saleor.order.models import Payment
 
 
 def test_get_purchased_items(order_with_lines, settings, voucher):
-
     payment = Payment.objects.create(order=order_with_lines, variant='paypal')
     discount = Money('10.0', currency=settings.DEFAULT_CURRENCY)
 
@@ -15,6 +16,7 @@ def test_get_purchased_items(order_with_lines, settings, voucher):
             payment.get_purchased_items(), order_with_lines.get_lines()):
         assert p.sku == o.product_sku
         assert p.quantity == o.quantity
+        assert p.price == o.unit_price_gross.quantize(Decimal('0.01')).amount
 
     order_with_lines.discount_name = 'Test'
     order_with_lines.discount_amount = discount
@@ -30,6 +32,7 @@ def test_get_purchased_items(order_with_lines, settings, voucher):
             payment.get_purchased_items()[:-1], order_with_lines.get_lines()):
         assert p.sku == o.product_sku
         assert p.quantity == o.quantity
+        assert p.price == o.unit_price_gross.quantize(Decimal('0.01')).amount
 
     discounted = payment.get_purchased_items()[-1]
 

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -17,6 +17,7 @@ def test_get_purchased_items(order_with_lines, settings, voucher):
         assert p.sku == o.product_sku
         assert p.quantity == o.quantity
         assert p.price == o.unit_price_gross.quantize(Decimal('0.01')).amount
+        assert p.currency == o.unit_price.currency
 
     order_with_lines.discount_name = 'Test'
     order_with_lines.discount_amount = discount
@@ -33,10 +34,12 @@ def test_get_purchased_items(order_with_lines, settings, voucher):
         assert p.sku == o.product_sku
         assert p.quantity == o.quantity
         assert p.price == o.unit_price_gross.quantize(Decimal('0.01')).amount
+        assert p.currency == o.unit_price.currency
 
     discounted = payment.get_purchased_items()[-1]
 
     assert discounted.name == order_with_lines.discount_name
     assert discounted.sku == 'DISCOUNT'
     assert discounted.price == -1 * order_with_lines.discount_amount.amount
+    assert discounted.currency == order_with_lines.discount_amount.currency
     assert discounted.quantity == 1


### PR DESCRIPTION
Fixes #1872

This PR fixes omission in prices handling wherein Payment items prices are passed as `Money` instances instead of `Decimal`, thus erroring with payment gateways.

I've also updated our tests suite to check that payment items prices are valid types, and updated checkout integration test to assert that valid total & tax is passed to created object, as well as number of items passed matches one of order lines.

I've also spotted that way in which we were adding item for order's discount used `self.currency` to get item's currency - which in `test_get_purchased_items` is empty. I've changed the `get_purchased_items` to always use `discount_amount.currency` when adding currency to items.

In long run, `PurchasedItem` could perhaps be redone to object that implements additional validation for passed fields?

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
