### PR TITLE
Allow fast_finish in travis build for jobs matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ matrix:
       sudo: required
       dist: xenial
       env: DJANGO="master"
+  fast_finish: true
   allow_failures:
     - python: "3.5"
       env: DJANGO="2.1"


### PR DESCRIPTION
What does this commit/MR do?

- Once the status of the builds is determined, allow the fast failure of
the remaining jobs rather than waiting for the job when the outcome is
pre-determined

Why is this commit/MR needed?

- Speed up CI

I want to merge this change because...

It will possibly help speed up CI


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
