### PR TITLE
Fix displaying price range in product details page

### DIFF
--- a/saleor/core/templatetags/taxed_prices.py
+++ b/saleor/core/templatetags/taxed_prices.py
@@ -8,10 +8,8 @@ register = template.Library()
 
 @register.inclusion_tag('product/_price_range.html', takes_context=True)
 def price_range(context, price_range):
-    display_gross_prices = context['site'].settings.display_gross_prices
-    return {
-        'price_range': price_range,
-        'display_gross_prices': display_gross_prices}
+    display_gross = context['site'].settings.display_gross_prices
+    return {'display_gross': display_gross, 'price_range': price_range}
 
 
 @register.simple_tag

--- a/templates/product/_price_range.html
+++ b/templates/product/_price_range.html
@@ -4,7 +4,7 @@
 <span>
   <span>
     {% if price_range.start != price_range.stop %}{% trans "from" context "product price range" %} {% endif %}
-    {% if site.settings.display_gross_prices %}
+    {% if display_gross %}
       {{ price_range.start.gross|amount:'html' }}
     {% else %}
       {{ price_range.start.net|amount:'html' }}


### PR DESCRIPTION
This PR fixes displaying price in product details page. There was a problem with a template for `price_range` templatetag, which was using `site.settings.display_gross_prices` to decide if gross or net price should be displayed, but site was unavailable there. Now it is took from context one level above. 

Fixes #2197

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
