### PR TITLE
Remove nedless dependency on importing prices.Money in order migration

### DIFF
--- a/saleor/order/migrations/0039_auto_20180312_1203.py
+++ b/saleor/order/migrations/0039_auto_20180312_1203.py
@@ -3,7 +3,6 @@
 from decimal import Decimal
 from django.db import migrations
 import django_prices.models
-import prices
 
 
 class Migration(migrations.Migration):
@@ -16,11 +15,11 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='order',
             name='total_gross',
-            field=django_prices.models.MoneyField(currency='USD', decimal_places=2, default=prices.Money('0', currency='USD'), max_digits=12),
+            field=django_prices.models.MoneyField(currency='USD', decimal_places=2, default=0, max_digits=12),
         ),
         migrations.AlterField(
             model_name='order',
             name='total_net',
-            field=django_prices.models.MoneyField(currency='USD', decimal_places=2, default=prices.Money('0', currency='USD'), max_digits=12),
+            field=django_prices.models.MoneyField(currency='USD', decimal_places=2, default=0, max_digits=12),
         ),
     ]

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -66,10 +66,10 @@ class Order(models.Model):
     token = models.CharField(max_length=36, unique=True)
     total_net = MoneyField(
         currency=settings.DEFAULT_CURRENCY, max_digits=12, decimal_places=2,
-        default=Money(0, settings.DEFAULT_CURRENCY))
+        default=0)
     total_gross = MoneyField(
         currency=settings.DEFAULT_CURRENCY, max_digits=12, decimal_places=2,
-        default=Money(0, settings.DEFAULT_CURRENCY))
+        default=0)
     total = TaxedMoneyField(net_field='total_net', gross_field='total_gross')
     voucher = models.ForeignKey(
         Voucher, null=True, related_name='+', on_delete=models.SET_NULL)


### PR DESCRIPTION
This PR is small cleanup after #1893 that replaces `default=Money(0, settings.DEFAULT_CURRENCY)` with more future-proof `default=0`. It also updates migration introduced in this change to specify `default=0` instead of importing and constructing Money in migration, thus in plan, making our migrations more maintainable as eventual changes in money handling should be limited to logic inside `django_prices.MoneyField`.


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
