### PR TITLE
Query menu by name

### DIFF
--- a/saleor/graphql/api.py
+++ b/saleor/graphql/api.py
@@ -8,7 +8,7 @@ from .account.mutations import (
     StaffUpdate, AddressCreate, AddressUpdate, AddressDelete)
 from .account.resolvers import resolve_users
 from .account.types import User
-from .menu.resolvers import resolve_menus, resolve_menu_items
+from .menu.resolvers import resolve_menu, resolve_menus, resolve_menu_items
 from .menu.types import Menu, MenuItem
 # FIXME: sorting import by putting below line at the beginning breaks app
 from .menu.mutations import (
@@ -86,7 +86,8 @@ class Query(graphene.ObjectType):
         description='List of the shop\'s collections.')
     menu = graphene.Field(
         Menu, id=graphene.Argument(graphene.ID),
-        description='Lookup a menu by ID.')
+        name=graphene.Argument(graphene.String, description="Menu name."),
+        description='Lookup a menu by ID or name.')
     menus = DjangoFilterConnectionField(
         Menu, query=graphene.String(description=DESCRIPTIONS['menu']),
         description="List of the shop\'s menus.")
@@ -176,8 +177,8 @@ class Query(graphene.ObjectType):
     def resolve_users(self, info, query=None, **kwargs):
         return resolve_users(info, query=query)
 
-    def resolve_menu(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, Menu)
+    def resolve_menu(self, info, id=None, name=None):
+        return resolve_menu(info, id, name)
 
     def resolve_menus(self, info, query=None, **kwargs):
         return resolve_menus(info, query)

--- a/saleor/graphql/core/types/shop.py
+++ b/saleor/graphql/core/types/shop.py
@@ -7,7 +7,6 @@ from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
 
 from ....core.permissions import get_permissions
 from ....site import models as site_models
-from ....menu import models as menu_models
 from ...menu.types import Menu
 from ...utils import format_permissions_for_display
 from .common import CountryDisplay, LanguageDisplay, PermissionDisplay

--- a/saleor/graphql/core/types/shop.py
+++ b/saleor/graphql/core/types/shop.py
@@ -7,6 +7,8 @@ from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
 
 from ....core.permissions import get_permissions
 from ....site import models as site_models
+from ....menu import models as menu_models
+from ...menu.types import Menu
 from ...utils import format_permissions_for_display
 from .common import CountryDisplay, LanguageDisplay, PermissionDisplay
 from .money import VAT
@@ -29,6 +31,14 @@ class Domain(graphene.ObjectType):
         description = 'Represents shop\'s domain.'
 
 
+class Navigation(graphene.ObjectType):
+    main = graphene.Field(Menu, description='Main navigation bar.')
+    secondary = graphene.Field(Menu, description='Secondary navigation bar.')
+
+    class Meta:
+        description = 'Represents shop\'s navigation menus.'
+
+
 class Shop(graphene.ObjectType):
     authorization_keys = graphene.List(
         AuthorizationKey, description='List of configured authorization keys.',
@@ -48,6 +58,8 @@ class Shop(graphene.ObjectType):
         LanguageDisplay,
         description='List of the shops\'s supported languages.', required=True)
     name = graphene.String(description='Shop\'s name.', required=True)
+    navigation = graphene.Field(
+        Navigation, description='Shop\'s navigation.')
     permissions = graphene.List(
         PermissionDisplay, description='List of available permissions.',
         required=True)
@@ -98,6 +110,11 @@ class Shop(graphene.ObjectType):
 
     def resolve_name(self, info):
         return info.context.site.name
+
+    def resolve_navigation(self, info):
+        site_settings = info.context.site.settings
+        return Navigation(
+            main=site_settings.top_menu, secondary=site_settings.bottom_menu)
 
     @permission_required('site.manage_settings')
     def resolve_permissions(self, info):

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -1,8 +1,21 @@
+import graphene
+
 from ...menu import models
 from ..utils import filter_by_query_param
+from .types import Menu
 
 MENU_SEARCH_FIELDS = ('name',)
 MENU_ITEM_SEARCH_FIELDS = ('name',)
+
+
+def resolve_menu(info, id=None, name=None):
+    assert id or name, 'No ID or name provided.'
+    if name is not None:
+        try:
+            return models.Menu.objects.get(name=name)
+        except models.Menu.DoesNotExist:
+            return None
+    return graphene.Node.get_node_from_global_id(info, id, Menu)
 
 
 def resolve_menus(info, query):

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -10,8 +10,12 @@ class Menu(CountableDjangoObjectType):
         description = """Represents a single menu - an object that is used
         to help navigate through the store."""
         interfaces = [relay.Node]
+        exclude_fields = ['json_content']
         filter_fields = {}
         model = models.Menu
+
+    def resolve_items(self, info):
+        return self.items.filter(level=0)
 
 
 class MenuItem(CountableDjangoObjectType):

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -206,6 +206,29 @@ def test_query_permissions(admin_api_client, user_api_client):
     assert_no_permission(response)
 
 
+def test_query_navigation(user_api_client, site_settings):
+    query = """
+    query {
+        shop {
+            navigation {
+                main {
+                    name
+                }
+                secondary {
+                    name
+                }
+            }
+        }
+    }
+    """
+    response = user_api_client.post(reverse('api'), {'query': query})
+    content = get_graphql_content(response)
+    assert 'errors' not in content
+    navigation_data = content['data']['shop']['navigation']
+    assert navigation_data['main']['name'] == site_settings.top_menu.name
+    assert navigation_data['secondary']['name'] == site_settings.bottom_menu.name
+
+
 def test_clean_seo_fields():
     title = 'lady title'
     description = 'fantasy description'

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -32,6 +32,14 @@ def test_menu_query(user_api_client, menu):
     assert 'errors' not in content
     assert content['data']['menu']['name'] == menu.name
 
+    # test query by invalid name returns null
+    variables = json.dumps({'menu_name': 'not-a-menu'})
+    response = user_api_client.post(
+        reverse('api'), {'query': query, 'variables': variables})
+    content = get_graphql_content(response)
+    assert 'errors' not in content
+    assert not content['data']['menu']
+
 
 def test_menus_query(user_api_client, menu, menu_item):
     query = """

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -6,7 +6,34 @@ from django.shortcuts import reverse
 from tests.utils import get_graphql_content
 
 
-def test_menu_query(user_api_client, menu, menu_item):
+def test_menu_query(user_api_client, menu):
+    query = """
+    query menu($id: ID, $menu_name: String){
+        menu(id: $id, name: $menu_name) {
+            name
+        }
+    }
+    """
+
+    # test query by name
+    variables = json.dumps({'menu_name': menu.name})
+    response = user_api_client.post(
+        reverse('api'), {'query': query, 'variables': variables})
+    content = get_graphql_content(response)
+    assert 'errors' not in content
+    assert content['data']['menu']['name'] == menu.name
+
+    # test query by id
+    menu_id = graphene.Node.to_global_id('Menu', menu.id)
+    variables = json.dumps({'id': menu_id})
+    response = user_api_client.post(
+        reverse('api'), {'query': query, 'variables': variables})
+    content = get_graphql_content(response)
+    assert 'errors' not in content
+    assert content['data']['menu']['name'] == menu.name
+
+
+def test_menus_query(user_api_client, menu, menu_item):
     query = """
     query menus($menu_name: String){
         menus(query: $menu_name) {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,6 +100,15 @@ def site_settings(db, settings):
         name="mirumee.com", domain="mirumee.com")[0]
     obj = SiteSettings.objects.get_or_create(site=site)[0]
     settings.SITE_ID = site.pk
+
+    # Default menus are created in migrations.
+    main_menu = Menu.objects.get(
+        name=settings.DEFAULT_MENUS['top_menu_name'])
+    secondary_menu = Menu.objects.get(
+        name=settings.DEFAULT_MENUS['bottom_menu_name'])
+    obj.top_menu = main_menu
+    obj.bottom_menu = secondary_menu
+    obj.save()
     return obj
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,11 +101,12 @@ def site_settings(db, settings):
     obj = SiteSettings.objects.get_or_create(site=site)[0]
     settings.SITE_ID = site.pk
 
-    # Default menus are created in migrations.
-    main_menu = Menu.objects.get(
-        name=settings.DEFAULT_MENUS['top_menu_name'])
-    secondary_menu = Menu.objects.get(
-        name=settings.DEFAULT_MENUS['bottom_menu_name'])
+    main_menu = Menu.objects.get_or_create(
+        name=settings.DEFAULT_MENUS['top_menu_name'])[0]
+    update_menu(main_menu)
+    secondary_menu = Menu.objects.get_or_create(
+        name=settings.DEFAULT_MENUS['bottom_menu_name'])[0]
+    update_menu(secondary_menu)
     obj.top_menu = main_menu
     obj.bottom_menu = secondary_menu
     obj.save()


### PR DESCRIPTION
Fixes #2708

This PR adds the ability to query menus by name and to query selected storefront's navigation through the `shop` query.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
