### PR TITLE
Fix to allow viewing and editing of stock for non-variant products

### DIFF
--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -231,6 +231,39 @@
                 </table>
               </div>
             </div>
+      {% if no_variants %}
+          <div class="card">
+            <div class="data-table-header">
+              <div class="data-table-title">
+                <h5>
+                  {% trans "Inventory" context "Product inventory card header" %}
+                </h5>
+              </div>
+            </div>
+            <div class="data-table-container">
+              <table class="data-table bordered highlight">
+                <tbody>
+                  <tr>
+                    <td>
+                      {% trans "Number in stock" context "Dashboard product details view" %}
+                    </td>
+                    <td class="right-align">
+                      {{ only_variant.quantity }}
+                    </td>
+                  </tr>
+                  <tr>
+                    <td>
+                      {% trans "Allocated" context "Dashboard product details view" %}
+                    </td>
+                    <td class="right-align">
+                      {{ only_variant.quantity_allocated }}
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+	{% endif %}
           </div>
         </div>
     </div>

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -94,6 +94,9 @@
                   <div class="row">
                     {{ variant_form.sku|materializecss }}
                   </div>
+                  <div class="row">
+                    {{ variant_form.quantity|materializecss }}
+                </div>
                 {% endif %}
                 <div class="row">
                   {{ product_form.category|materializecss }}


### PR DESCRIPTION
A previous change appears to have removed the ability to view or edit stock if a product doesn't have variants. I think this is the right location to add in the required functionality based on the variant dashboard code, but apologies if there is a better approach! 
