### PR TITLE
nodejs-legacy is no more available

### DIFF
--- a/docs/gettingstarted/installation-linux.rst
+++ b/docs/gettingstarted/installation-linux.rst
@@ -23,10 +23,6 @@ Node.js
 
 Version 10 or later is required. See the `installation instructions <https://nodejs.org/en/download/package-manager/>`_.
 
-.. note::
-
-   Debian and Ubuntu users who install Node.js using system packages will also need to install the ``nodejs-legacy`` package.
-
 
 PostgreSQL
 ~~~~~~~~~~


### PR DESCRIPTION
The [nodejs-legacy package](https://packages.debian.org/search?searchon=names&keywords=nodejs-legacy) is now installed through a node syslink with the distribution official repositories installation of nodejs on Debian and Ubuntu based systems.