### PR TITLE
Add ability to retrieve multiple nodes with one query

### DIFF
--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -16,14 +16,14 @@ def get_node(info, id, only_type=None):
 
 
 def get_nodes(ids, graphene_type):
-    """Return queryset of nodes of proper type."""
+    """Return a list of nodes of proper type."""
     pks = []
     for graphql_id in ids:
         _type, _id = from_global_id(graphql_id)
         assert str(graphene_type) == _type, (
             'Must receive an {} id.').format(graphene_type._meta.name)
         pks.append(_id)
-    nodes =  graphene_type._meta.model.objects.filter(pk__in=pks)
+    nodes = list(graphene_type._meta.model.objects.filter(pk__in=pks))
     if not nodes:
         raise Exception(
             "Could not resolve to a nodes with the global id list of '%s'."

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -1,6 +1,7 @@
 import graphene
 from django.utils.encoding import smart_text
 from django.utils.text import slugify
+from graphql_relay import from_global_id
 
 from ..product.models import AttributeChoiceValue, ProductAttribute
 
@@ -12,6 +13,17 @@ def get_node(info, id, only_type=None):
         raise Exception(
             "Could not resolve to a node with the global id of '%s'." % id)
     return node
+
+
+def get_nodes(ids, graphene_type):
+    """Return list of nodes of proper type."""
+    pks = []
+    for graphql_id in ids:
+        _type, _id = from_global_id(graphql_id)
+        assert str(graphene_type) == _type, (
+            'Must receive an {} id.').format(graphene_type._meta.name)
+        pks.append(_id)
+    return list(graphene_type._meta.model.objects.filter(pk__in=pks))
 
 
 def get_attributes_dict_from_list(attributes, attr_slug_id):

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -28,6 +28,11 @@ def get_nodes(ids, graphene_type):
         raise Exception(
             "Could not resolve to a nodes with the global id list of '%s'."
             % ids)
+    nodes_pk_list = [str(node.pk) for node in nodes]
+    for pk in pks:
+        assert pk in nodes_pk_list, (
+            'There is no node of type {} with pk {}'.format(_type, pk)
+        )
     return nodes
 
 

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -16,14 +16,14 @@ def get_node(info, id, only_type=None):
 
 
 def get_nodes(ids, graphene_type):
-    """Return list of nodes of proper type."""
+    """Return queryset of nodes of proper type."""
     pks = []
     for graphql_id in ids:
         _type, _id = from_global_id(graphql_id)
         assert str(graphene_type) == _type, (
             'Must receive an {} id.').format(graphene_type._meta.name)
         pks.append(_id)
-    return list(graphene_type._meta.model.objects.filter(pk__in=pks))
+    return graphene_type._meta.model.objects.filter(pk__in=pks)
 
 
 def get_attributes_dict_from_list(attributes, attr_slug_id):

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -23,7 +23,12 @@ def get_nodes(ids, graphene_type):
         assert str(graphene_type) == _type, (
             'Must receive an {} id.').format(graphene_type._meta.name)
         pks.append(_id)
-    return graphene_type._meta.model.objects.filter(pk__in=pks)
+    nodes =  graphene_type._meta.model.objects.filter(pk__in=pks)
+    if not nodes:
+        raise Exception(
+            "Could not resolve to a nodes with the global id list of '%s'."
+            % ids)
+    return nodes
 
 
 def get_attributes_dict_from_list(attributes, attr_slug_id):

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -241,7 +241,7 @@ def test_get_nodes(product_list):
     global_ids.append(to_global_id('Product', product_list[0].pk))
     # Return products corresponding to global ids
     products = get_nodes(global_ids, Product)
-    assert list(products) == product_list
+    assert products == product_list
 
     # Raise an error if requested id has no related database object
     nonexistent_item = Mock(type='Product', pk=123)

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -239,7 +239,7 @@ def test_get_nodes(product_list):
     global_ids = [to_global_id('Product', product.pk) for product in product_list]
     # Return products corresponding to global ids
     products = get_nodes(global_ids, Product)
-    assert products == product_list
+    assert list(products) == product_list
 
     # Raise an error if one of the node is of wrong type
     invalid_item = Mock(type='test', pk=123)


### PR DESCRIPTION
I'd like to have a tool to get many objects of selected type at once instead of iterating over `get_node` function like we are doing right now.

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
