### PR TITLE
Set default fallback static_url when not passed as argument

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN pip install -r /app/requirements.txt
 FROM node:10 as build-nodejs
 
 ARG STATIC_URL
+ENV STATIC_URL ${STATIC_URL:-/static/}
 
 # Install node_modules
 ADD webpack.config.js app.json package.json package-lock.json tsconfig.json webpack.d.ts /app/
@@ -36,6 +37,7 @@ RUN \
 FROM python:3.6-slim
 
 ARG STATIC_URL
+ENV STATIC_URL ${STATIC_URL:-/static/}
 
 RUN \
   apt-get update && \


### PR DESCRIPTION
What does this commit/MR do?

- Set default fallback static_url when not passed as argument

Why is this commit/MR needed?

- build will fail without STATIC_URL in build-args, allow a defailt

I want to merge this change because...

Without it a static_url build arg must be provided which is easily forgotten


### Screenshots

***Before:***
<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->
![image](https://user-images.githubusercontent.com/12668653/44611386-c5610d00-a7f8-11e8-89d8-0acdd0a272c2.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
