### PR TITLE
Remove shipping tax from order fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,9 +77,9 @@ def order(billing_address, customer_user):
     return Order.objects.create(
         billing_address=billing_address,
         user_email=customer_user.email,
-        total_net=Money(100, 'USD'),
+        total_net=Money(123, 'USD'),
         total_gross=Money(123, 'USD'),
-        shipping_price_net=Money(10, 'USD'),
+        shipping_price_net=Money(12, 'USD'),
         shipping_price_gross=Money(12, 'USD'),
         user=customer_user)
 


### PR DESCRIPTION
Our build is now failing due to `order` fixture creating order with different gross and net amounts for shipping price. This introduces the shipping taxes to our payment-handling logic that isn't ready to handle them yet and thus fails our tests.

This PR fixes the build by removing shipping tax from `order` fixture used in tests.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
