### PR TITLE
Require variant attributes when creating a variant

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1452,7 +1452,7 @@ type ProductVariantCreate {
 }
 
 input ProductVariantCreateInput {
-  attributes: [AttributeValueInput]
+  attributes: [AttributeValueInput]!
   costPrice: Decimal
   priceOverride: Decimal
   sku: String
@@ -1598,7 +1598,7 @@ input SetPasswordInput {
 type ShippingMethod implements Node {
   id: ID!
   name: String!
-  type: ShippingMethodTypeEnum!
+  type: ShippingMethodTypeEnum
   price: Money
   minimumOrderPrice: Money
   maximumOrderPrice: Money

--- a/saleor/static/dashboard-next/products/mutations.ts
+++ b/saleor/static/dashboard-next/products/mutations.ts
@@ -243,7 +243,7 @@ export const TypedVariantUpdateMutation = TypedMutation<
 export const variantCreateMutation = gql`
   ${fragmentVariant}
   mutation VariantCreate(
-    $attributes: [AttributeValueInput]
+    $attributes: [AttributeValueInput]!
     $costPrice: Decimal
     $priceOverride: Decimal
     $product: ID!

--- a/saleor/static/dashboard-next/products/types/VariantCreate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantCreate.ts
@@ -155,7 +155,7 @@ export interface VariantCreate {
 }
 
 export interface VariantCreateVariables {
-  attributes?: (AttributeValueInput | null)[] | null;
+  attributes: (AttributeValueInput | null)[];
   costPrice?: any | null;
   priceOverride?: any | null;
   product: string;

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -70,7 +70,7 @@ def test_create_variant(admin_api_client, product, product_type):
             $priceOverride: Decimal,
             $costPrice: Decimal,
             $quantity: Int!,
-            $attributes: [AttributeValueInput],
+            $attributes: [AttributeValueInput]!,
             $weight: WeightScalar,
             $trackInventory: Boolean!) {
                 productVariantCreate(
@@ -186,8 +186,7 @@ def test_create_product_variant_not_all_attributes(
     content = get_graphql_content(response)
     assert 'errors' not in content
     assert 'errors' in content['data']['productVariantCreate']
-    assert content['data']['productVariantCreate']['errors'] == [{
-        'field': 'attributes', 'message': 'Missing attributes: color'}]
+    assert content['data']['productVariantCreate']['errors'][0]['field'] == 'attributes:color'
     assert not product.variants.filter(sku=sku).exists()
 
 
@@ -285,8 +284,7 @@ def test_update_product_variant_not_all_attributes(
     content = get_graphql_content(response)
     assert 'errors' not in content
     assert 'errors' in content['data']['productVariantUpdate']
-    assert content['data']['productVariantUpdate']['errors'] == [{
-        'field': 'attributes', 'message': 'Missing attributes: color'}]
+    assert content['data']['productVariantUpdate']['errors'][0]['field'] == 'attributes:color'
     assert not product.variants.filter(sku=sku).exists()
 
 


### PR DESCRIPTION
Fixes #2879

A follow-up for PR #2911. Changes:
- `attributes` input field is now required in the mutation that creates a variant and optional in the update mutation.
- Variant attributes can't have empty values; a validation error would be raised if such input is provided. Previously it was possible as only presence of an attribute was checked and not the actual value.
- Changed format of an error returned by the API when attributes are missing or have no value to:
```
{
    "field": "attributes:size",
    "message": "This field cannot be blank."
}
```
`field` now contains name of the invalid attribute. 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
