### PR TITLE
Drop relative import in the WSGI application

### DIFF
--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -23,6 +23,6 @@ application = get_wsgi_application()
 # Apply WSGI middleware here.
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
-from .health_check import health_check  # noqa
+from saleor.wsgi.health_check import health_check  # noqa
 
 application = health_check(application, '/health/')


### PR DESCRIPTION
Hi!

I would like to merge this change because `mod_wsgi` doesn't use the WSGI application with the dotted WSGI app `__name__` but with the `_mod_wsgi_</md5_of/saleor/wsgi/__init__.py>` which creates an import error when the WSGI app is being called, as shown below.

```
ModuleNotFoundError: No module named '_mod_wsgi_ef45d16da4dfa0305bb6c003d6555503.health_check'
```

---


More information about this `mod_wsgi` behavior [here](https://modwsgi.readthedocs.io/en/develop/user-guides/assorted-tips-and-tricks.html#determining-if-running-under-mod-wsgi).


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
