### PR TITLE
Remove absolute positioning

### DIFF
--- a/saleor/static/dashboard/scss/components/_global.scss
+++ b/saleor/static/dashboard/scss/components/_global.scss
@@ -115,10 +115,6 @@ h6 {
 }
 
 li#version-indicator {
-  @media (min-height: 750px) {
-    position: absolute;
-    bottom: 0;
-  }
   p {
     @extend .grey-text, .text-lighten-1;
   }


### PR DESCRIPTION
This PR removes absolute positioning of the release number, that currently clashes with menu items. After these changes, it's rendered as the last menu item which is always below the actual clickable items.

Before:
![image](https://user-images.githubusercontent.com/5421321/37652067-7d6eb2ca-2c3a-11e8-9e53-6a47de3d8e99.png)

After:
![image](https://user-images.githubusercontent.com/5421321/37652077-90cb1d7c-2c3a-11e8-9706-2144312a7e8c.png)


### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
