### PR TITLE
Replaced hard coded site name in dashboard to site.name

### DIFF
--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -8,7 +8,9 @@
   <head>
     <title>
       {% block title %}
-        {% trans "Dashboard - Saleor" context "Dashboard default page title" %}
+        {% blocktrans trimmed context "Dashboard default page title" with site_name=site.name %}
+          Dashboard - {{ site_name }}
+        {% endblocktrans %}
       {% endblock %}
     </title>
     {% block meta %}


### PR DESCRIPTION
Heya!

This is a little edit, I saw that the site name was hardcoded in the title of dashboard.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.

### Note
*Also still in [dashboard-2.0](https://github.com/mirumee/saleor/blob/dashboard-2.0/templates/dashboard/base.html#L11)*