### PR TITLE
Use django-filters for sorting in API

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -3,12 +3,15 @@ import operator
 from collections import defaultdict
 
 from django.db.models import Q
+from django_filters import OrderingFilter
 from django_filters.fields import Lookup
 from graphene_django.filter.filterset import Filter
 
+from ...product.filters import SORT_BY_FIELDS
 from ...product.models import Product, ProductAttribute
 from ..core.filters import DistinctFilterSet
 from .fields import AttributeField
+
 
 
 class ProduductAttributeFilter(Filter):
@@ -50,6 +53,9 @@ class ProduductAttributeFilter(Filter):
 
 
 class ProductFilterSet(DistinctFilterSet):
+    sort_by = OrderingFilter(
+        fields=SORT_BY_FIELDS.keys(), field_labels=SORT_BY_FIELDS)
+
     class Meta:
         model = Product
         fields = {

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -13,8 +13,7 @@ from ..core.filters import DistinctFilterSet
 from .fields import AttributeField
 
 
-
-class ProduductAttributeFilter(Filter):
+class ProductAttributeFilter(Filter):
     field_class = AttributeField
 
     def filter(self, qs, value):
@@ -66,7 +65,7 @@ class ProductFilterSet(DistinctFilterSet):
     @classmethod
     def filter_for_field(cls, f, field_name, lookup_expr='exact'):
         if field_name == 'attributes':
-            return ProduductAttributeFilter(
+            return ProductAttributeFilter(
                 field_name=field_name, lookup_expr=lookup_expr, distinct=True)
         # this class method is called during class construction so we can't
         # reference ProductFilterSet here yet

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -61,8 +61,7 @@ class Product(CountableDjangoObjectType):
 
 class Category(CountableDjangoObjectType):
     products = DjangoFilterConnectionField(
-        Product, filterset_class=ProductFilterSet,
-        sort_by=graphene.Argument(graphene.String))
+        Product, filterset_class=ProductFilterSet)
     url = graphene.String()
     ancestors = DjangoFilterConnectionField(
         lambda: Category, filterset_class=DistinctFilterSet)
@@ -89,11 +88,9 @@ class Category(CountableDjangoObjectType):
         ancestors = self.get_ancestors().distinct()
         return self.get_absolute_url(ancestors)
 
-    def resolve_products(self, info, sort_by=None, **kwargs):
+    def resolve_products(self, info, **kwargs):
         qs = models.Product.objects.available_products()
         qs = qs.filter(category=self)
-        if sort_by == 'name':
-            qs = qs.order_by('name')
         return qs.distinct()
 
 


### PR DESCRIPTION
Currently, our `products` edge in API uses custom `sort_by` attribute to handle products sorting, but it only supports a single attribute ("name") and requires manual handling. Instead, we can use solution provided by `django-filters`.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
