### PR TITLE
Change "save changes" to "make payment"

### DIFF
--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -4681,7 +4681,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/bg_BG/LC_MESSAGES/django.po
+++ b/locale/bg_BG/LC_MESSAGES/django.po
@@ -4774,8 +4774,8 @@ msgstr "Промяна на плащането"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Запази промените"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -4708,8 +4708,8 @@ msgstr "Zahlungsart wechseln"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Änderungen speichern"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -5019,7 +5019,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -4773,8 +4773,8 @@ msgstr "Cambiar método de pago"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Guardar cambios"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/fa_IR/LC_MESSAGES/django.po
+++ b/locale/fa_IR/LC_MESSAGES/django.po
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "ذخیره تغییرات"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -4821,8 +4821,8 @@ msgstr "Changer de moyen de paiement"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Sauvegarder les changements"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -4682,7 +4682,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -4727,8 +4727,8 @@ msgstr "Cambia metodo di pagamento"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Salva modifiche"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -4678,8 +4678,8 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "変更保存"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -4690,8 +4690,8 @@ msgstr "결제 방법 변경"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "변경 저장"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -4684,7 +4684,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -4711,8 +4711,8 @@ msgstr "Wijzig betaalmethode"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Sla wijzigingen op"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -4752,8 +4752,8 @@ msgstr "Zmień metodę płatności"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Zapisz zmiany"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -4715,8 +4715,8 @@ msgstr "Mudar método de pagamento"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Salvar alterações"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -4688,7 +4688,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -4717,8 +4717,8 @@ msgstr "Изменить способ оплаты"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Сохранить изменения"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -4713,8 +4713,8 @@ msgstr "Zmeňte spôsob platby"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Uložiť zmeny"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -4682,7 +4682,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -4717,8 +4717,8 @@ msgstr "Змінити метод оплати"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "Зберегти зміни"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -4678,7 +4678,7 @@ msgstr ""
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
+msgid "Make payment"
 msgstr ""
 
 #: templates/order/payment/details.html:4

--- a/locale/zh/LC_MESSAGES/django.po
+++ b/locale/zh/LC_MESSAGES/django.po
@@ -4681,8 +4681,8 @@ msgstr "修改支付方式"
 
 #: templates/order/payment/default.html:19
 msgctxt "Payment form primary action"
-msgid "Save changes"
-msgstr "保存变更"
+msgid "Make payment"
+msgstr ""
 
 #: templates/order/payment/details.html:4
 msgctxt "Payment form page title"

--- a/templates/order/payment/default.html
+++ b/templates/order/payment/default.html
@@ -16,7 +16,7 @@
     <div class="col-sm-2"></div>
     <div class="col-sm-10">
       <button type="submit" class="btn primary">
-        {% trans "Save changes" context "Payment form primary action" %}
+        {% trans "Make payment" context "Payment form primary action" %}
       </button>
     </div>
   </div>


### PR DESCRIPTION
I want to merge this change because... it is kind of more or less remotely related to #2018. It is a little confusing, after completing all the steps required to make a payment, to see a button saying "save changes". When I first saw it, it felt like "what changes? I just correctly filled out a new payment form, to which I did not make any changes, what am I to confirm?". I think something more accurate and meaningful like "Make payment" would be better.

![selection_103](https://user-images.githubusercontent.com/7512741/38177083-03e5ce28-35fb-11e8-9bc3-a0aa8b83687a.png)

changing to: 

![selection_104](https://user-images.githubusercontent.com/7512741/38177086-0e23ef1e-35fb-11e8-861c-d58003ac4f3c.png)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
