### PR TITLE
Rich-text editor improvements

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -21,6 +21,12 @@ class RichTextField(forms.CharField):
 
     widget = RichTextEditorWidget
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.help_text = pgettext_lazy(
+            'Help text in rich-text editor field',
+            'Select text to enable text-formatting tools.')
+
     def to_python(self, value):
         tags = settings.ALLOWED_TAGS or bleach.ALLOWED_TAGS
         attributes = settings.ALLOWED_ATTRIBUTES or bleach.ALLOWED_ATTRIBUTES

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -1,6 +1,6 @@
 import bleach
-from bleach.sanitizer import ALLOWED_TAGS as BLEACH_ALLOWED_TAGS
 from django import forms
+from django.conf import settings
 from django.db.models import Count
 from django.forms.models import ModelChoiceIterator
 from django.forms.widgets import CheckboxSelectMultiple
@@ -20,11 +20,14 @@ class RichTextField(forms.CharField):
     """A field for rich text editor, providing backend sanitization."""
 
     widget = RichTextEditorWidget
-    ALLOWED_TAGS = BLEACH_ALLOWED_TAGS + ['br', 'p', 'h2', 'h3']
 
     def to_python(self, value):
+        tags = settings.ALLOWED_TAGS or bleach.ALLOWED_TAGS
+        attributes = settings.ALLOWED_ATTRIBUTES or bleach.ALLOWED_ATTRIBUTES
+        styles = settings.ALLOWED_STYLES or bleach.ALLOWED_STYLES
         value = super().to_python(value)
-        value = bleach.clean(value, tags=self.ALLOWED_TAGS)
+        value = bleach.clean(
+            value, tags=tags, attributes=attributes, styles=styles)
         return value
 
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -415,7 +415,7 @@ ALLOWED_TAGS = [
     'strong',
     'ul']
 ALLOWED_ATTRIBUTES = {
-    '*': 'style',
+    '*': ['align', 'style'],
     'a': ['href', 'title'],
     'img': ['src']}
 ALLOWED_STYLES = ['text-align']

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -396,3 +396,26 @@ IMPERSONATE = {
     'CUSTOM_USER_QUERYSET': 'saleor.account.impersonate.get_impersonatable_users',  # noqa
     'USE_HTTP_REFERER': True,
     'CUSTOM_ALLOW': 'saleor.account.impersonate.can_impersonate'}
+
+
+# Rich-text editor
+ALLOWED_TAGS = [
+    'a',
+    'b',
+    'blockquote',
+    'br',
+    'em',
+    'h2',
+    'h3',
+    'i',
+    'img',
+    'li',
+    'ol',
+    'p',
+    'strong',
+    'ul']
+ALLOWED_ATTRIBUTES = {
+    '*': 'style',
+    'a': ['href', 'title'],
+    'img': ['src']}
+ALLOWED_STYLES = ['text-align']

--- a/saleor/static/dashboard/images/editor/align_center.svg
+++ b/saleor/static/dashboard/images/editor/align_center.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M7 15v2h10v-2H7zm-4 6h18v-2H3v2zm0-8h18v-2H3v2zm4-6v2h10V7H7zM3 3v2h18V3H3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/align_justify.svg
+++ b/saleor/static/dashboard/images/editor/align_justify.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3 21h18v-2H3v2zm0-4h18v-2H3v2zm0-4h18v-2H3v2zm0-4h18V7H3v2zm0-6v2h18V3H3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/align_left.svg
+++ b/saleor/static/dashboard/images/editor/align_left.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M15 15H3v2h12v-2zm0-8H3v2h12V7zM3 13h18v-2H3v2zm0 8h18v-2H3v2zM3 3v2h18V3H3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/align_right.svg
+++ b/saleor/static/dashboard/images/editor/align_right.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M3 21h18v-2H3v2zm6-4h12v-2H9v2zm-6-4h18v-2H3v2zm6-4h12V7H9v2zM3 3v2h18V3H3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/format_clear.svg
+++ b/saleor/static/dashboard/images/editor/format_clear.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3.27 5L2 6.27l6.97 6.97L6.5 19h3l1.57-3.66L16.73 21 18 19.73 3.55 5.27 3.27 5zM6 5v.18L8.82 8h2.4l-.72 1.68 2.1 2.1L14.21 8H20V5H6z"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/insert_link.svg
+++ b/saleor/static/dashboard/images/editor/insert_link.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M0 0h24v24H0z" fill="none"/>
+    <path d="M3.9 12c0-1.71 1.39-3.1 3.1-3.1h4V7H7c-2.76 0-5 2.24-5 5s2.24 5 5 5h4v-1.9H7c-1.71 0-3.1-1.39-3.1-3.1zM8 13h8v-2H8v2zm9-6h-4v1.9h4c1.71 0 3.1 1.39 3.1 3.1s-1.39 3.1-3.1 3.1h-4V17h4c2.76 0 5-2.24 5-5s-2.24-5-5-5z"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/insert_photo.svg
+++ b/saleor/static/dashboard/images/editor/insert_photo.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M21 19V5c0-1.1-.9-2-2-2H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2zM8.5 13.5l2.5 3.01L14.5 12l4.5 6H5l3.5-4.5z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/images/editor/quote.svg
+++ b/saleor/static/dashboard/images/editor/quote.svg
@@ -1,0 +1,4 @@
+<svg fill="#FFFFFF" height="18" viewBox="0 0 24 24" width="18" xmlns="http://www.w3.org/2000/svg">
+    <path d="M6 17h3l2-4V7H5v6h3zm8 0h3l2-4V7h-6v6h3z"/>
+    <path d="M0 0h24v24H0z" fill="none"/>
+</svg>

--- a/saleor/static/dashboard/js/components/editor.js
+++ b/saleor/static/dashboard/js/components/editor.js
@@ -1,7 +1,22 @@
 import MediumEditor from 'medium-editor';
 
+import alignCenterIcon from '../../images/editor/align_center.svg';
+import alignJustifyIcon from '../../images/editor/align_justify.svg';
+import alignLeftIcon from '../../images/editor/align_left.svg';
+import alignRightIcon from '../../images/editor/align_right.svg';
+import insertLinkIcon from '../../images/editor/insert_link.svg';
+import insertPhotoIcon from '../../images/editor/insert_photo.svg';
+import quoteIcon from '../../images/editor/quote.svg';
+import formatClear from '../../images/editor/format_clear.svg';
+
+import doneIcon from '../../images/done.svg';
+import closeIcon from '../../images/close.svg';
+
 // eslint-disable
 const editor = new MediumEditor('.rich-text-editor', {
+  paste: {
+    forcePlainText: true
+  },
   toolbar: {
     buttons: [
       {
@@ -28,13 +43,45 @@ const editor = new MediumEditor('.rich-text-editor', {
       },
       {
         name: 'quote',
-        aria: pgettext('Rich text editor option', 'Quote')
+        aria: pgettext('Rich text editor option', 'Quote'),
+        contentDefault: `<img src="${quoteIcon}">`
       },
       {
         name: 'anchor',
         aria: pgettext('Rich text editor option', 'Link'),
-        formSaveLabel: '<img src="/static/dashboard/images/done.svg">',
-        formCloseLabel: '<img src="/static/dashboard/images/close.svg">'
+        contentDefault: `<img src="${insertLinkIcon}">`,
+        formSaveLabel: `<img src="${doneIcon}"`,
+        formCloseLabel: `<img src="${closeIcon}">`
+      },
+      {
+        name: 'image',
+        aria: pgettext('Rich text editor option', 'Image (converts selected text to an image tag)'),
+        contentDefault: `<img src="${insertPhotoIcon}">`
+      },
+      {
+        name: 'justifyLeft',
+        aria: pgettext('Rich text editor option', 'Left align'),
+        contentDefault: `<img src="${alignLeftIcon}">`
+      },
+      {
+        name: 'justifyCenter',
+        aria: pgettext('Rich text editor option', 'Center align'),
+        contentDefault: `<img src="${alignCenterIcon}">`
+      },
+      {
+        name: 'justifyRight',
+        aria: pgettext('Rich text editor option', 'Right align'),
+        contentDefault: `<img src="${alignRightIcon}">`
+      },
+      {
+        name: 'justifyFull',
+        aria: pgettext('Rich text editor option', 'Justify'),
+        contentDefault: `<img src="${alignJustifyIcon}">`
+      },
+      {
+        name: 'removeFormat',
+        aria: pgettext('Rich text editor option', 'Remove formatting'),
+        contentDefault: `<img src="${formatClear}">`
       }
     ]
   },

--- a/saleor/static/dashboard/scss/components/_rich-text-editor.scss
+++ b/saleor/static/dashboard/scss/components/_rich-text-editor.scss
@@ -122,3 +122,9 @@
     }
   }
 }
+
+.rich-text-editor {
+  // add bottom margin to make the field's help-text not clashing with the
+  // bottom border
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
This PR adds few improvements to the rich-text editor that I found useful when working with our new Pages app. It introduces few additional formatting options:
- converting image links to `<img>` tags
- text alignment options
- clear formatting

Backend sanitizer settings have been moved to `settings.py`.

Screen below shows how the editor looks like after these changes, including a charming example of a page that may be created using it.

![image](https://user-images.githubusercontent.com/5421321/37093577-1a381464-2210-11e8-88f9-ddd9479d2f68.png)


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
