### PR TITLE
Fix images are not shown when selecting variant images

### DIFF
--- a/templates/dashboard/product/product_variant/_image_select.html
+++ b/templates/dashboard/product/product_variant/_image_select.html
@@ -7,7 +7,7 @@
         <div class="image_select-item">
           <input id="{{ choice.id_for_label }}" name="{{ choice.data.name }}" class="filled-in" type="checkbox" value="{{ choice.data.value }}" {% if choice.data.selected %}checked{% endif %}>
           <label for="{{ choice.id_for_label }}"></label>
-          <img id="{{ choice.id_for_label }}" class="responsive-img" src="{{ image.image.crop.200x200 }}" srcset="{{ image.image.crop.200x200 }} 1x" alt="">
+          <img id="{{ choice.id_for_label }}" class="responsive-img" src="{{ image.image.crop.255x255 }}" srcset="{{ image.image.crop.255x255 }} 1x" alt="">
           <div id="{{ choice.id_for_label }}" class="image_select-item-overlay{% if choice.data.selected %} checked{% endif %}"></div>
         </div>
       {% endwith %}


### PR DESCRIPTION
There are only 6 kinds of thumbnail which will be generated when uploading product images. Size ```200x200``` is not one of them. This PR updates size ```200x200``` to ```255x255``` in selecting variants image of a product otherwise the images won't show up

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
