### PR TITLE
Bug fix: add .PDF extension to PDFs

### DIFF
--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -516,7 +516,7 @@ def order_invoice(request, order_pk):
     absolute_url = get_statics_absolute_url(request)
     pdf_file, order = create_invoice_pdf(order, absolute_url)
     response = HttpResponse(pdf_file, content_type='application/pdf')
-    name = "invoice-%s" % order.id
+    name = "invoice-%s.pdf" % order.id
     response['Content-Disposition'] = 'filename=%s' % name
     return response
 
@@ -556,7 +556,7 @@ def fulfillment_packing_slips(request, order_pk, fulfillment_pk):
     absolute_url = get_statics_absolute_url(request)
     pdf_file, order = create_packing_slip_pdf(order, fulfillment, absolute_url)
     response = HttpResponse(pdf_file, content_type='application/pdf')
-    name = "packing-slip-%s" % (order.id,)
+    name = "packing-slip-%s.pdf" % (order.id,)
     response['Content-Disposition'] = 'filename=%s' % name
     return response
 

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -551,7 +551,7 @@ def test_view_order_invoice(admin_client, order_with_lines):
     response = admin_client.get(url)
     assert response.status_code == 200
     assert response['content-type'] == 'application/pdf'
-    name = "invoice-%s" % order_with_lines.id
+    name = "invoice-%s.pdf" % order_with_lines.id
     assert response['Content-Disposition'] == 'filename=%s' % name
 
 
@@ -577,7 +577,7 @@ def test_view_fulfillment_packing_slips(admin_client, fulfilled_order):
     response = admin_client.get(url)
     assert response.status_code == 200
     assert response['content-type'] == 'application/pdf'
-    name = "packing-slip-%s" % (fulfilled_order.id,)
+    name = "packing-slip-%s.pdf" % (fulfilled_order.id,)
     assert response['Content-Disposition'] == 'filename=%s' % name
 
 


### PR DESCRIPTION
Hello! This is an issue I discovered some time ago on an office PC on Windows 10, but seems to be reproducible on any OS. I only know how to trigger the bug on firefox though.

By default, in old firefox profiles, the PDF preview is disabled, as it remains a quite *recent* feature of firefox. And by default, downloads are automatically being saved without any prompt. And thus, the browser, firefox at least, is downloading and saving the file from the file name the server responded with, which contains no file extension, firefox ignores mimetype while saving the file. Confusing the user.

### How to reproduce the bug on firefox
1. Go to settings -> Files and Applications,
   1. Search for the PDF mime type,
   2. Select 'Save file' instead of 'Preview in firefox'.

![settings](https://i.imgur.com/hIuHZqK.png)

2. Open an order in saleor dashboard and download PDF file (packing slip or invoice).
3. Go to your downloads, the PDF should have been saved without extension.

![downloads](https://i.imgur.com/BSZTo78.png)


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
