### PR TITLE
Use safe filter on product.description

### DIFF
--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -69,7 +69,7 @@
             </div>
           </div>
           <p>
-            {{ product.description }}
+            {{ product.description | safe }}
           </p>
         </div>
         <div class="card-action">


### PR DESCRIPTION
I want to merge this change because...

Parse product description through safe filter, else it renders the HTML tags

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/254250/42424589-a2541ce2-8306-11e8-847f-1b4cfe6078ee.png)


After:
![image](https://user-images.githubusercontent.com/254250/42424584-935cf74a-8306-11e8-8372-fa2ac8f0b503.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
