### PR TITLE
get_thumbnail should not decide what method to use

### DIFF
--- a/saleor/core/management/commands/create_thumbnails.py
+++ b/saleor/core/management/commands/create_thumbnails.py
@@ -9,13 +9,13 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = 'Generate thumbanails for all images'
+    help = 'Generate thumbnails for all images'
 
     def handle(self, *args, **options):
         self.warm_products()
 
     def warm_products(self):
-        self.stdout.write('Products thumbanails generation:')
+        self.stdout.write('Products thumbnails generation:')
         warmer = VersatileImageFieldWarmer(
             instance_or_queryset=ProductImage.objects.all(),
             rendition_key_set='products', image_attr='image', verbose=True)

--- a/saleor/product/templatetags/product_images.py
+++ b/saleor/product/templatetags/product_images.py
@@ -51,16 +51,13 @@ def get_thumbnail(instance, size, method='crop'):
     on_demand = settings.VERSATILEIMAGEFIELD_SETTINGS[
         'create_images_on_demand']
     if instance:
-        if (size_name not in AVAILABLE_SIZES and not on_demand):
+        if size_name not in AVAILABLE_SIZES and not on_demand:
             msg = (
                 "Thumbnail size %s is not defined in settings "
                 "and it won't be generated automatically" % size_name)
             warnings.warn(msg)
         try:
-            if method == 'crop':
-                thumbnail = instance.crop[size]
-            else:
-                thumbnail = instance.thumbnail[size]
+            thumbnail = getattr(instance, method)[size]
         except Exception:
             logger.exception(
                 'Thumbnail fetch failed',


### PR DESCRIPTION
When requesting `get_thumbnail` to do something else than `crop` and `thumbnail` it uses the `thumbnail` method, which is absolutely not what we want when we are using custom methods.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
