### PR TITLE
Use choices for tax rate type

### DIFF
--- a/saleor/core/__init__.py
+++ b/saleor/core/__init__.py
@@ -1,6 +1,6 @@
-from enum import Enum
 from django.conf import settings
-from django.core.checks import register, Warning
+from django.core.checks import Warning, register
+from django.utils.translation import pgettext_lazy
 
 TOKEN_PATTERN = ('(?P<token>[0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}'
                  '-[0-9a-z]{12})')
@@ -23,7 +23,7 @@ def check_session_caching(app_configs, **kwargs):  # pragma: no cover
     return errors
 
 
-class TaxRateType(Enum):
+class TaxRateType:
     ACCOMODATION = 'accomodation'
     ADMISSION_TO_CULTURAL_EVENTS = 'admission to cultural events'
     ADMISSION_TO_ENTERAINMENT_EVENTS = 'admission to entertainment events'
@@ -49,3 +49,38 @@ class TaxRateType(Enum):
     STANDARD = 'standard'
     WATER = 'water'
     WINE = 'wine'
+
+    CHOICES = (
+        (ACCOMODATION, pgettext_lazy('VAT rate type', 'accommodation')),
+        (ADMISSION_TO_CULTURAL_EVENTS, pgettext_lazy(
+            'VAT rate type', 'admission to cultural events')),
+        (ADMISSION_TO_ENTERAINMENT_EVENTS, pgettext_lazy(
+            'VAT rate type', 'admission to entertainment events')),
+        (ADMISSION_TO_SPORTING_EVENTS, pgettext_lazy(
+            'VAT rate type', 'admission to sporting events')),
+        (ADVERTISING, pgettext_lazy('VAT rate type', 'advertising')),
+        (AGRICULTURAL_SUPPLIES, pgettext_lazy(
+            'VAT rate type', 'agricultural supplies')),
+        (BABY_FOODSTUFFS, pgettext_lazy('VAT rate type', 'baby foodstuffs')),
+        (BIKES, pgettext_lazy('VAT rate type', 'bikes')),
+        (BOOKS, pgettext_lazy('VAT rate type', 'books')),
+        (CHILDRENDS_CLOTHING, pgettext_lazy(
+            'VAT rate type', 'childrens clothing')),
+        (DOMESTIC_FUEL, pgettext_lazy('VAT rate type', 'domestic fuel')),
+        (DOMESTIC_SERVICES, pgettext_lazy(
+            'VAT rate type', 'domestic services')),
+        (E_BOOKS, pgettext_lazy('VAT rate type', 'e-books')),
+        (FOODSTUFFS, pgettext_lazy('VAT rate type', 'foodstuffs')),
+        (HOTELS, pgettext_lazy('VAT rate type', 'hotels')),
+        (MEDICAL, pgettext_lazy('VAT rate type', 'medical')),
+        (NEWSPAPERS, pgettext_lazy('VAT rate type', 'newspapers')),
+        (PASSENGER_TRANSPORT, pgettext_lazy(
+            'VAT rate type', 'passenger transport')),
+        (PHARMACEUTICALS, pgettext_lazy(
+            'VAT rate type', 'pharmaceuticals')),
+        (PROPERTY_RENOVATIONS, pgettext_lazy(
+            'VAT rate type', 'property renovations')),
+        (RESTAURANTS, pgettext_lazy('VAT rate type', 'restaurants')),
+        (SOCIAL_HOUSING, pgettext_lazy('VAT rate type', 'social housing')),
+        (STANDARD, pgettext_lazy('VAT rate type', 'standard')),
+        (WATER, pgettext_lazy('VAT rate type', 'water')))

--- a/saleor/core/i18n.py
+++ b/saleor/core/i18n.py
@@ -1,52 +1,6 @@
 from django.utils.translation import pgettext_lazy
 from django_countries import countries
 
-from . import TaxRateType
-
 ANY_COUNTRY = ''
 ANY_COUNTRY_DISPLAY = pgettext_lazy('Country choice', 'Any Country')
 COUNTRY_CODE_CHOICES = [(ANY_COUNTRY, ANY_COUNTRY_DISPLAY)] + list(countries)
-
-VAT_RATE_TYPE_TRANSLATIONS = {
-    TaxRateType.ACCOMODATION: pgettext_lazy(
-        'VAT rate type', 'accommodation'),
-    TaxRateType.ADMISSION_TO_CULTURAL_EVENTS: pgettext_lazy(
-        'VAT rate type', 'admission to cultural events'),
-    TaxRateType.ADMISSION_TO_ENTERAINMENT_EVENTS: pgettext_lazy(
-        'VAT rate type', 'admission to entertainment events'),
-    TaxRateType.ADMISSION_TO_SPORTING_EVENTS: pgettext_lazy(
-        'VAT rate type', 'admission to sporting events'),
-    TaxRateType.ADVERTISING: pgettext_lazy(
-        'VAT rate type', 'advertising'),
-    TaxRateType.AGRICULTURAL_SUPPLIES: pgettext_lazy(
-        'VAT rate type', 'agricultural supplies'),
-    TaxRateType.BABY_FOODSTUFFS: pgettext_lazy(
-        'VAT rate type', 'baby foodstuffs'),
-    TaxRateType.BIKES: pgettext_lazy('VAT rate type', 'bikes'),
-    TaxRateType.BOOKS: pgettext_lazy('VAT rate type', 'books'),
-    TaxRateType.CHILDRENDS_CLOTHING: pgettext_lazy(
-        'VAT rate type', 'childrens clothing'),
-    TaxRateType.DOMESTIC_FUEL: pgettext_lazy(
-        'VAT rate type', 'domestic fuel'),
-    TaxRateType.DOMESTIC_SERVICES: pgettext_lazy(
-        'VAT rate type', 'domestic services'),
-    TaxRateType.E_BOOKS: pgettext_lazy('VAT rate type', 'e-books'),
-    TaxRateType.FOODSTUFFS: pgettext_lazy(
-        'VAT rate type', 'foodstuffs'),
-    TaxRateType.HOTELS: pgettext_lazy('VAT rate type', 'hotels'),
-    TaxRateType.MEDICAL: pgettext_lazy('VAT rate type', 'medical'),
-    TaxRateType.NEWSPAPERS: pgettext_lazy(
-        'VAT rate type', 'newspapers'),
-    TaxRateType.PASSENGER_TRANSPORT: pgettext_lazy(
-        'VAT rate type', 'passenger transport'),
-    TaxRateType.PHARMACEUTICALS: pgettext_lazy(
-        'VAT rate type', 'pharmaceuticals'),
-    TaxRateType.PROPERTY_RENOVATIONS: pgettext_lazy(
-        'VAT rate type', 'property renovations'),
-    TaxRateType.RESTAURANTS: pgettext_lazy(
-        'VAT rate type', 'restaurants'),
-    TaxRateType.SOCIAL_HOUSING: pgettext_lazy(
-        'VAT rate type', 'social housing'),
-    TaxRateType.STANDARD: pgettext_lazy('VAT rate type', 'standard'),
-    TaxRateType.WATER: pgettext_lazy('VAT rate type', 'water'),
-    TaxRateType.WINE: pgettext_lazy('VAT rate type', 'wine')}

--- a/saleor/core/utils/taxes.py
+++ b/saleor/core/utils/taxes.py
@@ -7,7 +7,7 @@ from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
 from ...core import TaxRateType
 
-DEFAULT_TAX_RATE_NAME = TaxRateType.STANDARD.value
+DEFAULT_TAX_RATE_NAME = TaxRateType.STANDARD
 
 ZERO_MONEY = Money(0, settings.DEFAULT_CURRENCY)
 ZERO_TAXED_MONEY = TaxedMoney(net=ZERO_MONEY, gross=ZERO_MONEY)

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -11,7 +11,7 @@ from django_prices_vatlayer.utils import get_tax_rate_types
 from mptt.forms import TreeNodeChoiceField
 
 from . import ProductBulkAction
-from ...core.i18n import VAT_RATE_TYPE_TRANSLATIONS
+from ...core import TaxRateType
 from ...core.utils.taxes import DEFAULT_TAX_RATE_NAME, include_taxes_in_prices
 from ...core.weight import WeightField, get_default_weight_unit
 from ...product.models import (
@@ -58,8 +58,9 @@ class ProductTypeSelectorForm(forms.Form):
 
 def get_tax_rate_type_choices():
     rate_types = get_tax_rate_types() + [DEFAULT_TAX_RATE_NAME, '']
+    translations = dict(TaxRateType.CHOICES)
     choices = [
-        (rate_name, VAT_RATE_TYPE_TRANSLATIONS.get(rate_name, '---------'))
+        (rate_name, translations.get(rate_name, '---------'))
         for rate_name in rate_types]
     # sort choices alphabetically by translations
     return sorted(choices, key=lambda x: x[1])

--- a/saleor/dashboard/taxes/views.py
+++ b/saleor/dashboard/taxes/views.py
@@ -9,7 +9,7 @@ from django.utils.translation import pgettext_lazy
 from django_countries.fields import Country
 from django_prices_vatlayer.models import VAT
 
-from ...core.i18n import VAT_RATE_TYPE_TRANSLATIONS
+from ...core import TaxRateType
 from ...core.utils import get_paginator_items
 from ...core.utils.taxes import get_taxes_for_country
 from ...dashboard.taxes.filters import TaxFilter
@@ -33,8 +33,9 @@ def tax_list(request):
 def tax_details(request, country_code):
     tax = get_object_or_404(VAT, country_code=country_code)
     tax_rates = get_taxes_for_country(Country(country_code))
+    translations = dict(TaxRateType.CHOICES)
     tax_rates = [
-        (VAT_RATE_TYPE_TRANSLATIONS.get(rate_name, rate_name), tax['value'])
+        (translations.get(rate_name, rate_name), tax['value'])
         for rate_name, tax in tax_rates.items()]
     ctx = {'tax': tax, 'tax_rates': sorted(tax_rates)}
     return TemplateResponse(request, 'dashboard/taxes/details.html', ctx)

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -1,7 +1,7 @@
 import graphene
 from django_prices.templatetags import prices_i18n
 
-from ....core import TaxRateType as TaxRateTypeEnum
+from ....core import TaxRateType as TaxRates
 
 
 class Money(graphene.ObjectType):
@@ -26,8 +26,6 @@ class MoneyRange(graphene.ObjectType):
 
     class Meta:
         description = 'Represents a range of amounts of money.'
-
-TaxRateType = graphene.Enum.from_enum(TaxRateTypeEnum)
 
 
 class TaxedMoney(graphene.ObjectType):
@@ -79,8 +77,19 @@ class VAT(graphene.ObjectType):
 class ReducedRate(graphene.ObjectType):
     rate = graphene.Float(
         description='Reduced VAT rate in percent.', required=True)
-    rate_type = TaxRateType(description='A type of goods.', required=True)
+    rate_type = graphene.String(description='A type of goods.', required=True)
 
     class Meta:
         description = '''
         Represents a reduced VAT rate for a particular type of goods.'''
+
+
+def _str_to_enum(name):
+    """
+    Enum can't contain spaces or dashes
+    """
+    return name.replace(' ', '_').replace('-', '_').upper()
+
+TaxRateType = graphene.Enum(
+    'TaxRateType',
+    [(_str_to_enum(rate[0]), rate[0]) for rate in TaxRates.CHOICES])

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -218,7 +218,7 @@ class ProductInput(graphene.InputObjectType):
         description='ID of the type that product belongs to.',
         name='productType')
     price = Decimal(description='Product price.')
-    tax_rate = graphene.String(description='Tax rate.')
+    tax_rate = TaxRateType(description='Tax rate.')
     seo = SeoInput(description='Search engine optimization fields.')
     weight = WeightScalar(
         description='Weight of the Product.', required=False)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -20,6 +20,7 @@ from prices import TaxedMoneyRange
 from text_unidecode import unidecode
 from versatileimagefield.fields import PPOIField, VersatileImageField
 
+from ..core import TaxRateType
 from ..core.exceptions import InsufficientStock
 from ..core.models import SortableModel
 from ..core.utils.taxes import DEFAULT_TAX_RATE_NAME, apply_tax_to_price
@@ -80,7 +81,8 @@ class ProductType(models.Model):
         'ProductAttribute', related_name='product_variant_types', blank=True)
     is_shipping_required = models.BooleanField(default=False)
     tax_rate = models.CharField(
-        max_length=128, default=DEFAULT_TAX_RATE_NAME, blank=True)
+        max_length=128, default=DEFAULT_TAX_RATE_NAME, blank=True,
+        choices=TaxRateType.CHOICES)
     weight = MeasurementField(
         measurement=Weight, unit_choices=WeightUnits.CHOICES,
         default=zero_weight)

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -10,9 +10,10 @@ from prices import Money
 from tests.utils import (
     create_image, create_pdf_file_with_image_ext, get_graphql_content)
 
+from saleor.core import TaxRateType
 from saleor.graphql.product.utils import update_variants_names
 from saleor.product.models import (
-    Category, Collection, Product, ProductType, ProductImage)
+    Category, Collection, Product, ProductImage, ProductType)
 
 from .utils import assert_no_permission, get_multipart_request_body
 
@@ -326,7 +327,7 @@ def test_create_product(
             $description: String!,
             $isPublished: Boolean!,
             $chargeTaxes: Boolean!,
-            $taxRate: String!,
+            $taxRate: TaxRateType!,
             $price: Decimal!,
             $attributes: [AttributeValueInput!]) {
                 productCreate(
@@ -381,7 +382,7 @@ def test_create_product(
     product_name = 'test name'
     product_isPublished = True
     product_chargeTaxes = True
-    product_taxRate = 'standard'
+    product_taxRate = 'STANDARD'
     product_price = "22.33"
 
     # Default attribute defined in product_type fixture
@@ -418,7 +419,7 @@ def test_create_product(
     assert data['product']['description'] == product_description
     assert data['product']['isPublished'] == product_isPublished
     assert data['product']['chargeTaxes'] == product_chargeTaxes
-    assert data['product']['taxRate'] == product_taxRate
+    assert data['product']['taxRate'] == product_taxRate.lower()
     assert data['product']['productType']['name'] == product_type.name
     assert data['product']['category']['name'] == category.name
     values = (
@@ -438,7 +439,7 @@ def test_update_product(
             $description: String!,
             $isPublished: Boolean!,
             $chargeTaxes: Boolean!,
-            $taxRate: String!,
+            $taxRate: TaxRateType!,
             $price: Decimal!,
             $attributes: [AttributeValueInput!]) {
                 productUpdate(
@@ -491,7 +492,7 @@ def test_update_product(
     product_name = 'updated name'
     product_isPublished = True
     product_chargeTaxes = True
-    product_taxRate = 'standard'
+    product_taxRate = 'STANDARD'
     product_price = "33.12"
 
     variables = json.dumps({
@@ -514,7 +515,7 @@ def test_update_product(
     assert data['product']['description'] == product_description
     assert data['product']['isPublished'] == product_isPublished
     assert data['product']['chargeTaxes'] == product_chargeTaxes
-    assert data['product']['taxRate'] == product_taxRate
+    assert data['product']['taxRate'] == product_taxRate.lower()
     assert not data['product']['category']['name'] == category.name
 
 


### PR DESCRIPTION
This is a missing part tax rate types refactoring. I've introduced choices in django model. I also modiffied previous tax rate types enum a bit.