### PR TITLE
Fixed typo: "" is missing for parameter method in get_thumbnail method

### DIFF
--- a/templates/cart_dropdown.html
+++ b/templates/cart_dropdown.html
@@ -12,8 +12,8 @@
         <div class="col-md-10">
           <a class="link--clean" href="{{ line.variant_url }}">
             <img class="cart-dropdown__image lazyload lazypreload"
-                 data-src="{% get_thumbnail line.image size=60 method=thumbnail %}"
-                 data-srcset="{% get_thumbnail line.image size=60 method=thumbnail %} 1x, {% get_thumbnail line.image size=120 method=thumbnail %} 2x"
+                 data-src="{% get_thumbnail line.image size=60 method="thumbnail" %}"
+                 data-srcset="{% get_thumbnail line.image size=60 method="thumbnail" %} 1x, {% get_thumbnail line.image size=120 method="thumbnail" %} 2x"
                  alt=""
                  src="{% placeholder size=120 %}">
             <h3>

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -27,7 +27,7 @@
   <meta property="og:url" content="{{ product_url }}">
   <link rel="canonical" href="{{ product_url }}">
 
-  {% get_thumbnail product.get_first_image size=510 method=thumbnail as product_image %}
+  {% get_thumbnail product.get_first_image size=510 method="thumbnail" as product_image %}
   {% if product_image %}
     <meta property="og:image" content="{{ product_image }}" />
     <meta property="og:image:width" content="510">


### PR DESCRIPTION
Obviously, ```"thumbnail"``` should be passed to ```get_thumbnail``` instead of a ```thumbnail``` variable

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
