### PR TITLE
Adds the mime-support dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ARG STATIC_URL
 
 RUN \
   apt-get update && \
-  apt-get install -y libxml2 libssl1.1 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 shared-mime-info && \
+  apt-get install -y libxml2 libssl1.1 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 shared-mime-info mime-support && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -8,3 +8,4 @@ memory-report = true
 module = saleor.wsgi:application
 processes = 4
 static-map = /static=/app/static
+mimefile = /etc/mime.types


### PR DESCRIPTION
What does this commit/MR do?

- Adds the mime-support dependency
- Seemingly, /etc/mime.types was absent before

Why is this commit/MR needed?

- Without /etc/mime.types, uwsgi doesn't serve svg files with the
appropriate svg format.
- Fixes issue with the chevron-up.svg static asset

I want to merge this change because...

#2623 

### Screenshots

***Before***
![image](https://user-images.githubusercontent.com/12668653/44293416-c3d89780-a282-11e8-99a7-a5b41acf4bc4.png)
***After***
![image](https://user-images.githubusercontent.com/12668653/44298571-632a7880-a2dd-11e8-8d2c-f1fe0d9fbbfc.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
