### PR TITLE
[WIP][Help wanted] Upgrade version of elasticsearch from 5.x -> 6.x

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - redis
 
   search:
-    image: elasticsearch:5.4.3
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.4.0
     container_name: saleor-elasticsearch
     restart: unless-stopped
     networks:

--- a/requirements.in
+++ b/requirements.in
@@ -27,8 +27,8 @@ django-webpack-loader>=0.3.0
 django-celery-results
 django-elasticsearch-dsl
 django-recaptcha
-elasticsearch>=5.4,<6.0.0
-elasticsearch-dsl>=5.0.0,<6.0.0
+elasticsearch>=6.0,<7.0
+elasticsearch-dsl>=6.0,<7.0
 faker>=0.7.7
 freezegun>=0.3.9
 google-measurement-protocol>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,8 +55,8 @@ django-versatileimagefield==1.9
 django-webpack-loader==0.6.0
 django==2.0.8
 docutils==0.14            # via botocore
-elasticsearch-dsl==5.4.0
-elasticsearch==5.5.2
+elasticsearch-dsl==6.1.0
+elasticsearch==6.1.1
 faker==0.9.0
 freezegun==0.3.10
 google-i18n-address==2.3.2


### PR DESCRIPTION
What does this commit/MR do?

- Upgrade version of elasticsearch from 5.x -> 6.x

Why is this commit/MR needed?

- To upgrade elasticsearch version
- Most kubernetes deployments are using 6.x rather than 5.x meaning that
it is harder to setup a helm kubernetes for 5.x

I want to merge this change because...

I would like to have elasticsearch 6.x, primarily because most recent charts for helm 
are for elasticsearch 6.x

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
