### PR TITLE
Fixes creating order issue when voucher name is optional

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -726,7 +726,7 @@ def recalculate_cart_discount(cart, discounts, taxes):
         else:
             subtotal = cart.get_subtotal(discounts, taxes).gross
             cart.discount_amount = min(discount, subtotal)
-            cart.discount_name = voucher.name
+            cart.discount_name = str(voucher)
             cart.translated_discount_name = (
                 voucher.translated.name
                 if voucher.translated.name != voucher.name else '')


### PR DESCRIPTION
In checkout process, ```recalculate_cart_discount``` will be called when voucher is added by the user and this method will update ```cart.discount_name``` according to voucher's name. The voucher's name field is optional which can be null. In ```handle_order_placement```, ```discount_name``` will be passsed into ```Order``` model's initialization. But ```discount_name``` field in ```Order``` model is non-nullable. So non-null contrainst error will be raised if user uses voucher which has empty name.

This is fixed by setting ```card.discount_name``` same as voucher's default name which is defined in ```__str__``` method.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
