### PR TITLE
More descriptive shipping methods list

### DIFF
--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -717,7 +717,7 @@ def change_fulfillment_tracking(request, order_pk, fulfillment_pk):
 def ajax_order_shipping_methods_list(request, order_pk):
     order = get_object_or_404(Order, pk=order_pk)
     queryset = ShippingMethodCountry.objects.select_related(
-        'shipping_method').order_by('price').all()
+        'shipping_method').order_by('shipping_method__name', 'price')
 
     if order.shipping_address:
         country_code = order.shipping_address.country.code

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -99,5 +99,5 @@ class ShippingMethodCountry(models.Model):
 
     def get_ajax_label(self):
         price_html = format_money(self.price)
-        label = mark_safe('%s %s' % (self.shipping_method, price_html))
+        label = mark_safe('%s %s' % (self, price_html))
         return label

--- a/tests/test_shipping.py
+++ b/tests/test_shipping.py
@@ -36,4 +36,4 @@ def test_shipping_get_total_price(monkeypatch, shipping_method, vatlayer):
 def test_shipping_get_ajax_label(shipping_method):
     method = shipping_method.price_per_country.get()
     label = method.get_ajax_label()
-    assert label == 'DHL $10.00'
+    assert label == 'DHL Rest of World $10.00'


### PR DESCRIPTION
I want to merge this change because it closes #2216.

The list of shipping methods is restricted only to methods available in the delivery country (which is took from a shipping address). If none is provided, then all methods are returned. This can end up with multiple inserts from the same provider. To make a displayed destination more descriptive, a country name is added now. Also sorting is improved - first by shippng method name and then by price.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
