### PR TITLE
Add endpoint for searching variants

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -18,13 +18,16 @@ from .product.mutations import (
 )
 from .product.resolvers import (
     resolve_attributes, resolve_categories, resolve_products,
-    resolve_product_types, resolve_available_variants_list)
+    resolve_product_types, resolve_search_variants)
 from .product.types import (
     Category, Product, ProductAttribute, ProductType, ProductVariant)
 from .utils import get_node
 
 
 class Query(graphene.ObjectType):
+    search_variants = DjangoFilterConnectionField(
+        ProductVariant, filterset_class=DistinctFilterSet, q=graphene.String(),
+        description='Search for variants by parameter q.')
     attributes = DjangoFilterConnectionField(
         ProductAttribute, filterset_class=DistinctFilterSet,
         in_category=graphene.Argument(graphene.ID),
@@ -55,13 +58,13 @@ class Query(graphene.ObjectType):
         ProductType, filterset_class=DistinctFilterSet,
         level=graphene.Argument(graphene.Int),
         description='List of the shop\'s product types.')
-    available_variants_list = DjangoFilterConnectionField(
-        ProductVariant, filterset_class=DistinctFilterSet, q=graphene.String(),
-        description='here goes desc.')
     node = graphene.Node.Field()
 
     def resolve_attributes(self, info, in_category=None, **kwargs):
         return resolve_attributes(in_category, info)
+
+    def resolve_available_variants_list(self, info, q):
+        return resolve_search_variants(info, q)
 
     def resolve_category(self, info, id):
         return get_node(info, id, only_type=Category)
@@ -88,9 +91,6 @@ class Query(graphene.ObjectType):
 
     def resolve_product_types(self, info):
         return resolve_product_types()
-
-    def resolve_available_variants_list(self, info, q):
-        return resolve_available_variants_list(info, q)
 
 
 class Mutations(graphene.ObjectType):

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -63,7 +63,7 @@ class Query(graphene.ObjectType):
     def resolve_attributes(self, info, in_category=None, **kwargs):
         return resolve_attributes(in_category, info)
 
-    def resolve_available_variants_list(self, info, q):
+    def resolve_search_variants(self, info, q):
         return resolve_search_variants(info, q)
 
     def resolve_category(self, info, id):

--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -18,9 +18,9 @@ from .product.mutations import (
 )
 from .product.resolvers import (
     resolve_attributes, resolve_categories, resolve_products,
-    resolve_product_types)
+    resolve_product_types, resolve_available_variants_list)
 from .product.types import (
-    Category, Product, ProductAttribute, ProductType)
+    Category, Product, ProductAttribute, ProductType, ProductVariant)
 from .utils import get_node
 
 
@@ -55,6 +55,9 @@ class Query(graphene.ObjectType):
         ProductType, filterset_class=DistinctFilterSet,
         level=graphene.Argument(graphene.Int),
         description='List of the shop\'s product types.')
+    available_variants_list = DjangoFilterConnectionField(
+        ProductVariant, filterset_class=DistinctFilterSet, q=graphene.String(),
+        description='here goes desc.')
     node = graphene.Node.Field()
 
     def resolve_attributes(self, info, in_category=None, **kwargs):
@@ -85,6 +88,9 @@ class Query(graphene.ObjectType):
 
     def resolve_product_types(self, info):
         return resolve_product_types()
+
+    def resolve_available_variants_list(self, info, q):
+        return resolve_available_variants_list(info, q)
 
 
 class Mutations(graphene.ObjectType):

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -51,6 +51,8 @@ def resolve_search_variants(info, q):
     Look for sku, variant name or product name.
 
     """
+    if len(q) < 2:
+        raise ValueError('Search query must be at least two characters long.')
     available_products = models.Product.objects.available_products()
     queryset = models.ProductVariant.objects.filter(
         product__in=available_products)

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -45,7 +45,7 @@ def resolve_product_types():
     return models.ProductType.objects.all().distinct()
 
 
-def resolve_available_variants_list(info, q):
+def resolve_search_variants(info, q):
     """Return variants filtered by q parameter.
 
     Look for sku, variant name or product name.

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 from ...product import models
 from ...product.utils import products_visible_to_user
 from ..utils import get_node
-from .types import Category, SelectedAttribute
+from .types import Category
 
 
 def resolve_categories(info, level=None):
@@ -43,3 +43,19 @@ def resolve_attributes(category_id, info):
 
 def resolve_product_types():
     return models.ProductType.objects.all().distinct()
+
+
+def resolve_available_variants_list(info, q):
+    """Return variants filtered by q parameter.
+
+    Look for sku, variant name or product name.
+
+    """
+    available_products = models.Product.objects.available_products()
+    queryset = models.ProductVariant.objects.filter(
+        product__in=available_products)
+    queryset = queryset.filter(
+        Q(sku__icontains=q) |
+        Q(name__icontains=q) |
+        Q(product__name__icontains=q))
+    return queryset.distinct()

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -273,4 +273,3 @@ class ProductImage(CountableDjangoObjectType):
         if size:
             return self.image.crop[size].url
         return self.image.url
-


### PR DESCRIPTION
Closes #2195.

I think endpoint should be guarded by some permissions, bu I am not sure which; it is used now while creating orders in dashboard, so `view/edit.order` seems to be more appropriate than `view.product`.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
