### PR TITLE
Fix changing linked object in menu item

### DIFF
--- a/saleor/dashboard/menu/forms.py
+++ b/saleor/dashboard/menu/forms.py
@@ -8,6 +8,7 @@ from ...product.models import Category, Collection
 from ...site.models import SiteSettings
 from ..forms import (
     AjaxSelect2CombinedChoiceField, OrderedModelMultipleChoiceField)
+from .utils import update_menu_item_linked_object
 
 
 class AssignMenuForm(forms.ModelForm):
@@ -93,17 +94,9 @@ class MenuItemForm(forms.ModelForm):
                 code='invalid')
         return self.cleaned_data
 
-    def save(self, commit=True):
+    def save(self):
         linked_object = self.cleaned_data.get('linked_object')
-
-        if isinstance(linked_object, Collection):
-            self.instance.collection = linked_object
-        elif isinstance(linked_object, Category):
-            self.instance.category = linked_object
-        elif isinstance(linked_object, Page):
-            self.instance.page = linked_object
-
-        return super().save(commit)
+        return update_menu_item_linked_object(self.instance, linked_object)
 
 
 class ReorderMenuItemsForm(forms.ModelForm):

--- a/saleor/dashboard/menu/utils.py
+++ b/saleor/dashboard/menu/utils.py
@@ -1,0 +1,18 @@
+from ...page.models import Page
+from ...product.models import Category, Collection
+
+
+def update_menu_item_linked_object(menu_item, linked_object):
+    """Assign new linked object to a menu item. Clear other links."""
+    menu_item.category = None
+    menu_item.collection = None
+    menu_item.page = None
+
+    if isinstance(linked_object, Category):
+        menu_item.category = linked_object
+    elif isinstance(linked_object, Collection):
+        menu_item.collection = linked_object
+    elif isinstance(linked_object, Page):
+        menu_item.page = linked_object
+
+    return menu_item.save()

--- a/saleor/menu/models.py
+++ b/saleor/menu/models.py
@@ -66,12 +66,12 @@ class MenuItem(MPTTModel, SortableModel):
             prefix = pgettext_lazy('Link object type description', 'URL: ')
             return prefix + self.url
 
-        if isinstance(linked_object, Collection):
-            prefix = pgettext_lazy(
-                'Link object type description', 'Collection: ')
-        elif isinstance(linked_object, Category):
+        if isinstance(linked_object, Category):
             prefix = pgettext_lazy(
                 'Link object type description', 'Category: ')
+        elif isinstance(linked_object, Collection):
+            prefix = pgettext_lazy(
+                'Link object type description', 'Collection: ')
         else:
             prefix = pgettext_lazy(
                 'Link object type description', 'Page: ')

--- a/tests/dashboard/test_menu.py
+++ b/tests/dashboard/test_menu.py
@@ -1,10 +1,10 @@
 import json
 
 import pytest
-
 from django.urls import reverse
-from saleor.account.models import User
+
 from saleor.dashboard.menu.forms import AssignMenuForm
+from saleor.dashboard.menu.utils import update_menu_item_linked_object
 from saleor.menu.models import Menu, MenuItem
 
 from ..utils import get_redirect_location
@@ -304,3 +304,14 @@ def test_view_ajax_menu_links(
 
     assert response.status_code == 200
     assert resp_decoded == {'results': groups}
+
+
+def test_update_menu_item_linked_object(menu, default_category, page):
+    menu_item = menu.items.create(category=default_category)
+
+    update_menu_item_linked_object(menu_item, page)
+
+    assert menu_item.linked_object == page
+    assert menu_item.get_url() == page.get_absolute_url()
+    assert not menu_item.category
+    assert not menu_item.collection


### PR DESCRIPTION
I want to merge this change because it fixes #2208. Changing a linked object in a menu item now clears other linked object before assigning new one.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
