### PR TITLE
Return OrderEventsEmail as Enum in GraphQL API

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -39,8 +39,7 @@ class OrderEvent(CountableDjangoObjectType):
         exclude_fields = ['order', 'parameters']
 
     def resolve_email(self, info):
-        email =  self.parameters.get('email')
-        return email.upper() if email else None
+        return self.parameters.get('email', None)
 
     def resolve_email_type(self, info):
         return self.parameters.get('email_type', None)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1,16 +1,15 @@
-from decimal import Decimal
-
 import graphene
 from graphene import relay
 from payments import PaymentStatus
 
-from ...order import OrderEvents, models
+from ...order import OrderEvents, OrderEventsEmails, models
 from ...product.templatetags.product_images import get_thumbnail
 from ..account.types import User
 from ..core.types.common import CountableDjangoObjectType
 from ..core.types.money import Money, TaxedMoney
 
 OrderEventsEnum = graphene.Enum.from_enum(OrderEvents)
+OrderEventsEmailsEnum = graphene.Enum.from_enum(OrderEventsEmails)
 PaymentStatusEnum = graphene.Enum(
     'PaymentStatusEnum',
     [(code.upper(), code) for code, name in PaymentStatus.CHOICES])
@@ -26,7 +25,7 @@ class OrderEvent(CountableDjangoObjectType):
     message = graphene.String(
         description='Content of a note added to the order.')
     email = graphene.String(description='Email of the customer')
-    email_type = graphene.String(
+    email_type = OrderEventsEmailsEnum(
         description='Type of an email sent to the customer')
     amount = graphene.Float(description='Amount of money.')
     quantity = graphene.Int(description='Number of items.')
@@ -40,7 +39,8 @@ class OrderEvent(CountableDjangoObjectType):
         exclude_fields = ['order', 'parameters']
 
     def resolve_email(self, info):
-        return self.parameters.get('email', None)
+        email =  self.parameters.get('email')
+        return email.upper() if email else None
 
     def resolve_email_type(self, info):
         return self.parameters.get('email_type', None)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -953,7 +953,7 @@ type OrderEvent implements Node {
   user(id: ID): User
   message: String
   email: String
-  emailType: String
+  emailType: OrderEventsEmails
   amount: Float
   quantity: Int
   composedId: String
@@ -977,6 +977,13 @@ enum OrderEvents {
   OTHER
 }
 
+enum OrderEventsEmails {
+  PAYMENT
+  SHIPPING
+  ORDER
+  FULFILLMENT
+}
+
 type OrderLine implements Node {
   id: ID!
   productName: String!
@@ -987,7 +994,7 @@ type OrderLine implements Node {
   quantityFulfilled: Int!
   unitPrice: TaxedMoney
   taxRate: Float!
-  thumbnailUrl: String
+  thumbnailUrl(size: Int): String
 }
 
 type OrderLineCountableConnection {

--- a/saleor/static/dashboard-next/orders/types/OrderCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCancel.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderCancel
@@ -34,7 +34,7 @@ export interface OrderCancel_orderCancel_order_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/orders/types/OrderCapture.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCapture.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderCapture
@@ -40,7 +40,7 @@ export interface OrderCapture_orderCapture_order_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/orders/types/OrderDetails.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetails.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL query operation: OrderDetails
@@ -34,7 +34,7 @@ export interface OrderDetails_order_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL fragment: OrderDetailsFragment
@@ -34,7 +34,7 @@ export interface OrderDetailsFragment_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/orders/types/OrderRefund.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderRefund.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderRefund
@@ -40,7 +40,7 @@ export interface OrderRefund_orderRefund_order_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/orders/types/OrderRelease.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderRelease.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 // This file was automatically generated and should not be edited.
 
-import { AddressCountry, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
+import { AddressCountry, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentStatusEnum, OrderStatus } from "./../../types/globalTypes";
 
 // ====================================================
 // GraphQL mutation operation: OrderRelease
@@ -34,7 +34,7 @@ export interface OrderRelease_orderRelease_order_events {
   amount: number | null;
   date: any | null;
   email: string | null;
-  emailType: string | null;
+  emailType: OrderEventsEmails | null;
   message: string | null;
   quantity: number | null;
   type: OrderEvents | null;

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -281,6 +281,13 @@ export enum OrderEvents {
   UPDATED = "UPDATED",
 }
 
+export enum OrderEventsEmails {
+  FULFILLMENT = "FULFILLMENT",
+  ORDER = "ORDER",
+  PAYMENT = "PAYMENT",
+  SHIPPING = "SHIPPING",
+}
+
 export enum OrderStatus {
   CANCELED = "CANCELED",
   DRAFT = "DRAFT",

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -10,7 +10,7 @@ from saleor.graphql.order.mutations.draft_orders import (
     check_for_draft_order_errors)
 from saleor.graphql.order.mutations.orders import (
     clean_refund_payment, clean_release_payment)
-from saleor.graphql.order.types import PaymentStatusEnum
+from saleor.graphql.order.types import OrderEventsEmailsEnum, PaymentStatusEnum
 from saleor.order import CustomPaymentChoices, OrderEvents, OrderEventsEmails
 from saleor.order.models import Order, OrderStatus, Payment, PaymentStatus
 from tests.utils import get_graphql_content
@@ -152,7 +152,7 @@ def test_order_events_query(admin_api_client, fulfilled_order, admin_user):
     data = content['data']['orders']['edges'][0]['node']['events'][0]
     assert data['message'] == event.parameters['message']
     assert data['amount'] == float(event.parameters['amount'])
-    assert data['emailType'] == event.parameters['email_type']
+    assert data['emailType'] == OrderEventsEmailsEnum.PAYMENT.name
     assert data['quantity'] == int(event.parameters['quantity'])
     assert data['composedId'] == event.parameters['composed_id']
     assert data['user']['email'] == admin_user.email


### PR DESCRIPTION
I've missed it in #2811, OrderEventsEmail should be returned as an Enum