### PR TITLE
Remove label of the second address in checkout page

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -98,8 +98,7 @@ class AddressForm(forms.ModelForm):
                 'Company or organization', 'Company or organization'),
             'street_address_1': pgettext_lazy(
                 'Address', 'Address'),
-            'street_address_2': pgettext_lazy(
-                'Address', 'Address'),
+            'street_address_2': '',
             'city': pgettext_lazy(
                 'City', 'City'),
             'city_area': pgettext_lazy(


### PR DESCRIPTION
It looks like https://github.com/mirumee/saleor/pull/2569 adds additional padding top for second adddress but forgets to remove second address's label which makes the alignment not horizontal, such as in https://demo.getsaleor.com/zh-tw/checkout/shipping-address/.

Here is a screenshot.

![screenshot from 2018-09-19 15-14-03](https://user-images.githubusercontent.com/1401630/45736917-f9c0c100-bc1e-11e8-9b1e-f823e3b5b27e.png)


### Screenshots

Here is the screenshopt after this PR fixes this issue.

![image](https://user-images.githubusercontent.com/1401630/45738486-270f6e00-bc23-11e8-84e3-0fd53c3fe6ee.png)



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
