### PR TITLE
Fix Navigation set None on SiteSettingsForm save

### DIFF
--- a/saleor/dashboard/sites/forms.py
+++ b/saleor/dashboard/sites/forms.py
@@ -19,7 +19,7 @@ class SiteForm(forms.ModelForm):
 class SiteSettingsForm(forms.ModelForm):
     class Meta:
         model = SiteSettings
-        exclude = ['site']
+        fields = ['header_text', 'description']
         labels = {
             'header_text': pgettext_lazy(
                 'Header text', 'Header text'),


### PR DESCRIPTION
Navigation menus (top and bottom) were included in SiteSettingsForm, however they were not rendered on the storefront. Saving SiteSettingsForm set them to None
I think that including fields, rather than excluding, is a better way to prevent such bugs in the future
close #2139 