### PR TITLE
Lock django version smaller than 2.1 since django-filter 1.1 doesn't support 2.1

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -2,7 +2,7 @@ Babel>=2.5
 bleach<3.0
 boto3
 cairosvg
-Django>=1.11
+Django>=1.11,<2.1
 dj_database_url>=0.3.0
 dj_email_url>=0.0.4
 django-babel>=0.6.1


### PR DESCRIPTION
Saleor requires django-filter 1.1 but django-filter 1.1 does not support django 2.1 since django 2.1 removes ```django.db.models.sql.constants.QUERY_TERMS``` but django-filter 1.1 will try to import it.

So ```Django>=1.11,<2.1``` is added in ```requirements.in```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
