### PR TITLE
Disable JWT

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -177,7 +177,7 @@ MIDDLEWARE = [
     'saleor.core.middleware.taxes',
     'social_django.middleware.SocialAuthExceptionMiddleware',
     'impersonate.middleware.ImpersonateMiddleware',
-    'saleor.graphql.middleware.jwt_middleware'
+    # 'saleor.graphql.middleware.jwt_middleware'
 ]
 
 INSTALLED_APPS = [

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -63,6 +63,9 @@ def test_order_query(admin_api_client, fulfilled_order):
 
 
 def test_non_staff_user_can_only_see_his_order(user_api_client, order):
+    # FIXME: Remove client.login() when JWT authentication is re-enabled.
+    user_api_client.login(username=order.user.email, password='password')
+
     query = """
     query OrderQuery($id: ID!) {
         order(id: $id) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,10 @@ class ApiClient(Client):
 
 @pytest.fixture
 def admin_api_client(admin_user):
-    return ApiClient(user=admin_user)
+    client = ApiClient(user=admin_user)
+    # FIXME: Remove client.login() when JWT authentication is re-enabled.
+    client.login(username=admin_user.email, password='password')
+    return client
 
 
 @pytest.fixture
@@ -82,7 +85,10 @@ def user_api_client(customer_user):
 
 @pytest.fixture
 def staff_api_client(staff_user):
-    return ApiClient(user=staff_user)
+    client = ApiClient(user=staff_user)
+    # FIXME: Remove client.login() when JWT authentication is re-enabled.
+    client.login(username=staff_user.email, password='password')
+    return client
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
I've disabled the JWT middleware for now as we still don't have the login screen plugged in in the new dashboard. I'll re-enable it when we finish the authentication flow. For now, users will have to be logged in in the "old" dashboard.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
