### PR TITLE
Fix bad formatting on a few gettext

### DIFF
--- a/saleor/dashboard/customer/views.py
+++ b/saleor/dashboard/customer/views.py
@@ -60,7 +60,7 @@ def customer_create(request):
     if form.is_valid():
         form.save()
         msg = pgettext_lazy(
-            'Dashboard message', 'Added customer %s' % customer)
+            'Dashboard message', 'Added customer %s') % customer
         send_set_password_email(customer)
         messages.success(request, msg)
         return redirect('dashboard:customer-details', pk=customer.pk)
@@ -76,7 +76,7 @@ def customer_edit(request, pk=None):
     if form.is_valid():
         form.save()
         msg = pgettext_lazy(
-            'Dashboard message', 'Updated customer %s' % customer)
+            'Dashboard message', 'Updated customer %s') % customer
         messages.success(request, msg)
         return redirect('dashboard:customer-details', pk=customer.pk)
     ctx = {'form': form, 'customer': customer}


### PR DESCRIPTION
Hi!

This is a little change that I reported a while ago (which was part of one of my PR which I cancelled some time ago). I would like to implement this fix on master as it is a bug.

Seems like there are only these two lines. Regex does not match any others.
```regex
%s[^']+' % \w+\s*\)
```

### Pull Request Checklist

(Please keep this section. It will make maintainer's life easier.)

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] Python code quality checks pass: `pycodestyle`, `pydocstyle`, `pylint`.
1. [x] JavaScript code quality checks pass: `eslint`.
