### PR TITLE
Display appropriate images for variants

### DIFF
--- a/saleor/checkout/views/__init__.py
+++ b/saleor/checkout/views/__init__.py
@@ -112,7 +112,9 @@ def cart_index(request, cart):
     lines = lines.prefetch_related(
         'variant__translations', 'variant__product__translations',
         'variant__product__images',
-        'variant__product__product_type__variant_attributes__translations')
+        'variant__product__product_type__variant_attributes__translations',
+        'variant__images',
+        'variant__product__product_type__variant_attributes')
     for line in lines:
         initial = {'quantity': line.quantity}
         form = ReplaceCartLineForm(

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -3,12 +3,7 @@ from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 
 from ...product import models
-<<<<<<< HEAD
-from ...product.templatetags.product_images import (
-    get_thumbnail, product_first_image)
-=======
 from ...product.templatetags.product_images import get_thumbnail
->>>>>>> Remove duplicated product_first_image templatetag
 from ...product.utils import products_with_details
 from ...product.utils.availability import get_availability
 from ...product.utils.costs import (

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -3,8 +3,12 @@ from graphene import relay
 from graphene_django.filter import DjangoFilterConnectionField
 
 from ...product import models
+<<<<<<< HEAD
 from ...product.templatetags.product_images import (
     get_thumbnail, product_first_image)
+=======
+from ...product.templatetags.product_images import get_thumbnail
+>>>>>>> Remove duplicated product_first_image templatetag
 from ...product.utils import products_with_details
 from ...product.utils.availability import get_availability
 from ...product.utils.costs import (
@@ -154,7 +158,7 @@ class Product(CountableDjangoObjectType):
     def resolve_thumbnail_url(self, info, *, size=None):
         if not size:
             size = 255
-        return product_first_image(self, size)
+        return get_thumbnail(self.get_first_image(), size)
 
     def resolve_url(self, info):
         return self.get_absolute_url()

--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def details(request, token):
     orders = Order.objects.confirmed().prefetch_related(
-        'lines__variant__product__images', 'fulfillments',
+        'lines__variant__images', 'lines__variant__product__images',
         'fulfillments__lines', 'fulfillments__lines__order_line')
     orders = orders.select_related(
         'billing_address', 'shipping_address', 'user')
@@ -50,7 +50,8 @@ def details(request, token):
 
 def payment(request, token):
     orders = Order.objects.confirmed().filter(billing_address__isnull=False)
-    orders = orders.prefetch_related('lines__variant__product__images')
+    orders = orders.prefetch_related(
+        'lines__variant__images', 'lines__variant__product__images')
     orders = orders.select_related(
         'billing_address', 'shipping_address', 'user')
     order = get_object_or_404(orders, token=token)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -269,6 +269,9 @@ class ProductVariant(models.Model):
         return smart_text(product_display)
 
     def get_first_image(self):
+        images = list(self.images.all())
+        if images:
+            return images[0].image
         return self.product.get_first_image()
 
     def get_ajax_label(self, discounts=None):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -157,8 +157,8 @@ class Product(SeoModel):
         return self.available_on is None or self.available_on <= today
 
     def get_first_image(self):
-        first_image = self.images.first()
-        return first_image.image if first_image else None
+        images = list(self.images.all())
+        return images[0].image if images else None
 
     def get_price_range(self, discounts=None, taxes=None):
         if self.variants.exists():

--- a/saleor/product/templatetags/product_images.py
+++ b/saleor/product/templatetags/product_images.py
@@ -91,4 +91,4 @@ def get_thumbnail(instance, size, method='crop'):
                 extra={'instance': instance, 'size': size})
         else:
             return thumbnail.url
-    return static(choose_placeholder(size))
+    return static(choose_placeholder('%sx%s' % (size, size)))

--- a/saleor/product/templatetags/product_images.py
+++ b/saleor/product/templatetags/product_images.py
@@ -91,12 +91,4 @@ def get_thumbnail(instance, size, method='crop'):
                 extra={'instance': instance, 'size': size})
         else:
             return thumbnail.url
-    return static(choose_placeholder('%sx%s' % (size, size)))
-
-
-@register.simple_tag()
-def product_first_image(product, size, method='crop'):
-    """Return the main image of the given product."""
-    all_images = product.images.all() if product else []
-    main_image = all_images[0].image if all_images else None
-    return get_thumbnail(main_image, size, method)
+    return static(choose_placeholder(size))

--- a/templates/checkout/index.html
+++ b/templates/checkout/index.html
@@ -42,8 +42,8 @@
           <div class="row">
             <div class="col-7 cart__line__product">
               <a class="link--clean" href="{{ line.variant.get_absolute_url }}">
-                <img class="lazyload lazypreload" data-src="{% get_thumbnail line.variant.product.images.first.image method="crop" size=60 %}"
-                     data-srcset="{% get_thumbnail line.variant.product.images.first.image method="crop" size=60 %} 1x, {% get_thumbnail line.variant.product.images.first.image method="crop" size=120 %} 2x"
+                <img class="lazyload lazypreload" data-src="{% get_thumbnail line.variant.get_first_image method="crop" size=60 %}"
+                     data-srcset="{% get_thumbnail line.variant.get_first_image method="crop" size=60 %} 1x, {% get_thumbnail line.variant.get_first_image method="crop" size=120 %} 2x"
                      alt="">
                 <p>{{ line.variant.product.translated }}<br><small>{{ line.variant.translated }}</small></p>
               </a>

--- a/templates/dashboard/product/list.html
+++ b/templates/dashboard/product/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load materializecss %}
 {% load price from taxed_prices %}
-{% load product_first_image from product_images %}
+{% load get_thumbnail from product_images %}
 {% load staticfiles %}
 {% load utils %}
 
@@ -73,8 +73,8 @@
                 <label for="id_products_{{ product.pk }}"></label>
               </td>
               <td class="avatar">
-                <img src="{% product_first_image product size=60 method="crop" %}"
-                    srcset="{% product_first_image product size=60 method="crop" %} 1x, {% product_first_image product size=120 method="crop" %} 2x"
+                <img src="{% get_thumbnail product.get_first_image size=60 method="crop" %}"
+                    srcset="{% get_thumbnail product.get_first_image size=60 method="crop" %} 1x, {% get_thumbnail product.get_first_image size=120 method="crop" %} 2x"
                     alt="">
               </td>
               <td>

--- a/templates/dashboard/search/results.html
+++ b/templates/dashboard/search/results.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load materializecss %}
 {% load price from taxed_prices %}
-{% load product_first_image from product_images %}
+{% load get_thumbnail from product_images %}
 {% load staticfiles %}
 
 {% block title %}
@@ -27,8 +27,13 @@
           {% for product in products %}
             <li class="collection-item avatar list-item">
               <a href="{% url 'dashboard:product-details' pk=product.pk %}">
+<<<<<<< HEAD
                 <img src="{% product_first_image product size=60 method="crop" %}"
                      srcset="{% product_first_image product size=60 method="crop" %} 1x, {% product_first_image product size=120 method="crop" %} 2x"
+=======
+                <img src="{% get_thumbnail product.get_first_image size="60x60" method="crop" %}"
+                     srcset="{% get_thumbnail product.get_first_image size="60x60" method="crop" %} 1x, {% get_thumbnail product.get_first_image size="120x120" method="crop" %} 2x"
+>>>>>>> Remove duplicated product_first_image templatetag
                      class="circle" alt="{{ product.name }}">
                 <span class="list-item-name">
                   {{ product.name }}

--- a/templates/dashboard/search/results.html
+++ b/templates/dashboard/search/results.html
@@ -27,13 +27,8 @@
           {% for product in products %}
             <li class="collection-item avatar list-item">
               <a href="{% url 'dashboard:product-details' pk=product.pk %}">
-<<<<<<< HEAD
-                <img src="{% product_first_image product size=60 method="crop" %}"
-                     srcset="{% product_first_image product size=60 method="crop" %} 1x, {% product_first_image product size=120 method="crop" %} 2x"
-=======
-                <img src="{% get_thumbnail product.get_first_image size="60x60" method="crop" %}"
-                     srcset="{% get_thumbnail product.get_first_image size="60x60" method="crop" %} 1x, {% get_thumbnail product.get_first_image size="120x120" method="crop" %} 2x"
->>>>>>> Remove duplicated product_first_image templatetag
+                <img src="{% get_thumbnail product.get_first_image size=60 method="crop" %}"
+                     srcset="{% get_thumbnail product.get_first_image size=60 method="crop" %} 1x, {% get_thumbnail product.get_first_image size=120 method="crop" %} 2x"
                      class="circle" alt="{{ product.name }}">
                 <span class="list-item-name">
                   {{ product.name }}

--- a/templates/order/_ordered_items_table.html
+++ b/templates/order/_ordered_items_table.html
@@ -3,7 +3,7 @@
 {% load i18n_address_tags %}
 {% load placeholder %}
 {% load price from taxed_prices %}
-{% load product_first_image from product_images %}
+{% load get_thumbnail from product_images %}
 
 {% if order.user == user %}
   <div class="order-details__addresses">
@@ -50,8 +50,8 @@
     <div class="row">
       <div class="col-md-8">
         <a class="link--clean" href="{% if line.variant %}{{ line.variant.get_absolute_url }}{% endif %}">
-          <img data-src="{% product_first_image line.variant.product size=60 method="crop" %}"
-                data-srcset="{% product_first_image line.variant.product size=60 method="crop" %} 1x, {% product_first_image line.variant.product size=120 method="crop" %} 2x"
+          <img data-src="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %}"
+                data-srcset="{% get_thumbnail line.variant.get_first_image size=60 method="crop" %} 1x, {% get_thumbnail line.variant.get_first_image size=120 method="crop" %} 2x"
                 class="float-left lazyload lazypreload"
                 src="{% placeholder size=60 %}">
           <span class="order-details__product__description">{{ line.translated_product_name|default:line.product_name }}</span>

--- a/templates/product/_items.html
+++ b/templates/product/_items.html
@@ -1,7 +1,6 @@
 {% load i18n %}
 {% load staticfiles %}
 {% load taxed_prices %}
-{% load product_first_image from product_images %}
 {% load get_thumbnail from product_images %}
 {% load placeholder %}
 
@@ -11,8 +10,8 @@
       <div class="text-center">
         <div>
           <img class="img-responsive lazyload lazypreload"
-               data-src="{% product_first_image product method="crop" size=255 %}"
-               data-srcset="{% product_first_image product method="crop" size=255 %} 1x, {% product_first_image product method="crop" size=510 %} 2x"
+               data-src="{% get_thumbnail product.get_first_image method="crop" size=255 %}"
+               data-srcset="{% get_thumbnail product.get_first_image method="crop" size=255 %} 1x, {% get_thumbnail product.get_first_image method="crop" size=510 %} 2x"
                alt=""
                src="{% placeholder size=255 %}">
           <span class="product-list-item-name" title="{{ product.translated }}">{{ product.translated }}</span>

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -3,7 +3,7 @@
 {% load bootstrap_field from bootstrap4 %}
 {% load build_absolute_uri from urls %}
 {% load get_object_properties from attributes %}
-{% load get_thumbnail product_first_image from product_images %}
+{% load get_thumbnail from product_images %}
 {% load i18n %}
 {% load markdown from markdown %}
 {% load placeholder %}
@@ -27,7 +27,7 @@
   <meta property="og:url" content="{{ product_url }}">
   <link rel="canonical" href="{{ product_url }}">
 
-  {% product_first_image product size=510 as product_image %}
+  {% get_thumbnail product.get_first_image size=510 as product_image %}
   {% if product_image %}
     <meta property="og:image" content="{{ product_image }}" />
     <meta property="og:image:width" content="510">

--- a/tests/test_product_tags.py
+++ b/tests/test_product_tags.py
@@ -4,7 +4,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.test import override_settings
 
 from saleor.product.templatetags.product_images import (
-    choose_placeholder, get_thumbnail, get_thumbnail)
+    choose_placeholder, get_thumbnail)
 
 
 @override_settings(

--- a/tests/test_product_tags.py
+++ b/tests/test_product_tags.py
@@ -4,7 +4,7 @@ from django.contrib.staticfiles.templatetags.staticfiles import static
 from django.test import override_settings
 
 from saleor.product.templatetags.product_images import (
-    choose_placeholder, get_thumbnail, product_first_image)
+    choose_placeholder, get_thumbnail, get_thumbnail)
 
 
 @override_settings(
@@ -69,20 +69,6 @@ def test_get_thumbnail_no_match_by_method():
     instance.crop = {'1000x1000': cropped_value}
     cropped = get_thumbnail(instance, 800, method='crop')
     assert cropped == static('images/placeholder1080x1080.png')
-
-
-@override_settings(
-    VERSATILEIMAGEFIELD_SETTINGS={'create_images_on_demand': True})
-def test_product_first_image():
-    mock_product_image = Mock()
-    mock_product_image.image = Mock()
-    mock_product_image.image.crop = {'10x10': Mock(url='crop.jpg')}
-
-    mock_queryset = Mock()
-    mock_queryset.all.return_value = [mock_product_image]
-    mock_product = Mock(images=mock_queryset)
-    out = product_first_image(mock_product, 10, method='crop')
-    assert out == 'crop.jpg'
 
 
 def test_choose_placeholder(settings):


### PR DESCRIPTION
This work is taken from  https://github.com/mirumee/saleor/pull/1634

Also removed 'product_first_image' template tag as I found it unnecessary, replaced with classic "get_thumbnail"

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
