### PR TITLE
Variant edit form is now showing the correct track inventory value

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -289,10 +289,8 @@ class ProductVariantForm(forms.ModelForm, AttributesMixin):
                 'product variant handle stock field help text',
                 'Automatically track this product\'s inventory')}
 
-    def __init__(self, *args, initial_track_inventory=True, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-
-        self.initial['track_inventory'] = initial_track_inventory
 
         if self.instance.product.pk:
             self.fields['price_override'].widget.attrs[

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -100,17 +100,17 @@ def product_select_type(request):
 @staff_member_required
 @permission_required('product.edit_product')
 def product_create(request, type_pk):
-    site_settings = request.site.settings
+    track_inventory = request.site.settings.track_inventory_by_default
     product_type = get_object_or_404(ProductType, pk=type_pk)
     create_variant = not product_type.has_variants
     product = Product()
     product.product_type = product_type
     product_form = forms.ProductForm(request.POST or None, instance=product)
     if create_variant:
-        variant = ProductVariant(product=product)
+        variant = ProductVariant(
+            product=product, track_inventory=track_inventory)
         variant_form = forms.ProductVariantForm(
             request.POST or None,
-            initial_track_inventory=site_settings.track_inventory_by_default,
             instance=variant, prefix='variant')
         variant_errors = not variant_form.is_valid()
     else:
@@ -315,12 +315,11 @@ def variant_details(request, product_pk, variant_pk):
 @staff_member_required
 @permission_required('product.edit_product')
 def variant_create(request, product_pk):
-    site_settings = request.site.settings
+    track_inventory = request.site.settings.track_inventory_by_default
     product = get_object_or_404(Product.objects.all(), pk=product_pk)
-    variant = ProductVariant(product=product)
+    variant = ProductVariant(product=product, track_inventory=track_inventory)
     form = forms.ProductVariantForm(
         request.POST or None,
-        initial_track_inventory=site_settings.track_inventory_by_default,
         instance=variant)
     if form.is_valid():
         form.save()


### PR DESCRIPTION
This PR fixes #2342. The initial value of `track_inventory` should be set during the variant instance creation as the instance (and its default value) is passed to the form.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
