### PR TITLE
Enable Pythonic environment variables

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -18,6 +18,10 @@ def get_list(text):
 def get_bool_from_env(name, default_value):
     if name in os.environ:
         value = os.environ[name]
+        # Enable Pythonic environment variables,
+        # i.e. DEBUG='' or DEBUG= is Falsy but would generate an error
+        if value == '':
+            return False
         try:
             return ast.literal_eval(value)
         except ValueError as e:


### PR DESCRIPTION
I want to merge this change because it makes environment variable more Pythonic (intuitive) and reduces newby error.

No issues reported as far as I know but I did see one on Gitter:
Stephen Moloney @stephenmoloney 14:56
I though that get_bool_from_env would coerce it...
to False

Not sure how to add tests for this but if that's possible, happy to do so.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
