### PR TITLE
Filter button is now a real button (for mobile users)

### DIFF
--- a/saleor/static/scss/components/_filters.scss
+++ b/saleor/static/scss/components/_filters.scss
@@ -83,9 +83,6 @@
     }
   }
   &__title {
-    @include media-breakpoint-down(sm) {
-      padding: $global-padding *2 0;
-    }
     @media (max-width: 370px) {
       padding-top: 5rem;
     }
@@ -158,20 +155,14 @@
     border-radius: 50%;
   }
   &__wrapper {
-    @include media-breakpoint-down(sm) {
-      padding-top: 8px;
-    }
+    padding: 0 0 $global-padding * 2 0;
   }
 }
 
-.filters-toggle {
-  margin: 1.1rem 0 1rem;
-  cursor: pointer;
-}
 .sort-by {
   text-align: right;
   position: relative;
-  margin: 1rem 0 1rem 5rem;
+  margin: 1rem 0 1rem auto;
   .btn-link {
     padding-right: $global-padding;
     color: $body-color;
@@ -268,4 +259,10 @@
 .load-more {
   clear: both;
   text-align: center;
+}
+
+@include media-breakpoint-up(md) {
+  .d-md-hidden {
+    visibility: hidden;
+  }
 }

--- a/templates/product/product_list_base.html
+++ b/templates/product/product_list_base.html
@@ -46,10 +46,13 @@
         {% block breadcrumb_part %}{% endblock %}
       </ul>
     </div>
-    <div class="col-md-5">
-      <h3 class="d-md-none float-left filters-toggle">
-        {% trans 'Filters' context 'Filter heading title' %}
-      </h3>
+  </div>
+  <div class="row filters-menu__wrapper">
+    <div class="col-6 col-md-2 d-md-hidden filters-menu">
+      <span class="btn secondary"
+      >{% trans 'Filters' context 'Filter heading title' %}</span>
+    </div>
+    <div class="col-6 col-md-10">
       <div class="sort-by">
         <div class="click-area d-none"></div>
         <button class="btn btn-link">

--- a/templates/product/product_list_base.html
+++ b/templates/product/product_list_base.html
@@ -49,8 +49,9 @@
   </div>
   <div class="row filters-menu__wrapper">
     <div class="col-6 col-md-2 d-md-hidden filters-menu">
-      <span class="btn secondary"
-      >{% trans 'Filters' context 'Filter heading title' %}</span>
+      <span class="btn secondary">
+        {% trans 'Filters' context 'Filter heading title' %}
+      </span>
     </div>
     <div class="col-6 col-md-10">
       <div class="sort-by">


### PR DESCRIPTION
Hello!

After two weeks or so of testing in post-production, I'm opening this PR to replace the simple text button to toggle filter menu, to a real button. Otherwise, users don't know it's a button but just a label.

----

#### Before
![](https://i.imgur.com/vTJlOAf.png)

#### After
![](https://i.imgur.com/WqihVK2.png)

----

#### Before
![](https://i.imgur.com/U9jxwEr.png)

#### After
![](https://i.imgur.com/1GupZKY.png)

----

#### Before
![](https://i.imgur.com/zlx4dmR.png)

#### After
![](https://i.imgur.com/OBMxynV.png)

----


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
