### PR TITLE
Remove import of unused package

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1,7 +1,6 @@
 import graphene
 from django.template.defaultfilters import slugify
 from graphene.types import InputObjectType
-from graphene_file_upload import Upload
 from graphql_jwt.decorators import permission_required
 
 from ....product import models


### PR DESCRIPTION
During the last rebase of `dashboard-2.0` I missed one import in Python code that should be removed as the related library file that is not used anymore.

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
