### PR TITLE
Fix ReleasePaymentForm, add tests for ManagePaymentForms

### DIFF
--- a/templates/dashboard/order/modal/release.html
+++ b/templates/dashboard/order/modal/release.html
@@ -12,10 +12,10 @@
 {% endblock %}
 
 {% block content %}
+  {{ form|materializecss }}
   <div class="col s12">
     {% trans "Do you want to release the payment?" context "Modal release payment text" %}
   </div>
-{{ form|materializecss }}
 {% endblock %}
 
 {% block primary_action %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils.encoding import smart_text
 from PIL import Image
+from payments import FraudStatus, PaymentStatus
 from prices import Money
 
 from saleor.account.models import Address, User
@@ -498,6 +499,63 @@ def order_with_variant_from_different_stocks(order_with_lines_and_stock):
         variant=variant, cost_price=Money(1, 'USD'), quantity=5,
         quantity_allocated=0, location=warehouse_2)
     return order_with_lines_and_stock
+
+
+@pytest.fixture()
+def payment_waiting(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.WAITING,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
+
+
+@pytest.fixture()
+def payment_preauth(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.PREAUTH,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
+
+
+@pytest.fixture()
+def payment_confirmed(order_with_lines_and_stock):
+    order_amount = order_with_lines_and_stock.total_gross.amount
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.CONFIRMED,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_amount, captured_amount=order_amount)
+
+
+@pytest.fixture()
+def payment_rejected(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.REJECTED,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
+
+
+@pytest.fixture()
+def payment_refunded(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.REFUNDED,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
+
+
+@pytest.fixture()
+def payment_error(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.ERROR,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
+
+
+@pytest.fixture()
+def payment_input(order_with_lines_and_stock):
+    return order_with_lines_and_stock.payments.create(
+        variant='default', status=PaymentStatus.INPUT,
+        fraud_status=FraudStatus.ACCEPT, currency='USD',
+        total=order_with_lines_and_stock.total_gross.amount)
 
 
 @pytest.fixture()


### PR DESCRIPTION
This PR redoes the `ReleasePaymentForm` to don't inherit from `ManagePaymentForm` that expects user to input money amount that doesn't really make sense for releasing payment. Instead redone "Release payment" modal simply asks user to confirm the action.

This PR also adds tests checking that refund/capture/release forms return 400 if payment status is invalid, so we know that those are handled gracefully by Saleor's Dashboard.

Fixes #1791

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
