### PR TITLE
Fixed disappearing link to clear filters

### DIFF
--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -12,8 +12,8 @@
 <div class="filters-menu__body d-none d-md-block">
   <h2>
     {% trans 'Filters' context 'Filter heading title' %}
-    {% if filter.is_bound_unsorted %}
-      <a href="../">
+    {% if filter_set.is_bound_unsorted %}
+      <a href="./">
         <span class="clear-filters float-right">{% trans 'Clear filters' context 'Product list page filters' %}</span>
       </a>
     {% endif %}


### PR DESCRIPTION
In `templates/product/_filters.html` was used `filter` variable, when variable passed in context is `filter_set`.
<!-- Please mention all relevant issue numbers. -->
This commit is fix for [Issue 2453](https://github.com/mirumee/saleor/issues/2453)
close #2453 
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
