### PR TITLE
split payment_success and order_success views

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -261,7 +261,7 @@ class Payment(BasePayment):
     def get_success_url(self):
         return build_absolute_uri(
             reverse(
-                'order:checkout-success', kwargs={'token': self.order.token}))
+                'order:payment-success', kwargs={'token': self.order.token}))
 
     def get_purchased_items(self):
         lines = [

--- a/saleor/order/urls.py
+++ b/saleor/order/urls.py
@@ -11,6 +11,8 @@ urlpatterns = [
         views.start_payment, name='payment'),
     url(r'^%s/cancel-payment/$' % (TOKEN_PATTERN,), views.cancel_payment,
         name='cancel-payment'),
+    url(r'^%s/payment-success/$' % (TOKEN_PATTERN,),
+        views.payment_success, name='payment-success'),
     url(r'^%s/checkout-success/$' % (TOKEN_PATTERN,),
         views.checkout_success, name='checkout-success'),
     url(r'^%s/attach/$' % (TOKEN_PATTERN,),

--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
 from django.urls import reverse
 from django.utils.translation import pgettext_lazy
+from django.views.decorators.csrf import csrf_exempt
 from payments import PaymentStatus, RedirectNeeded
 
 from . import FulfillmentStatus, OrderStatus

--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -7,6 +7,7 @@ from django.db import transaction
 from django.http import Http404, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect
 from django.template.response import TemplateResponse
+from django.urls import reverse
 from django.utils.translation import pgettext_lazy
 from payments import PaymentStatus, RedirectNeeded
 
@@ -139,6 +140,17 @@ def cancel_payment(request, order):
             form.save()
         return redirect('order:payment', token=order.token)
     return HttpResponseForbidden()
+
+
+@csrf_exempt
+def payment_success(request, token):
+    """Receive request from payment gateway after paying for an order.
+
+    Redirects user to payment success.
+    All post data and query strings are dropped.
+    """
+    url = reverse('order:checkout-success', kwargs={'token': token})
+    return redirect(url)
 
 
 def checkout_success(request, token):

--- a/tests/test_checkout_integration.py
+++ b/tests/test_checkout_integration.py
@@ -67,9 +67,14 @@ def test_checkout_flow(
         'verification_result': 'waiting'}
     payment_response = client.post(payment_page_url, data=payment_data)
     assert payment_response.status_code == 302
+    payment_redirect = reverse(
+        'order:payment-success', kwargs={'token': order.token})
+    assert get_redirect_location(payment_response) == payment_redirect
+    success_response = client.post(payment_redirect, data={'status': 'ok'})
+    assert success_response.status_code == 302
     order_password = reverse(
         'order:checkout-success', kwargs={'token': order.token})
-    assert get_redirect_location(payment_response) == order_password
+    assert get_redirect_location(success_response) == order_password
     mock_send_confirmation.delay.assert_called_once_with(order.pk)
 
 
@@ -123,7 +128,7 @@ def test_checkout_flow_authenticated_user(
 
     assert payment_response.status_code == 302
     order_password = reverse(
-        'order:checkout-success', kwargs={'token': order.token})
+        'order:payment-success', kwargs={'token': order.token})
     assert get_redirect_location(payment_response) == order_password
 
     # Assert that payment object was created and contains correct data


### PR DESCRIPTION
I think just an ordinary redirect will suffice. Post and get data is ignored. Let me know what you think.

I want to merge this change because...

#1987

(Please mention all relevant issue numbers.)

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
