### PR TITLE
Switch from psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -38,7 +38,7 @@ maxminddb
 maxminddb-geolite2
 phonenumberslite>=8.9.1
 prices>=1.0.0
-psycopg2>=2.6
+psycopg2-binary>=2.7
 purl>=0.4.1
 pytest
 pytest-django

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ pillow==5.0.0             # via cairosvg, django-versatileimagefield
 pluggy==0.6.0             # via pytest
 prices==1.0.0
 promise==2.1              # via graphene, graphene-django, graphql-core, graphql-relay
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 purl==1.3.1
 py==1.5.2                 # via pytest
 pycparser==2.18           # via cffi


### PR DESCRIPTION
Switching to `psycopg2-binary` removes the warning that is displayed in the console when using `psycopg2`:

```
UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
```

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
