### PR TITLE
Disabled mjml's beautify compilation as it breaks django statements

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,6 @@
     "build-assets": "webpack -p --progress",
     "heroku-postbuild": "npm run build-assets && npm run build-emails",
     "start": "webpack -d --watch --progress",
-    "build-emails": "mjml -l skip \"templates/templated_email/source/*.mjml\" -o templates/templated_email/compiled"
+    "build-emails": "mjml --config.beautify false -l skip \"templates/templated_email/source/*.mjml\" -o templates/templated_email/compiled"
   }
 }


### PR DESCRIPTION
This fixes #2335, mjml was beautifying the compiled HTML templates, which broke and could break many django statements, thus almost any templates.


Example of code change from this PR:

```diff

--- templates/templated_email/compiled/confirm_fulfillment.html	(date 1530363815000)
+++ templates/templated_email/compiled/confirm_fulfillment.html	(date 1530363815000)
@@ -186,16 +186,17 @@
                   </tr>
                   <tr>
                     <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+                      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"> {% blocktrans trimmed context "Fulfillment confirmation email text" %} Thank you for your order. Below is the list of shipped products. {% endblocktrans %} {% if fulfillment.tracking_number %} {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %} You can track your shipment with {{ tracking_number }} code. {% endblocktrans %} {% endif %} </div>
-                      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"> {% blocktrans trimmed context "Fulfillment confirmation email text" %} Thank you for your order. Below is the list of shipped products. {% endblocktrans %} {% if fulfillment.tracking_number %} {% blocktrans trimmed with tracking_number=fulfillment.tracking_number
-                        context "Fulfillment confirmation email text" %} You can track your shipment with {{ tracking_number }} code. {% endblocktrans %} {% endif %} </div>
                     </td>
                   </tr>
                 </table>
               </div>

```



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
