### PR TITLE
Expose one price for variants in the API

### DIFF
--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -90,6 +90,7 @@ class ProductVariant(CountableDjangoObjectType):
         Money,
         description="""Override the base price of a product if necessary.
         A value of `null` indicates that the default product price is used.""")
+    price = graphene.Field(Money, description="Price of the product variant.")
     attributes = graphene.List(
         SelectedAttribute,
         description='List of attributes assigned to this variant.')
@@ -113,6 +114,15 @@ class ProductVariant(CountableDjangoObjectType):
 
     def resolve_margin(self, info):
         return get_margin_for_variant(self)
+
+    def resolve_price(self, info):
+        return (
+            self.price_override
+            if self.price_override is not None else self.product.price)
+
+    @permission_required('product.manage_products')
+    def resolve_price_override(self, info):
+        return self.price_override
 
 
 class ProductAvailability(graphene.ObjectType):


### PR DESCRIPTION
I want to merge this change because it closes #2794

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
