### PR TITLE
Fix: make the language picker redirect the user to the url they were

### DIFF
--- a/templates/_language_picker.html
+++ b/templates/_language_picker.html
@@ -14,7 +14,7 @@
       <div class="dropdown-menu scrollable-menu" role="menu" aria-labelledby="dropdownMenuLink">
         <form id="language-picker" action="{% url 'set_language' %}" method="post">
           {% csrf_token %}
-          <input name="next" type="hidden" value="/">
+          <input name="next" type="hidden" value="{{ request.get_full_path }}">
           {# Language code will be dynamically appended to the form via JS due to select-box styling nature #}
           {% for language in languages %}
             <a data-lang="{{ language.code }}" class="dropdown-item language-pick dropdown-link{% if language.code == LANGUAGE_CODE %} active{% endif %}">


### PR DESCRIPTION
This PR fixes **one of the issues** reported by #2188, which, fixes the redirection URL when the user sets a new language: gets the redirected to their current endpoint. Allowing the user to stay to the page they were, and that they wanted to get in their given language.

Acknowledgement: if the user hit previous, and then hit a link, they will go back to the previous language.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
