### PR TITLE
Upgrade Bootstrap to 4.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7834,9 +7834,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.0.0.tgz",
-      "integrity": "sha512-gulJE5dGFo6Q61V/whS6VM4WIyrlydXfCgkE+Gxe5hjrJ8rXLLZlALq7zq2RPhOc45PSwQpJkrTnc2KgD6cvmA=="
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.2.tgz",
+      "integrity": "sha512-3bP609EdMc/8EwgGp8KgpN8HwnR4V4lZ9CTi5pImMrXNxpkw7dK1B05aMwQWpG1ZWmTLlBSN/uzkuz5GsmQNFA=="
     },
     "bowser": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "apollo-link-error": "^1.0.7",
     "apollo-link-http": "^1.5.4",
     "apollo-upload-client": "^8.0.0",
-    "bootstrap": "4.0.0",
+    "bootstrap": "4.1.2",
     "classnames": "^2.2.6",
     "crc-32": "^1.2.0",
     "detect-passive-events": "^1.0.4",


### PR DESCRIPTION
Upgrade Bootstrap to 4.1.2 to fix the [XSS vulnerability in 4.0.0](https://nvd.nist.gov/vuln/detail/CVE-2018-14041).

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
