### PR TITLE
Use the venv module that comes with Python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,12 +4,12 @@ ENV PYTHONUNBUFFERED 1
 
 RUN \
   apt-get -y update && \
-  apt-get install -y gettext virtualenv && \
+  apt-get install -y gettext && \
   # Cleanup apt cache
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-RUN virtualenv -p python3 /app/virtualenv
+RUN python3 -m venv /app/virtualenv
 ADD requirements.txt /app/
 RUN /app/virtualenv/bin/pip install -r /app/requirements.txt
 


### PR DESCRIPTION
There's no reason to use the `virtualenv` package.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
