### PR TITLE
Add doc section for GraphQL API

### DIFF
--- a/docs/architecture/graphq_api.rst
+++ b/docs/architecture/graphq_api.rst
@@ -1,0 +1,43 @@
+GraphQL API (Beta)
+====================
+
+.. note::
+
+    The GraphQL API is in the early version and is subject to change.
+
+
+Saleor supports GraphQL API. It allows to create apps that can handle fulfillment, orders, pages, product and shipping management.
+
+You can test API under ``/graphql`` URL. You can perform queries normally, however you need to log in to an account with proper permissions to run mutations and query for restricted data.
+
+
+Authorization
+----------------------------
+Saleor GraphQL API uses `JWT <https://jwt.io/>`_ - to authorize you need to create and add token to the ``Authorization`` header. You can do it with the following mutation:
+
+.. code-block::
+
+    mutation tokenCreate($username: String!, $password: String!) {
+      tokenAuth(username: $username, password: $password) {
+        token
+      }
+    }
+
+Verification and refreshing the token is very simple:
+
+.. code-block::
+
+    mutation tokenVerify($token: String!) {
+      verifyToken(token: $token) {
+        payload
+      }
+    }
+
+.. code-block::
+
+    mutation tokenRefresh($token: String!) {
+      tokenRefresh(token: $token) {
+        token
+        payload
+      }
+    }


### PR DESCRIPTION
I want to merge this change because it adds some doc about GraphQL API.

### Pull Request Checklist


1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
