### PR TITLE
Update django-versatileimagefield to 1.10 and pillow to 5.2.0

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -23,7 +23,7 @@ django-prices-vatlayer>=1.0.2
 django-redis>=4.0.0
 django-storages>=1.4.1
 django-templated-email>=2.2.0
-django-versatileimagefield>=1.0.1
+django-versatileimagefield>=1.10
 django-webpack-loader>=0.3.0
 django-celery-results
 django-elasticsearch-dsl

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ django-redis==4.9.0
 django-render-block==0.5  # via django-templated-email
 django-storages==1.6.6
 django-templated-email==2.2.0
-django-versatileimagefield==1.9
+django-versatileimagefield==1.10
 django-webpack-loader==0.6.0
 django==2.0.8
 docutils==0.14            # via botocore
@@ -82,7 +82,7 @@ multidict==4.3.1          # via yarl
 oauthlib==2.1.0           # via requests-oauthlib, social-auth-core
 pdfrw==0.4                # via weasyprint
 phonenumberslite==8.9.10
-pillow==5.0.0             # via cairosvg, django-versatileimagefield
+pillow==5.2.0             # via cairosvg, django-versatileimagefield
 pluggy==0.7.1             # via pytest
 prices==1.0.0
 promise==2.1              # via graphene, graphene-django, graphql-core, graphql-relay


### PR DESCRIPTION
This adds pillow 5.1.0 which allows Windows users to install Pillow directly through a wheel on Python 3.7. Which fixes compilation issues that some users had on Windows.

This closes #2758.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
