### PR TITLE
Address Form translation

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -90,28 +90,28 @@ class AddressForm(forms.ModelForm):
         ('email', 'email')]
 
     labels = {
-            'first_name': pgettext_lazy(
-                'Personal name', 'Given name'),
-            'last_name': pgettext_lazy(
-                'Personal name', 'Family name'),
-            'company_name': pgettext_lazy(
-                'Company or organization', 'Company or organization'),
-            'street_address_1': pgettext_lazy(
-                'Address', 'Address'),
-            'street_address_2': pgettext_lazy(
-                'Address', 'Address'),
-            'city': pgettext_lazy(
-                'City', 'City'),
-            'city_area': pgettext_lazy(
-                'City area', 'District'),
-            'postal_code': pgettext_lazy(
-                'Postal code', 'Postal code'),
-            'country': pgettext_lazy(
-                'Country', 'Country'),
-            'country_area': pgettext_lazy(
-                'Country area', 'State or province'),
-            'phone': pgettext_lazy(
-                'Phone number', 'Phone number')}
+        'first_name': pgettext_lazy(
+            'Personal name', 'Given name'),
+        'last_name': pgettext_lazy(
+            'Personal name', 'Family name'),
+        'company_name': pgettext_lazy(
+            'Company or organization', 'Company or organization'),
+        'street_address_1': pgettext_lazy(
+            'Address', 'Address'),
+        'street_address_2': pgettext_lazy(
+            'Address', 'Address'),
+        'city': pgettext_lazy(
+            'City', 'City'),
+        'city_area': pgettext_lazy(
+            'City area', 'District'),
+        'postal_code': pgettext_lazy(
+            'Postal code', 'Postal code'),
+        'country': pgettext_lazy(
+            'Country', 'Country'),
+        'country_area': pgettext_lazy(
+            'Country area', 'State or province'),
+        'phone': pgettext_lazy(
+            'Phone number', 'Phone number')}
 
     class Meta:
         model = Address

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -229,8 +229,6 @@ def get_form_i18n_lines(form_instance):
         return bound_fields
 
     if fields_order:
-        a = [_convert_to_bound_fields(form_instance, line)
-                for line in fields_order]
         return [_convert_to_bound_fields(form_instance, line)
                 for line in fields_order]
 

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -89,30 +89,6 @@ class AddressForm(forms.ModelForm):
         ('phone', 'tel'),
         ('email', 'email')]
 
-    labels = {
-        'first_name': pgettext_lazy(
-            'Personal name', 'Given name'),
-        'last_name': pgettext_lazy(
-            'Personal name', 'Family name'),
-        'company_name': pgettext_lazy(
-            'Company or organization', 'Company or organization'),
-        'street_address_1': pgettext_lazy(
-            'Address', 'Address'),
-        'street_address_2': pgettext_lazy(
-            'Address', 'Address'),
-        'city': pgettext_lazy(
-            'City', 'City'),
-        'city_area': pgettext_lazy(
-            'City area', 'District'),
-        'postal_code': pgettext_lazy(
-            'Postal code', 'Postal code'),
-        'country': pgettext_lazy(
-            'Country', 'Country'),
-        'country_area': pgettext_lazy(
-            'Country area', 'State or province'),
-        'phone': pgettext_lazy(
-            'Phone number', 'Phone number')}
-
     class Meta:
         model = Address
         exclude = []
@@ -149,7 +125,6 @@ class AddressForm(forms.ModelForm):
         autocomplete_dict = defaultdict(
             lambda: 'off', self.AUTOCOMPLETE_MAPPING)
         for field_name, field in self.fields.items():
-            field.label = self.labels[field_name]
             if autocomplete_type:
                 autocomplete = '%s %s' % (
                     autocomplete_type, autocomplete_dict[field_name])
@@ -234,6 +209,10 @@ def get_form_i18n_lines(form_instance):
 
 
 def update_base_fields(form_class, i18n_rules):
+    for field_name, label_value in AddressForm.Meta.labels.items():
+        field = form_class.base_fields[field_name]
+        field.label = label_value
+
     if i18n_rules.country_area_choices:
         form_class.base_fields['country_area'] = CountryAreaChoiceField(
             choices=i18n_rules.country_area_choices)

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -89,6 +89,30 @@ class AddressForm(forms.ModelForm):
         ('phone', 'tel'),
         ('email', 'email')]
 
+    labels = {
+            'first_name': pgettext_lazy(
+                'Personal name', 'Given name'),
+            'last_name': pgettext_lazy(
+                'Personal name', 'Family name'),
+            'company_name': pgettext_lazy(
+                'Company or organization', 'Company or organization'),
+            'street_address_1': pgettext_lazy(
+                'Address', 'Address'),
+            'street_address_2': pgettext_lazy(
+                'Address', 'Address'),
+            'city': pgettext_lazy(
+                'City', 'City'),
+            'city_area': pgettext_lazy(
+                'City area', 'District'),
+            'postal_code': pgettext_lazy(
+                'Postal code', 'Postal code'),
+            'country': pgettext_lazy(
+                'Country', 'Country'),
+            'country_area': pgettext_lazy(
+                'Country area', 'State or province'),
+            'phone': pgettext_lazy(
+                'Phone number', 'Phone number')}
+
     class Meta:
         model = Address
         exclude = []
@@ -125,6 +149,7 @@ class AddressForm(forms.ModelForm):
         autocomplete_dict = defaultdict(
             lambda: 'off', self.AUTOCOMPLETE_MAPPING)
         for field_name, field in self.fields.items():
+            field.label = self.labels[field_name]
             if autocomplete_type:
                 autocomplete = '%s %s' % (
                     autocomplete_type, autocomplete_dict[field_name])
@@ -204,6 +229,8 @@ def get_form_i18n_lines(form_instance):
         return bound_fields
 
     if fields_order:
+        a = [_convert_to_bound_fields(form_instance, line)
+                for line in fields_order]
         return [_convert_to_bound_fields(form_instance, line)
                 for line in fields_order]
 


### PR DESCRIPTION
I want to merge this change because...
Address Form was not translated (as mentioned in #1917). This pull request fix that.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [X] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
