### PR TITLE
Fix duplicated queries

### DIFF
--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 
 from ...product import models
-from ...product.utils import products_visible_to_user
+from ...product.utils import products_with_details
 from ..utils import filter_by_query_param, get_node
 from .types import Category
 
@@ -48,8 +48,7 @@ def resolve_collections(info, query):
 
 def resolve_products(info, category_id, query):
     user = info.context.user
-    queryset = products_visible_to_user(
-        user=user).prefetch_related('category').distinct()
+    queryset = products_with_details(user=user).distinct()
     queryset = filter_by_query_param(queryset, query, PRODUCT_SEARCH_FIELDS)
     if category_id is not None:
         category = get_node(info, category_id, only_type=Category)

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -4,7 +4,7 @@ from graphene_django.filter import DjangoFilterConnectionField
 
 from ...product import models
 from ...product.templatetags.product_images import product_first_image
-from ...product.utils import products_visible_to_user
+from ...product.utils import products_with_details
 from ...product.utils.availability import get_availability
 from ...product.utils.costs import (
     get_margin_for_variant, get_product_costs_data)
@@ -197,7 +197,7 @@ class ProductType(CountableDjangoObjectType):
 
     def resolve_products(self, info):
         user = info.context.user
-        return products_visible_to_user(
+        return products_with_details(
             user=user).filter(product_type=self).distinct()
 
 
@@ -215,7 +215,7 @@ class Collection(CountableDjangoObjectType):
 
     def resolve_products(self, info, **kwargs):
         user = info.context.user
-        return products_visible_to_user(
+        return products_with_details(
             user=user).filter(collections=self).distinct()
 
 


### PR DESCRIPTION
Currently fetching `availability` in the `Product` type is very slow due to duplicated queries. There is still a lot of optimization to do but this PR fixes page load time in our current dashboard-2.0.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
