### PR TITLE
Use custom connection to return non-null edges

### DIFF
--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -1,0 +1,42 @@
+import graphene
+from graphene import Field, ObjectType, String, NonNull, List
+from graphene.relay.connection import ConnectionOptions, Connection
+
+
+class NonNullConnection(Connection):
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def __init_subclass_with_meta__(cls, node=None, name=None, **options):
+        super().__init_subclass_with_meta__(node=node, name=name, **options)
+
+        # Override the original EdgeBase type to make to `node`` field required.
+        class EdgeBase(object):
+            node = Field(
+                cls._meta.node, description='The item at the end of the edge',
+                required=True)
+            cursor = String(
+                required=True, description='A cursor for use in pagination')
+
+        # Create the edge type using the new EdgeBase.
+        edge_name = cls.Edge._meta.name
+        edge_bases = (EdgeBase, ObjectType,)
+        edge = type(edge_name, edge_bases, {})
+        cls.Edge = edge
+
+        # Override the `edges` field to make it non-null list of non-null edges.
+        cls._meta.fields['edges'] = Field(NonNull(List(NonNull(cls.Edge))))
+
+
+class CountableConnection(NonNullConnection):
+    class Meta:
+        abstract = True
+
+    total_count = graphene.Int(
+        description='A total count of items in the collection')
+
+    @staticmethod
+    def resolve_total_count(root, info, *args, **kwargs):
+        return root.length

--- a/saleor/graphql/core/types.py
+++ b/saleor/graphql/core/types.py
@@ -35,17 +35,7 @@ class CountryDisplay(graphene.ObjectType):
     code = graphene.String(description='Country code.')
     country = graphene.String(description='Country.')
 
-
-class CountableConnection(graphene.relay.Connection):
-    class Meta:
-        abstract = True
-
-    total_count = graphene.Int(
-        description='A total count of items in the collection')
-
-    @staticmethod
-    def resolve_total_count(root, info, *args, **kwargs):
-        return root.length
+from .connection import CountableConnection
 
 
 class CountableDjangoObjectType(DjangoObjectType):


### PR DESCRIPTION
Fixes #1998 

After hacking a bit in Graphene I've added custom Connection class that makes the edges and nodes inside them required.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
