### PR TITLE
Add custom CreateToken mutation

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -5,6 +5,7 @@ from graphene_django.filter import DjangoFilterConnectionField
 
 from ..page import models as page_models
 from .core.filters import DistinctFilterSet
+from .core.mutations import CreateToken
 from .page.resolvers import resolve_pages
 from .page.types import Page
 from .page.mutations import PageCreate, PageDelete, PageUpdate
@@ -88,7 +89,7 @@ class Query(graphene.ObjectType):
 
 
 class Mutations(graphene.ObjectType):
-    token_create = graphql_jwt.ObtainJSONWebToken.Field()
+    token_create = CreateToken.Field()
     token_refresh = graphql_jwt.Refresh.Field()
 
     category_create = CategoryCreateMutation.Field()

--- a/saleor/graphql/core/types.py
+++ b/saleor/graphql/core/types.py
@@ -31,7 +31,9 @@ class CountableDjangoObjectType(DjangoObjectType):
 
 class Error(graphene.ObjectType):
     field = graphene.String(
-        description='Name of a field that caused the error.')
+        description="""Name of a field that caused the error. A value of
+        `null` indicates that the error isn't associated with a particular
+        field.""", required=False)
     message = graphene.String(description='The error message.')
 
     class Meta:

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -55,7 +55,7 @@ class ProductVariant(CountableDjangoObjectType):
     price_override = graphene.Field(
         Money,
         description="""Override the base price of a product if necessary.
-        A value of `null` indicates the the default product price is used.""")
+        A value of `null` indicates that the default product price is used.""")
     attributes = graphene.List(
         SelectedAttribute,
         description='List of attributes assigned to this variant.')


### PR DESCRIPTION
Wrap default token mutation with a custom one to handle errors nicely.

Closes #1990 

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
