### PR TITLE
Move dashboard URL to non-translatable URL patterns

### DIFF
--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -23,10 +23,12 @@ from .search.urls import urlpatterns as search_urls
 handler404 = 'saleor.core.views.handle_404'
 
 non_translatable_urlpatterns = [
-    url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
-        name='django.contrib.sitemaps.views.sitemap'),
+    url(r'^dashboard/',
+        include((dashboard_urls, 'dashboard'), namespace='dashboard')),
     url(r'^graphql', GraphQLView.as_view(
         schema=schema, graphiql=settings.DEBUG), name='api'),
+    url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
+        name='django.contrib.sitemaps.views.sitemap'),
     url(r'^i18n/$', set_language, name='set_language')]
 
 translatable_urlpatterns = [
@@ -34,8 +36,6 @@ translatable_urlpatterns = [
     url(r'^cart/', include((cart_urls, 'cart'), namespace='cart')),
     url(r'^checkout/',
         include((checkout_urls, 'checkout'), namespace='checkout')),
-    url(r'^dashboard/',
-        include((dashboard_urls, 'dashboard'), namespace='dashboard')),
     url(r'^jsi18n/$', JavaScriptCatalog.as_view(), name='javascript-catalog'),
     url(r'^order/', include((order_urls, 'order'), namespace='order')),
     url(r'^page/', include((page_urls, 'page'), namespace='page')),


### PR DESCRIPTION
Language changing feature should be enabled only in the storefront for now. This PR also fixes the dashboard's API URL, which should be independent of the language.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
