### PR TITLE
Update django-payments to 0.12.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ django-graphql-jwt==0.1.9
 django-impersonate==1.3
 django-js-asset==1.0.0    # via django-mptt
 django-mptt==0.9.0
-django-payments==0.12.1
+django-payments==0.12.3
 django-phonenumber-field==2.0.0
 django-prices-openexchangerates==1.0.0
 django-prices-vatlayer==1.0.1


### PR DESCRIPTION
django-payments 0.12.3 allows correct operation with DotPay payments.