### PR TITLE
Ability to add a new billing address when no shipping required

### DIFF
--- a/saleor/checkout/views/summary.py
+++ b/saleor/checkout/views/summary.py
@@ -160,8 +160,7 @@ def summary_without_shipping(request, checkout):
         address_form, preview = get_address_form(
             request.POST or None, autocomplete_type='billing',
             initial={'country': request.country},
-            country_code=billing_address.country.code,
-            instance=billing_address)
+            country_code=billing_address.country.code)
         addresses_form = BillingWithoutShippingAddressForm(
             request.POST or None, additional_addresses=user_addresses,
             initial={'address': billing_address.id})


### PR DESCRIPTION
I want to merge this change because it fixes #2192. Now, when adding a new billing address in the checkout when no shipping is required, always a new Address object is used. A more detailed description of a problem is provided in an issue.

As I work on merging checkout with cart and this logic will change, tests will be provided in separate issue.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
