### PR TITLE
Fix failing docs build on RTD

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -125,4 +125,4 @@ weasyprint==0.42.3
 webencodings==0.5.1       # via html5lib, tinycss2
 wrapt==1.10.11            # via vcrpy
 xmltodict==0.11.0         # via django-payments
-yarl==1.2.6               # via vcrpy
+yarl               # via vcrpy


### PR DESCRIPTION
As described in the issue #2889 there is a problem with installing `yarl` on RTD. This is a workaround to install any version of this package, which I believe shouldn't break anything in Saleor, but for not should fix the issue on RTD.

Fixes #2889 
