### PR TITLE
Remove explicit "currency=" when instantiating Money objects

### DIFF
--- a/docs/architecture/money.rst
+++ b/docs/architecture/money.rst
@@ -17,7 +17,7 @@ Money and TaxedMoney
 
 In Saleor's codebase, money amounts exist either as `Money` or `TaxedMoney` instances.
 
-`Money` is a type representing amount of money in specific currency: 100 USD is represented by `Money(100, currency='USD')`. This type doesn't hold any additional information useful for commerce but, unlike `Decimal`, it implements safeguards and checks for calculations and comparisions of monetary values. Money amounts are stored on model using `MoneyField` that provides its own safechecks on currency and precision of stored amount. If you ever need to get to the `Decimal` of your `Money` object, you'll find it on the `amount` property.
+`Money` is a type representing amount of money in specific currency: 100 USD is represented by `Money(100, 'USD')`. This type doesn't hold any additional information useful for commerce but, unlike `Decimal`, it implements safeguards and checks for calculations and comparisions of monetary values. Money amounts are stored on model using `MoneyField` that provides its own safechecks on currency and precision of stored amount. If you ever need to get to the `Decimal` of your `Money` object, you'll find it on the `amount` property.
 
 Products and shipping methods prices are stored using `MoneyField` and are assumed to be gross amounts. Those amounts are then naively converted to `TaxedMoney` objects using the `TaxedAmount(net=item.price, gross=item.price)` approach with conversion happening before resolving item's final price (before taxes and discounts).
 

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -216,7 +216,7 @@ class Checkout:
         value = self.storage.get('discount_value')
         currency = self.storage.get('discount_currency')
         if value is not None and currency is not None:
-            return Money(value, currency=currency)
+            return Money(value, currency)
         return None
 
     @discount.setter
@@ -319,8 +319,8 @@ class Checkout:
             shipping_price = self.shipping_method.get_total_price()
         else:
             shipping_price = TaxedMoney(
-                net=Money(0, currency=settings.DEFAULT_CURRENCY),
-                gross=Money(0, currency=settings.DEFAULT_CURRENCY))
+                net=Money(0, settings.DEFAULT_CURRENCY),
+                gross=Money(0, settings.DEFAULT_CURRENCY))
 
         order_data = {
             'language_code': get_language(),

--- a/saleor/core/utils/__init__.py
+++ b/saleor/core/utils/__init__.py
@@ -19,8 +19,8 @@ from prices import Money, TaxedMoney, MoneyRange
 from ...account.models import User
 
 ZERO_TAXED_MONEY = TaxedMoney(
-    net=Money(0, currency=settings.DEFAULT_CURRENCY),
-    gross=Money(0, currency=settings.DEFAULT_CURRENCY))
+    net=Money(0, settings.DEFAULT_CURRENCY),
+    gross=Money(0, settings.DEFAULT_CURRENCY))
 
 georeader = geolite2.reader()
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -230,8 +230,7 @@ def create_products_by_schema(placeholder_dir, how_many, create_images,
 class SaleorProvider(BaseProvider):
     def money(self):
         return Money(
-            fake.pydecimal(2, 2, positive=True),
-            currency=settings.DEFAULT_CURRENCY)
+            fake.pydecimal(2, 2, positive=True), settings.DEFAULT_CURRENCY)
 
     def delivery_region(self):
         return random.choice(DELIVERY_REGIONS)

--- a/saleor/dashboard/discount/forms.py
+++ b/saleor/dashboard/discount/forms.py
@@ -108,7 +108,7 @@ def country_choices():
 class ShippingVoucherForm(forms.ModelForm):
 
     limit = MoneyField(
-        min_value=Money(0, currency=settings.DEFAULT_CURRENCY),
+        min_value=Money(0, settings.DEFAULT_CURRENCY),
         required=False, currency=settings.DEFAULT_CURRENCY)
     apply_to = forms.ChoiceField(
         choices=country_choices,
@@ -134,7 +134,7 @@ class ShippingVoucherForm(forms.ModelForm):
 class ValueVoucherForm(forms.ModelForm):
 
     limit = MoneyField(
-        min_value=Money(0, currency=settings.DEFAULT_CURRENCY),
+        min_value=Money(0, settings.DEFAULT_CURRENCY),
         required=False, currency=settings.DEFAULT_CURRENCY)
 
     class Meta:

--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -113,7 +113,7 @@ class Voucher(models.Model):
     def get_discount(self):
         if self.discount_value_type == DiscountValueType.FIXED:
             discount_amount = Money(
-                self.discount_value, currency=settings.DEFAULT_CURRENCY)
+                self.discount_value, settings.DEFAULT_CURRENCY)
             return partial(fixed_discount, discount=discount_amount)
         if self.discount_value_type == DiscountValueType.PERCENTAGE:
             return partial(percentage_discount, percentage=self.discount_value)
@@ -162,8 +162,7 @@ class Sale(models.Model):
 
     def get_discount(self):
         if self.type == DiscountValueType.FIXED:
-            discount_amount = Money(
-                self.value, currency=settings.DEFAULT_CURRENCY)
+            discount_amount = Money(self.value, settings.DEFAULT_CURRENCY)
             return partial(fixed_discount, discount=discount_amount)
         if self.type == DiscountValueType.PERCENTAGE:
             return partial(percentage_discount, percentage=self.value)

--- a/saleor/discount/templatetags/voucher.py
+++ b/saleor/discount/templatetags/voucher.py
@@ -7,5 +7,5 @@ register = template.Library()
 
 @register.simple_tag
 def discount_as_negative(discount, html=False):
-    zero = Money(0, currency=discount.currency)
+    zero = Money(0, discount.currency)
     return prices_i18n.amount(zero - discount, 'html' if html else 'text')

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -115,7 +115,7 @@ def _get_product_or_category_voucher_discount_for_checkout(voucher, checkout):
         discounts = (
             voucher.get_discount_amount_for(price) for price in prices)
         total_amount = sum(
-            discounts, Money(0, currency=settings.DEFAULT_CURRENCY))
+            discounts, Money(0, settings.DEFAULT_CURRENCY))
         return total_amount
     product_total = sum(prices, ZERO_TAXED_MONEY)
     return voucher.get_discount_amount_for(product_total)

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -102,8 +102,8 @@ class Order(models.Model):
                 payment.get_total_price() for payment in
                 self.payments.filter(status=PaymentStatus.CONFIRMED)],
             TaxedMoney(
-                net=Money(0, currency=settings.DEFAULT_CURRENCY),
-                gross=Money(0, currency=settings.DEFAULT_CURRENCY)))
+                net=Money(0, settings.DEFAULT_CURRENCY),
+                gross=Money(0, settings.DEFAULT_CURRENCY)))
         return total_paid.gross >= self.total.gross
 
     def get_user_current_email(self):
@@ -313,13 +313,13 @@ class Payment(BasePayment):
 
     def get_total_price(self):
         return TaxedMoney(
-            net=Money(self.total - self.tax, currency=self.currency),
-            gross=Money(self.total, currency=self.currency))
+            net=Money(self.total - self.tax, self.currency),
+            gross=Money(self.total, self.currency))
 
     def get_captured_price(self):
         return TaxedMoney(
-            net=Money(self.captured_amount, currency=self.currency),
-            gross=Money(self.captured_amount, currency=self.currency))
+            net=Money(self.captured_amount, self.currency),
+            gross=Money(self.captured_amount, self.currency))
 
 
 class OrderHistoryEntry(models.Model):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -264,7 +264,7 @@ class ProductVariant(models.Model):
         stock = [
             stock_item for stock_item in self.stock.all()
             if stock_item.quantity_available >= quantity]
-        zero_price = Money(0, currency=settings.DEFAULT_CURRENCY)
+        zero_price = Money(0, settings.DEFAULT_CURRENCY)
         stock = sorted(
             stock, key=(lambda s: s.cost_price or zero_price), reverse=False)
         if stock:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -242,7 +242,7 @@ def product_in_stock(product_type, default_category):
     attributes = {smart_text(product_attr.pk): smart_text(attr_value.pk)}
 
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, attributes=attributes,
         category=default_category)
 
@@ -257,14 +257,14 @@ def product_in_stock(product_type, default_category):
     warehouse_2 = StockLocation.objects.create(name='Warehouse 2')
     warehouse_3 = StockLocation.objects.create(name='Warehouse 3')
     Stock.objects.create(
-        variant=variant, cost_price=Money('1.00', currency='USD'),
-        quantity=5, quantity_allocated=5, location=warehouse_1)
+        variant=variant, cost_price=Money('1.00', 'USD'), quantity=5,
+        quantity_allocated=5, location=warehouse_1)
     Stock.objects.create(
-        variant=variant, cost_price=Money('100.00', currency='USD'),
-        quantity=5, quantity_allocated=5, location=warehouse_2)
+        variant=variant, cost_price=Money('100.00', 'USD'), quantity=5,
+        quantity_allocated=5, location=warehouse_2)
     Stock.objects.create(
-        variant=variant, cost_price=Money('10.00', currency='USD'),
-        quantity=5, quantity_allocated=0, location=warehouse_3)
+        variant=variant, cost_price=Money('10.00', 'USD'), quantity=5,
+        quantity_allocated=0, location=warehouse_3)
     return product
 
 
@@ -274,7 +274,7 @@ def product_without_shipping(default_category):
         name='Type with no shipping', has_variants=False,
         is_shipping_required=False)
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, category=default_category)
     ProductVariant.objects.create(product=product, sku='SKU_B')
     return product
@@ -287,17 +287,17 @@ def product_list(product_type, default_category):
     attributes = {smart_text(product_attr.pk): smart_text(attr_value.pk)}
 
     product_1 = Product.objects.create(
-        name='Test product 1', price=Money('10.00', currency='USD'),
+        name='Test product 1', price=Money('10.00', 'USD'),
         product_type=product_type, attributes=attributes, is_published=True,
         category=default_category)
 
     product_2 = Product.objects.create(
-        name='Test product 2', price=Money('20.00', currency='USD'),
+        name='Test product 2', price=Money('20.00', 'USD'),
         product_type=product_type, attributes=attributes, is_published=False,
         category=default_category)
 
     product_3 = Product.objects.create(
-        name='Test product 3', price=Money('20.00', currency='USD'),
+        name='Test product 3', price=Money('20.00', 'USD'),
         product_type=product_type, attributes=attributes, is_published=True,
         category=default_category)
 
@@ -308,9 +308,8 @@ def product_list(product_type, default_category):
 def order_list(admin_user, billing_address):
     data = {
         'billing_address': billing_address, 'user': admin_user,
-        'user_email': admin_user.email,
-        'total_net': Money(123, currency='USD'),
-        'total_gross': Money(123, currency='USD')}
+        'user_email': admin_user.email, 'total_net': Money(123, 'USD'),
+        'total_gross': Money(123, 'USD')}
     order = Order.objects.create(**data)
     order1 = Order.objects.create(**data)
     order2 = Order.objects.create(**data)
@@ -342,7 +341,7 @@ def product_with_image(product_in_stock, product_image):
 @pytest.fixture
 def unavailable_product(product_type, default_category):
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, is_published=False,
         category=default_category)
     return product
@@ -351,7 +350,7 @@ def unavailable_product(product_type, default_category):
 @pytest.fixture
 def product_with_images(product_type, default_category):
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, category=default_category)
     file_mock_0 = MagicMock(spec=File, name='FileMock0')
     file_mock_0.name = 'image0.jpg'
@@ -376,7 +375,7 @@ def voucher(db):  # pylint: disable=W0613
 def order_with_lines(order, product_type, default_category):
     group = DeliveryGroup.objects.create(order=order)
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, category=default_category)
 
     OrderLine.objects.create(
@@ -389,7 +388,7 @@ def order_with_lines(order, product_type, default_category):
         unit_price_net=Decimal('10.00'),
         unit_price_gross=Decimal('10.00'))
     product = Product.objects.create(
-        name='Test product 2', price=Money('20.00', currency='USD'),
+        name='Test product 2', price=Money('20.00', 'USD'),
         product_type=product_type, category=default_category)
 
     OrderLine.objects.create(
@@ -402,7 +401,7 @@ def order_with_lines(order, product_type, default_category):
         unit_price_net=Decimal('20.00'),
         unit_price_gross=Decimal('20.00'))
     product = Product.objects.create(
-        name='Test product 3', price=Money('30.00', currency='USD'),
+        name='Test product 3', price=Money('30.00', 'USD'),
         product_type=product_type, category=default_category)
 
     OrderLine.objects.create(
@@ -423,13 +422,13 @@ def order_with_lines(order, product_type, default_category):
 def order_with_lines_and_stock(order, product_type, default_category):
     group = DeliveryGroup.objects.create(order=order)
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, category=default_category)
     variant = ProductVariant.objects.create(product=product, sku='SKU_A')
     warehouse = StockLocation.objects.create(name='Warehouse 1')
     stock = Stock.objects.create(
-        variant=variant, cost_price=Money(1, currency='USD'),
-        quantity=5, quantity_allocated=3, location=warehouse)
+        variant=variant, cost_price=Money(1, 'USD'), quantity=5,
+        quantity_allocated=3, location=warehouse)
     OrderLine.objects.create(
         delivery_group=group,
         product=product,
@@ -442,12 +441,12 @@ def order_with_lines_and_stock(order, product_type, default_category):
         stock=stock,
         stock_location=stock.location.name)
     product = Product.objects.create(
-        name='Test product 2', price=Money('20.00', currency='USD'),
+        name='Test product 2', price=Money('20.00', 'USD'),
         product_type=product_type, category=default_category)
     variant = ProductVariant.objects.create(product=product, sku='SKU_B')
     stock = Stock.objects.create(
-        variant=variant, cost_price=Money(2, currency='USD'),
-        quantity=2, quantity_allocated=2, location=warehouse)
+        variant=variant, cost_price=Money(2, 'USD'), quantity=2,
+        quantity_allocated=2, location=warehouse)
     OrderLine.objects.create(
         delivery_group=group,
         product=product,
@@ -470,8 +469,8 @@ def order_with_variant_from_different_stocks(order_with_lines_and_stock):
     variant = ProductVariant.objects.get(sku=line.product_sku)
     warehouse_2 = StockLocation.objects.create(name='Warehouse 2')
     stock = Stock.objects.create(
-        variant=variant, cost_price=Money(1, currency='USD'),
-        quantity=5, quantity_allocated=2, location=warehouse_2)
+        variant=variant, cost_price=Money(1, 'USD'), quantity=5,
+        quantity_allocated=2, location=warehouse_2)
     OrderLine.objects.create(
         delivery_group=line.delivery_group,
         product=variant.product,
@@ -485,8 +484,8 @@ def order_with_variant_from_different_stocks(order_with_lines_and_stock):
         stock_location=stock.location.name)
     warehouse_2 = StockLocation.objects.create(name='Warehouse 3')
     Stock.objects.create(
-        variant=variant, cost_price=Money(1, currency='USD'),
-        quantity=5, quantity_allocated=0, location=warehouse_2)
+        variant=variant, cost_price=Money(1, 'USD'), quantity=5,
+        quantity_allocated=0, location=warehouse_2)
     return order_with_lines_and_stock
 
 
@@ -494,13 +493,13 @@ def order_with_variant_from_different_stocks(order_with_lines_and_stock):
 def delivery_group(order, product_type, default_category):
     group = DeliveryGroup.objects.create(order=order)
     product = Product.objects.create(
-        name='Test product', price=Money('10.00', currency='USD'),
+        name='Test product', price=Money('10.00', 'USD'),
         product_type=product_type, category=default_category)
     variant = ProductVariant.objects.create(product=product, sku='SKU_A')
     warehouse = StockLocation.objects.create(name='Warehouse 2')
     stock = Stock.objects.create(
-        variant=variant, cost_price=Money(1, currency='USD'),
-        quantity=5, quantity_allocated=3, location=warehouse)
+        variant=variant, cost_price=Money(1, 'USD'), quantity=5,
+        quantity_allocated=3, location=warehouse)
     OrderLine.objects.create(
         delivery_group=group,
         product=product,

--- a/tests/dashboard/test_discount.py
+++ b/tests/dashboard/test_discount.py
@@ -41,4 +41,4 @@ def test_voucher_shipping_add(admin_client):
     assert voucher.end_date == date(2018, 6, 1)
     assert voucher.discount_value_type == DiscountValueType.FIXED
     assert voucher.discount_value == Decimal('15.99')
-    assert voucher.limit == Money('59.99', currency='USD')
+    assert voucher.limit == Money('59.99', 'USD')

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -68,8 +68,8 @@ def test_checkout_deliveries():
 
 
 def test_checkout_deliveries_with_shipping_method(monkeypatch):
-    shipping_cost = Money(3, currency=settings.DEFAULT_CURRENCY)
-    items_cost = Money(5, currency=settings.DEFAULT_CURRENCY)
+    shipping_cost = Money(3, settings.DEFAULT_CURRENCY)
+    items_cost = Money(5, settings.DEFAULT_CURRENCY)
     cost_with_shipping = items_cost + shipping_cost
 
     items_price = TaxedMoney(net=items_cost, gross=items_cost)
@@ -233,7 +233,7 @@ def test_checkout_discount(request_cart, sale, product_in_stock):
     request_cart.add(variant, 1)
     checkout = Checkout(request_cart, AnonymousUser(), 'tracking_code')
     assert checkout.get_total() == TaxedMoney(
-        net=Money(5, currency="USD"), gross=Money(5, currency="USD"))
+        net=Money(5, 'USD'), gross=Money(5, 'USD'))
 
 
 def test_checkout_create_order_insufficient_stock(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -12,15 +12,14 @@ from saleor.order.utils import add_variant_to_delivery_group, recalculate_order
 
 
 def test_total_setter():
-    price = TaxedMoney(
-        net=Money(10, currency='USD'), gross=Money(15, currency='USD'))
+    price = TaxedMoney(net=Money(10, 'USD'), gross=Money(15, 'USD'))
     order = models.Order()
     order.total = price
-    assert order.total_net == Money(10, currency='USD')
-    assert order.total.net == Money(10, currency='USD')
-    assert order.total_gross == Money(15, currency='USD')
-    assert order.total.gross == Money(15, currency='USD')
-    assert order.total.tax == Money(5, currency='USD')
+    assert order.total_net == Money(10, 'USD')
+    assert order.total.net == Money(10, 'USD')
+    assert order.total_gross == Money(15, 'USD')
+    assert order.total.gross == Money(15, 'USD')
+    assert order.total.tax == Money(5, 'USD')
 
 
 def test_order_get_subtotal(order_with_lines):

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -7,7 +7,7 @@ from saleor.order.models import Payment
 
 def test_get_purchased_items(order_with_lines, settings, voucher):
     payment = Payment.objects.create(order=order_with_lines, variant='paypal')
-    discount = Money('10.0', currency=settings.DEFAULT_CURRENCY)
+    discount = Money('10.0', settings.DEFAULT_CURRENCY)
 
     assert len(payment.get_purchased_items()) == len(
         order_with_lines.get_lines())


### PR DESCRIPTION
This pull request goes trough our codebase and removes superficial `currency=` from places where we are instantiating `Money` objects. This change doesn't affect any of our business logic, but shaves some cruft.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
