### PR TITLE
Create new attribute values from variant form

### DIFF
--- a/saleor/dashboard/forms.py
+++ b/saleor/dashboard/forms.py
@@ -4,6 +4,25 @@ from django import forms
 from django.core.exceptions import ValidationError
 
 
+class ModelChoiceOrCreationField(forms.ModelChoiceField):
+    """ModelChoiceField with the ability to create new choices.
+
+    This field allows to select values from a queryset, but it also accepts
+    new values that can be used to create new model choices.
+    """
+
+    def to_python(self, value):
+        if value in self.empty_values:
+            return None
+        try:
+            key = self.to_field_name or 'pk'
+            obj = self.queryset.get(**{key: value})
+        except (ValueError, TypeError, self.queryset.model.DoesNotExist):
+            return value
+        else:
+            return obj
+
+
 class OrderedModelMultipleChoiceField(forms.ModelMultipleChoiceField):
     def clean(self, value):
         qs = super().clean(value)

--- a/saleor/static/dashboard/js/components/selects.js
+++ b/saleor/static/dashboard/js/components/selects.js
@@ -6,6 +6,14 @@ function appendOption ($select, option) {
 }
 
 function initSelects() {
+  // Custom variant attribute select that allows creating new attribute values.
+  let $variantAttrsSelect = $('.variant-attribute-select select');
+  $variantAttrsSelect.select2({
+    tags: true,
+    width: '100%'
+  });
+  $variantAttrsSelect.addClass('select2-enabled');
+
   $('select:not(.browser-default):not(.enable-ajax-select2):not([multiple])').material_select();
   $('select[multiple]:not(.browser-default):not(.enable-ajax-select2)').select2({width: '100%'});
 

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -78,7 +78,7 @@
                 </div>
                 {% if attribute_form.fields %}
                   {% for attribute_field in attribute_form %}
-                    <div class="row">
+                    <div class="row variant-attribute-select">
                       {{ attribute_field|materializecss }}
                     </div>
                   {% endfor %}

--- a/tests/dashboard/test_forms.py
+++ b/tests/dashboard/test_forms.py
@@ -1,0 +1,18 @@
+from django import forms
+
+from saleor.product.models import Category
+from saleor.dashboard.product.forms import ModelChoiceOrCreationField
+
+
+def test_model_choice_or_creation_field(default_category):
+    class Form(forms.Form):
+        field = ModelChoiceOrCreationField(queryset=Category.objects.all())
+
+    form = Form({'field': default_category})
+    assert form.is_valid()
+    assert form.cleaned_data['field'] == default_category
+
+    choice = 'new-value'
+    form = Form({'field': choice})
+    assert form.is_valid()
+    assert form.cleaned_data['field'] == choice


### PR DESCRIPTION
Fixes #1735.

This PR changes the variant form behavior in order to always create new attribute values instead of storing raw strings. Originally this was developed in PR #1736 by @NyanKiyoshi partially, but this PR also adds a new form field rendered as Select2 widget, that allows creating new values in the select box.

![image](https://user-images.githubusercontent.com/5421321/37772167-1c5c50ea-2dda-11e8-9208-d67b4e5ef0c7.png)

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
