### PR TITLE
Fix main menu displaying child items

### DIFF
--- a/saleor/core/templatetags/shop.py
+++ b/saleor/core/templatetags/shop.py
@@ -23,5 +23,7 @@ def menu(context, site_menu=None, horizontal=False):
         return
     menus = context[NAVIGATION_CONTEXT_NAME]
     menu = next((menu for menu in menus if menu.pk == site_menu.pk), None)
-    menu_items = menu.items.all() if menu else None
+    if not menu:
+        return
+    menu_items = [item for item in menu.items.all() if item.parent_id is None]
     return {'menu_items': menu_items, 'horizontal': horizontal}

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -1,6 +1,6 @@
 from django.urls import reverse
 
-from saleor.core.templatetags.shop import get_sort_by_url
+from saleor.core.templatetags.shop import get_sort_by_url, menu
 
 
 def test_sort_by_url_ascending(admin_client, default_category):
@@ -21,3 +21,9 @@ def test_sort_by_url_descending(admin_client, default_category):
     result = get_sort_by_url(response.context, 'name', descending=True)
     expected = url + '?sort_by=-name'
     assert result == expected
+
+
+def test_menu(client, menu_with_items):
+    response = client.get(reverse('home'))
+    result = menu(response.context, menu_with_items)
+    assert all((i for i in result['menu_items'] if i.parent_id is None))


### PR DESCRIPTION
Current menu implementation displays child `MenuItems` on the main nav. 

#### How to reproduce

1. With sample data
2. Edit a menu item on the dashboard
3. Add a menu item

#### Before

![image](https://user-images.githubusercontent.com/208952/38789513-0e7bacfe-413b-11e8-8c4f-cd803f509b4d.png)

#### After

![image](https://user-images.githubusercontent.com/208952/38789538-2fda52ce-413b-11e8-9813-7cd0d92b56cc.png)


### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [ ] JavaScript code quality checks pass: `eslint`.
