### PR TITLE
Add thumbnails to OrderLine api

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -975,6 +975,7 @@ type OrderLine implements Node {
   quantityFulfilled: Int!
   unitPrice: TaxedMoney
   taxRate: Float!
+  thumbnailUrl: String
 }
 
 type OrderLineCountableConnection {

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -45,8 +45,9 @@ def test_orderline_query(admin_api_client, fulfilled_order):
     order_data = content['data']['orders']['edges'][0]['node']
     lines_data = order_data['lines']['edges']
     thumbnails = [l['node']['thumbnailUrl'] for l in lines_data]
-    assert sorted(thumbnails) == [
-        None, '/static/images/placeholder540x540.png']
+    assert len(thumbnails) == 2
+    assert None in thumbnails
+    assert '/static/images/placeholder540x540.png' in thumbnails
 
 
 def test_order_query(admin_api_client, fulfilled_order):


### PR DESCRIPTION
Expanded the OrderLine resolver to contain the `thumbnailUrl`
Close #2858 