### PR TITLE
Fix button style in variant picker

### DIFF
--- a/saleor/static/scss/components/_variant-picker.scss
+++ b/saleor/static/scss/components/_variant-picker.scss
@@ -5,7 +5,7 @@
   }
   &__label {
     margin-bottom: $global-margin;
-    
+
   }
   &__options {
     display: block;
@@ -17,6 +17,9 @@
     float: left;
     &.active {
       border-color: $darken-gray;
+    }
+    input {
+      display: none;
     }
   }
 }


### PR DESCRIPTION
We already resolved it on the demo, but missed on master:

![image](https://user-images.githubusercontent.com/5421321/38560855-e5eb408c-3cd6-11e8-977e-542b737f6bec.png)

This PR fixes the buttons rendering.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
