### PR TITLE
Rewrite file-upload handling in GraphQL

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -34,7 +34,6 @@ freezegun>=0.3.9
 google-measurement-protocol>=1.0.0
 google-i18n-address>=2.3.0
 graphene-django>=2.0.dev
-graphene-file-upload==0.1.1
 jsonfield>=2.0.2
 Markdown>=2.4
 maxminddb

--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,6 @@ freezegun==0.3.10
 google-i18n-address==2.3.0
 google-measurement-protocol==1.0.0
 graphene-django==2.0.0
-graphene-file-upload==0.1.1
 graphene==2.0.1           # via django-graphql-jwt, graphene-django
 graphql-core==2.0         # via graphene, graphql-relay
 graphql-relay==0.4.5      # via graphene

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -4,12 +4,12 @@ import graphene
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from graphene.types.mutation import MutationOptions
 from graphene_django.registry import get_global_registry
-from graphene_file_upload import Upload
 from graphql_jwt import ObtainJSONWebToken, Verify
 from graphql_jwt.exceptions import GraphQLJWTError, PermissionDenied
 
 from ...account import models
 from ..account.types import User
+from ..file_upload.types import Upload
 from ..utils import get_node, get_nodes
 from .types import Error
 

--- a/saleor/graphql/file_upload/types.py
+++ b/saleor/graphql/file_upload/types.py
@@ -1,0 +1,15 @@
+import graphene
+
+
+class Upload(graphene.types.Scalar):
+    @staticmethod
+    def serialize(value):
+        return value
+
+    @staticmethod
+    def parse_literal(node):
+        return node
+
+    @staticmethod
+    def parse_value(value):
+        return value

--- a/saleor/graphql/file_upload/views.py
+++ b/saleor/graphql/file_upload/views.py
@@ -1,0 +1,86 @@
+from graphene_django.views import GraphQLView
+import json
+import graphene
+
+# This class is modified verion of the `ModifiedGraphQLView` class from
+# `graphene-file-upload` (https://github.com/lmcgartland/graphene-file-upload).
+
+
+class FileUploadGraphQLView(GraphQLView):
+
+    @staticmethod
+    def get_graphql_params(request, data):
+        content_type = GraphQLView.get_content_type(request)
+
+        # Only check multipart/form-data if content_type is not None (this is
+        # not checked in the original version from `graphene-file-upload`).
+        if content_type and 'multipart/form-data' in content_type:
+            query, variables, operation_name, id = super(
+                FileUploadGraphQLView, FileUploadGraphQLView).get_graphql_params(
+                    request, data)
+            operations = data.get('operations')
+            files_map = data.get('map')
+            try:
+                operations = json.loads(operations)
+                files_map = json.loads(files_map)
+                variables = operations.get('variables')
+                for file_key in files_map:
+                    # file key is which file it is in the form-data
+                    file_instances = files_map[file_key]
+                    for file_instance in file_instances:
+                        test = obj_set(operations, file_instance, file_key, False)
+                query = operations.get('query')
+                variables = operations.get('variables')
+            except Exception as e:
+                raise e
+        else:
+            query, variables, operation_name, id = super(
+                FileUploadGraphQLView, FileUploadGraphQLView).get_graphql_params(
+                    request, data)
+        return query, variables, operation_name, id
+
+
+def getKey(key):
+    try:
+        intKey = int(key)
+        return intKey
+    except:
+        return key
+
+
+def getShallowProperty(obj, prop):
+    if type(prop) is int:
+        return obj[prop]
+
+    try:
+        return obj.get(prop)
+    except:
+        return None
+
+
+def obj_set(obj, path, value, doNotReplace):
+    if type(path) is int:
+        path = [path]
+    if path is None or len(path) == 0:
+        return obj
+    if isinstance(path, str):
+        newPath = list(map(getKey, path.split('.')))
+        return obj_set(obj, newPath, value, doNotReplace )
+
+    currentPath = path[0]
+    currentValue = getShallowProperty(obj, currentPath)
+
+    if len(path) == 1:
+        if currentValue is None or not doNotReplace:
+            obj[currentPath] = value
+
+    if currentValue is None:
+        try:
+            if type(path[1]) == int:
+                obj[currentPath] = []
+            else:
+                obj[currentPath] = {}
+        except Exception as e:
+            pass
+
+    return obj_set(obj[currentPath], path[1:], value, doNotReplace)

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1,13 +1,13 @@
 import graphene
 from django.template.defaultfilters import slugify
 from graphene.types import InputObjectType
-from graphene_file_upload import Upload
 from graphql_jwt.decorators import permission_required
 
 from ....product import models
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.types import Decimal, Error, SeoInput
 from ...core.utils import clean_seo_fields
+from ...file_upload.types import Upload
 from ...utils import get_attributes_dict_from_list, get_node, get_nodes
 from ..types import Collection, Product, ProductImage
 

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -6,7 +6,6 @@ from django.contrib.sitemaps.views import sitemap
 from django.contrib.staticfiles.views import serve
 from django.views.decorators.csrf import csrf_exempt
 from django.views.i18n import JavaScriptCatalog, set_language
-from graphene_file_upload import ModifiedGraphQLView
 
 from .account.urls import urlpatterns as account_urls
 from .checkout.urls import (
@@ -16,6 +15,7 @@ from .core.urls import urlpatterns as core_urls
 from .dashboard.urls import urlpatterns as dashboard_urls
 from .data_feeds.urls import urlpatterns as feed_urls
 from .graphql.api import schema
+from .graphql.file_upload.views import FileUploadGraphQLView
 from .order.urls import urlpatterns as order_urls
 from .page.urls import urlpatterns as page_urls
 from .product.urls import urlpatterns as product_urls
@@ -26,7 +26,7 @@ handler404 = 'saleor.core.views.handle_404'
 non_translatable_urlpatterns = [
     url(r'^dashboard/',
         include((dashboard_urls, 'dashboard'), namespace='dashboard')),
-    url(r'^graphql/', csrf_exempt(ModifiedGraphQLView.as_view(
+    url(r'^graphql/', csrf_exempt(FileUploadGraphQLView.as_view(
         schema=schema, graphiql=settings.DEBUG)), name='api'),
     url(r'^sitemap\.xml$', sitemap, {'sitemaps': sitemaps},
         name='django.contrib.sitemaps.views.sitemap'),


### PR DESCRIPTION
We initially used [graphene-file-upload](https://github.com/lmcgartland/graphene-file-upload) library to handle file upload in GraphQL, but it turns out that there is a bug in the lib. This bug causes a 500 error on our demo when accessing `/graphql`. I moved their code to Saleor and fixed the issue. We will keep those changes until they release a new version. I'll open an issue and PR in their repository.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
