### PR TITLE
Update the documentations with the latest requirements and restore the transifex link

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built with top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL an
 
 ## 💾 Installation and requirements
 
-Saleor requires Python 3.4+, Node.js 8.0+, PostgreSQL and OS-specific dependency tools.
+Saleor requires Python 3.5+, Node.js 8.0+, PostgreSQL and OS-specific dependency tools.
 
 [See the Saleor docs](https://saleor.readthedocs.io) for step-by-step installation and deployment instructions.
 
@@ -42,6 +42,12 @@ Login credentials: `admin@example.com`/`admin`
 * Join the chat on [gitter](https://gitter.im/mirumee/saleor)
 * Follow us on [Twitter](https://twitter.com/getsaleor?lang=en)
 * Check our latest blog posts on [Medium](https://medium.com/saleor)
+
+## 🗺 Translate
+
+Saleor is available in 30 languages translated by our community, 
+the repository gets synchronized weekly to the latest contributions on 
+[the localization platform Transifex](https://www.transifex.com/mirumee/saleor-1/languages/). Join us!
 
 ## 🎁 Contribute
 Any contributions are warmly welcomed, we will do our best to provide you with mentorship and support throughout the whole collaboration.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Built with top-notch technologies. Django, PostgreSQL, ElasticSearch, GraphQL an
 
 ## 💾 Installation and requirements
 
-Saleor requires Python 3.5+, Node.js 8.0+, PostgreSQL and OS-specific dependency tools.
+Saleor requires Python 3.5+, Node.js 10.0+, PostgreSQL and OS-specific dependency tools.
 
 [See the Saleor docs](https://saleor.readthedocs.io) for step-by-step installation and deployment instructions.
 
@@ -43,12 +43,6 @@ Login credentials: `admin@example.com`/`admin`
 * Follow us on [Twitter](https://twitter.com/getsaleor?lang=en)
 * Check our latest blog posts on [Medium](https://medium.com/saleor)
 
-## 🗺 Translate
-
-Saleor is available in 30 languages translated by our community, 
-the repository gets synchronized weekly to the latest contributions on 
-[the localization platform Transifex](https://www.transifex.com/mirumee/saleor-1/languages/). Join us!
-
 ## 🎁 Contribute
 Any contributions are warmly welcomed, we will do our best to provide you with mentorship and support throughout the whole collaboration.
 
@@ -60,6 +54,14 @@ Some of them however might not be listed yet. Check [our roadmap](https://github
 If you have any ideas, just [open an issue](https://github.com/mirumee/saleor/issues/new) and tell us what you think!
 
 Get more details in our [Contributing Guide](https://saleor.readthedocs.io/en/latest/contributing.html).
+
+## 🌎 Translate
+
+Did you know that Saleor is available in almost 30 languages, translated entirely by our community?
+
+If you'd like to help us, you can join one of our translation teams on [the localization platform Transifex](https://www.transifex.com/mirumee/saleor-1/languages/).
+
+The repository gets synchronized weekly with the latest contributions. 
 
 ## 📝 Your feedback
 

--- a/docs/gettingstarted/installation-linux.rst
+++ b/docs/gettingstarted/installation-linux.rst
@@ -21,7 +21,7 @@ Saleor requires Python 3.5 or later. A compatible version comes preinstalled wit
 Node.js
 ~~~~~~~
 
-Version 8 or later is required. See the `installation instructions <https://nodejs.org/en/download/package-manager/>`_.
+Version 10 or later is required. See the `installation instructions <https://nodejs.org/en/download/package-manager/>`_.
 
 .. note::
 

--- a/docs/gettingstarted/installation-linux.rst
+++ b/docs/gettingstarted/installation-linux.rst
@@ -15,7 +15,7 @@ Before you are ready to run Saleor you will need additional software installed o
 Python 3
 ~~~~~~~~
 
-Saleor requires Python 3.4 or later. A compatible version comes preinstalled with most current Linux systems. If that is not the case consult your distribution for instructions on how to install Python 3.6 or 3.7.
+Saleor requires Python 3.5 or later. A compatible version comes preinstalled with most current Linux systems. If that is not the case consult your distribution for instructions on how to install Python 3.6 or 3.7.
 
 
 Node.js

--- a/docs/gettingstarted/installation-macos.rst
+++ b/docs/gettingstarted/installation-macos.rst
@@ -10,7 +10,7 @@ Before you are ready to run Saleor you will need additional software installed o
 Node.js
 ~~~~~~~
 
-Version 8 or later is required. Download the macOS installer from the `Node.js downloads page <https://nodejs.org/en/download/>`_.
+Version 10 or later is required. Download the macOS installer from the `Node.js downloads page <https://nodejs.org/en/download/>`_.
 
 
 PostgreSQL

--- a/docs/gettingstarted/installation-windows.rst
+++ b/docs/gettingstarted/installation-windows.rst
@@ -21,7 +21,7 @@ Make sure that "**Add Python 3.7 to PATH**" is checked.
 Node.js
 ~~~~~~~
 
-Version 8 or later is required. Download the Windows installer from the `Node.js downloads page <https://nodejs.org/en/download/>`_.
+Version 10 or later is required. Download the Windows installer from the `Node.js downloads page <https://nodejs.org/en/download/>`_.
 
 Make sure that "**Add to PATH**" is selected.
 


### PR DESCRIPTION
Python 3.4 was dropped in #2601, this change replace the minimal Python version 3.4 to 3.5 in the documentations.

This also the restore the transifex link that was accidentally removed from the readme file.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
