### PR TITLE
Unify SEO fields naming

### DIFF
--- a/saleor/dashboard/seo/fields.py
+++ b/saleor/dashboard/seo/fields.py
@@ -30,7 +30,7 @@ class SeoTitleField(forms.CharField):
             (
                 'Field name, ',
                 'Title that will be used to describe page in Search Engines'),
-            'SEO Title')
+            'Search engine title')
 
 
 class SeoDescriptionField(forms.CharField):
@@ -50,6 +50,7 @@ class SeoDescriptionField(forms.CharField):
         self.required = required
         self.help_text = SEO_FIELD_HELP_TEXT
         self.label = pgettext_lazy(
-            ('Field name, Meta Description is page '
-             'summary used by Search Engines'),
-            'Meta Description')
+            (
+                'Field name, description that will be used as a summary '
+                'in Search Engines'),
+            'Search engine description')


### PR DESCRIPTION
As discussed in #1953, in the comments, we should unify our naming for seo fields to not confuse our users.

I want to merge this change because...

(Please mention all relevant issue numbers.)

(If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work.)

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
