### PR TITLE
Fix missing variable over site settings

### DIFF
--- a/saleor/dashboard/sites/views.py
+++ b/saleor/dashboard/sites/views.py
@@ -34,7 +34,8 @@ def site_settings_edit(request, pk):
         messages.success(request, pgettext_lazy(
             'Dashboard message', 'Updated site settings'))
         return redirect('dashboard:site-details', pk=site_settings.id)
-    ctx = {'site': site_settings, 'site_settings_form': site_settings_form,
+    ctx = {'site_settings': site_settings,
+           'site_settings_form': site_settings_form,
            'site_form': site_form}
     return TemplateResponse(request, 'dashboard/sites/form.html', ctx)
 
@@ -46,7 +47,8 @@ def site_settings_details(request, pk):
     authorization_keys = AuthorizationKey.objects.filter(
         site_settings=site_settings)
     ctx = {
-        'site': site_settings, 'authorization_keys': authorization_keys,
+        'site_settings': site_settings,
+        'authorization_keys': authorization_keys,
         'is_empty': not authorization_keys.exists()}
     return TemplateResponse(request, 'dashboard/sites/detail.html', ctx)
 

--- a/templates/dashboard/sites/detail.html
+++ b/templates/dashboard/sites/detail.html
@@ -4,7 +4,7 @@
 {% load staticfiles %}
 
 {% block title %}
-  {{ site }} - {{ block.super }}
+  {{ site_settings }} - {{ block.super }}
 {% endblock %}
 
 {% block menu_settings_class %}active{% endblock %}
@@ -25,7 +25,7 @@
       <div class="card">
         <div class="card-content">
           <span class="card-title">
-            {{ site.site.name }}
+            {{ site.name }}
           </span>
           <div class="row">
             <div class="col s12 m4 l12">
@@ -33,7 +33,7 @@
                 {% trans "Domain" context "Site settings field" %}
               </h4>
               <p>
-                {{ site.site.domain }}
+                {{ site.domain }}
               </p>
             </div>
           </div>
@@ -43,7 +43,7 @@
                 {% trans "Header text" context "Site settings field" %}
               </h4>
               <p>
-                {{ site.header_text }}
+                {{ site_settings.header_text }}
               </p>
             </div>
           </div>
@@ -53,13 +53,13 @@
                 {% trans "Description" context "Site settings field" %}
               </h4>
               <p>
-                {{ site.description|default:"-" }}
+                {{ site_settings.description|default:"-" }}
               </p>
             </div>
           </div>
         </div>
         <div class="card-action">
-          <a class="btn-flat waves-effect" href="{% url 'dashboard:site-update' pk=site.pk %}">
+          <a class="btn-flat waves-effect" href="{% url 'dashboard:site-update' pk=site_settings.pk %}">
             {% trans "Edit site settings" context "Site settings action" %}
           </a>
         </div>
@@ -73,7 +73,7 @@
           </span>
         </div>
         <div class="data-table-header-action">
-          <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site.pk %}" class="btn-flat waves-effect">
+          <a href="{% url 'dashboard:authorization-key-add' site_settings_pk=site_settings.pk %}" class="btn-flat waves-effect">
             {% trans "Add" %}
           </a>
         </div>
@@ -95,10 +95,10 @@
                   <td>{{ key.name }}</td>
                   <td>{{ key.key }}</td>
                   <td class="right-align">
-                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site.pk key_pk=key.pk %}" class="btn-flat waves-effect">
+                    <a href="{% url 'dashboard:authorization-key-edit' site_settings_pk=site_settings.pk key_pk=key.pk %}" class="btn-flat waves-effect">
                       {% trans 'Edit' context 'Authorization key edit action' %}
                     </a>
-                    <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site.pk key_pk=key.pk %}">
+                    <a class="btn-flat waves-effect modal-trigger-custom" href="#base-modal" data-href="{% url 'dashboard:authorization-key-delete' site_settings_pk=site_settings.pk key_pk=key.pk %}">
                       {% trans 'Remove' context 'Authorization key remove action' %}
                     </a>
                   </td>

--- a/templates/dashboard/sites/form.html
+++ b/templates/dashboard/sites/form.html
@@ -4,7 +4,7 @@
 
 {% block title %}
   {% if site.pk %}
-    {{ site }}
+    {{ site_settings }}
   {% else %}
     {% trans "Add new site settings" context "Site settings page title" %}
   {% endif %}

--- a/tests/dashboard/test_site_settings.py
+++ b/tests/dashboard/test_site_settings.py
@@ -15,7 +15,7 @@ def test_index_view(admin_client, site_settings):
     assert response.status_code == 200
 
     context = response.context
-    assert context['site'] == site_settings
+    assert context['site_settings'] == site_settings
 
 
 def test_site_form():


### PR DESCRIPTION
This fixes a missing variable that occurs on dashboard's site settings template.

To reproduce this issue:
1. Go over site settings;
2. The title (super block) should show a missing variable for `site.name`.

This fix refactors the context variable `site` to `site_settings` as it's not an instance of `Site` but of `SiteSettings` which was conflicting with the `site` middleware which is used by `dashboard/base.html` that is expecting a `Site` instance.

I also refactored `site_settings.site` to `site` as it was wasting some time for the database.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
