### PR TITLE
Bump cryptography to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ celery[redis]==4.2.0
 certifi==2018.1.18        # via requests
 cffi==1.11.4              # via cairocffi, cryptography, weasyprint
 chardet==3.0.4            # via requests
-cryptography==2.1.4       # via django-payments
+cryptography==2.2.2       # via django-payments
 cssselect2==0.2.1         # via cairosvg, weasyprint
 defusedxml==0.5.0         # via cairosvg, python3-openid, social-auth-core
 dj-database-url==0.4.2
@@ -63,7 +63,7 @@ graphene==2.0.1           # via django-graphql-jwt, graphene-django
 graphql-core==2.0         # via graphene, graphql-relay
 graphql-relay==0.4.5      # via graphene
 html5lib==1.0.1           # via bleach, weasyprint
-idna==2.6                 # via cryptography, requests, yarl
+idna==2.6                 # via cryptography, requests
 iso8601==0.1.12           # via graphene-django
 jmespath==0.9.3           # via boto3, botocore
 jsonfield==2.0.2
@@ -71,7 +71,6 @@ kombu==4.2.1              # via celery
 markdown==2.6.11
 maxminddb-geolite2==2017.803
 maxminddb==1.3.0
-multidict==3.3.2          # via yarl
 oauthlib==2.0.6           # via requests-oauthlib, social-auth-core
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.9.1
@@ -117,4 +116,3 @@ weasyprint==0.42.2
 webencodings==0.5.1       # via html5lib, tinycss2
 wrapt==1.10.11            # via vcrpy
 xmltodict==0.11.0         # via django-payments
-yarl==0.17.0              # via vcrpy


### PR DESCRIPTION
After switching to Python 3.7 I was unable to install `cryptography=2.1.4` on macOS Sierra 10.12.6. Upgrading it to the latest version solves the issue.

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
