### PR TITLE
Use TreeNodeChoiceField to render category field

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -7,13 +7,15 @@ from django.forms.widgets import CheckboxSelectMultiple
 from django.utils.encoding import smart_text
 from django.utils.text import slugify
 from django.utils.translation import pgettext_lazy
+from mptt.forms import TreeNodeChoiceField
 
-from . import ProductBulkAction
 from ...product.models import (
-    AttributeChoiceValue, Collection, Product, ProductAttribute, ProductImage,
-    ProductType, ProductVariant, Stock, StockLocation, VariantImage)
+    AttributeChoiceValue, Category, Collection, Product, ProductAttribute,
+    ProductImage, ProductType, ProductVariant, Stock, StockLocation,
+    VariantImage)
 from ..widgets import RichTextEditorWidget
 from .widgets import ImagePreviewWidget
+from . import ProductBulkAction
 
 
 class RichTextField(forms.CharField):
@@ -134,7 +136,6 @@ class ProductTypeForm(forms.ModelForm):
 
 
 class ProductForm(forms.ModelForm):
-
     class Meta:
         model = Product
         exclude = ['attributes', 'product_type', 'updated_at']
@@ -152,6 +153,7 @@ class ProductForm(forms.ModelForm):
             'collections': pgettext_lazy(
                 'Add to collection select', 'Collections')}
 
+    category = TreeNodeChoiceField(queryset=Category.objects.all())
     collections = forms.ModelMultipleChoiceField(
         required=False, queryset=Collection.objects.all())
     description = RichTextField()


### PR DESCRIPTION
Fixes #1887

Using `TreeNodeChoiceField` to render Category selection nests the subcategories without making any additional queries. This solution is satisfying for now and we can come up with a better-looking solution once we rewrite this view in React.

![image](https://user-images.githubusercontent.com/5421321/37456596-0c64fa88-2840-11e8-8ef5-5e47f6f401ab.png)

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
