### PR TITLE
Set image as 100% in product detail page in shop's frontend

### DIFF
--- a/saleor/static/scss/layouts/_product-page.scss
+++ b/saleor/static/scss/layouts/_product-page.scss
@@ -62,6 +62,9 @@
         padding: 0 2rem;
         font-style: italic;
       }
+      img {
+        max-width: 100%;
+      }
     }
   }
   &__gallery {


### PR DESCRIPTION
In frontend, images in product description in product detail page are overflow if image are too big.

![screenshot from 2018-09-18 17-57-00](https://user-images.githubusercontent.com/1401630/45680657-076a3e00-bb6e-11e8-876a-5a6d7e6770b1.png)


### Screenshots

This is the screenshot after this PR fixes this issue.

![screenshot from 2018-09-18 18-08-21](https://user-images.githubusercontent.com/1401630/45680677-1650f080-bb6e-11e8-8560-6f974b426374.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
