### PR TITLE
Fix language picker breaking when switching from mobile to desktop view

### DIFF
--- a/saleor/static/js/components/navbar.js
+++ b/saleor/static/js/components/navbar.js
@@ -15,11 +15,11 @@ const renderNavbar = () => {
     if ($desktopLinks.length) {
       $searchForm.addClass('search-form--hidden');
       $mobileNav.append('<ul class="nav navbar-nav navbar__menu__login"></ul>');
-      $desktopLinks
-        .appendTo('.navbar__menu__login')
+      $languagePicker.appendTo('.navbar__menu__login')
         .wrap('<li class="nav-item login-item"></li>')
         .addClass('nav-link');
-      $languagePicker.appendTo('.navbar__menu__login')
+      $desktopLinks
+        .appendTo('.navbar__menu__login')
         .wrap('<li class="nav-item login-item"></li>')
         .addClass('nav-link');
       $desktopLinkBar
@@ -27,9 +27,12 @@ const renderNavbar = () => {
         .remove();
     }
   } else {
-    const $mobileLinks = $mobileLinkBar.find('a');
+    const $mobileLinks = $mobileLinkBar.find('a').not('.dropdown-link');
     if ($mobileLinks.length) {
       $searchForm.removeClass('search-form--hidden');
+      $languagePicker.appendTo('.navbar__login ul')
+        .wrap('<li></li>')
+        .removeClass('nav-link');
       $mobileLinks
         .appendTo('.navbar__login ul')
         .wrap('<li></li>')


### PR DESCRIPTION
This fixes **one of the issues** reported by #2188, which, has for meaning to fix the breaking of the language selector after the window size was resized from mobile to desktop.

This was happening because the children of the language were restored from the mobile view to orphan items to the navbar.

It also fixes the language picker going from the begging of the list (`.navbar__login ul`) to the end of the list after resize.

### Screenshots

#### Before (non-clickable items)
![before](https://i.imgur.com/zUzctNI.png)

---

#### After (clickable items)
![after](https://i.imgur.com/NNWt2tJ.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
