### PR TITLE
Rename default_category to category

### DIFF
--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -371,7 +371,7 @@ def test_attributes_in_category_query(user_api_client, product):
 
 
 def test_create_product(
-        admin_api_client, product_type, default_category, size_attribute):
+        admin_api_client, product_type, category, size_attribute):
     query = """
         mutation createProduct(
             $productTypeId: ID!,
@@ -430,7 +430,7 @@ def test_create_product(
     product_type_id = graphene.Node.to_global_id(
         'ProductType', product_type.pk)
     category_id = graphene.Node.to_global_id(
-        'Category', default_category.pk)
+        'Category', category.pk)
     product_description = 'test description'
     product_name = 'test name'
     product_isPublished = True
@@ -474,7 +474,7 @@ def test_create_product(
     assert data['product']['chargeTaxes'] == product_chargeTaxes
     assert data['product']['taxRate'] == product_taxRate
     assert data['product']['productType']['name'] == product_type.name
-    assert data['product']['category']['name'] == default_category.name
+    assert data['product']['category']['name'] == category.name
     values = (
         data['product']['attributes'][0]['value']['slug'],
         data['product']['attributes'][1]['value']['slug'])
@@ -483,8 +483,7 @@ def test_create_product(
 
 
 def test_update_product(
-        admin_api_client, default_category, non_default_category,
-        product):
+        admin_api_client, category, non_default_category, product):
     query = """
         mutation updateProduct(
             $productId: ID!,
@@ -570,7 +569,7 @@ def test_update_product(
     assert data['product']['isPublished'] == product_isPublished
     assert data['product']['chargeTaxes'] == product_chargeTaxes
     assert data['product']['taxRate'] == product_taxRate
-    assert not data['product']['category']['name'] == default_category.name
+    assert not data['product']['category']['name'] == category.name
 
 
 def test_delete_product(admin_api_client, product):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -268,7 +268,7 @@ def size_attribute(db):  # pylint: disable=W0613
 
 
 @pytest.fixture
-def default_category(db):  # pylint: disable=W0613
+def category(db):  # pylint: disable=W0613
     return Category.objects.create(name='Default', slug='default')
 
 
@@ -297,15 +297,14 @@ def product_type(color_attribute, size_attribute):
 
 
 @pytest.fixture
-def product(product_type, default_category):
+def product(product_type, category):
     product_attr = product_type.product_attributes.first()
     attr_value = product_attr.values.first()
     attributes = {smart_text(product_attr.pk): smart_text(attr_value.pk)}
 
     product = Product.objects.create(
         name='Test product', price=Money('10.00', 'USD'),
-        product_type=product_type, attributes=attributes,
-        category=default_category)
+        product_type=product_type, attributes=attributes, category=category)
 
     variant_attr = product_type.variant_attributes.first()
     variant_attr_value = variant_attr.values.first()
@@ -327,37 +326,34 @@ def variant(product):
 
 
 @pytest.fixture
-def product_without_shipping(default_category):
+def product_without_shipping(category):
     product_type = ProductType.objects.create(
         name='Type with no shipping', has_variants=False,
         is_shipping_required=False)
     product = Product.objects.create(
         name='Test product', price=Money('10.00', 'USD'),
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     ProductVariant.objects.create(product=product, sku='SKU_B')
     return product
 
 
 @pytest.fixture
-def product_list(product_type, default_category):
+def product_list(product_type, category):
     product_attr = product_type.product_attributes.first()
     attr_value = product_attr.values.first()
     attributes = {smart_text(product_attr.pk): smart_text(attr_value.pk)}
 
     product_1 = Product.objects.create(
-        name='Test product 1', price=Money('10.00', 'USD'),
-        product_type=product_type, attributes=attributes, is_published=True,
-        category=default_category)
+        name='Test product 1', price=Money('10.00', 'USD'), category=category,
+        product_type=product_type, attributes=attributes, is_published=True)
 
     product_2 = Product.objects.create(
-        name='Test product 2', price=Money('20.00', 'USD'),
-        product_type=product_type, attributes=attributes, is_published=False,
-        category=default_category)
+        name='Test product 2', price=Money('20.00', 'USD'), category=category,
+        product_type=product_type, attributes=attributes, is_published=False)
 
     product_3 = Product.objects.create(
-        name='Test product 3', price=Money('20.00', 'USD'),
-        product_type=product_type, attributes=attributes, is_published=True,
-        category=default_category)
+        name='Test product 3', price=Money('20.00', 'USD'), category=category,
+        product_type=product_type, attributes=attributes, is_published=True)
 
     return [product_1, product_2, product_3]
 
@@ -390,19 +386,18 @@ def product_with_image(product, product_image):
 
 
 @pytest.fixture
-def unavailable_product(product_type, default_category):
+def unavailable_product(product_type, category):
     product = Product.objects.create(
         name='Test product', price=Money('10.00', 'USD'),
-        product_type=product_type, is_published=False,
-        category=default_category)
+        product_type=product_type, is_published=False, category=category)
     return product
 
 
 @pytest.fixture
-def product_with_images(product_type, default_category):
+def product_with_images(product_type, category):
     product = Product.objects.create(
         name='Test product', price=Money('10.00', 'USD'),
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     file_mock_0 = MagicMock(spec=File, name='FileMock0')
     file_mock_0.name = 'image0.jpg'
     file_mock_1 = MagicMock(spec=File, name='FileMock1')
@@ -419,11 +414,11 @@ def voucher(db):  # pylint: disable=W0613
 
 @pytest.fixture()
 def order_with_lines(
-        order, product_type, default_category, shipping_zone, vatlayer):
+        order, product_type, category, shipping_zone, vatlayer):
     taxes = vatlayer
     product = Product.objects.create(
         name='Test product', price=Money('10.00', 'USD'),
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     variant = ProductVariant.objects.create(
         product=product, sku='SKU_A', cost_price=Money(1, 'USD'), quantity=5,
         quantity_allocated=3)
@@ -438,7 +433,7 @@ def order_with_lines(
 
     product = Product.objects.create(
         name='Test product 2', price=Money('20.00', 'USD'),
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     variant = ProductVariant.objects.create(
         product=product, sku='SKU_B', cost_price=Money(2, 'USD'), quantity=2,
         quantity_allocated=2)
@@ -551,9 +546,9 @@ def payment_input(order_with_lines):
 
 
 @pytest.fixture()
-def sale(default_category, collection):
+def sale(category, collection):
     sale = Sale.objects.create(name="Sale", value=5)
-    sale.categories.add(default_category)
+    sale.categories.add(category)
     sale.collections.add(collection)
     return sale
 
@@ -647,12 +642,10 @@ def menu_item(menu):
 
 
 @pytest.fixture
-def menu_with_items(menu, default_category, collection):
+def menu_with_items(menu, category, collection):
     menu.items.create(name='Link 1', url='http://example.com/')
     menu_item = menu.items.create(name='Link 2', url='http://example.com/')
-    menu.items.create(
-        name=default_category.name, category=default_category,
-        parent=menu_item)
+    menu.items.create(name=category.name, category=category, parent=menu_item)
     menu.items.create(
         name=collection.name, collection=collection, parent=menu_item)
     update_menu(menu)

--- a/tests/dashboard/test_category.py
+++ b/tests/dashboard/test_category.py
@@ -4,7 +4,7 @@ from django.urls import reverse
 from saleor.product.models import Category
 
 
-def test_category_list(admin_client, default_category):
+def test_category_list(admin_client, category):
     url = reverse('dashboard:category-list')
     response = admin_client.get(url)
     assert response.status_code == 200
@@ -28,24 +28,24 @@ def test_category_add_not_valid(admin_client):
     assert Category.objects.count() == 0
 
 
-def test_category_add_subcategory(admin_client, default_category):
+def test_category_add_subcategory(admin_client, category):
     assert Category.objects.count() == 1
     url = reverse('dashboard:category-add',
-                  kwargs={'root_pk': default_category.pk})
+                  kwargs={'root_pk': category.pk})
     data = {'name': 'Cars', 'description': 'Fastest cars'}
     response = admin_client.post(url, data, follow=True)
     assert response.status_code == 200
     assert Category.objects.count() == 2
-    default_category.refresh_from_db()
-    subcategories = default_category.get_children()
+    category.refresh_from_db()
+    subcategories = category.get_children()
     assert len(subcategories) == 1
     assert subcategories[0].name == 'Cars'
 
 
-def test_category_edit(admin_client, default_category):
+def test_category_edit(admin_client, category):
     assert Category.objects.count() == 1
     url = reverse('dashboard:category-edit',
-                  kwargs={'root_pk': default_category.pk})
+                  kwargs={'root_pk': category.pk})
     data = {'name': 'Cars', 'description': 'Super fast!'}
     response = admin_client.post(url, data, follow=True)
     assert response.status_code == 200
@@ -53,10 +53,10 @@ def test_category_edit(admin_client, default_category):
     assert Category.objects.all()[0].name == 'Cars'
 
 
-def test_category_details(admin_client, default_category):
+def test_category_details(admin_client, category):
     assert Category.objects.count() == 1
     url = reverse('dashboard:category-details',
-                  kwargs={'pk': default_category.pk})
+                  kwargs={'pk': category.pk})
     response = admin_client.post(url, follow=True)
     assert response.status_code == 200
 
@@ -64,11 +64,11 @@ def test_category_details(admin_client, default_category):
 @patch('saleor.dashboard.category.views.get_menus_that_needs_update')
 @patch('saleor.dashboard.category.views.update_menus')
 def test_category_delete(
-        mock_update_menus, mock_get_menus, admin_client, default_category):
+        mock_update_menus, mock_get_menus, admin_client, category):
     assert Category.objects.count() == 1
     mock_get_menus.return_value = [1]
     url = reverse('dashboard:category-delete',
-                  kwargs={'pk': default_category.pk})
+                  kwargs={'pk': category.pk})
     response = admin_client.post(url, follow=True)
     assert mock_update_menus.called
 
@@ -79,9 +79,9 @@ def test_category_delete(
 @patch('saleor.dashboard.category.views.get_menus_that_needs_update')
 @patch('saleor.dashboard.category.views.update_menus')
 def test_category_delete_menus_not_updated(
-        mock_update_menus, mock_get_menus, admin_client, default_category):
+        mock_update_menus, mock_get_menus, admin_client, category):
     url = reverse('dashboard:category-delete',
-                  kwargs={'pk': default_category.pk})
+                  kwargs={'pk': category.pk})
     mock_get_menus.return_value = []
     response = admin_client.post(url, follow=True)
     assert response.status_code == 200

--- a/tests/dashboard/test_chips.py
+++ b/tests/dashboard/test_chips.py
@@ -102,7 +102,7 @@ def test_nullboolean_field_chip():
     assert 'is_featured=1' not in chip['link']
 
 
-def test_model_choice_field_chip(default_category):
+def test_model_choice_field_chip(category):
     obj = Category.objects.first()
     data = querydict({'categories': obj.pk})
     filter_set = ModelChoiceFieldFilterSet(

--- a/tests/dashboard/test_discounts.py
+++ b/tests/dashboard/test_discounts.py
@@ -49,13 +49,13 @@ def test_voucher_shipping_add(admin_client):
     assert voucher.min_amount_spent == Money('59.99', 'USD')
 
 
-def test_view_sale_add(admin_client, default_category, collection):
+def test_view_sale_add(admin_client, category, collection):
     url = reverse('dashboard:sale-add')
     data = {
         'name': 'Free products',
         'type': DiscountValueType.PERCENTAGE,
         'value': 100,
-        'categories': [default_category.id],
+        'categories': [category.id],
         'collections': [collection.id],
         'start_date': '2018-01-01'}
 
@@ -65,12 +65,12 @@ def test_view_sale_add(admin_client, default_category, collection):
     assert Sale.objects.count() == 1
     sale = Sale.objects.first()
     assert sale.name == data['name']
-    assert default_category in sale.categories.all()
+    assert category in sale.categories.all()
     assert collection in sale.collections.all()
 
 
 def test_view_sale_add_requires_product_category_or_collection(
-        admin_client, default_category, product, collection):
+        admin_client, category, product, collection):
     initial_sales_count = Sale.objects.count()
     url = reverse('dashboard:sale-add')
     data = {
@@ -84,7 +84,7 @@ def test_view_sale_add_requires_product_category_or_collection(
     assert response.status_code == 200
     assert Sale.objects.count() == initial_sales_count
     products_data = [
-        {'categories': [default_category.id]},
+        {'categories': [category.id]},
         {'products': [product.id]}, {'collections': [collection.pk]}]
     for count, proper_data in enumerate(products_data):
         proper_data.update(data)

--- a/tests/dashboard/test_forms.py
+++ b/tests/dashboard/test_forms.py
@@ -4,13 +4,13 @@ from saleor.product.models import Category
 from saleor.dashboard.product.forms import ModelChoiceOrCreationField
 
 
-def test_model_choice_or_creation_field(default_category):
+def test_model_choice_or_creation_field(category):
     class Form(forms.Form):
         field = ModelChoiceOrCreationField(queryset=Category.objects.all())
 
-    form = Form({'field': default_category})
+    form = Form({'field': category})
     assert form.is_valid()
-    assert form.cleaned_data['field'] == default_category
+    assert form.cleaned_data['field'] == category
 
     choice = 'new-value'
     form = Form({'field': choice})

--- a/tests/dashboard/test_menu.py
+++ b/tests/dashboard/test_menu.py
@@ -108,9 +108,9 @@ def test_view_menu_delete(admin_client, menu):
     assert Menu.objects.count() == menus_before - 1
 
 
-def test_view_menu_item_create(admin_client, menu, default_category):
+def test_view_menu_item_create(admin_client, menu, category):
     url = reverse('dashboard:menu-item-add', kwargs={'menu_pk': menu.pk})
-    linked_object = str(default_category.id) + '_Category'
+    linked_object = str(category.id) + '_Category'
     data = {'name': 'Link', 'linked_object': linked_object}
 
     response = admin_client.post(url, data)
@@ -124,11 +124,11 @@ def test_view_menu_item_create(admin_client, menu, default_category):
 
 
 def test_view_menu_item_create_with_parent(
-        admin_client, menu, menu_item, default_category):
+        admin_client, menu, menu_item, category):
     url = reverse(
         'dashboard:menu-item-add',
         kwargs={'menu_pk': menu.pk, 'root_pk': menu_item.pk})
-    linked_object = str(default_category.id) + '_Category'
+    linked_object = str(category.id) + '_Category'
     data = {'name': 'Link 2', 'linked_object': linked_object}
 
     response = admin_client.post(url, data)
@@ -154,11 +154,11 @@ def test_view_menu_item_create_not_valid(admin_client, menu):
     assert MenuItem.objects.count() == 0
 
 
-def test_view_menu_item_edit(admin_client, menu, menu_item, default_category):
+def test_view_menu_item_edit(admin_client, menu, menu_item, category):
     url = reverse(
         'dashboard:menu-item-edit',
         kwargs={'menu_pk': menu.pk, 'item_pk': menu_item.pk})
-    linked_object = str(default_category.id) + '_Category'
+    linked_object = str(category.id) + '_Category'
     data = {'name': 'New link', 'linked_object': linked_object}
 
     response = admin_client.post(url, data)
@@ -257,14 +257,13 @@ def test_view_ajax_reorder_menu_items_with_parent(
 
 
 @pytest.mark.integration
-def test_view_ajax_menu_links(
-        admin_client, collection, default_category, page):
+def test_view_ajax_menu_links(admin_client, collection, category, page):
     collection_repr = {
         'id': str(collection.pk) + '_' + 'Collection',
         'text': str(collection)}
     category_repr = {
-        'id': str(default_category.pk) + '_' + 'Category',
-        'text': str(default_category)}
+        'id': str(category.pk) + '_' + 'Category',
+        'text': str(category)}
     page_repr = {
         'id': str(page.pk) + '_' + 'Page',
         'text': str(page)}
@@ -282,8 +281,8 @@ def test_view_ajax_menu_links(
     assert resp_decoded == {'results': groups}
 
 
-def test_update_menu_item_linked_object(menu, default_category, page):
-    menu_item = menu.items.create(category=default_category)
+def test_update_menu_item_linked_object(menu, category, page):
+    menu_item = menu.items.create(category=category)
 
     update_menu_item_linked_object(menu_item, page)
 
@@ -348,7 +347,7 @@ def test_update_menu(mock_json_menu, menu):
     assert menu.json_content == 'Return value'
 
 
-def test_get_menus_that_needs_update(default_category, collection, page):
+def test_get_menus_that_needs_update(category, collection, page):
     assert not get_menus_that_needs_update()
 
     menus = Menu.objects.bulk_create([
@@ -356,11 +355,10 @@ def test_get_menus_that_needs_update(default_category, collection, page):
         Menu(name='collection'),
         Menu(name='page')])
 
-    MenuItem.objects.create(
-        name='item', menu=menus[0], category=default_category),
+    MenuItem.objects.create(name='item', menu=menus[0], category=category),
     MenuItem.objects.create(name='item', menu=menus[1], collection=collection),
     MenuItem.objects.create(name='item', menu=menus[2], page=page)
 
     result = get_menus_that_needs_update(
-        categories=[default_category], collection=collection, page=page)
+        categories=[category], collection=collection, page=page)
     assert sorted(list(result)) == sorted([m.pk for m in menus])

--- a/tests/dashboard/test_page.py
+++ b/tests/dashboard/test_page.py
@@ -70,7 +70,7 @@ def test_page_delete_menu_not_updated(
     assert not mock_update_menus.called
 
 
-def test_sanitize_page_content(page, default_category):
+def test_sanitize_page_content(page, category):
     data = model_to_dict(page)
     data['content'] = (
         '<b>bold</b><p><i>italic</i></p><h2>Header</h2><h3>subheader</h3>'

--- a/tests/dashboard/test_permissions.py
+++ b/tests/dashboard/test_permissions.py
@@ -136,44 +136,44 @@ def test_staff_can_view_category_add_root(
 
 
 def test_staff_can_view_category_add_subcategory(
-        staff_client, staff_user, permission_manage_products, default_category):
+        staff_client, staff_user, permission_manage_products, category):
     assert not staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-add', args=[default_category.pk]))
+        reverse('dashboard:category-add', args=[category.pk]))
     assert response.status_code == 302
     staff_user.user_permissions.add(permission_manage_products)
     staff_user = User.objects.get(pk=staff_user.pk)
     assert staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-add', args=[default_category.pk]))
+        reverse('dashboard:category-add', args=[category.pk]))
     assert response.status_code == 200
 
 
 def test_staff_can_view_category_edit(
-        staff_client, staff_user, permission_manage_products, default_category):
+        staff_client, staff_user, permission_manage_products, category):
     assert not staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-edit', args=[default_category.pk]))
+        reverse('dashboard:category-edit', args=[category.pk]))
     assert response.status_code == 302
     staff_user.user_permissions.add(permission_manage_products)
     staff_user = User.objects.get(pk=staff_user.pk)
     assert staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-edit', args=[default_category.pk]))
+        reverse('dashboard:category-edit', args=[category.pk]))
     assert response.status_code == 200
 
 
 def test_staff_can_view_category_delete(
-        staff_client, staff_user, permission_manage_products, default_category):
+        staff_client, staff_user, permission_manage_products, category):
     assert not staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-delete', args=[default_category.pk]))
+        reverse('dashboard:category-delete', args=[category.pk]))
     assert response.status_code == 302
     staff_user.user_permissions.add(permission_manage_products)
     staff_user = User.objects.get(pk=staff_user.pk)
     assert staff_user.has_perm('product.manage_products')
     response = staff_client.get(
-        reverse('dashboard:category-delete', args=[default_category.pk]))
+        reverse('dashboard:category-delete', args=[category.pk]))
     assert response.status_code == 200
 
 

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -51,11 +51,11 @@ def test_view_product_list_with_filters_sort_by(admin_client, product_list):
 
 
 def test_view_product_list_with_filters_is_published(
-        admin_client, product_list, default_category):
+        admin_client, product_list, category):
     url = reverse('dashboard:product-list')
     data = {
         'price_1': [''], 'price_0': [''], 'is_featured': [''],
-        'name': ['Test'], 'sort_by': ['name'], 'category': default_category.pk,
+        'name': ['Test'], 'sort_by': ['name'], 'category': category.pk,
         'is_published': ['1']}
 
     response = admin_client.get(url, data)
@@ -178,11 +178,11 @@ def test_view_product_select_type_by_ajax(admin_client, product_type):
         'dashboard:product-add', kwargs={'type_pk': product_type.pk})
 
 
-def test_view_product_create(admin_client, product_type, default_category):
+def test_view_product_create(admin_client, product_type, category):
     url = reverse('dashboard:product-add', kwargs={'type_pk': product_type.pk})
     data = {
         'name': 'Product', 'description': 'This is product description.',
-        'price': 10, 'category': default_category.pk, 'variant-sku': '123',
+        'price': 10, 'category': category.pk, 'variant-sku': '123',
         'variant-quantity': 2}
 
     response = admin_client.post(url, data)
@@ -559,11 +559,10 @@ def test_view_variant_images(admin_client, product_with_image):
     assert variant.variant_images.filter(image=product_image).exists()
 
 
-def test_view_ajax_available_variants_list(
-        admin_client, product, default_category):
+def test_view_ajax_available_variants_list(admin_client, product, category):
     unavailable_product = Product.objects.create(
         name='Test product', price=10, product_type=product.product_type,
-        category=default_category, is_published=False)
+        category=category, is_published=False)
     unavailable_product.variants.create()
     url = reverse('dashboard:ajax-available-variants')
 
@@ -1030,11 +1029,10 @@ def test_product_form_assign_collection_to_product(product):
     assert collection.products.first().name == product.name
 
 
-def test_product_form_sanitize_product_description(
-        product_type, default_category):
+def test_product_form_sanitize_product_description(product_type, category):
     product = Product.objects.create(
         name='Test Product', price=10, description='', pk=10,
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     data = model_to_dict(product)
     data['description'] = (
         '<b>bold</b><p><i>italic</i></p><h2>Header</h2><h3>subheader</h3>'

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -107,14 +107,14 @@ def test_products_voucher_checkout_discount_not(
     assert discount == Money(expected_value, 'USD')
 
 
-def test_sale_applies_to_correct_products(product_type, default_category):
+def test_sale_applies_to_correct_products(product_type, category):
     product = Product.objects.create(
         name='Test Product', price=Money(10, 'USD'), description='',
-        pk=111, product_type=product_type, category=default_category)
+        pk=111, product_type=product_type, category=category)
     variant = ProductVariant.objects.create(product=product, sku='firstvar')
     product2 = Product.objects.create(
         name='Second product', price=Money(15, 'USD'), description='',
-        product_type=product_type, category=default_category)
+        product_type=product_type, category=category)
     sec_variant = ProductVariant.objects.create(
         product=product2, sku='secvar', pk=111)
     sale = Sale.objects.create(

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -40,7 +40,7 @@ def elasticsearch_autosync_disabled(settings):
 
 @pytest.mark.vcr()
 @pytest.fixture
-def indexed_products(product_type, default_category):
+def indexed_products(product_type, category):
     """Products to be found by search backend.
 
     We need existing objects with primary keys same as search service
@@ -54,7 +54,7 @@ def indexed_products(product_type, default_category):
             name='Test product ' + str(object_id),
             price=Decimal(10.0),
             product_type=product_type,
-            category=default_category)
+            category=category)
         return product
     return [gen_product_with_id(prod) for prod in PRODUCTS_INDEXED]
 

--- a/tests/test_postgresql_search.py
+++ b/tests/test_postgresql_search.py
@@ -20,14 +20,14 @@ PRODUCTS = [('Arabica Coffee', 'The best grains in galactic'),
 
 
 @pytest.fixture
-def named_products(default_category, product_type):
+def named_products(category, product_type):
     def gen_product(name, description):
         product = Product.objects.create(
             name=name,
             description=description,
             price=Decimal(6.6),
             product_type=product_type,
-            category=default_category)
+            category=category)
         return product
     return [gen_product(name, desc) for name, desc in PRODUCTS]
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -65,7 +65,7 @@ def test_product_preview(admin_client, client, product):
     assert response.status_code == 200
 
 
-def test_filtering_by_attribute(db, color_attribute, default_category):
+def test_filtering_by_attribute(db, color_attribute, category):
     product_type_a = models.ProductType.objects.create(
         name='New class', has_variants=True)
     product_type_a.product_attributes.add(color_attribute)
@@ -74,11 +74,11 @@ def test_filtering_by_attribute(db, color_attribute, default_category):
     product_type_b.variant_attributes.add(color_attribute)
     product_a = models.Product.objects.create(
         name='Test product a', price=10, product_type=product_type_a,
-        category=default_category)
+        category=category)
     models.ProductVariant.objects.create(product=product_a, sku='1234')
     product_b = models.Product.objects.create(
         name='Test product b', price=10, product_type=product_type_b,
-        category=default_category)
+        category=category)
     variant_b = models.ProductVariant.objects.create(product=product_b,
                                                      sku='12345')
     color = color_attribute.values.first()
@@ -142,19 +142,18 @@ def test_render_home_page_with_taxes(client, product, vatlayer):
     assert response.status_code == 200
 
 
-def test_render_category(client, default_category, product):
-    response = client.get(default_category.get_absolute_url())
+def test_render_category(client, category, product):
+    response = client.get(category.get_absolute_url())
     assert response.status_code == 200
 
 
-def test_render_category_with_sale(client, default_category, product, sale):
-    response = client.get(default_category.get_absolute_url())
+def test_render_category_with_sale(client, category, product, sale):
+    response = client.get(category.get_absolute_url())
     assert response.status_code == 200
 
 
-def test_render_category_with_taxes(
-        client, default_category, product, vatlayer):
-    response = client.get(default_category.get_absolute_url())
+def test_render_category_with_taxes(client, category, product, vatlayer):
+    response = client.get(category.get_absolute_url())
     assert response.status_code == 200
 
 
@@ -311,32 +310,30 @@ def test_adding_to_cart_with_closed_cart_token(
     assert customer_user.carts.count() == 1
 
 
-def test_product_filter_before_filtering(
-        authorized_client, product, default_category):
+def test_product_filter_before_filtering(authorized_client, product, category):
     products = models.Product.objects.all().filter(
-        category__name=default_category).order_by('-price')
+        category__name=category).order_by('-price')
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
 
     response = authorized_client.get(url)
 
     assert list(products) == list(response.context['filter_set'].qs)
 
 
-def test_product_filter_product_exists(authorized_client, product,
-                                       default_category):
+def test_product_filter_product_exists(authorized_client, product, category):
     products = (
         models.Product.objects.all()
-        .filter(category__name=default_category)
+        .filter(category__name=category)
         .order_by('-price'))
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
     data = {'price_0': [''], 'price_1': ['20']}
 
     response = authorized_client.get(url, data)
@@ -345,12 +342,12 @@ def test_product_filter_product_exists(authorized_client, product,
 
 
 def test_product_filter_product_does_not_exist(
-        authorized_client, product, default_category):
+        authorized_client, product, category):
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
     data = {'price_0': ['20'], 'price_1': ['']}
 
     response = authorized_client.get(url, data)
@@ -358,17 +355,16 @@ def test_product_filter_product_does_not_exist(
     assert not list(response.context['filter_set'].qs)
 
 
-def test_product_filter_form(authorized_client, product,
-                             default_category):
+def test_product_filter_form(authorized_client, product, category):
     products = (
         models.Product.objects.all()
-        .filter(category__name=default_category)
+        .filter(category__name=category)
         .order_by('-price'))
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
 
     response = authorized_client.get(url)
 
@@ -378,16 +374,16 @@ def test_product_filter_form(authorized_client, product,
 
 
 def test_product_filter_sorted_by_price_descending(
-        authorized_client, product_list, default_category):
+        authorized_client, product_list, category):
     products = (
         models.Product.objects.all()
-        .filter(category__name=default_category, is_published=True)
+        .filter(category__name=category, is_published=True)
         .order_by('-price'))
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
     data = {'sort_by': '-price'}
 
     response = authorized_client.get(url, data)
@@ -396,12 +392,12 @@ def test_product_filter_sorted_by_price_descending(
 
 
 def test_product_filter_sorted_by_wrong_parameter(
-        authorized_client, product, default_category):
+        authorized_client, product, category):
     url = reverse(
         'product:category',
         kwargs={
-            'slug': default_category.slug,
-            'category_id': default_category.pk})
+            'slug': category.slug,
+            'category_id': category.pk})
     data = {'sort_by': 'aaa'}
 
     response = authorized_client.get(url, data)
@@ -432,15 +428,15 @@ def test_render_product_page_with_no_variant(
 
 
 def test_include_products_from_subcategories_in_main_view(
-        default_category, product, authorized_client):
+        category, product, authorized_client):
     subcategory = models.Category.objects.create(
-        name='sub', slug='test', parent=default_category)
+        name='sub', slug='test', parent=category)
     product.category = subcategory
     product.save()
     # URL to parent category view
     url = reverse(
         'product:category', kwargs={
-            'slug': default_category.slug, 'category_id': default_category.pk})
+            'slug': category.slug, 'category_id': category.pk})
     response = authorized_client.get(url)
     assert product in response.context_data['products'][0]
 
@@ -466,14 +462,14 @@ def test_create_product_thumbnails(
         ('15.00', True, False, True, '10.00', '10.00'),
         ('15.00', True, True, True, '8.13', '10.00')])
 def test_get_price(
-        product_type, default_category, taxes, sale, product_price,
+        product_type, category, taxes, sale, product_price,
         include_taxes_in_prices, include_taxes, include_discounts,
         product_net, product_gross, site_settings):
     site_settings.include_taxes_in_prices = include_taxes_in_prices
     site_settings.save()
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money(product_price, 'USD'))
     variant = product.variants.create()
 
@@ -486,12 +482,12 @@ def test_get_price(
 
 
 def test_product_get_price_variant_has_no_price(
-        product_type, default_category, taxes, site_settings):
+        product_type, category, taxes, site_settings):
     site_settings.include_taxes_in_prices = False
     site_settings.save()
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('10.00', 'USD'))
     variant = product.variants.create()
 
@@ -502,12 +498,12 @@ def test_product_get_price_variant_has_no_price(
 
 
 def test_product_get_price_variant_with_price(
-        product_type, default_category, taxes, site_settings):
+        product_type, category, taxes, site_settings):
     site_settings.include_taxes_in_prices = False
     site_settings.save()
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('10.00', 'USD'))
     variant = product.variants.create(price_override=Money('20.00', 'USD'))
 
@@ -518,12 +514,12 @@ def test_product_get_price_variant_with_price(
 
 
 def test_product_get_price_range_with_variants(
-        product_type, default_category, taxes, site_settings):
+        product_type, category, taxes, site_settings):
     site_settings.include_taxes_in_prices = False
     site_settings.save()
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('15.00', 'USD'))
     product.variants.create(sku='1')
     product.variants.create(sku='2', price_override=Money('20.00', 'USD'))
@@ -539,12 +535,12 @@ def test_product_get_price_range_with_variants(
 
 
 def test_product_get_price_range_no_variants(
-        product_type, default_category, taxes, site_settings):
+        product_type, category, taxes, site_settings):
     site_settings.include_taxes_in_prices = False
     site_settings.save()
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('10.00', 'USD'))
 
     price = product.get_price_range(taxes=taxes)
@@ -555,10 +551,10 @@ def test_product_get_price_range_no_variants(
 
 
 def test_product_get_price_do_not_charge_taxes(
-        product_type, default_category, taxes, sale):
+        product_type, category, taxes, sale):
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('10.00', 'USD'),
         charge_taxes=False)
     variant = product.variants.create()
@@ -570,10 +566,10 @@ def test_product_get_price_do_not_charge_taxes(
 
 
 def test_product_get_price_range_do_not_charge_taxes(
-        product_type, default_category, taxes, sale):
+        product_type, category, taxes, sale):
     product = models.Product.objects.create(
         product_type=product_type,
-        category=default_category,
+        category=category,
         price=Money('10.00', 'USD'),
         charge_taxes=False)
 
@@ -602,7 +598,7 @@ def test_product_json_serialization(product):
     assert data[0]['fields']['price'] == '10.00'
 
 
-def test_product_json_deserialization(default_category, product_type):
+def test_product_json_deserialization(category, product_type):
     product_json = """
     [{{
         "model": "product.product",
@@ -625,7 +621,7 @@ def test_product_json_deserialization(default_category, product_type):
         }}
     }}]
     """.format(
-        category_pk=default_category.pk, product_type_pk=product_type.pk)
+        category_pk=category.pk, product_type_pk=product_type.pk)
     product_deserialized = list(serializers.deserialize(
         'json', product_json, ignorenonexistent=True))[0]
     product_deserialized.save()

--- a/tests/test_product_attributes.py
+++ b/tests/test_product_attributes.py
@@ -8,10 +8,10 @@ from saleor.product.utils.attributes import (
 
 
 @pytest.fixture()
-def product_with_no_attributes(product_type, default_category):
+def product_with_no_attributes(product_type, category):
     product = Product.objects.create(
         name='Test product', price='10.00', product_type=product_type,
-        category=default_category)
+        category=category)
     return product
 
 

--- a/tests/test_templatetags.py
+++ b/tests/test_templatetags.py
@@ -4,20 +4,20 @@ from django.urls import reverse
 from saleor.core.templatetags.shop import get_sort_by_url, menu
 
 
-def test_sort_by_url_ascending(admin_client, default_category):
-    url = reverse('product:category',
-                  kwargs={'slug': default_category.slug,
-                          'category_id': default_category.id})
+def test_sort_by_url_ascending(admin_client, category):
+    url = reverse(
+        'product:category',
+        kwargs={'slug': category.slug, 'category_id': category.id})
     response = admin_client.get(url)
     result = get_sort_by_url(response.context, 'name')
     expected = url + '?sort_by=name'
     assert result == expected
 
 
-def test_sort_by_url_descending(admin_client, default_category):
-    url = reverse('product:category',
-                  kwargs={'slug': default_category.slug,
-                          'category_id': default_category.id})
+def test_sort_by_url_descending(admin_client, category):
+    url = reverse(
+        'product:category',
+        kwargs={'slug': category.slug, 'category_id': category.id})
     response = admin_client.get(url)
     result = get_sort_by_url(response.context, 'name', descending=True)
     expected = url + '?sort_by=-name'

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -79,15 +79,15 @@ def test_collection_translation(settings, collection):
     assert collection.translated.name == french_name
 
 
-def test_category_translation(settings, default_category):
+def test_category_translation(settings, category):
     settings.LANGUAGE_CODE = 'fr'
     french_name = 'French name'
     french_description = 'French description'
     CategoryTranslation.objects.create(
         language_code='fr', name=french_name, description=french_description,
-        category=default_category)
-    assert default_category.translated.name == french_name
-    assert default_category.translated.description == french_description
+        category=category)
+    assert category.translated.name == french_name
+    assert category.translated.description == french_description
 
 
 def test_product_variant_translation(settings, variant):


### PR DESCRIPTION
close #2666 
Just a little cleanup, renamed `default_category` to the `category`, to keep the naming consistent with the rest of the fixtures. 