### PR TITLE
Handle user_email resolver with an empty string

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -98,6 +98,8 @@ class Order(CountableDjangoObjectType):
     events = graphene.List(
         OrderEvent,
         description='List of events associated with the order.')
+    user_email = graphene.String(
+        required=False, description='Email address of the customer.')
 
     class Meta:
         description = 'Represents an order in the shop.'
@@ -157,6 +159,7 @@ class Order(CountableDjangoObjectType):
             return obj.user_email
         if obj.user_id:
             return obj.user.email
+        return None
 
 
 class OrderLine(CountableDjangoObjectType):


### PR DESCRIPTION
As the field was nonnullable, we could not return a null value for it in the API 

close #2849 

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
