### PR TITLE
Only load raven if configured

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -232,8 +232,7 @@ INSTALLED_APPS = [
     'django_celery_results',
     'impersonate',
     'phonenumber_field',
-    'captcha',
-    'raven.contrib.django.raven_compat']
+    'captcha']
 
 if DEBUG:
     MIDDLEWARE.append(
@@ -507,6 +506,7 @@ RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
 #  Sentry
 SENTRY_DSN = os.environ.get('SENTRY_DSN')
 if SENTRY_DSN:
+    INSTALLED_APPS.append('raven.contrib.django.raven_compat')
     RAVEN_CONFIG = {
         'dsn': SENTRY_DSN,
         'release': __version__}


### PR DESCRIPTION
As it was mentioned in #2402, this change makes raven to be only loaded if configured.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
