### PR TITLE
Allow to create attribute values from product form

### DIFF
--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -411,20 +411,15 @@ def variant_add(request, product_pk):
     product = get_object_or_404(Product.objects.all(), pk=product_pk)
     variant = ProductVariant(product=product)
     form = forms.ProductVariantForm(request.POST or None, instance=variant)
-    attribute_form = forms.VariantAttributeForm(
-        request.POST or None, instance=variant)
-    if form.is_valid() and attribute_form.is_valid():
+    if form.is_valid():
         form.save()
-        attribute_form.save()
         msg = pgettext_lazy(
             'Dashboard message', 'Saved variant %s') % (variant.name,)
         messages.success(request, msg)
         return redirect(
             'dashboard:variant-details', product_pk=product.pk,
             variant_pk=variant.pk)
-    ctx = {
-        'attribute_form': attribute_form, 'form': form, 'product': product,
-        'variant': variant}
+    ctx = {'form': form, 'product': product, 'variant': variant}
     return TemplateResponse(
         request,
         'dashboard/product/product_variant/form.html',
@@ -437,20 +432,15 @@ def variant_edit(request, product_pk, variant_pk):
     product = get_object_or_404(Product.objects.all(), pk=product_pk)
     variant = get_object_or_404(product.variants.all(), pk=variant_pk)
     form = forms.ProductVariantForm(request.POST or None, instance=variant)
-    attribute_form = forms.VariantAttributeForm(
-        request.POST or None, instance=variant)
-    if form.is_valid() and attribute_form.is_valid():
+    if form.is_valid():
         form.save()
-        attribute_form.save()
         msg = pgettext_lazy(
             'Dashboard message', 'Saved variant %s') % (variant.name,)
         messages.success(request, msg)
         return redirect(
             'dashboard:variant-details', product_pk=product.pk,
             variant_pk=variant.pk)
-    ctx = {
-        'attribute_form': attribute_form, 'form': form, 'product': product,
-        'variant': variant}
+    ctx = {'form': form, 'product': product, 'variant': variant}
     return TemplateResponse(
         request,
         'dashboard/product/product_variant/form.html',

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -83,14 +83,14 @@ def item_brand(item, attributes_dict, attribute_values_dict):
     publisher_attribute_pk = attributes_dict.get('publisher')
 
     if brand_attribute_pk:
-        brand = item.get_attribute(brand_attribute_pk)
+        brand = item.attributes.get(str(brand_attribute_pk))
         if brand is None:
-            brand = item.product.get_attribute(brand_attribute_pk)
+            brand = item.product.attributes.get(str(brand_attribute_pk))
 
     if brand is None and publisher_attribute_pk is not None:
-        brand = item.get_attribute(publisher_attribute_pk)
+        brand = item.attributes.get(str(publisher_attribute_pk))
         if brand is None:
-            brand = item.product.get_attribute(publisher_attribute_pk)
+            brand = item.product.attributes.get(str(publisher_attribute_pk))
 
     if brand is not None:
         brand_name = attribute_values_dict.get(brand)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -156,12 +156,6 @@ class Product(models.Model):
         first_image = self.images.first()
         return first_image.image if first_image else None
 
-    def get_attribute(self, pk):
-        return self.attributes.get(smart_text(pk))
-
-    def set_attribute(self, pk, value_pk):
-        self.attributes[smart_text(pk)] = smart_text(value_pk)
-
     def get_price_per_item(self, item, discounts=None):
         return item.get_price_per_item(discounts)
 
@@ -236,12 +230,6 @@ class ProductVariant(models.Model):
     def is_in_stock(self):
         return any(
             [stock.quantity_available > 0 for stock in self.stock.all()])
-
-    def get_attribute(self, pk):
-        return self.attributes.get(smart_text(pk))
-
-    def set_attribute(self, pk, value_pk):
-        self.attributes[smart_text(pk)] = smart_text(value_pk)
 
     def display_variant_attributes(self, attributes=None):
         if attributes is None:

--- a/saleor/static/dashboard/js/components/selects.js
+++ b/saleor/static/dashboard/js/components/selects.js
@@ -7,7 +7,7 @@ function appendOption ($select, option) {
 
 function initSelects() {
   // Custom variant attribute select that allows creating new attribute values.
-  let $variantAttrsSelect = $('.variant-attribute-select select');
+  let $variantAttrsSelect = $('.attribute-select-or-create select');
   $variantAttrsSelect.select2({
     tags: true,
     width: '100%'

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -76,7 +76,7 @@
                   {{ product_form.seo_description|materializecss }}
                 </div>
                 {% for attribute_field in product_form.iter_attribute_fields %}
-                  <div class="row">
+                  <div class="row attribute-select-or-create">
                     {{ attribute_field|materializecss:"input-field s12" }}
                   </div>
                 {% endfor %}

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -76,17 +76,11 @@
                 <div class="row">
                   {{ form.name|materializecss }}
                 </div>
-                {% if attribute_form.fields %}
-                  {% for attribute_field in attribute_form %}
-                    <div class="row attribute-select-or-create">
-                      {{ attribute_field|materializecss }}
-                    </div>
-                  {% endfor %}
-                {% else %}
-                  <p>
-                    {% trans "This product has no attributes." context "Variant form text" %}
-                  </p>
-                {% endif %}
+                {% for attribute_field in form.iter_attribute_fields %}
+                  <div class="row attribute-select-or-create">
+                    {{ attribute_field|materializecss:"input-field s12" }}
+                  </div>
+                {% endfor %}
               </div>
               <div class="col s12 m4">
                 <div class="row">

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -78,7 +78,7 @@
                 </div>
                 {% if attribute_form.fields %}
                   {% for attribute_field in attribute_form %}
-                    <div class="row variant-attribute-select">
+                    <div class="row attribute-select-or-create">
                       {{ attribute_field|materializecss }}
                     </div>
                   {% endfor %}

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -140,19 +140,21 @@ def test_change_attributes_in_product_form(
     product_type.product_attributes.add(text_attribute)
     color_value = color_attribute.values.first()
     new_author = 'Main Tester'
-    new_color = color_value.pk
     data = {
         'name': product.name,
         'price': product.price.amount,
         'category': product.category.pk,
         'description': 'description',
         'attribute-author': new_author,
-        'attribute-color': new_color}
+        'attribute-color': color_value.pk}
     form = ProductForm(data, instance=product)
     assert form.is_valid()
     product = form.save()
-    assert product.get_attribute(color_attribute.pk) == smart_text(new_color)
-    assert product.get_attribute(text_attribute.pk) == new_author
+    assert product.attributes[str(color_attribute.pk)] == str(color_value.pk)
+
+    # Check that new attribute was created for author
+    author_value = AttributeChoiceValue.objects.get(name=new_author)
+    assert product.attributes[str(text_attribute.pk)] == str(author_value.pk)
 
 
 def test_attribute_list(db, product_in_stock, color_attribute, admin_client):
@@ -726,7 +728,7 @@ def test_set_product_description_too_long_for_seo(unavailable_product):
         'fly divided midst, gathering can\'t moveth seed greater subdue. '
         'Lesser meat living fowl called. Dry don\'t wherein. Doesn\'t above '
         'form sixth. Image moving earth without forth light whales. Seas '
-        'were first form fruit that form they\'re, shall air. And. Good of' 
+        'were first form fruit that form they\'re, shall air. And. Good of'
         'signs darkness be place. Was. Is form it. Whose. Herb signs stars '
         'fill own fruit wherein. '
         'Don\'t set man face living fifth Thing the whales were. '

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -144,9 +144,9 @@ def test_filtering_by_attribute(db, color_attribute, default_category):
                                                      sku='12345')
     color = color_attribute.values.first()
     color_2 = color_attribute.values.last()
-    product_a.set_attribute(color_attribute.pk, color.pk)
+    product_a.attributes[str(color_attribute.pk)] = str(color.pk)
     product_a.save()
-    variant_b.set_attribute(color_attribute.pk, color.pk)
+    variant_b.attributes[str(color_attribute.pk)] = str(color.pk)
     variant_b.save()
 
     filtered = filter_products_by_attribute(models.Product.objects.all(),
@@ -154,7 +154,7 @@ def test_filtering_by_attribute(db, color_attribute, default_category):
     assert product_a in list(filtered)
     assert product_b in list(filtered)
 
-    product_a.set_attribute(color_attribute.pk, color_2.pk)
+    product_a.attributes[str(color_attribute.pk)] = str(color_2.pk)
     product_a.save()
     filtered = filter_products_by_attribute(models.Product.objects.all(),
                                             color_attribute.pk, color.pk)
@@ -327,11 +327,11 @@ def test_get_attributes_display_map_no_choices(product_in_stock):
     attributes = product_in_stock.product_type.product_attributes.all()
     product_attr = attributes.first()
 
-    product_in_stock.set_attribute(product_attr.pk, -1)
+    product_in_stock.attributes[str(product_attr.pk)] = '-1'
     attributes_display_map = get_attributes_display_map(
         product_in_stock, attributes)
 
-    assert attributes_display_map == {product_attr.pk: smart_text(-1)}
+    assert attributes_display_map == {product_attr.pk: '-1'}
 
 
 def test_product_availability_status(unavailable_product):


### PR DESCRIPTION
This PR is follow-up to #1964. Just as with variant attributes, it introduces the ability to create new attribute values from the product form. 

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
