### PR TITLE
Allow to force SSL (301 all HTTP connections to HTTPS)

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -93,6 +93,9 @@ EMAIL_USE_SSL = email_config['EMAIL_USE_SSL']
 ENABLE_SSL = ast.literal_eval(
     os.environ.get('ENABLE_SSL', 'False'))
 
+if ENABLE_SSL and ast.literal_eval(os.environ.get('FORCE_SSL', 'False')):
+    SECURE_SSL_REDIRECT = True
+
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL')
 ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 
@@ -148,6 +151,7 @@ SECRET_KEY = os.environ.get('SECRET_KEY')
 
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.middleware.security.SecurityMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',


### PR DESCRIPTION
Hello!

This change introduce a new settings key: `FORCE_SSL` for users that are using (enable) SSL in Saleor. 
`FORCE_SSL` is using (setting) `SECURE_SSL_REDIRECT` of `django.middleware.security.SecurityMiddleware` which permanently redirect every HTTP connections to HTTPS (301).

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
