### PR TITLE
Remove partition logic from checkout and cart

### DIFF
--- a/saleor/cart/models.py
+++ b/saleor/cart/models.py
@@ -29,21 +29,6 @@ def find_open_cart_for_user(user):
     return carts.first()
 
 
-class ProductGroup(list):
-    """A group of products."""
-
-    def is_shipping_required(self):
-        """Return `True` if any product in group requires shipping."""
-        return any(p.is_shipping_required() for p in self)
-
-    def get_total(self, discounts=None):
-        subtotals = [line.get_total(discounts) for line in self]
-        if not subtotals:
-            raise AttributeError(
-                'Calling get_total() on an empty product group')
-        return sum_prices(subtotals)
-
-
 class CartQueryset(models.QuerySet):
     """A specialized queryset for dealing with carts."""
 
@@ -144,6 +129,8 @@ class Cart(models.Model):
 
     def get_total(self, discounts=None):
         """Return the total cost of the cart prior to shipping."""
+        if not discounts:
+            discounts = self.discounts
         subtotals = [line.get_total(discounts) for line in self.lines.all()]
         if not subtotals:
             raise AttributeError('Calling get_total() on an empty cart')
@@ -210,14 +197,6 @@ class Cart(models.Model):
         else:
             cart_line.save(update_fields=['quantity'])
         self.update_quantity()
-
-    def partition(self):
-        """Split the cart into a list of groups for shipping."""
-        grouper = (
-            lambda p: 'physical' if p.is_shipping_required() else 'digital')
-        subject = sorted(self.lines.all(), key=grouper)
-        for _, lines in groupby(subject, key=grouper):
-            yield ProductGroup(lines)
 
 
 class CartLine(models.Model):

--- a/saleor/checkout/core.py
+++ b/saleor/checkout/core.py
@@ -97,32 +97,6 @@ class Checkout:
         return self.cart.is_shipping_required()
 
     @property
-    def deliveries(self):
-        """Return the cart split into shipment groups.
-
-        Generates tuples consisting of a partition, its shipping cost and its
-        total cost.
-
-        Each partition is a list of tuples containing the cart line, its unit
-        price and the line total.
-        """
-        for partition in self.cart.partition():
-            if self.shipping_method and partition.is_shipping_required():
-                shipping_cost = self.shipping_method.get_total_price()
-            else:
-                shipping_cost = ZERO_TAXED_MONEY
-            total_with_shipping = partition.get_total(
-                discounts=self.cart.discounts) + shipping_cost
-
-            partition = [
-                (item,
-                 item.get_price_per_item(discounts=self.cart.discounts),
-                 item.get_total(discounts=self.cart.discounts))
-                for item in partition]
-
-            yield partition, shipping_cost, total_with_shipping
-
-    @property
     def shipping_address(self):
         """Return a shipping address if any."""
         if self._shipping_address is None:
@@ -395,20 +369,15 @@ class Checkout:
 
     def get_subtotal(self):
         """Calculate order total without shipping and discount."""
-        cost_iterator = (
-            total - shipping_cost
-            for shipment, shipping_cost, total in self.deliveries)
-        total = sum(cost_iterator, ZERO_TAXED_MONEY)
-        return total
+        return self.cart.get_total()
 
     def get_total(self):
         """Calculate order total with shipping and discount amount."""
-        cost_iterator = (
-            total
-            for shipment, shipping_cost, total in self.deliveries)
-        total = sum(cost_iterator, ZERO_TAXED_MONEY)
+        total = self.cart.get_total()
+        if self.shipping_method and self.is_shipping_required:
+            total += self.shipping_method.get_total_price()
         if self.discount:
-            return total - self.discount
+            total -= self.discount
         return total
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -378,6 +378,14 @@ def anonymous_checkout():
 
 
 @pytest.fixture
+def checkout_with_items(
+        request_cart_with_item, customer_user, billing_address):
+    checkout = Checkout(request_cart_with_item, customer_user, 'tracking_code')
+    checkout.shipping_address = billing_address
+    return checkout
+
+
+@pytest.fixture
 def voucher(db):  # pylint: disable=W0613
     return Voucher.objects.create(code='mirumee', discount_value=20)
 

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -13,7 +13,7 @@ from prices import Money, TaxedMoney
 
 from saleor.cart import CartStatus, forms, utils
 from saleor.cart.context_processors import cart_counter
-from saleor.cart.models import Cart, ProductGroup, find_open_cart_for_user
+from saleor.cart.models import Cart, find_open_cart_for_user
 from saleor.cart.views import update
 from saleor.core.exceptions import InsufficientStock
 from saleor.discount.models import Sale
@@ -599,17 +599,6 @@ def test_total_with_discount(client, sale, request_cart, product_in_stock):
     line = request_cart.lines.first()
     assert line.get_total(discounts=sales) == TaxedMoney(
         net=Money(5, 'USD'), gross=Money(5, 'USD'))
-
-
-def test_product_group():
-    group = ProductGroup([
-        Mock(is_shipping_required=Mock(return_value=False)),
-        Mock(is_shipping_required=Mock(return_value=False))])
-    assert not group.is_shipping_required()
-    group = ProductGroup([
-        Mock(is_shipping_required=Mock(return_value=True)),
-        Mock(is_shipping_required=Mock(return_value=False))])
-    assert group.is_shipping_required()
 
 
 def test_cart_queryset(customer_user):


### PR DESCRIPTION
I want to merge this change because after merging #1777 there were some leftovers related to `DeliveryGroup`s in checkout.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
