### PR TITLE
Fix duplicate address creation during demo checkout

### DIFF
--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -4,10 +4,10 @@ from ..core.demo_obfuscators import obfuscate_address
 
 def store_user_address(user, address, address_type):
     """Add address to user address book and set as default one."""
-    address, _ = user.addresses.get_or_create(**address.as_data())
-
     # DEMO: obfuscate user address
     address = obfuscate_address(address)
+
+    address, _ = user.addresses.get_or_create(**address.as_data())
 
     if address_type == AddressType.BILLING:
         if not user.default_billing_address:


### PR DESCRIPTION
This pull request fix #2310. The duplicate address was being created when creating a new address during the shipping step in checkout and then choosing "Same as shipping" in the billing address step.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
