### PR TITLE
Localization fix: added missing label for filter 'price'

### DIFF
--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -98,7 +98,8 @@ class Product(SeoModel):
         Category, related_name='products', on_delete=models.CASCADE)
     price = MoneyField(
         currency=settings.DEFAULT_CURRENCY, max_digits=12,
-        decimal_places=settings.DEFAULT_DECIMAL_PLACES)
+        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
+        verbose_name=pgettext_lazy('Product list sorting option', 'price'))
     available_on = models.DateField(blank=True, null=True)
     is_published = models.BooleanField(default=True)
     attributes = HStoreField(default={}, blank=True)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -99,7 +99,7 @@ class Product(SeoModel):
     price = MoneyField(
         currency=settings.DEFAULT_CURRENCY, max_digits=12,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        verbose_name=pgettext_lazy('Product list sorting option', 'price'))
+        verbose_name=pgettext_lazy('Currency amount', 'Price'))
     available_on = models.DateField(blank=True, null=True)
     is_published = models.BooleanField(default=True)
     attributes = HStoreField(default={}, blank=True)

--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -63,11 +63,11 @@
                         value="{% if field.value.1 %}{{ field.value.1 }}{% endif %}" type="number" min="0"
                         class="form-control d-inline" placeholder="{% trans 'to' context 'Product price filter' %}"/>
                 </div>
-                <button class="btn primary" type="submit">{% trans 'Update' context 'Product price filter' %}</button>
               </div>
             </div>
           {% endif %}
         {% endfor %}
+        <button class="btn primary" type="submit">{% trans 'Update' context 'Product price filter' %}</button>
       </form>
     </div>
   </div>

--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -67,7 +67,7 @@
             </div>
           {% endif %}
         {% endfor %}
-        <button class="btn primary" type="submit">{% trans 'Update' context 'Product price filter' %}</button>
+        <button class="btn primary" type="submit">{% trans 'Update' context 'Apply filters button' %}</button>
       </form>
     </div>
   </div>


### PR DESCRIPTION
Hi there! The 'price' filter was not being translated (no label), it has been fixed.
\+ moved update button outside of the price filter section (fixes #2168)


Before:
![scr](https://i.imgur.com/A0OkiKz.png)

After:
![scr](https://i.imgur.com/o09j8ve.png)



### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
