### PR TITLE
Adds a travis stage for linting the dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,22 @@ env:
   global:
     - DJANGO_SETTINGS_MODULE=tests.settings
     - DATABASE_URL='postgres://postgres@localhost:5432/saleor'
+    - HADOLINT=${HOME}/hadolint
+    - HADOLINT_VERSION=1.11.1
+    - HADOLINT_URL=https://github.com/hadolint/hadolint/releases/download
   matrix:
   - DJANGO="1.11"
   - DJANGO="2.0"
   - DJANGO="2.1"
   - DJANGO="master"
+jobs:
+  include:
+  - stage: lint
+    install:
+    - curl -sL "${HADOLINT_URL}/v${HADOLINT_VERSION}/hadolint-$(uname -s)-$(uname -m)" -o ${HADOLINT}
+    - chmod +x ${HADOLINT}
+    script:
+    - ${HADOLINT} ./Dockerfile
 matrix:
   include:
     - python: "3.7"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM python:3.6 as build-python
 
 RUN \
   apt-get -y update && \
-  apt-get install --no-install-recommends -y gettext=0.19.8.1-2 && \
+  apt-get install --no-install-recommends -y gettext="0.19.8.1-2" && \
   # Cleanup apt cache
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-ADD requirements.txt /app/
+COPY requirements.txt /app/
 RUN pip install -r /app/requirements.txt
 
 
@@ -18,13 +18,13 @@ FROM node:8.6.0 as build-nodejs
 ARG STATIC_URL
 
 # Install node_modules
-ADD webpack.config.js app.json package.json package-lock.json /app/
+COPY webpack.config.js app.json package.json package-lock.json /app/
 WORKDIR /app
 RUN npm install
 
 # Build static
-ADD ./saleor/static /app/saleor/static/
-ADD ./templates /app/templates/
+COPY ./saleor/static /app/saleor/static/
+COPY ./templates /app/templates/
 RUN \
   STATIC_URL=${STATIC_URL} \
   npm run build-assets --production && \
@@ -55,7 +55,7 @@ RUN \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 
-ADD . /app
+COPY . /app
 COPY --from=build-python /usr/local/lib/python3.6/site-packages/ /usr/local/lib/python3.6/site-packages/
 COPY --from=build-python /usr/local/bin/ /usr/local/bin/
 COPY --from=build-nodejs /app/saleor/static /app/saleor/static

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,19 +41,17 @@ ARG AWS_SECRET_ACCESS_KEY
 ARG AWS_STORAGE_BUCKET_NAME
 ARG STATIC_URL
 
-ENV INSTALL_DEPS=" \
-libcairo=1.14.8-1 \
-libgdk-pixbuf2.0-0=2.36.5-2+deb9u2 \
-libpango-1.0-0=1.40.5-1 \
-libpangocairo-1.0-0=1.40.5-1 \
-libssl1.1=1.1.0f-3+deb9u2 \
-libxml2=2.9.4+dfsg1-2.2+deb9u2 \
-shared-mime-info=1.8-1+deb9u1 \
-"
-
 RUN \
   apt-get update && \
-  apt-get install --no-install-recommends -y ${INSTALL_DEPS} && \
+  apt-get install -y --no-install-recommends \
+    libxml2="2.9.4+dfsg1-2.2+deb9u2" \
+    libssl1.1="1.1.0f-3+deb9u2" \
+    libcairo2="1.14.8-1" \
+    libpango-1.0-0="1.40.5-1" \
+    libpangocairo-1.0-0="1.40.5-1" \
+    libgdk-pixbuf2.0-0="2.36.5-2+deb9u2" \
+    shared-mime-info="1.8-1+deb9u1" \
+    mime-support="3.60" && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6 as build-python
 
 RUN \
   apt-get -y update && \
-  apt-get install -y gettext=0.19.8.1-2 && \
+  apt-get install --no-install-recommends -y gettext=0.19.8.1-2 && \
   # Cleanup apt cache
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
@@ -53,7 +53,7 @@ shared-mime-info=1.8-1+deb9u1 \
 
 RUN \
   apt-get update && \
-  apt-get install -y ${INSTALL_DEPS} && \
+  apt-get install --no-install-recommends -y ${INSTALL_DEPS} && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.6 as build-python
 
 RUN \
   apt-get -y update && \
-  apt-get install -y gettext && \
+  apt-get install -y gettext=0.19.8.1-2 && \
   # Cleanup apt cache
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
@@ -41,9 +41,19 @@ ARG AWS_SECRET_ACCESS_KEY
 ARG AWS_STORAGE_BUCKET_NAME
 ARG STATIC_URL
 
+ENV INSTALL_DEPS=" \
+libcairo=1.14.8-1 \
+libgdk-pixbuf2.0-0=2.36.5-2+deb9u2 \
+libpango-1.0-0=1.40.5-1 \
+libpangocairo-1.0-0=1.40.5-1 \
+libssl1.1=1.1.0f-3+deb9u2 \
+libxml2=2.9.4+dfsg1-2.2+deb9u2 \
+shared-mime-info=1.8-1+deb9u1 \
+"
+
 RUN \
   apt-get update && \
-  apt-get install -y libxml2 libssl1.1 libcairo2 libpango-1.0-0 libpangocairo-1.0-0 libgdk-pixbuf2.0-0 shared-mime-info && \
+  apt-get install -y ${INSTALL_DEPS} && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
What does this commit/MR do?

- Adds a travis stage for linting the dockerfile
- Ideally this would/will eventaully be moved into codeclimate but
support for hadolint seems to be still pending. Ref:
`https://github.com/hadolint/hadolint/issues/20`

Why is this commit/MR needed?

- Linting on the dockerfile is preferred to follow best practices
- To standardize the approach in an open source project with many
contributors with their own styles.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
