### PR TITLE
Fixes applicable shipping method is not filtered by the discounts

### DIFF
--- a/saleor/checkout/forms.py
+++ b/saleor/checkout/forms.py
@@ -273,11 +273,12 @@ class CartShippingMethodForm(forms.ModelForm):
         fields = ['shipping_method']
 
     def __init__(self, *args, **kwargs):
+        discounts = kwargs.pop('discounts')
         taxes = kwargs.pop('taxes')
         super().__init__(*args, **kwargs)
         country_code = self.instance.shipping_address.country.code
         qs = ShippingMethod.objects.applicable_shipping_methods(
-            price=self.instance.get_subtotal().gross,
+            price=self.instance.get_subtotal(discounts, taxes).gross,
             weight=self.instance.get_total_weight(),
             country_code=country_code)
         self.fields['shipping_method'].queryset = qs

--- a/saleor/checkout/views/__init__.py
+++ b/saleor/checkout/views/__init__.py
@@ -63,17 +63,18 @@ def checkout_shipping_address(request, cart):
 @add_voucher_form
 def checkout_shipping_method(request, cart):
     """Display the shipping method selection step."""
+    discounts = request.discounts
     taxes = get_taxes_for_cart(cart, request.taxes)
-    is_valid_shipping_method(cart, request.taxes, request.discounts)
+    is_valid_shipping_method(cart, request.taxes, discounts)
 
     form = CartShippingMethodForm(
-        request.POST or None, taxes=taxes, instance=cart,
+        request.POST or None, discounts=discounts, taxes=taxes, instance=cart,
         initial={'shipping_method': cart.shipping_method})
     if form.is_valid():
         form.save()
         return redirect('checkout:summary')
 
-    ctx = get_cart_data_for_checkout(cart, request.discounts, taxes)
+    ctx = get_cart_data_for_checkout(cart, discounts, taxes)
     ctx.update({'shipping_method_form': form})
     return TemplateResponse(request, 'checkout/shipping_method.html', ctx)
 


### PR DESCRIPTION
If there is a sale on a product, a price based shipping method is filtered by product's original price instead of its discount price. So it may be shown in checkout's shipping method view but can not proceed to checkout's summary view since the latter view will take discounts into account when validating shipping method.

A price based shipping method should be filtered according to order's subtotal after discount. This PR fixes this issue.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
