### PR TITLE
Use fields default value if no value is provided and field is not nullable

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -211,11 +211,13 @@ class ModelMutation(BaseMutation):
         opts = instance._meta
 
         for f in opts.fields:
-            if not f.editable or isinstance(
-                    f, models.AutoField) or f.name not in cleaned_data:
+            if any([not f.editable, isinstance(f, models.AutoField),
+                    f.name not in cleaned_data]):
                 continue
-            else:
-                f.save_form_data(instance, cleaned_data[f.name])
+            data = cleaned_data[f.name]
+            if not f.null and data is None:
+                data = f._get_default()
+            f.save_form_data(instance, data)
         return instance
 
     @classmethod

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -10,7 +10,6 @@ from prices import Money
 from tests.utils import (
     create_image, create_pdf_file_with_image_ext, get_graphql_content)
 
-from saleor.core import TaxRateType
 from saleor.graphql.product.utils import update_variants_names
 from saleor.product.models import (
     Category, Collection, Product, ProductImage, ProductType, ProductVariant)


### PR DESCRIPTION
This is a fallback for fields that have a default, were nulled in the API, but are not nullable at the database level. 
