### PR TITLE
Hide `Make Payment` button from the payment form for autosubmit payments

### DIFF
--- a/templates/order/payment/default.html
+++ b/templates/order/payment/default.html
@@ -12,13 +12,15 @@
       {% trans "Change payment method" context "Payment form (Stripe) secondary action" %}
     </a>
   {% endif %}
-  <div class="form-group">
-    <div class="col-sm-2"></div>
-    <div class="col-sm-10">
-      <button type="submit" class="btn primary">
-        {% trans "Make payment" context "Payment form primary action" %}
-      </button>
+  {% if not form.autosubmit %}
+    <div class="form-group">
+      <div class="col-sm-2"></div>
+      <div class="col-sm-10">
+        <button type="submit" class="btn primary">
+          {% trans "Make payment" context "Payment form primary action" %}
+        </button>
+      </div>
     </div>
-  </div>
+  {% endif %}
 </form>
 {% endblock forms %}


### PR DESCRIPTION
Hello,

I would like to merge this change as it allows to hide the `Make Payment` button on providers forms that are submitted through Javascript.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
