### PR TITLE
Remove Django 2.1 from allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,17 +43,9 @@ matrix:
   fast_finish: true
   allow_failures:
     - python: "3.5"
-      env: DJANGO="2.1"
-    - python: "3.5"
       env: DJANGO="master"
     - python: "3.6"
-      env: DJANGO="2.1"
-    - python: "3.6"
       env: DJANGO="master"
-    - python: "3.7"
-      sudo: required
-      dist: xenial
-      env: DJANGO="2.1"
     - python: "3.7"
       env: DJANGO="master"
       sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,10 @@ env:
     - DATABASE_URL='postgres://postgres@localhost:5432/saleor'
   matrix:
   - DJANGO="1.11"
-  - DJANGO="2.0"
   - DJANGO="2.1"
   - DJANGO="master"
 matrix:
   include:
-    - python: "3.7"
-      sudo: required
-      dist: xenial
-      env: DJANGO="2.0"
     - python: "3.7"
       sudo: required
       dist: xenial

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ deps =
     pytest-cov
 commands =
     django111: pip install "django>=1.11a1,<1.12" --upgrade --pre
-    django20: pip install "django>=2.0a1,<2.1" --upgrade --pre
     django21: pip install "django>=2.1a1,<2.2" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     pip install pytest-xdist
@@ -26,6 +25,5 @@ unignore_outcomes = True
 [travis:env]
 DJANGO =
     1.11: django111
-    2.0: django20
     2.1: django21
     master: django_master

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}-django{111,20,21,_master}
+envlist = py{35,36,37}-django{111,21,_master}
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
I think after resolving #2616 we can remove Django 2.1 from allowed failures on Travis CI