### PR TITLE
Do not set cached_db as session engine when locmem cache is used

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -322,7 +322,11 @@ PAYMENT_VARIANTS = {
     'default': ('payments.dummy.DummyProvider', {})}
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
-SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
+
+# Do not use cached session if locmem cache backend is used but fallback to use
+# default django.contrib.sessions.backends.db instead
+if not CACHES['default']['BACKEND'].endswith('LocMemCache'):
+    SESSION_ENGINE = 'django.contrib.sessions.backends.cached_db'
 
 CHECKOUT_PAYMENT_CHOICES = [
     ('default', 'Dummy provider')]


### PR DESCRIPTION
If locmem cache is enabled, do not set cached_db as session engine.

Without this PR, warning ```Session caching cannot work with locmem backend``` will be raised if user does not set REDIS_URL. With this PR, it will be more friendly for new users.

Refer to https://github.com/mirumee/saleor/issues/2354

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
