### PR TITLE
Data of the previous user remains cached in the browser when switching accounts

### DIFF
--- a/saleor/static/dashboard-next/auth/AuthProvider.tsx
+++ b/saleor/static/dashboard-next/auth/AuthProvider.tsx
@@ -84,10 +84,11 @@ class AuthProvider extends React.Component<
       if (user) {
         setAuthToken(tokenAuth.data.tokenCreate.token, this.state.persistToken);
       }
-    }
-    if (tokenVerify.data && tokenVerify.data.tokenVerify.user) {
-      const user = tokenVerify.data.tokenVerify.user;
-      this.setState({ user });
+    } else {
+      if (tokenVerify.data && tokenVerify.data.tokenVerify.user) {
+        const user = tokenVerify.data.tokenVerify.user;
+        this.setState({ user });
+      }
     }
   }
 

--- a/saleor/static/dashboard-next/auth/index.tsx
+++ b/saleor/static/dashboard-next/auth/index.tsx
@@ -3,6 +3,8 @@ import * as React from "react";
 import { User } from "./types/User";
 import Login from "./views/Login";
 
+const TOKEN_STORAGE_KEY = "dashboardAuth";
+
 interface UserContext {
   login: (username: string, password: string, persist: boolean) => void;
   logout: () => void;
@@ -15,17 +17,17 @@ export const UserContext = React.createContext<UserContext>({
 });
 
 export const getAuthToken = () =>
-  localStorage.getItem("dashboardAuth") ||
-  sessionStorage.getItem("dashboardAuth");
+  localStorage.getItem(TOKEN_STORAGE_KEY) ||
+  sessionStorage.getItem(TOKEN_STORAGE_KEY);
 
 export const setAuthToken = (token: string, persist: boolean) =>
   persist
-    ? localStorage.setItem("dashboardAuth", token)
-    : sessionStorage.setItem("dashboardAuth", token);
+    ? localStorage.setItem(TOKEN_STORAGE_KEY, token)
+    : sessionStorage.setItem(TOKEN_STORAGE_KEY, token);
 
 export const removeAuthToken = () => {
-  localStorage.removeItem("dashboardAuth");
-  sessionStorage.removeItem("dashboardAuth");
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+  sessionStorage.removeItem(TOKEN_STORAGE_KEY);
 };
 
 export default Login;


### PR DESCRIPTION
Fixes #2963

Explanation: this was happening because of double `setState()` in `componentWillReceiveProps` method, for the first time correctly setting user data to those received in `tokenAuth` mutation, but then the state was being set for the second time to credentials received from `tokenVerify` mutation. 