### PR TITLE
Added a request history panel to the debug toolbar for easier Ajax debug

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -54,3 +54,4 @@ uwsgi>=2.0.0 ; platform_system != "Windows"
 celery[redis]
 weasyprint>=0.42.2
 django-debug-toolbar
+django-debug-toolbar-request-history

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,6 +29,7 @@ django-bootstrap4==0.0.5
 django-cache-url==2.0.0
 django-celery-results==1.0.1
 django-countries==5.2
+django-debug-toolbar-request-history==0.0.7
 django-debug-toolbar==1.9.1
 django-elasticsearch-dsl==0.4.4
 django-environ==0.4.4     # via django-graphql-jwt

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -233,6 +233,26 @@ if DEBUG:
     MIDDLEWARE.append(
         'debug_toolbar.middleware.DebugToolbarMiddleware')
     INSTALLED_APPS.append('debug_toolbar')
+    DEBUG_TOOLBAR_PANELS = [
+        # adds a request history to the debug toolbar
+        'ddt_request_history.panels.request_history.RequestHistoryPanel',
+
+        'debug_toolbar.panels.versions.VersionsPanel',
+        'debug_toolbar.panels.timer.TimerPanel',
+        'debug_toolbar.panels.settings.SettingsPanel',
+        'debug_toolbar.panels.headers.HeadersPanel',
+        'debug_toolbar.panels.request.RequestPanel',
+        'debug_toolbar.panels.sql.SQLPanel',
+        'debug_toolbar.panels.templates.TemplatesPanel',
+        'debug_toolbar.panels.staticfiles.StaticFilesPanel',
+        'debug_toolbar.panels.cache.CachePanel',
+        'debug_toolbar.panels.signals.SignalsPanel',
+        'debug_toolbar.panels.logging.LoggingPanel',
+        'debug_toolbar.panels.redirects.RedirectsPanel',
+        'debug_toolbar.panels.profiling.ProfilingPanel',
+    ]
+    DEBUG_TOOLBAR_CONFIG = {
+        'RESULTS_STORE_SIZE': 100}
 
 ENABLE_SILK = get_bool_from_env('ENABLE_SILK', False)
 if ENABLE_SILK:


### PR DESCRIPTION
Hello! 

This is a little edit that I think quite useful to debug and profile Ajax requests that I think could be useful to Saleor to have.

This PR adds a new panel to `django-debug-toolbar` which tracks the request history and kept the list updated, allowing us to to gain an easy access to Ajax requests.

### Screenshots

#### Request list made on dashboard 2.0
![](https://i.imgur.com/AvY3FCz.png)

#### SQL requests made on dashboard 2.0 on an Ajax request
![](https://i.imgur.com/hskIf3U.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
