### PR TITLE
Move typescript tests to the correct travis section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ install:
   - npm i
   - npm run build-assets --production
   - npm run build-emails
-  - npm run test
 script:
+  - npm run test
   - tox
 env:
   global:


### PR DESCRIPTION
Hi,

I noticed that travis was running `jest` as a build script instead as of a test script. This fixes this.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
