### PR TITLE
Fixed wrong references to the cart namespace

### DIFF
--- a/saleor/checkout/views/__init__.py
+++ b/saleor/checkout/views/__init__.py
@@ -160,7 +160,7 @@ def cart_shipping_options(request, cart):
 def update_cart_line(request, cart, variant_id):
     """Update the line quantities."""
     if not request.is_ajax():
-        return redirect('checkout:index')
+        return redirect('cart:index')
     variant = get_object_or_404(ProductVariant, pk=variant_id)
     discounts = request.discounts
     taxes = request.taxes

--- a/saleor/checkout/views/summary.py
+++ b/saleor/checkout/views/summary.py
@@ -26,7 +26,7 @@ def handle_order_placement(request, cart):
             discounts=request.discounts,
             taxes=get_taxes_for_cart(cart, request.taxes))
     except InsufficientStock:
-        return redirect('checkout:index')
+        return redirect('cart:index')
 
     if not order:
         msg = pgettext('Checkout warning', 'Please review your checkout.')

--- a/saleor/checkout/views/validators.py
+++ b/saleor/checkout/views/validators.py
@@ -15,7 +15,7 @@ def validate_cart(view):
     def func(request, cart):
         if cart:
             return view(request, cart)
-        return redirect('checkout:index')
+        return redirect('cart:index')
     return func
 
 

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -25,8 +25,8 @@ from .utils import compare_taxes, get_redirect_location
 
 
 @pytest.mark.parametrize('cart_length, is_shipping_required, redirect_url', [
-    (0, True, reverse('checkout:index')),
-    (0, False, reverse('checkout:index')),
+    (0, True, reverse('cart:index')),
+    (0, False, reverse('cart:index')),
     (1, True, reverse('checkout:shipping-address')),
     (1, False, reverse('checkout:summary'))])
 def test_view_checkout_index(


### PR DESCRIPTION
The merge of checkout and cart (#2206) missed some references that were targeting the cart namespace instead of the checkout namespace. This fixes that.

It also fixes the infinite HTTP redirection happening when the user was checking out without a cart (closes #2311).


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
