### PR TITLE
Unify resolving nodes in Graphene

### DIFF
--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -8,10 +8,9 @@ from graphql_jwt.decorators import permission_required
 
 from ...account import emails, models
 from ...core.permissions import MODELS_PERMISSIONS, get_permissions
-from ..account.types import AddressInput
+from ..account.types import AddressInput, User
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import Error
-from ..utils import get_node
 
 
 def send_user_password_reset_email(user, site):
@@ -279,8 +278,8 @@ class AddressCreate(ModelMutation):
 
     @classmethod
     def clean_input(cls, info, instance, input, errors):
-        user_id = input.get('user_id')
-        user = get_node(info, user_id)
+        user_id = input.pop('user_id')
+        user = cls.get_node_or_error(info, user_id, errors, 'user_id', User)
         cleaned_input = super().clean_input(info, instance, input, errors)
         cleaned_input['user'] = user
         return cleaned_input

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -1,9 +1,5 @@
-from django.contrib.auth import models as auth_models
-from graphql_jwt.decorators import permission_required, staff_member_required
-
 from ...account import models
-from ..utils import filter_by_query_param, get_node
-from .types import User
+from ..utils import filter_by_query_param
 
 
 USER_SEARCH_FIELDS = (
@@ -12,13 +8,7 @@ USER_SEARCH_FIELDS = (
     'default_shipping_address__country')
 
 
-@permission_required(['account.manage_users'])
 def resolve_users(info, query):
     qs = models.User.objects.all().prefetch_related('addresses')
     return filter_by_query_param(
         queryset=qs, query=query, search_fields=USER_SEARCH_FIELDS)
-
-
-@permission_required(['account.manage_users'])
-def resolve_user(info, id):
-    return get_node(info, id, only_type=User)

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -1,7 +1,6 @@
 from ...account import models
 from ..utils import filter_by_query_param
 
-
 USER_SEARCH_FIELDS = (
     'email', 'default_shipping_address__first_name',
     'default_shipping_address__last_name', 'default_shipping_address__city',

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -11,7 +11,7 @@ from graphql_jwt.exceptions import GraphQLJWTError, PermissionDenied
 from ...account import models
 from ..account.types import User
 from ..file_upload.types import Upload
-from ..utils import get_node, get_nodes
+from ..utils import get_nodes
 from .types.common import Error
 from .utils import snake_to_camel_case
 
@@ -52,28 +52,33 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def add_error(cls, errors, field, message):
-        """Add an error to the errors list.
+        """Add a mutation user error.
 
-        `errors` is the list of errors that happened during execution of the
-        mutation. `field` is the name of model field the error is related
-        to. `None` is allowed and it indicates that the error is a general one
-        and not related to any of the model fields. `message` is the actual
-        error message.
+        `errors` is the list of errors that happened during the execution of
+        the mutation. `field` is the name of an input field the error is
+        related to. `None` value is allowed and it indicates that the error
+        is general and is not related to any of the input fields. `message`
+        is the actual error message to be returned in the response.
 
-        As a result of this method, the `errors` argument is updated with an
-        Error object to be returned in mutation result.
+        As a result of this method, the `errors` list is updated with an Error
+        object to be returned as mutation result.
         """
         field = snake_to_camel_case(field)
         errors.append(Error(field=field, message=message))
 
     @classmethod
-    def get_node_or_error(cls, info, id, errors, field, only_type=None):
-        instance = None
+    def get_node_or_error(cls, info, global_id, errors, field, only_type=None):
+        node = None
         try:
-            instance = get_node(info, id, only_type)
-        except GraphQLError as e:
-            cls.add_error(field=field, message=str(e), errors=errors)
-        return instance
+            node = graphene.Node.get_node_from_global_id(
+                info, global_id, only_type)
+        except (AssertionError, GraphQLError) as e:
+            cls.add_error(errors, field, str(e))
+        else:
+            if node is None:
+                message = "Couldn't resolve to a node: %s" % global_id
+                cls.add_error(errors, field, message)
+        return node
 
     @classmethod
     def get_nodes_or_error(cls, ids, errors, field, only_type=None):
@@ -114,12 +119,6 @@ class ModelMutation(BaseMutation):
             arguments=arguments, fields=fields)
 
     @classmethod
-    def _check_type(cls, field, target_type):
-        if hasattr(field.type, 'of_type'):
-            return field.type.of_type == target_type
-        return field.type == target_type
-
-    @classmethod
     def clean_input(cls, info, instance, input, errors):
         """Clean input data received from mutation arguments.
 
@@ -132,31 +131,44 @@ class ModelMutation(BaseMutation):
         Override this method to provide custom transformations of incoming
         data.
         """
+
+        def is_list_of_ids(field):
+            return (
+                isinstance(field.type, graphene.List) and
+                    field.type.of_type == graphene.ID)
+
+        def is_id_field(field):
+            return (
+                field.type == graphene.ID or
+                    isinstance(field.type, graphene.NonNull) and
+                        field.type.of_type == graphene.ID)
+
+        def is_upload_field(field):
+            if hasattr(field.type, 'of_type'):
+                return field.type.of_type == Upload
+            return field.type == Upload
+
         InputCls = getattr(cls.Arguments, 'input')
         cleaned_input = {}
+
         for field_name, field in InputCls._meta.fields.items():
             if field_name in input:
                 value = input[field_name]
-                # FIXME: maybe we could have custom input field type that takes
-                # the type of IDs
-                # e.g. graphene.IdList(graphene.ID, type=Product).
 
                 # handle list of IDs field
-                if value is not None and (
-                    isinstance(field.type, graphene.List)) and (
-                        field.type.of_type == graphene.ID):
+                if value is not None and is_list_of_ids(field):
                     instances = cls.get_nodes_or_error(
-                        value, errors=errors, field=field.name) if value else []
+                        value, errors=errors, field=field_name) if value else []
                     cleaned_input[field_name] = instances
 
                 # handle ID field
-                elif value is not None and field.type == graphene.ID:
+                elif value is not None and is_id_field(field):
                     instance = cls.get_node_or_error(
-                        info, value, errors=errors, field=field.name)
+                        info, value, errors=errors, field=field_name)
                     cleaned_input[field_name] = instance
 
                 # handle uploaded files
-                elif value is not None and cls._check_type(field, Upload):
+                elif value is not None and is_upload_field(field):
                     value = info.context.FILES.get(value)
                     cleaned_input[field_name] = value
 
@@ -255,7 +267,8 @@ class ModelMutation(BaseMutation):
         # Initialize model instance based on presence of `id` attribute.
         if id:
             model_type = registry.get_type_for_model(cls._meta.model)
-            instance = get_node(info, id, only_type=model_type)
+            instance = cls.get_node_or_error(
+                info, id, errors, 'id', model_type)
         else:
             instance = cls._meta.model()
 
@@ -279,9 +292,15 @@ class ModelDeleteMutation(ModelMutation):
         if not cls.user_is_allowed(info.context.user, data):
             raise PermissionDenied()
 
+        errors = []
         node_id = data.get('id')
         model_type = registry.get_type_for_model(cls._meta.model)
-        instance = get_node(info, node_id, only_type=model_type)
+        instance = cls.get_node_or_error(
+            info, node_id, errors, 'id', model_type)
+
+        if errors:
+            return cls(errors=errors)
+
         db_id = instance.id
         instance.delete()
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -134,14 +134,14 @@ class ModelMutation(BaseMutation):
 
         def is_list_of_ids(field):
             return (
-                isinstance(field.type, graphene.List) and
-                    field.type.of_type == graphene.ID)
+                isinstance(field.type, graphene.List)
+                and field.type.of_type == graphene.ID)
 
         def is_id_field(field):
             return (
-                field.type == graphene.ID or
-                    isinstance(field.type, graphene.NonNull) and
-                        field.type.of_type == graphene.ID)
+                field.type == graphene.ID
+                or isinstance(field.type, graphene.NonNull)
+                and field.type.of_type == graphene.ID)
 
         def is_upload_field(field):
             if hasattr(field.type, 'of_type'):
@@ -158,7 +158,8 @@ class ModelMutation(BaseMutation):
                 # handle list of IDs field
                 if value is not None and is_list_of_ids(field):
                     instances = cls.get_nodes_or_error(
-                        value, errors=errors, field=field_name) if value else []
+                        value, errors=errors,
+                        field=field_name) if value else []
                     cleaned_input[field_name] = instances
 
                 # handle ID field

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -7,11 +7,9 @@ MENU_ITEM_SEARCH_FIELDS = ('name',)
 
 def resolve_menus(info, query):
     queryset = models.Menu.objects.all()
-    queryset = filter_by_query_param(queryset, query, MENU_SEARCH_FIELDS)
-    return queryset
+    return filter_by_query_param(queryset, query, MENU_SEARCH_FIELDS)
 
 
 def resolve_menu_items(info, query):
     queryset = models.MenuItem.objects.all()
-    queryset = filter_by_query_param(queryset, query, MENU_ITEM_SEARCH_FIELDS)
-    return queryset
+    return filter_by_query_param(queryset, query, MENU_ITEM_SEARCH_FIELDS)

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -1,28 +1,27 @@
-from graphql_jwt.decorators import login_required
+import graphene
 
 from ...order import models
-from ..utils import filter_by_query_param, get_node
+from ..utils import filter_by_query_param
 from .types import Order
 
 ORDER_SEARCH_FIELDS = (
     'id', 'discount_name', 'token', 'user_email', 'user__email')
 
 
-@login_required
 def resolve_orders(info, query):
     user = info.context.user
-    queryset = user.orders.confirmed().distinct()
-    if user.get_all_permissions() & {'order.manage_orders'}:
-        queryset = models.Order.objects.all().distinct()
-    queryset = filter_by_query_param(queryset, query, ORDER_SEARCH_FIELDS)
-    return queryset.prefetch_related('lines')
+    if user.has_perm('order.manage_orders'):
+        qs = models.Order.objects.all()
+    else:
+        qs = user.orders.confirmed()
+    qs = filter_by_query_param(qs, query, ORDER_SEARCH_FIELDS)
+    return qs.prefetch_related('lines').distinct()
 
 
-@login_required
 def resolve_order(info, id):
     """Return order only for user assigned to it or proper staff user."""
-    order = get_node(info, id, only_type=Order)
     user = info.context.user
-    if (order.user == user or user.get_all_permissions() & {
-            'order.manage_orders'}):
+    order = graphene.Node.get_node_from_global_id(info, id, Order)
+    if user.has_perm('order.manage_orders') or order.user == user:
         return order
+    return None

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -8,6 +8,7 @@ class Page(CountableDjangoObjectType):
     class Meta:
         description = """A static page that can be manually added by a shop
         operator through the dashboard."""
+        exclude_fields = ['voucher_set', 'sale_set', 'menuitem_set']
         interfaces = [relay.Node]
         filter_fields = ['id', 'name']
         model = models.Page

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -221,6 +221,7 @@ class Collection(CountableDjangoObjectType):
 
     class Meta:
         description = "Represents a collection of products."
+        exclude_fields = ['voucher_set', 'sale_set', 'menuitem_set']
         filter_fields = {
             'name': ['exact', 'icontains', 'istartswith']}
         interfaces = [relay.Node]
@@ -252,7 +253,9 @@ class Category(CountableDjangoObjectType):
         description = """Represents a single category of products. Categories
         allow to organize products in a tree-hierarchies which can be used for
         navigation in the storefront."""
-        exclude_fields = ['lft', 'rght', 'tree_id']
+        exclude_fields = [
+            'lft', 'rght', 'tree_id', 'voucher_set', 'sale_set',
+            'menuitem_set']
         interfaces = [relay.Node]
         filter_fields = ['id', 'name']
         model = models.Category

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -21,15 +21,6 @@ def get_database_id(info, node_id, only_type):
     return _id
 
 
-def get_node(info, id, only_type=None):
-    """Return node or throw an error if the node does not exist."""
-    node = graphene.Node.get_node_from_global_id(info, id, only_type=only_type)
-    if not node:
-        raise GraphQLError(
-            "Could not resolve to a node with the global id of '%s'." % id)
-    return node
-
-
 def get_nodes(ids, graphene_type=None):
     """Return a list of nodes.
 

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -1,0 +1,96 @@
+import graphene
+from saleor.graphql.core.mutations import BaseMutation
+from saleor.graphql.product import types as product_types
+
+
+class Mutation(BaseMutation):
+    name = graphene.Field(graphene.String)
+
+    class Arguments:
+        product_id = graphene.ID(required=True)
+
+    @classmethod
+    def mutate(cls, root, info, product_id):
+        errors = []
+        product = cls.get_node_or_error(
+            info, product_id, errors, 'product_id', product_types.Product)
+        if errors:
+            return Mutation(errors=errors)
+        return Mutation(name=product.name)
+
+
+class Mutations(graphene.ObjectType):
+    test = Mutation.Field()
+
+
+schema = graphene.Schema(
+    mutation=Mutations,
+    types=[product_types.Product, product_types.ProductVariant])
+
+
+def test_resolve_id(product):
+    product_id = graphene.Node.to_global_id('Product', product.pk)
+    query = """
+        mutation testMutation($productId: ID!) {
+            test(productId: $productId) {
+                name
+                errors {
+                    field
+                    message
+                }
+            }
+        }
+    """
+    variables = {'productId': product_id}
+    result = schema.execute(query, variables=variables)
+    assert not result.errors
+    assert result.data['test']['name'] == product.name
+
+
+def test_user_error_nonexistent_id():
+    query = """
+        mutation testMutation($productId: ID!) {
+            test(productId: $productId) {
+                name
+                errors {
+                    field
+                    message
+                }
+            }
+        }
+    """
+    variables = {'productId': 'not-really'}
+    result = schema.execute(query, variables=variables)
+    assert not result.errors
+    user_errors = result.data['test']['errors']
+    assert user_errors
+    assert user_errors[0]['field'] == 'productId'
+    assert "Couldn't resolve to a node" in user_errors[0]['message']
+
+
+def test_user_error_id_of_different_type(product):
+    query = """
+        mutation testMutation($productId: ID!) {
+            test(productId: $productId) {
+                name
+                errors {
+                    field
+                    message
+                }
+            }
+        }
+    """
+
+    # Test that get_node_or_error checks that the returned ID must be of
+    # proper type. Providing correct ID but of different type than expected
+    # should result in user error.
+    variant = product.variants.first()
+    variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
+
+    variables = {'productId': variant_id}
+    result = schema.execute(query, variables=variables)
+    assert not result.errors
+    user_errors = result.data['test']['errors']
+    assert user_errors
+    assert user_errors[0]['field'] == 'productId'
+    assert user_errors[0]['message'] == 'Must receive a Product id.'

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -29,6 +29,7 @@ def test_menu_query(user_api_client, menu, menu_item):
         }
     }
     """
+
     menu.items.add(menu_item)
     menu.save()
     menu_name = menu.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,6 +42,7 @@ class ApiClient(Client):
 
     def __init__(self, *args, **kwargs):
         user = kwargs.pop('user')
+        self.user = user
         self.token = get_token(user)
         super().__init__(*args, **kwargs)
 
@@ -595,7 +596,7 @@ def collection(db):
 @pytest.fixture
 def draft_collection(db):
     collection = Collection.objects.create(
-        name='Collection', slug='collection')
+        name='Draft collection', slug='draft-collection')
     return collection
 
 
@@ -620,8 +621,7 @@ def model_form_class():
 
 @pytest.fixture
 def menu(db):
-    # navbar menu object can be already created by default in migration
-    return Menu.objects.get_or_create(name='navbar', json_content={})[0]
+    return Menu.objects.get_or_create(name='test-navbar', json_content={})[0]
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR unifies the way we resolve nodes from global IDs. Assumptions about the new approach:
- return `null` when ID is unresolved in queries
- return a user error when ID is unresolved in mutations

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
