### PR TITLE
Change permission display view in group details

### DIFF
--- a/saleor/core/permissions.py
+++ b/saleor/core/permissions.py
@@ -33,5 +33,5 @@ MODELS_PERMISSIONS = [
 
 def get_permissions():
     codenames = [permission.split('.')[1] for permission in MODELS_PERMISSIONS]
-    return Permission.objects.filter(codename__in=codenames)\
-        .prefetch_related('content_type')
+    return Permission.objects.filter(codename__in=codenames).prefetch_related(
+        'content_type').order_by('codename')

--- a/saleor/dashboard/forms.py
+++ b/saleor/dashboard/forms.py
@@ -149,3 +149,10 @@ class AjaxSelect2MultipleChoiceField(forms.MultipleChoiceField):
         """Set initially selected objects on field's widget."""
         selected = [{'id': obj.pk, 'text': str(obj)} for obj in objects]
         self.widget.attrs['data-initial'] = json.dumps(selected)
+
+
+class PermissionMultipleChoiceField(forms.ModelMultipleChoiceField):
+    """ Permission multiple choice field with label override."""
+
+    def label_from_instance(self, obj):
+        return obj.name

--- a/saleor/dashboard/group/filters.py
+++ b/saleor/dashboard/group/filters.py
@@ -5,16 +5,21 @@ from django_filters import (
 
 from ...core.filters import SortedFilterSet
 from ...core.permissions import get_permissions
+from ..forms import PermissionMultipleChoiceField
 
 SORT_BY_FIELDS = {
     'name': pgettext_lazy('Group list sorting option', 'name')}
+
+
+class PermissionMultipleChoiceFilter(ModelMultipleChoiceFilter):
+    field_class = PermissionMultipleChoiceField
 
 
 class GroupFilter(SortedFilterSet):
     name = CharFilter(
         label=pgettext_lazy('Group list filter label', 'Name'),
         lookup_expr='icontains')
-    permissions = ModelMultipleChoiceFilter(
+    permissions = PermissionMultipleChoiceFilter(
         label=pgettext_lazy('Group list filter label', 'Permissions'),
         name='permissions',
         queryset=get_permissions())

--- a/saleor/dashboard/group/forms.py
+++ b/saleor/dashboard/group/forms.py
@@ -3,6 +3,7 @@ from django.contrib.auth.models import Group
 from django.utils.translation import pgettext_lazy
 
 from ...core.permissions import get_permissions
+from ..forms import PermissionMultipleChoiceField
 
 
 class GroupPermissionsForm(forms.ModelForm):
@@ -13,6 +14,6 @@ class GroupPermissionsForm(forms.ModelForm):
             'name': pgettext_lazy('Item name', 'Name'),
             'permissions': pgettext_lazy('Permissions', 'Permissions')}
 
-    permissions = forms.ModelMultipleChoiceField(
+    permissions = PermissionMultipleChoiceField(
         queryset=get_permissions(),
         widget=forms.CheckboxSelectMultiple)


### PR DESCRIPTION
I want to merge this change because it closes #2151. Permission description is simplified to `Can view/edit ...`. App and model name are no loger shown.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
