### PR TITLE
Bump django-graphql-jwt

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -11,8 +11,7 @@ django-cache-url>=1.0.0
 django-countries>=5.2
 django-filter==1.1
 django-fsm>=2.6.0
-django-graphql-jwt==0.1.8
-django-graphql-extensions==0.0.1
+django-graphql-jwt==0.1.9
 django-impersonate==1.3
 django-mptt>=0.7.1
 django-payments>=0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,8 +33,7 @@ django-elasticsearch-dsl==0.4.4
 django-environ==0.4.4     # via django-graphql-jwt
 django-filter==1.1
 django-fsm==2.6.0
-django-graphql-extensions==0.0.1
-django-graphql-jwt==0.1.8
+django-graphql-jwt==0.1.9
 django-impersonate==1.3
 django-js-asset==1.0.0    # via django-mptt
 django-mptt==0.9.0

--- a/saleor/dashboard/graphql/api.py
+++ b/saleor/dashboard/graphql/api.py
@@ -2,7 +2,7 @@ import graphene
 import graphql_jwt
 from graphene_django.debug import DjangoDebug
 from graphene_django.filter import DjangoFilterConnectionField
-from graphql_extensions.auth.decorators import staff_member_required
+from graphql_jwt.decorators import staff_member_required
 
 from ...graphql.core.filters import DistinctFilterSet
 from ...graphql.page.types import Page

--- a/saleor/dashboard/graphql/mutations.py
+++ b/saleor/dashboard/graphql/mutations.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ImproperlyConfigured
 from graphene.types.mutation import MutationOptions
 from graphene_django.form_converter import convert_form_field
 from graphene_django.registry import get_global_registry
-from graphql_extensions.auth.decorators import staff_member_required
+from graphql_jwt.decorators import staff_member_required
 
 from ...graphql.core.types import Error
 from ...graphql.utils import get_node

--- a/saleor/dashboard/graphql/product/mutations.py
+++ b/saleor/dashboard/graphql/product/mutations.py
@@ -1,5 +1,4 @@
 import graphene
-from graphql_extensions.auth.decorators import staff_member_required
 
 from ....graphql.product.types import Category
 from ....graphql.utils import get_node


### PR DESCRIPTION
This PR bumps `django-grapql-jwt` to the latest version. As a result, we no longer have to use `django-graphql-extensions`, as the first package covers everything that we used it for.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
