### PR TITLE
Fix: delete variants can be fulfilled without crashing

### DIFF
--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -47,7 +47,7 @@ def create_packing_slip_pdf(order, fulfillment, absolute_url):
 
 def fulfill_order_line(order_line, quantity):
     """Fulfill order line with given quantity."""
-    if order_line.variant.track_inventory:
+    if order_line.variant and order_line.variant.track_inventory:
         decrease_stock(order_line.variant, quantity)
         order_line.quantity_fulfilled += quantity
         order_line.save(update_fields=['quantity_fulfilled'])

--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -49,8 +49,8 @@ def fulfill_order_line(order_line, quantity):
     """Fulfill order line with given quantity."""
     if order_line.variant and order_line.variant.track_inventory:
         decrease_stock(order_line.variant, quantity)
-        order_line.quantity_fulfilled += quantity
-        order_line.save(update_fields=['quantity_fulfilled'])
+    order_line.quantity_fulfilled += quantity
+    order_line.save(update_fields=['quantity_fulfilled'])
 
 
 def update_order_with_user_addresses(order):

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -629,6 +629,15 @@ def test_fulfill_order_line(order_with_lines):
     assert line.quantity_fulfilled == quantity_fulfilled_before + line.quantity
 
 
+def test_fulfill_order_line_with_variant_deleted(order_with_lines):
+    line = order_with_lines.lines.first()
+    line.variant.delete()
+
+    line.refresh_from_db()
+
+    fulfill_order_line(line, line.quantity)
+
+
 def test_view_change_fulfillment_tracking(admin_client, fulfilled_order):
     fulfillment = fulfilled_order.fulfillments.first()
     url = reverse(

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -638,6 +638,24 @@ def test_fulfill_order_line_with_variant_deleted(order_with_lines):
     fulfill_order_line(line, line.quantity)
 
 
+def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
+    order = order_with_lines
+    line = order.lines.first()
+    quantity_fulfilled_before = line.quantity_fulfilled
+    variant = line.variant
+    variant.track_inventory = False
+    variant.save()
+
+    # stock should not change
+    stock_quantity_after = variant.quantity
+
+    fulfill_order_line(line, line.quantity)
+
+    variant.refresh_from_db()
+    assert variant.quantity == stock_quantity_after
+    assert line.quantity_fulfilled == quantity_fulfilled_before + line.quantity
+
+
 def test_view_change_fulfillment_tracking(admin_client, fulfilled_order):
     fulfillment = fulfilled_order.fulfillments.first()
     url = reverse(


### PR DESCRIPTION
Hi!

There was a missed check when trying to fulfill deleted items (variants) which caused a crash on dashboard.

And it was impossible to fully fulfill an order with variant having `track_inventory` set to `False` as they were not updating the fulfilled quantities.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
