### PR TITLE
Enable creating sale either for products or categories 

### DIFF
--- a/saleor/dashboard/discount/forms.py
+++ b/saleor/dashboard/discount/forms.py
@@ -17,7 +17,7 @@ from ..forms import AjaxSelect2ChoiceField, AjaxSelect2MultipleChoiceField
 class SaleForm(forms.ModelForm):
     products = AjaxSelect2MultipleChoiceField(
         queryset=Product.objects.all(),
-        fetch_data_url=reverse_lazy('dashboard:ajax-products'), required=True)
+        fetch_data_url=reverse_lazy('dashboard:ajax-products'), required=False)
 
     class Meta:
         model = Sale
@@ -52,6 +52,13 @@ class SaleForm(forms.ModelForm):
             self.add_error('value', pgettext_lazy(
                 'Sale (discount) error',
                 'Sale cannot exceed 100%'))
+        products = cleaned_data.get('products')
+        categories = cleaned_data.get('categories')
+        if not products and not categories:
+            raise forms.ValidationError(pgettext_lazy(
+                'Sale (discount) error',
+                'A single sale must point to at least one product and/or '
+                'category.'))
         return cleaned_data
 
 

--- a/templates/dashboard/discount/sale/form.html
+++ b/templates/dashboard/discount/sale/form.html
@@ -69,6 +69,13 @@
         <form method="post" enctype="multipart/form-data" id="form-sales" novalidate>
           <div class="card-content card-content-form">
             {% csrf_token %}
+            {% if form.non_field_errors %}
+              <blockquote>
+                {% for non_field_error in form.non_field_errors %}
+                  {{ non_field_error }}
+                {% endfor %}
+              </blockquote>
+            {% endif %}
             <div class="row">
               {{ form.name|materializecss }}
             </div>

--- a/tests/dashboard/test_discount.py
+++ b/tests/dashboard/test_discount.py
@@ -42,3 +42,50 @@ def test_voucher_shipping_add(admin_client):
     assert voucher.discount_value_type == DiscountValueType.FIXED
     assert voucher.discount_value == Decimal('15.99')
     assert voucher.limit == Money('59.99', 'USD')
+
+
+def test_view_sale_add(admin_client, default_category):
+    url = reverse('dashboard:sale-add')
+    data = {
+        'name': 'Free products',
+        'type': DiscountValueType.PERCENTAGE,
+        'value': 100,
+        'categories': [default_category.id]}
+
+    response = admin_client.post(url, data)
+
+    assert response.status_code == 302
+    assert Sale.objects.count() == 1
+    sale = Sale.objects.first()
+    assert sale.name == data['name']
+    assert default_category in sale.categories.all()
+
+
+def test_view_sale_add_requires_product_or_category(
+        admin_client, default_category, product_in_stock):
+    url = reverse('dashboard:sale-add')
+    data = {
+        'name': 'Free products',
+        'type': DiscountValueType.PERCENTAGE,
+        'value': 100}
+
+    response = admin_client.post(url, data)
+
+    assert response.status_code == 200
+    assert Sale.objects.count() == 0
+
+    data_with_category = data.copy()
+    data_with_category.update({'categories': [default_category.id]})
+
+    response = admin_client.post(url, data_with_category)
+
+    assert response.status_code == 302
+    assert Sale.objects.count() == 1
+
+    data_with_product = data.copy()
+    data_with_product.update({'products': [product_in_stock.id]})
+
+    response = admin_client.post(url, data_with_product)
+
+    assert response.status_code == 302
+    assert Sale.objects.count() == 2


### PR DESCRIPTION
I want to merge this change because it enables creating sale either for products or categories (or both). It also adds displaying `non_field_errors` in the template, which is not made by default.

Closes #1920 

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
