### PR TITLE
Add default weight unit field in site settings form

### DIFF
--- a/saleor/dashboard/sites/forms.py
+++ b/saleor/dashboard/sites/forms.py
@@ -20,7 +20,8 @@ class SiteSettingsForm(forms.ModelForm):
     class Meta:
         model = SiteSettings
         fields = [
-            'header_text', 'description', 'track_inventory_by_default']
+            'header_text', 'description',
+            'track_inventory_by_default', 'default_weight_unit']
         labels = {
             'header_text': pgettext_lazy(
                 'Header text', 'Header text'),
@@ -28,7 +29,9 @@ class SiteSettingsForm(forms.ModelForm):
                 'Description', 'Description'),
             'track_inventory_by_default': pgettext_lazy(
                 'Inventory tracking by default settings toggle label',
-                'Enable inventory tracking for newly created products')}
+                'Enable inventory tracking for newly created products'),
+            'default_weight_unit': pgettext_lazy(
+                'Default weight unit', 'Default weight unit')}
         help_texts = {
             'track_inventory_by_default': pgettext_lazy(
                 'handle stock by default settings field help text',

--- a/tests/dashboard/test_site_settings.py
+++ b/tests/dashboard/test_site_settings.py
@@ -29,15 +29,17 @@ def test_site_form():
 
 
 def test_site_settings_form(site_settings):
-    data = {'header_text': 'mirumee', 'description': 'mirumee.com'}
+    data = {'header_text': 'mirumee', 'description': 'mirumee.com',
+            'default_weight_unit': 'lb'}
     form = SiteSettingsForm(data, instance=site_settings)
     assert form.is_valid()
 
     site = form.save()
     assert site.header_text == 'mirumee'
     assert smart_text(site) == 'mirumee.com'
+    assert site.default_weight_unit == 'lb'
 
-    form = SiteSettingsForm({})
+    form = SiteSettingsForm({'default_weight_unit': 'lb'})
     assert form.is_valid()
 
 
@@ -48,13 +50,14 @@ def test_site_update_view(admin_client, site_settings):
     assert response.status_code == 200
 
     data = {'name': 'Mirumee Labs', 'header_text': 'We have all the things!',
-            'domain': 'newmirumee.com', 'form-TOTAL_FORMS': 0,
-            'form-INITIAL_FORMS': 0}
+            'domain': 'newmirumee.com', 'default_weight_unit': 'lb',
+            'form-TOTAL_FORMS': 0, 'form-INITIAL_FORMS': 0}
     response = admin_client.post(url, data)
     assert response.status_code == 302
 
     site_settings = SiteSettings.objects.get(pk=site_settings.id)
     assert site_settings.header_text == 'We have all the things!'
+    assert site_settings.default_weight_unit == 'lb'
     assert site_settings.site.domain == 'newmirumee.com'
     assert site_settings.site.name == 'Mirumee Labs'
 


### PR DESCRIPTION
```site_settings_form.default_weight_unit|materializecss``` is added in site settings edit view in PR #2529. But ```default_weight_unit``` in ```SiteSettingForm``` is missing. This will raise exceptions when user update site settings in ```/dashboard/settings/1/update/```

For example, https://demo.getsaleor.com/dashboard/settings/1/update/ will return server error because of this bug.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
