### PR TITLE
Fix frontstore order details crashing when variant was deleted

### DIFF
--- a/saleor/static/scss/layouts/_order-details.scss
+++ b/saleor/static/scss/layouts/_order-details.scss
@@ -9,17 +9,10 @@
     .col-3 {
       margin-top: $global-margin / 2;
     }
-    a {
-      transition: 0.3s;
-      &:hover {
-        color: $skull-gray;
-      }
-      p {
-        display: inline-block;
-        margin-top: $global-margin / 2;
-        margin-bottom: 0;
-        line-height: 1rem;
-        small {
+    &__description {
+      a {
+        transition: 0.3s;
+        &:hover {
           color: $skull-gray;
         }
       }
@@ -27,9 +20,9 @@
         vertical-align: top;
         margin-right: $global-margin;
       }
-    }
-    &__description {
-      line-height: 60px;
+      span {
+        line-height: 60px;
+      }
     }
   }
   &__total {

--- a/templates/order/_ordered_items_table.html
+++ b/templates/order/_ordered_items_table.html
@@ -48,14 +48,19 @@
 {% for line in order %}
   <div class="table__row order-details__product{% if forloop.last %} order-details__last-row{% endif %}">
     <div class="row">
-      <div class="col-md-8">
-        <a class="link--clean" href="{% if line.variant %}{{ line.variant.get_absolute_url }}{% endif %}">
-          <img data-src="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %}"
-                data-srcset="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %} 1x, {% get_thumbnail line.variant.get_first_image size=120 method="crop" %} 2x"
-                class="float-left lazyload lazypreload"
-                src="{% placeholder size=60 %}">
-          <span class="order-details__product__description">{{ line.translated_product_name|default:line.product_name }}</span>
-        </a>
+      <div class="col-md-8 order-details__product__description">
+        {% if line.variant %}
+          <a class="link--clean" href="{{ line.variant.get_absolute_url }}">
+            <img data-src="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %}"
+                  data-srcset="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %} 1x, {% get_thumbnail line.variant.get_first_image size=120 method="crop" %} 2x"
+                  class="float-left lazyload lazypreload"
+                  src="{% placeholder size=60 %}">
+            <span>{{ line.translated_product_name|default:line.product_name }}</span>
+          </a>
+        {% else %}
+          <img src="{% placeholder size=60 %}" class="float-left">
+          <span>{{ line.translated_product_name|default:line.product_name }}</span>
+        {% endif %}
       </div>
       <div class="col-md-4">
         <div class="row">
@@ -175,16 +180,22 @@
       </div>
     </div>
   </div>
-  {% for line in fulfillment %}
+  {% for fulfillment_line in fulfillment %}
     <div class="table__row fulfillment__row order-details__product{% if forloop.last %} order-details__last-row{% endif %}">
       <div class="row">
-        <div class="col-md-6 col-9">
-          <a class="link--clean" href="{% if line.variant.product %}{{ line.variant.product.get_absolute_url }}{% endif %}">
-            <span class="order-details__product__description">{{ line.order_line.translated_product_name|default:line.order_line.product_name }}</span>
-          </a>
+        <div class="col-md-6 col-9 order-details__product__description">
+          {% with variant=fulfillment_line.order_line.variant %}
+            {% if variant %}
+              <a class="link--clean" href="{{ variant.get_absolute_url }}">
+                <span>{{ fulfillment_line.order_line.translated_product_name|default:fulfillment_line.order_line.product_name }}</span>
+              </a>
+            {% else %}
+              <span>{{ fulfillment_line.order_line.translated_product_name|default:fulfillment_line.order_line.product_name }}</span>
+            {% endif %}
+          {% endwith %}
         </div>
         <div class="col-md-6 col-3">
-          <p class="float-right">x {{ line.quantity }}</p>
+          <p class="float-right">x {{ fulfillment_line.quantity }}</p>
         </div>
       </div>
     </div>

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -161,6 +161,31 @@ def test_view_connect_order_with_user_different_email(
     assert order.user is None
 
 
+def test_view_order_with_deleted_variant(authorized_client, order_with_lines):
+    order = order_with_lines
+    order_details_url = reverse('order:details', kwargs={'token': order.token})
+
+    # delete a variant associated to the order
+    order.lines.first().variant.delete()
+
+    # check if the order details view handles the deleted variant
+    response = authorized_client.get(order_details_url)
+    assert response.status_code == 200
+
+
+def test_view_fulfilled_order_with_deleted_variant(
+        authorized_client, fulfilled_order):
+    order = fulfilled_order
+    order_details_url = reverse('order:details', kwargs={'token': order.token})
+
+    # delete a variant associated to the order
+    order.lines.first().variant.delete()
+
+    # check if the order details view handles the deleted variant
+    response = authorized_client.get(order_details_url)
+    assert response.status_code == 200
+
+
 @pytest.mark.parametrize('track_inventory', (True, False))
 def test_restock_order_lines(order_with_lines, track_inventory):
 


### PR DESCRIPTION
This fixes #2501 and also fix the invalid variable in fulfilled lines (`fulfilled_line.variant -> fulfilled_line.order_line.variant`).

As mentioned in #2501, there should not be any link to the product (variant); I dropped the `<a>` tag to order lines that no longer have a variant associated to them.

Thus, some changes on the structure were made. I decided to move the class `order-details__product__description` that was used for the product name of the order line (under `<span>`); this was moved to wrap the order lines first column (thumbnail and product name). Instead of selecting the product name by this class, it is now selecting the `span` tag.

Those changes allowing to more easily select the whole first column instead of selecting it by the tag `a` or the bootstrap column, thus preventing from being too dependent over the template structure or introducing new classes.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
