### PR TITLE
Return the original ID of an instance in delete mutations

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -255,10 +255,15 @@ class ModelDeleteMutation(ModelMutation):
         if not cls.user_is_allowed(info.context.user, data):
             raise PermissionDenied()
 
-        id = data.get('id')
+        node_id = data.get('id')
         model_type = registry.get_type_for_model(cls._meta.model)
-        instance = get_node(info, id, only_type=model_type)
+        instance = get_node(info, node_id, only_type=model_type)
+        db_id = instance.id
         instance.delete()
+
+        # After the instance is deleted, set its ID to the original database's
+        # ID so that the success response contains ID of the deleted object.
+        instance.id = db_id
         return cls.success_response(instance)
 
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -577,8 +577,8 @@ def test_delete_product(admin_api_client, product):
               }
             }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Product', product.id)})
+    node_id = graphene.Node.to_global_id('Product', product.id)
+    variables = json.dumps({'id': node_id})
     response = admin_api_client.post(
         reverse('api'), {'query': query, 'variables': variables})
     content = get_graphql_content(response)
@@ -587,6 +587,7 @@ def test_delete_product(admin_api_client, product):
     assert data['product']['name'] == product.name
     with pytest.raises(product._meta.model.DoesNotExist):
         product.refresh_from_db()
+    assert node_id == data['product']['id']
 
 
 def test_product_type(user_api_client, product_type):
@@ -890,13 +891,14 @@ def test_product_image_delete(admin_api_client, product_with_image):
                 productImageDelete(id: $id) {
                     productImage {
                         url
+                        id
                     }
                 }
             }
         """
     image_obj = product.images.first()
-    variables = {
-        'id': graphene.Node.to_global_id('ProductImage', image_obj.id)}
+    node_id = graphene.Node.to_global_id('ProductImage', image_obj.id)
+    variables = {'id': node_id}
     response = admin_api_client.post(
         reverse('api'), {'query': query, 'variables': variables})
     content = get_graphql_content(response)
@@ -905,6 +907,7 @@ def test_product_image_delete(admin_api_client, product_with_image):
     assert data['productImage']['url'] == image_obj.image.url
     with pytest.raises(image_obj._meta.model.DoesNotExist):
         image_obj.refresh_from_db()
+    assert node_id == data['productImage']['id']
 
 
 def test_reorder_images(admin_api_client, product_with_images):


### PR DESCRIPTION
Graphene generates the node ID from the type name and instance's database `id`. It doesn't work for `ModelDeleteMutation`s - after an instance is deleted, the database `id` is `None` which results in different node ID generated in the output. We assume that the node ID returned by "delete" mutations should be the same as the ID provided as an argument.

In this PR we store the original ID before deleting an instance and re-set it later.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
