### PR TITLE
Fixes images are overflow in dashboard's product descriptions

### DIFF
--- a/saleor/static/dashboard/scss/layouts/_product-details.scss
+++ b/saleor/static/dashboard/scss/layouts/_product-details.scss
@@ -5,3 +5,9 @@
   &__title {}
   &__switch {}
 }
+
+.product-description {
+  img {
+    max-width: 100%;
+  }
+}

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -66,9 +66,11 @@
               <h5>{% render_availability_status product %}</h5>
             </div>
           </div>
-          <p>
-            {{ product.description | safe }}
-          </p>
+          <div class="product-description">
+            <p>
+              {{ product.description | safe }}
+            </p>
+          </div>
         </div>
         <div class="card-action">
           <a href="{% url "dashboard:product-update" product.pk %}" class="btn-flat waves-effect">


### PR DESCRIPTION
If images in product description in dashboard are too large, they will overflow as the following image.

![screenshot from 2018-09-18 17-25-53](https://user-images.githubusercontent.com/1401630/45679018-4b5b4400-bb6a-11e8-9e25-6d8e2130a5e6.png)


### Screenshots

Here is screenshot after this PR fixes this issue.

![screenshot from 2018-09-18 17-33-21](https://user-images.githubusercontent.com/1401630/45678993-3bdbfb00-bb6a-11e8-9d2d-dc7487ab3470.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
