### PR TITLE
Fix menu tests and generating random menus

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -605,8 +605,8 @@ def create_page():
 
 def create_menus():
     # Create navbar menu with category links
-    menu, created = Menu.objects.get_or_create(slug='navbar')
-    if created:
+    menu, _ = Menu.objects.get_or_create(slug='navbar')
+    if not menu.items.exists():
         categories = Category.objects.all()
         for category in categories:
             menu.items.get_or_create(
@@ -615,8 +615,8 @@ def create_menus():
         yield 'Created navbar menu'
 
     # Create footer menu with collections and pages
-    menu, created = Menu.objects.get_or_create(slug='footer')
-    if created:
+    menu, _ = Menu.objects.get_or_create(slug='footer')
+    if not menu.items.exists():
         collection = Collection.objects.order_by('?')[0]
         item, _ = menu.items.get_or_create(
             name='Collections',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -677,7 +677,8 @@ def model_form_class():
 
 @pytest.fixture
 def menu():
-    return Menu.objects.create(slug='navbar')
+    # navbar menu object can be already created by default in migration
+    return Menu.objects.get_or_create(slug='navbar')[0]
 
 
 @pytest.fixture

--- a/tests/dashboard/test_menu.py
+++ b/tests/dashboard/test_menu.py
@@ -16,30 +16,32 @@ def test_view_menu_list(admin_client, menu):
     menu_list = response.context['menus'].object_list
     assert response.status_code == 200
     assert menu in menu_list
-    assert len(menu_list) == 1
+    assert len(menu_list) == Menu.objects.count()
 
 
 @pytest.mark.django_db
 def test_view_menu_create(admin_client):
+    menus_before = Menu.objects.count()
     url = reverse('dashboard:menu-add')
-    data = {'slug': 'footer'}
+    data = {'slug': 'new-menu'}
 
     response = admin_client.post(url, data)
 
     assert response.status_code == 302
     assert get_redirect_location(response) == reverse('dashboard:menu-list')
-    assert Menu.objects.count() == 1
+    assert Menu.objects.count() == menus_before + 1
 
 
 @pytest.mark.django_db
 def test_view_menu_create_not_valid(admin_client):
+    menus_before = Menu.objects.count()
     url = reverse('dashboard:menu-add')
     data = {}
 
     response = admin_client.post(url, data)
 
     assert response.status_code == 200
-    assert Menu.objects.count() == 0
+    assert Menu.objects.count() == menus_before
 
 
 @pytest.mark.django_db
@@ -69,13 +71,14 @@ def test_view_menu_detail(admin_client, menu):
 
 @pytest.mark.django_db
 def test_view_menu_delete(admin_client, menu):
+    menus_before = Menu.objects.count()
     url = reverse('dashboard:menu-delete', kwargs={'pk': menu.pk})
 
     response = admin_client.post(url)
 
     assert response.status_code == 302
     assert get_redirect_location(response) == reverse('dashboard:menu-list')
-    assert Menu.objects.count() == 0
+    assert Menu.objects.count() == menus_before - 1
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
I want to merge this change because it fixes menu tests. Tests were broken because of applying Menu app migrations that populate DB with default navbar and footer menu and by recreating navbar menu again in conftest as a menu fixture with repeated unique navbar slug.

It also fixes random data generator to generate menu items if menu has none instead of when menu is just created in populatedb (it is created by default in migration).

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
