### PR TITLE
Expose default country in API

### DIFF
--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -50,6 +50,8 @@ class Shop(graphene.ObjectType):
         required=True)
     default_currency = graphene.String(
         description='Default shop\'s currency.', required=True)
+    default_country = graphene.Field(
+        CountryDisplay, description='Default shop\'s country')
     description = graphene.String(description='Shop\'s description.')
     domain = graphene.Field(
         Domain, required=True, description='Shop\'s domain data.')
@@ -144,3 +146,13 @@ class Shop(graphene.ObjectType):
 
     def resolve_default_weight_unit(self, info):
         return info.context.site.settings.default_weight_unit
+
+    def resolve_default_country(self, info):
+        default_country_code = settings.DEFAULT_COUNTRY
+        default_country_name = countries.countries.get(default_country_code)
+        if default_country_name:
+            default_country = CountryDisplay(
+                code=default_country_code, country=default_country_name)
+        else:
+            default_country = None
+        return default_country

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -261,3 +261,23 @@ def test_homepage_collection_update(admin_api_client, collection):
     assert data['homepageCollection']['name'] == collection.name
     site = Site.objects.get_current()
     assert site.settings.homepage_collection == collection
+
+
+def test_query_default_country(user_api_client, settings):
+    settings.DEFAULT_COUNTRY = 'US'
+    query = """
+    query {
+        shop {
+            defaultCountry {
+                code
+                country
+            }
+        }
+    }
+    """
+    response = user_api_client.post(reverse('api'), {'query': query})
+    content = get_graphql_content(response)
+    assert 'errors' not in content
+    data = content['data']['shop']['defaultCountry']
+    assert data['code'] == settings.DEFAULT_COUNTRY
+    assert data['country'] == 'United States of America'


### PR DESCRIPTION
I want to merge this change because it closes #2676

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
