### PR TITLE
Use dev server instead of uwsgi to support code hot reloading

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
       - db
       - redis
       - search
+    command: python manage.py runserver 0.0.0.0:8000
 
   db:
     image: library/postgres:latest


### PR DESCRIPTION
I want to merge this change because it closes #2713 
In fact, there is no conflict in ports and container names, both `db` and `saleor-postgres` names work well as database URLs using docker-compose.
So I just changed command used to run server in compose.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
