### PR TITLE
Send payment notification on payment status change.

### DIFF
--- a/saleor/order/signals.py
+++ b/saleor/order/signals.py
@@ -3,7 +3,7 @@ import logging
 from django.utils.translation import pgettext_lazy
 
 from ..core import analytics
-from .emails import send_order_confirmation
+from .emails import send_payment_confirmation
 
 logger = logging.getLogger(__name__)
 
@@ -15,7 +15,7 @@ def order_status_change(sender, instance, **kwargs):
         msg = pgettext_lazy('Order status history entry', 'Order fully paid')
         order.history.create(content=msg)
         if order.get_user_current_email():
-            send_order_confirmation.delay(order.pk)
+            send_payment_confirmation.delay(order.pk)
         try:
             analytics.report_order(order.tracking_client_id, order)
         except Exception:


### PR DESCRIPTION
I could be wrong, but I think this is meant to say `send_payment_notification` rather than `send_order_notification`.

Before this change, the order notifications are sent twice (once after order placed, once after payment) while payment notifications aren't sent at all.

With this change, the order notification is sent after order placed and the payment notification is sent after payment is confirmed.
