### PR TITLE
3003/ Refactor API client in tests

### DIFF
--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1,4 +1,3 @@
-import json
 import re
 from unittest.mock import Mock, patch
 
@@ -17,8 +16,8 @@ from .utils import assert_no_permission, convert_dict_keys_to_camel_case
 
 def test_create_token_mutation(admin_api_client, staff_user):
     query = """
-    mutation {
-        tokenCreate(email: "%(email)s", password: "%(password)s") {
+    mutation TokenCreate($email: String!, $password: String!) {
+        tokenCreate(email: $email, password: $password) {
             token
             errors {
                 field
@@ -27,15 +26,15 @@ def test_create_token_mutation(admin_api_client, staff_user):
         }
     }
     """
-    success_query = query % {'email': staff_user.email, 'password': 'password'}
-    response = admin_api_client.post_graphql(success_query)
+    variables = {'email': staff_user.email, 'password': 'password'}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['token']
     assert not token_data['errors']
 
-    error_query = query % {'email': staff_user.email, 'password': 'wat'}
-    response = admin_api_client.post_graphql(error_query)
+    incorrect_variables = {'email': staff_user.email, 'password': 'wat'}
+    response = admin_api_client.post_graphql(query, incorrect_variables)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert not token_data['token']
@@ -47,8 +46,8 @@ def test_create_token_mutation(admin_api_client, staff_user):
 def test_token_create_user_data(
         permission_manage_orders, staff_api_client, staff_user):
     query = """
-    mutation {
-        tokenCreate(email: "%(email)s", password: "%(password)s") {
+    mutation TokenCreate($email: String!, $password: String!) {
+        tokenCreate(email: $email, password: $password) {
             user {
                 id
                 email
@@ -67,8 +66,8 @@ def test_token_create_user_data(
     name = permission.name
     user_id = graphene.Node.to_global_id('User', staff_user.id)
 
-    query = query % {'email': staff_user.email, 'password': 'password'}
-    response = staff_api_client.post_graphql(query)
+    variables = {'email': staff_user.email, 'password': 'password'}
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['user']['id'] == user_id
@@ -110,7 +109,7 @@ def test_query_user(admin_api_client, customer_user):
     }
     """
     ID = graphene.Node.to_global_id('User', customer_user.id)
-    variables = json.dumps({'id': ID})
+    variables = {'id': ID}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['user']
@@ -147,7 +146,7 @@ def test_query_customers(admin_api_client, user_api_client):
         }
     }
     """
-    variables = json.dumps({})
+    variables = {}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     users = content['data']['customers']['edges']
@@ -174,7 +173,7 @@ def test_query_staff(
         }
     }
     """
-    variables = json.dumps({})
+    variables = {}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['staffUsers']['edges']
@@ -209,7 +208,7 @@ def test_who_can_see_user(
 
     # Random person (even staff) can't see users data without permissions
     ID = graphene.Node.to_global_id('User', customer_user.id)
-    variables = json.dumps({'id': ID})
+    variables = {'id': ID}
     response = staff_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
@@ -242,7 +241,7 @@ def test_customer_register(user_api_client):
         }
     """
     email = 'customer@example.com'
-    variables = json.dumps({'email': email, 'password': 'Password'})
+    variables = {'email': email, 'password': 'Password'}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['customerRegister']
@@ -296,9 +295,12 @@ def test_customer_create(
     note = 'Test user'
     address_data = convert_dict_keys_to_camel_case(address.as_data())
 
-    variables = json.dumps(
-        {'email': email, 'note': note, 'shipping': address_data,
-        'billing': address_data, 'send_mail': True})
+    variables = {
+        'email': email,
+        'note': note,
+        'shipping': address_data,
+        'billing': address_data,
+        'send_mail': True}
 
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
@@ -369,9 +371,11 @@ def test_customer_update(
     new_street_address = 'Updated street address'
     address_data['streetAddress1'] = new_street_address
 
-    variables = json.dumps({
-        'id': id, 'note': note, 'billing': address_data,
-        'shipping': address_data})
+    variables = {
+        'id': id,
+        'note': note,
+        'billing': address_data,
+        'shipping': address_data}
 
     # check unauthorized access
     response = user_api_client.post_graphql(query, variables)
@@ -425,9 +429,10 @@ def test_staff_create(
 
     email = 'api_user@example.com'
     staff_user.user_permissions.add(permission_manage_users)
-    variables = json.dumps({
-        'email': email, 'permissions': [permission_manage_products_codename],
-        'send_mail': True})
+    variables = {
+        'email': email,
+        'permissions': [permission_manage_products_codename],
+        'send_mail': True}
 
     # check unauthorized access
     response = user_api_client.post_graphql(query, variables)
@@ -472,7 +477,7 @@ def test_staff_update(admin_api_client, staff_user, user_api_client):
     }
     """
     id = graphene.Node.to_global_id('User', staff_user.id)
-    variables = json.dumps({'id': id, 'permissions': [], 'is_active': False})
+    variables = {'id': id, 'permissions': [], 'is_active': False}
 
     # check unauthorized access
     response = user_api_client.post_graphql(query, variables)
@@ -501,7 +506,7 @@ def test_staff_delete(admin_api_client, staff_user, user_api_client):
         }
     """
     user_id = graphene.Node.to_global_id('User', staff_user.id)
-    variables = json.dumps({'id': user_id})
+    variables = {'id': user_id}
 
     # check unauthorized access
     response = user_api_client.post_graphql(query, variables)
@@ -526,8 +531,7 @@ def test_staff_delete_errors(staff_user, customer_user, admin_user):
 
     errors = StaffDelete.clean_user(admin_user, staff_user, [])
     assert errors[0].field == 'id'
-    assert errors[0].message == (
-        'Only superuser can delete his own account.')
+    assert errors[0].message == 'Only superuser can delete his own account.'
     errors = StaffDelete.clean_user(staff_user, admin_user, [])
     assert not errors
 
@@ -567,15 +571,14 @@ def test_set_password(user_api_client, customer_user):
     password = 'spanish-inquisition'
 
     # check invalid token
-    post_data = {'id': id, 'password': password, 'token': 'nope'}
-    variables = json.dumps(post_data)
+    variables = {'id': id, 'password': password, 'token': 'nope'}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['setPassword']['errors']
     assert errors[0]['message'] == SetPassword.INVALID_TOKEN
 
-    post_data['token'] = token
-    response = user_api_client.post_graphql(query, json.dumps(post_data))
+    variables['token'] = token
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['setPassword']
     assert data['user']['id']
@@ -598,7 +601,7 @@ def test_password_reset_email(
     }
     """
     email = customer_user.email
-    variables = json.dumps({'email': email})
+    variables = {'email': email}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
@@ -625,12 +628,13 @@ def test_password_reset_email_non_existing_user(
     }
     """
     email = 'not_exists@example.com'
-    variables = json.dumps({'email': email})
+    variables = {'email': email}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
     assert data['errors'] == [{
-        'field': 'email', 'message': "User with this email doesn't exist"}]
+        'field': 'email',
+        'message': "User with this email doesn't exist"}]
     send_password_reset_mock.assert_not_called()
 
 
@@ -653,8 +657,7 @@ def test_create_address_mutation(admin_api_client, customer_user):
     }
     """
     user_id = graphene.Node.to_global_id('User', customer_user.id)
-    variables = json.dumps(
-        {'user': user_id, 'city': 'Dummy', 'country': 'PL'})
+    variables = {'user': user_id, 'city': 'Dummy', 'country': 'PL'}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['addressCreate']['errors'] == []
@@ -699,8 +702,7 @@ def test_address_delete_mutation(admin_api_client, customer_user):
             }
         """
     address_obj = customer_user.addresses.first()
-    variables = {
-        'id': graphene.Node.to_global_id('Address', address_obj.id)}
+    variables = {'id': graphene.Node.to_global_id('Address', address_obj.id)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['addressDelete']
@@ -721,11 +723,11 @@ def test_address_validator(user_api_client):
         }
     }
     """
-    variables = json.dumps({'input': {
-        'countryCode': 'PL',
-        'countryArea': None,
-        'cityArea': None
-    }})
+    variables = {
+        'input': {
+            'countryCode': 'PL',
+            'countryArea': None,
+            'cityArea': None}}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['addressValidator']
@@ -748,11 +750,11 @@ def test_address_validator_uses_geip_when_country_code_missing(
         }
     }
     """
-    variables = json.dumps({'input': {
-        'countryCode': None,
-        'countryArea': None,
-        'cityArea': None
-    }})
+    variables = {
+        'input': {
+            'countryCode': None,
+            'countryArea': None,
+            'cityArea': None}}
     mock_country_by_ip = Mock(return_value=Mock(code='US'))
     monkeypatch.setattr(
         'saleor.graphql.account.resolvers.get_client_ip',
@@ -782,12 +784,12 @@ def test_customer_reset_password(
         }
     """
     # we have no user with given email
-    variables = json.dumps({'email': 'non-existing-email@email.com'})
+    variables = {'email': 'non-existing-email@email.com'}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not send_password_reset_mock.called
 
-    variables = json.dumps({'email': customer_user.email})
+    variables = {'email': customer_user.email}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert send_password_reset_mock.called

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -30,7 +30,7 @@ def test_create_token_mutation(admin_client, staff_user):
     '''
     success_query = query % {'email': staff_user.email, 'password': 'password'}
     response = admin_client.post(
-        reverse('api'), json.dumps({'query': success_query}),
+        json.dumps({'query': success_query}),
         content_type='application/json')
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
@@ -39,7 +39,7 @@ def test_create_token_mutation(admin_client, staff_user):
 
     error_query = query % {'email': staff_user.email, 'password': 'wat'}
     response = admin_client.post(
-        reverse('api'), json.dumps({'query': error_query}),
+        json.dumps({'query': error_query}),
         content_type='application/json')
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
@@ -74,7 +74,7 @@ def test_token_create_user_data(
 
     query = query % {'email': staff_user.email, 'password': 'password'}
     response = staff_client.post(
-        reverse('api'), json.dumps({'query': query}),
+        json.dumps({'query': query}),
         content_type='application/json')
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
@@ -119,7 +119,7 @@ def test_query_user(admin_api_client, customer_user):
     ID = graphene.Node.to_global_id('User', customer_user.id)
     variables = json.dumps({'id': ID})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['user']
     assert data['email'] == user.email
@@ -157,7 +157,7 @@ def test_query_customers(admin_api_client, user_api_client):
     """
     variables = json.dumps({})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     users = content['data']['customers']['edges']
     assert users
@@ -165,7 +165,7 @@ def test_query_customers(admin_api_client, user_api_client):
 
     # check permissions
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
 
@@ -186,7 +186,7 @@ def test_query_staff(
     """
     variables = json.dumps({})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['staffUsers']['edges']
     assert len(data) == 2
@@ -196,7 +196,7 @@ def test_query_staff(
 
     # check permissions
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
 
@@ -223,21 +223,21 @@ def test_who_can_see_user(
     ID = graphene.Node.to_global_id('User', customer_user.id)
     variables = json.dumps({'id': ID})
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = staff_api_client.post(
-        reverse('api'), {'query': query_2})
+        {'query': query_2})
     assert_no_permission(response)
 
     # Add permission and ensure staff can see user(s)
     staff_user.user_permissions.add(permission_manage_users)
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['user']['email'] == customer_user.email
 
-    response = staff_api_client.post(reverse('api'), {'query': query_2})
+    response = staff_api_client.post({'query': query_2})
     content = get_graphql_content(response)
     assert content['data']['customers']['totalCount'] == 1
 
@@ -259,14 +259,14 @@ def test_customer_register(user_api_client):
     email = 'customer@example.com'
     variables = json.dumps({'email': email, 'password': 'Password'})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['customerRegister']
     assert not data['errors']
     assert User.objects.filter(email=email).exists()
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['customerRegister']
     assert data['errors']
@@ -318,11 +318,11 @@ def test_customer_create(
         'billing': address_data, 'send_mail': True})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
 
     User = get_user_model()
@@ -394,11 +394,11 @@ def test_customer_update(
 
     # check unauthorized access
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
 
     User = get_user_model()
@@ -452,11 +452,11 @@ def test_staff_create(
 
     # check unauthorized access
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['staffCreate']
     assert data['errors'] == []
@@ -499,11 +499,11 @@ def test_staff_update(admin_api_client, staff_user, user_api_client):
 
     # check unauthorized access
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['staffUpdate']
     assert data['errors'] == []
@@ -530,11 +530,11 @@ def test_staff_delete(admin_api_client, staff_user, user_api_client):
 
     # check unauthorized access
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['staffDelete']
     assert data['errors'] == []
@@ -598,14 +598,14 @@ def test_set_password(user_api_client, customer_user):
     # check invalid token
     variables['token'] = 'nope'
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': json.dumps(variables)})
+        {'query': query, 'variables': json.dumps(variables)})
     content = get_graphql_content(response)
     errors = content['data']['setPassword']['errors']
     assert errors[0]['message'] == SetPassword.INVALID_TOKEN
 
     variables['token'] = token
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': json.dumps(variables)})
+        {'query': query, 'variables': json.dumps(variables)})
     content = get_graphql_content(response)
     data = content['data']['setPassword']
     assert data['user']['id']
@@ -630,7 +630,7 @@ def test_password_reset_email(
     email = customer_user.email
     variables = json.dumps({'email': email})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
     assert data is None
@@ -658,7 +658,7 @@ def test_password_reset_email_non_existing_user(
     email = 'not_exists@example.com'
     variables = json.dumps({'email': email})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
     assert data['errors'] == [{
@@ -688,7 +688,7 @@ def test_create_address_mutation(admin_api_client, customer_user):
     variables = json.dumps(
         {'user': user_id, 'city': 'Dummy', 'country': 'PL'})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['addressCreate']['errors'] == []
     address_response = content['data']['addressCreate']['address']
@@ -714,7 +714,7 @@ def test_address_update_mutation(admin_api_client, customer_user):
         'addressId': graphene.Node.to_global_id('Address', address_obj.id),
         'city': new_city}
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['addressUpdate']
     assert data['address']['city'] == new_city
@@ -736,7 +736,7 @@ def test_address_delete_mutation(admin_api_client, customer_user):
     variables = {
         'id': graphene.Node.to_global_id('Address', address_obj.id)}
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['addressDelete']
     assert data['address']['city'] == address_obj.city
@@ -762,7 +762,7 @@ def test_address_validator(user_api_client):
         'cityArea': None
     }})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['addressValidator']
     assert data['countryCode'] == 'PL'
@@ -797,7 +797,7 @@ def test_address_validator_uses_geip_when_country_code_missing(
         'saleor.graphql.account.resolvers.get_country_by_ip',
         mock_country_by_ip)
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert mock_country_by_ip.called
     data = content['data']['addressValidator']
@@ -821,13 +821,13 @@ def test_customer_reset_password(
     # we have no user with given email
     variables = json.dumps({'email': 'non-existing-email@email.com'})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert not send_password_reset_mock.called
 
     variables = json.dumps({'email': customer_user.email})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert send_password_reset_mock.called
     assert send_password_reset_mock.mock_calls[0][1][1] == customer_user.email

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1,3 +1,4 @@
+import json
 import re
 from unittest.mock import Mock, patch
 
@@ -6,6 +7,7 @@ import pytest
 import graphene
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
+from django.shortcuts import reverse
 from saleor.account.models import Address, User
 from saleor.graphql.account.mutations import (
     SetPassword, StaffDelete, StaffUpdate)
@@ -14,7 +16,7 @@ from tests.api.utils import get_graphql_content
 from .utils import assert_no_permission, convert_dict_keys_to_camel_case
 
 
-def test_create_token_mutation(admin_api_client, staff_user):
+def test_create_token_mutation(admin_client, staff_user):
     query = """
     mutation TokenCreate($email: String!, $password: String!) {
         tokenCreate(email: $email, password: $password) {
@@ -26,21 +28,27 @@ def test_create_token_mutation(admin_api_client, staff_user):
         }
     }
     """
-    variables = {'email': staff_user.email, 'password': 'password'}
-    response = admin_api_client.post_graphql(query, variables)
+    variables = json.dumps({'email': staff_user.email, 'password': 'password'})
+    response = admin_client.post(
+        reverse('api'), json.dumps({'query': query, 'variables': variables}),
+        content_type='application/json')
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['token']
     assert not token_data['errors']
 
-    incorrect_variables = {'email': staff_user.email, 'password': 'wat'}
-    response = admin_api_client.post_graphql(query, incorrect_variables)
+    incorrect_variables = json.dumps(
+        {'email': staff_user.email, 'password': 'incorrect'})
+    response = admin_client.post(
+        reverse('api'),
+        json.dumps({'query': query, 'variables': incorrect_variables}),
+        content_type='application/json')
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
-    assert not token_data['token']
     errors = token_data['errors']
     assert errors
     assert not errors[0]['field']
+    assert not token_data['token']
 
 
 def test_token_create_user_data(

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -17,7 +17,7 @@ from .utils import assert_no_permission, convert_dict_keys_to_camel_case
 
 
 def test_create_token_mutation(admin_client, staff_user):
-    query = '''
+    query = """
     mutation {
         tokenCreate(email: "%(email)s", password: "%(password)s") {
             token
@@ -27,7 +27,7 @@ def test_create_token_mutation(admin_client, staff_user):
             }
         }
     }
-    '''
+    """
     success_query = query % {'email': staff_user.email, 'password': 'password'}
     response = admin_client.post_graphql(success_query)
     content = get_graphql_content(response)

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -7,7 +7,6 @@ import pytest
 import graphene
 from django.contrib.auth import get_user_model
 from django.contrib.auth.tokens import default_token_generator
-from django.shortcuts import reverse
 from saleor.account.models import Address, User
 from saleor.graphql.account.mutations import (
     SetPassword, StaffDelete, StaffUpdate)
@@ -16,7 +15,7 @@ from tests.api.utils import get_graphql_content
 from .utils import assert_no_permission, convert_dict_keys_to_camel_case
 
 
-def test_create_token_mutation(admin_client, staff_user):
+def test_create_token_mutation(admin_api_client, staff_user):
     query = """
     mutation {
         tokenCreate(email: "%(email)s", password: "%(password)s") {
@@ -29,14 +28,14 @@ def test_create_token_mutation(admin_client, staff_user):
     }
     """
     success_query = query % {'email': staff_user.email, 'password': 'password'}
-    response = admin_client.post_graphql(success_query)
+    response = admin_api_client.post_graphql(success_query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['token']
     assert not token_data['errors']
 
     error_query = query % {'email': staff_user.email, 'password': 'wat'}
-    response = admin_client.post_graphql(error_query)
+    response = admin_api_client.post_graphql(error_query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert not token_data['token']
@@ -46,7 +45,7 @@ def test_create_token_mutation(admin_client, staff_user):
 
 
 def test_token_create_user_data(
-        permission_manage_orders, staff_client, staff_user):
+        permission_manage_orders, staff_api_client, staff_user):
     query = """
     mutation {
         tokenCreate(email: "%(email)s", password: "%(password)s") {
@@ -69,7 +68,7 @@ def test_token_create_user_data(
     user_id = graphene.Node.to_global_id('User', staff_user.id)
 
     query = query % {'email': staff_user.email, 'password': 'password'}
-    response = staff_client.post_graphql(query)
+    response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['user']['id'] == user_id

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -29,18 +29,14 @@ def test_create_token_mutation(admin_client, staff_user):
     }
     '''
     success_query = query % {'email': staff_user.email, 'password': 'password'}
-    response = admin_client.post(
-        json.dumps({'query': success_query}),
-        content_type='application/json')
+    response = admin_client.post_graphql(success_query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['token']
     assert not token_data['errors']
 
     error_query = query % {'email': staff_user.email, 'password': 'wat'}
-    response = admin_client.post(
-        json.dumps({'query': error_query}),
-        content_type='application/json')
+    response = admin_client.post_graphql(error_query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert not token_data['token']
@@ -73,9 +69,7 @@ def test_token_create_user_data(
     user_id = graphene.Node.to_global_id('User', staff_user.id)
 
     query = query % {'email': staff_user.email, 'password': 'password'}
-    response = staff_client.post(
-        json.dumps({'query': query}),
-        content_type='application/json')
+    response = staff_client.post_graphql(query)
     content = get_graphql_content(response)
     token_data = content['data']['tokenCreate']
     assert token_data['user']['id'] == user_id
@@ -118,8 +112,7 @@ def test_query_user(admin_api_client, customer_user):
     """
     ID = graphene.Node.to_global_id('User', customer_user.id)
     variables = json.dumps({'id': ID})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['user']
     assert data['email'] == user.email
@@ -156,16 +149,14 @@ def test_query_customers(admin_api_client, user_api_client):
     }
     """
     variables = json.dumps({})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     users = content['data']['customers']['edges']
     assert users
     assert all([not user['node']['isStaff'] for user in users])
 
     # check permissions
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
 
@@ -185,8 +176,7 @@ def test_query_staff(
     }
     """
     variables = json.dumps({})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['staffUsers']['edges']
     assert len(data) == 2
@@ -195,8 +185,7 @@ def test_query_staff(
     assert all([user['node']['isStaff'] for user in data])
 
     # check permissions
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
 
@@ -222,22 +211,19 @@ def test_who_can_see_user(
     # Random person (even staff) can't see users data without permissions
     ID = graphene.Node.to_global_id('User', customer_user.id)
     variables = json.dumps({'id': ID})
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = staff_api_client.post(
-        {'query': query_2})
+    response = staff_api_client.post_graphql(query_2)
     assert_no_permission(response)
 
     # Add permission and ensure staff can see user(s)
     staff_user.user_permissions.add(permission_manage_users)
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['user']['email'] == customer_user.email
 
-    response = staff_api_client.post({'query': query_2})
+    response = staff_api_client.post_graphql(query_2)
     content = get_graphql_content(response)
     assert content['data']['customers']['totalCount'] == 1
 
@@ -258,15 +244,13 @@ def test_customer_register(user_api_client):
     """
     email = 'customer@example.com'
     variables = json.dumps({'email': email, 'password': 'Password'})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['customerRegister']
     assert not data['errors']
     assert User.objects.filter(email=email).exists()
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['customerRegister']
     assert data['errors']
@@ -317,12 +301,10 @@ def test_customer_create(
         {'email': email, 'note': note, 'shipping': address_data,
         'billing': address_data, 'send_mail': True})
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
 
     User = get_user_model()
@@ -393,12 +375,10 @@ def test_customer_update(
         'shipping': address_data})
 
     # check unauthorized access
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
 
     User = get_user_model()
@@ -451,12 +431,10 @@ def test_staff_create(
         'send_mail': True})
 
     # check unauthorized access
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['staffCreate']
     assert data['errors'] == []
@@ -498,12 +476,10 @@ def test_staff_update(admin_api_client, staff_user, user_api_client):
     variables = json.dumps({'id': id, 'permissions': [], 'is_active': False})
 
     # check unauthorized access
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['staffUpdate']
     assert data['errors'] == []
@@ -529,12 +505,10 @@ def test_staff_delete(admin_api_client, staff_user, user_api_client):
     variables = json.dumps({'id': user_id})
 
     # check unauthorized access
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['staffDelete']
     assert data['errors'] == []
@@ -593,19 +567,16 @@ def test_set_password(user_api_client, customer_user):
     token = default_token_generator.make_token(customer_user)
     password = 'spanish-inquisition'
 
-    variables = {'id': id, 'password': password}
-
     # check invalid token
-    variables['token'] = 'nope'
-    response = user_api_client.post(
-        {'query': query, 'variables': json.dumps(variables)})
+    post_data = {'id': id, 'password': password, 'token': 'nope'}
+    variables = json.dumps(post_data)
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['setPassword']['errors']
     assert errors[0]['message'] == SetPassword.INVALID_TOKEN
 
-    variables['token'] = token
-    response = user_api_client.post(
-        {'query': query, 'variables': json.dumps(variables)})
+    post_data['token'] = token
+    response = user_api_client.post_graphql(query, json.dumps(post_data))
     content = get_graphql_content(response)
     data = content['data']['setPassword']
     assert data['user']['id']
@@ -629,8 +600,7 @@ def test_password_reset_email(
     """
     email = customer_user.email
     variables = json.dumps({'email': email})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
     assert data is None
@@ -657,8 +627,7 @@ def test_password_reset_email_non_existing_user(
     """
     email = 'not_exists@example.com'
     variables = json.dumps({'email': email})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['passwordReset']
     assert data['errors'] == [{
@@ -687,8 +656,7 @@ def test_create_address_mutation(admin_api_client, customer_user):
     user_id = graphene.Node.to_global_id('User', customer_user.id)
     variables = json.dumps(
         {'user': user_id, 'city': 'Dummy', 'country': 'PL'})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['addressCreate']['errors'] == []
     address_response = content['data']['addressCreate']['address']
@@ -713,8 +681,7 @@ def test_address_update_mutation(admin_api_client, customer_user):
     variables = {
         'addressId': graphene.Node.to_global_id('Address', address_obj.id),
         'city': new_city}
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['addressUpdate']
     assert data['address']['city'] == new_city
@@ -735,8 +702,7 @@ def test_address_delete_mutation(admin_api_client, customer_user):
     address_obj = customer_user.addresses.first()
     variables = {
         'id': graphene.Node.to_global_id('Address', address_obj.id)}
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['addressDelete']
     assert data['address']['city'] == address_obj.city
@@ -761,8 +727,7 @@ def test_address_validator(user_api_client):
         'countryArea': None,
         'cityArea': None
     }})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['addressValidator']
     assert data['countryCode'] == 'PL'
@@ -796,8 +761,7 @@ def test_address_validator_uses_geip_when_country_code_missing(
     monkeypatch.setattr(
         'saleor.graphql.account.resolvers.get_country_by_ip',
         mock_country_by_ip)
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert mock_country_by_ip.called
     data = content['data']['addressValidator']
@@ -820,14 +784,12 @@ def test_customer_reset_password(
     """
     # we have no user with given email
     variables = json.dumps({'email': 'non-existing-email@email.com'})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not send_password_reset_mock.called
 
     variables = json.dumps({'email': customer_user.email})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert send_password_reset_mock.called
     assert send_password_reset_mock.mock_calls[0][1][1] == customer_user.email

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -58,7 +58,7 @@ def test_attributes_query(user_api_client, product):
         }
     }
     '''
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']
     assert len(attributes_data) == attributes.count()
@@ -84,7 +84,7 @@ def test_attributes_in_category_query(user_api_client, product):
         }
     }
     ''' % {'category_id': graphene.Node.to_global_id('Category', category.id)}
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']
     assert len(attributes_data) == Attribute.objects.count()
@@ -116,10 +116,9 @@ def test_create_attribute_and_attribute_values(admin_api_client):
     query = CREATE_ATTRIBUTES_QUERY
     attribute_name = 'Example name'
     name = 'Value name'
-    variables = json.dumps({
-        'name': attribute_name, 'values': [{'name': name, 'value': '#1231'}]})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = {
+        'name': 'Example name', 'values': [{'name': name, 'value': '#1231'}]}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not content['data']['attributeCreate']['errors']
     data = content['data']['attributeCreate']['attribute']
@@ -142,13 +141,12 @@ def test_create_attribute_and_attribute_values(admin_api_client):
 def test_create_attribute_and_attribute_values_errors(
         admin_api_client, name_1, name_2, error_msg):
     query = CREATE_ATTRIBUTES_QUERY
-    variables = json.dumps({
+    variables = {
         'name': 'Example name',
         'values': [
             {'name': name_1, 'value': '#1231'},
-            {'name': name_2, 'value': '#121'}]})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+            {'name': name_2, 'value': '#121'}]}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['attributeCreate']['errors']
     assert errors
@@ -187,10 +185,8 @@ def test_update_attribute_name(admin_api_client, color_attribute):
     attribute = color_attribute
     name = 'Wings name'
     id = graphene.Node.to_global_id('Attribute', attribute.id)
-    variables = json.dumps({
-        'name': name, 'id': id, 'addValues': [], 'removeValues': []})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+    variables = {'name': name, 'id': id, 'addValues': [], 'removeValues': []}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     attribute.refresh_from_db()
     data = content['data']['attributeUpdate']
@@ -207,12 +203,11 @@ def test_update_attribute_remove_and_add_values(
     attribute_value_id = attribute.values.first().id
     value_id = graphene.Node.to_global_id(
         'AttributeValue', attribute_value_id)
-    variables = json.dumps({
+    variables = {
         'name': name, 'id': id,
         'addValues': [{'name': attribute_value_name, 'value': '#1231'}],
-        'removeValues': [value_id]})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+        'removeValues': [value_id]}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     attribute.refresh_from_db()
     data = content['data']['attributeUpdate']
@@ -235,12 +230,11 @@ def test_update_attribute_and_add_attribute_values_errors(
     query = UPDATE_ATTRIBUTE_QUERY
     attribute = color_attribute
     id = graphene.Node.to_global_id('Attribute', attribute.id)
-    variables = json.dumps({
+    variables = {
         'name': 'Example name', 'id': id, 'removeValues': [],
         'addValues': [
-            {'name': name_1, 'value': '#1'}, {'name': name_2, 'value': '#2'}]})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+            {'name': name_1, 'value': '#1'}, {'name': name_2, 'value': '#2'}]}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['attributeUpdate']['errors']
     assert errors
@@ -256,11 +250,10 @@ def test_update_attribute_and_remove_others_attribute_value(
     size_attribute = size_attribute.values.first()
     attr_id = graphene.Node.to_global_id(
         'AttributeValue', size_attribute.pk)
-    variables = json.dumps({
+    variables = {
         'name': 'Example name', 'id': id, 'slug': 'example-slug',
-        'addValues': [], 'removeValues': [attr_id]})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        'addValues': [], 'removeValues': [attr_id]}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['attributeUpdate']['errors']
     assert errors
@@ -282,9 +275,8 @@ def test_delete_attribute(admin_api_client, color_attribute):
     }
     """
     id = graphene.Node.to_global_id('Attribute', attribute.id)
-    variables = json.dumps({'id': id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = {'id': id}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     with pytest.raises(attribute._meta.model.DoesNotExist):
         attribute.refresh_from_db()
@@ -321,10 +313,8 @@ def test_create_attribute_value(admin_api_client, color_attribute):
     attribute_id = graphene.Node.to_global_id('Attribute', attribute.id)
     name = 'test name'
     value = 'test-string'
-    variables = json.dumps(
-        {'name': name, 'value': value, 'id': attribute_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = {'name': name, 'value': value, 'id': attribute_id}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributeValueCreate']
     assert not data['errors']
@@ -343,10 +333,9 @@ def test_create_attribute_value_not_unique_name(
     query = CREATE_ATTRIBUTE_VALUE_QUERY
     attribute_id = graphene.Node.to_global_id('Attribute', attribute.id)
     value_name = attribute.values.first().name
-    variables = json.dumps(
-        {'name': value_name, 'value': 'test-string', 'id': attribute_id})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+    variables = {
+        'name': value_name, 'value': 'test-string', 'id': attribute_id}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributeValueCreate']
     assert data['errors']
@@ -383,12 +372,9 @@ def test_update_attribute_value(admin_api_client, pink_attribute_value):
     value = pink_attribute_value
     id = graphene.Node.to_global_id('AttributeValue', value.id)
     name = 'Crimson name'
-    variables = json.dumps(
-        {'name': name, 'value': '#RED', 'id': id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = {'name': name, 'value': '#RED', 'id': id}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
-    value.refresh_from_db()
     data = content['data']['attributeValueUpdate']
     assert data['attributeValue']['name'] == name == value.name
     assert data['attributeValue']['slug'] == slugify(name)
@@ -401,12 +387,9 @@ def test_update_attribute_value_name_not_unique(
     value = pink_attribute_value.attribute.values.create(
         name='Example Name', slug='example-name', value='#RED')
     id = graphene.Node.to_global_id('AttributeValue', value.id)
-    variables = json.dumps(
-        {'name': pink_attribute_value.name, 'value': '#RED', 'id': id})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+    variables = {'name': pink_attribute_value.name, 'value': '#RED', 'id': id}
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
-    assert 'errors' not in content
     data = content['data']['attributeValueUpdate']
     assert data['errors']
     assert data['errors'][0]['field'] == 'name'
@@ -419,12 +402,9 @@ def test_update_same_attribute_value(
     value = pink_attribute_value
     id = graphene.Node.to_global_id('AttributeValue', value.id)
     attr_value = '#BLUE'
-    variables = json.dumps(
-        {'name': value.name, 'value': attr_value, 'id': id})
-    response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+    variables = {'name': value.name, 'value': attr_value, 'id': id}
+    response = admin_api_client.post(query, variables)
     content = get_graphql_content(response)
-    assert 'errors' not in content
     data = content['data']['attributeValueUpdate']
     assert not data['errors']
     assert data['attributeValue']['value'] == attr_value
@@ -445,9 +425,8 @@ def test_delete_attribute_value(
     }
     """
     id = graphene.Node.to_global_id('AttributeValue', value.id)
-    variables = json.dumps({'id': id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = {'id': id}
+    response = admin_api_client.post_graphql(query, variables)
     with pytest.raises(value._meta.model.DoesNotExist):
         value.refresh_from_db()
 
@@ -493,8 +472,7 @@ def test_query_attribute_values(
     }
     """
     variables = json.dumps({'id': attribute_id})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributes']['edges'][0]['node']
     values = data['values']

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -40,7 +40,7 @@ def test_attributes_to_hstore(product, color_attribute):
 
 def test_attributes_query(user_api_client, product):
     attributes = Attribute.objects.prefetch_related('values')
-    query = '''
+    query = """
     query {
         attributes {
             edges {
@@ -57,7 +57,7 @@ def test_attributes_query(user_api_client, product):
             }
         }
     }
-    '''
+    """
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']
@@ -66,7 +66,7 @@ def test_attributes_query(user_api_client, product):
 
 def test_attributes_in_category_query(user_api_client, product):
     category = Category.objects.first()
-    query = '''
+    query = """
     query {
         attributes(inCategory: "%(category_id)s") {
             edges {
@@ -83,7 +83,7 @@ def test_attributes_in_category_query(user_api_client, product):
             }
         }
     }
-    ''' % {'category_id': graphene.Node.to_global_id('Category', category.id)}
+    """ % {'category_id': graphene.Node.to_global_id('Category', category.id)}
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -1,9 +1,6 @@
-import json
-
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from django.template.defaultfilters import slugify
 from saleor.graphql.product.types import (
     AttributeValueType, resolve_attribute_value_type)
@@ -471,7 +468,7 @@ def test_query_attribute_values(
         }
     }
     """
-    variables = json.dumps({'id': attribute_id})
+    variables = {'id': attribute_id}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributes']['edges'][0]['node']

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -58,7 +58,7 @@ def test_attributes_query(user_api_client, product):
         }
     }
     '''
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']
     assert len(attributes_data) == attributes.count()
@@ -84,7 +84,7 @@ def test_attributes_in_category_query(user_api_client, product):
         }
     }
     ''' % {'category_id': graphene.Node.to_global_id('Category', category.id)}
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     attributes_data = content['data']['attributes']['edges']
     assert len(attributes_data) == Attribute.objects.count()
@@ -119,7 +119,7 @@ def test_create_attribute_and_attribute_values(admin_api_client):
     variables = json.dumps({
         'name': attribute_name, 'values': [{'name': name, 'value': '#1231'}]})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert not content['data']['attributeCreate']['errors']
     data = content['data']['attributeCreate']['attribute']
@@ -148,7 +148,7 @@ def test_create_attribute_and_attribute_values_errors(
             {'name': name_1, 'value': '#1231'},
             {'name': name_2, 'value': '#121'}]})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     errors = content['data']['attributeCreate']['errors']
     assert errors
@@ -212,7 +212,7 @@ def test_update_attribute_remove_and_add_values(
         'addValues': [{'name': attribute_value_name, 'value': '#1231'}],
         'removeValues': [value_id]})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     attribute.refresh_from_db()
     data = content['data']['attributeUpdate']
@@ -284,7 +284,7 @@ def test_delete_attribute(admin_api_client, color_attribute):
     id = graphene.Node.to_global_id('Attribute', attribute.id)
     variables = json.dumps({'id': id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     with pytest.raises(attribute._meta.model.DoesNotExist):
         attribute.refresh_from_db()
@@ -324,7 +324,7 @@ def test_create_attribute_value(admin_api_client, color_attribute):
     variables = json.dumps(
         {'name': name, 'value': value, 'id': attribute_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['attributeValueCreate']
     assert not data['errors']
@@ -386,7 +386,7 @@ def test_update_attribute_value(admin_api_client, pink_attribute_value):
     variables = json.dumps(
         {'name': name, 'value': '#RED', 'id': id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     value.refresh_from_db()
     data = content['data']['attributeValueUpdate']
@@ -447,7 +447,7 @@ def test_delete_attribute_value(
     id = graphene.Node.to_global_id('AttributeValue', value.id)
     variables = json.dumps({'id': id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     with pytest.raises(value._meta.model.DoesNotExist):
         value.refresh_from_db()
 
@@ -494,7 +494,7 @@ def test_query_attribute_values(
     """
     variables = json.dumps({'id': attribute_id})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['attributes']['edges'][0]['node']
     values = data['values']

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -373,6 +373,7 @@ def test_update_attribute_value(admin_api_client, pink_attribute_value):
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributeValueUpdate']
+    value.refresh_from_db()
     assert data['attributeValue']['name'] == name == value.name
     assert data['attributeValue']['slug'] == slugify(name)
     assert name in [value['name'] for value in data['attribute']['values']]
@@ -400,7 +401,7 @@ def test_update_same_attribute_value(
     id = graphene.Node.to_global_id('AttributeValue', value.id)
     attr_value = '#BLUE'
     variables = {'name': value.name, 'value': attr_value, 'id': id}
-    response = admin_api_client.post(query, variables)
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['attributeValueUpdate']
     assert not data['errors']

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -1,12 +1,11 @@
 import json
 
-import graphene
 import pytest
-from django.shortcuts import reverse
-from django.template.defaultfilters import slugify
-from tests.api.utils import get_graphql_content
 
+import graphene
+from django.template.defaultfilters import slugify
 from saleor.product.models import Category
+from tests.api.utils import get_graphql_content
 
 
 def test_category_query(user_api_client, product):

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -11,7 +11,7 @@ from saleor.product.models import Category
 
 def test_category_query(user_api_client, product):
     category = Category.objects.first()
-    query = '''
+    query = """
     query {
         category(id: "%(category_pk)s") {
             id
@@ -32,7 +32,7 @@ def test_category_query(user_api_client, product):
             }
         }
     }
-    ''' % {'category_pk': graphene.Node.to_global_id('Category', category.pk)}
+    """ % {'category_pk': graphene.Node.to_global_id('Category', category.pk)}
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     category_data = content['data']['category']

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -79,9 +77,9 @@ def test_category_create_mutation(admin_api_client):
     category_description = 'Test description'
 
     # test creating root category
-    variables = json.dumps({
+    variables = {
         'name': category_name, 'description': category_description,
-        'slug': category_slug})
+        'slug': category_slug}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
@@ -92,9 +90,9 @@ def test_category_create_mutation(admin_api_client):
 
     # test creating subcategory
     parent_id = data['category']['id']
-    variables = json.dumps({
+    variables = {
         'name': category_name, 'description': category_description,
-        'parentId': parent_id, 'slug': category_slug})
+        'parentId': parent_id, 'slug': category_slug}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
@@ -137,9 +135,9 @@ def test_category_update_mutation(admin_api_client, category):
     category_description = 'Updated description'
 
     category_id = graphene.Node.to_global_id('Category', child_category.pk)
-    variables = json.dumps({
+    variables = {
         'name': category_name, 'description': category_description,
-        'id': category_id, 'slug': category_slug})
+        'id': category_id, 'slug': category_slug}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryUpdate']
@@ -166,8 +164,7 @@ def test_category_delete_mutation(admin_api_client, category):
             }
         }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Category', category.id)})
+    variables = {'id': graphene.Node.to_global_id('Category', category.id)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryDelete']
@@ -193,7 +190,7 @@ def test_category_level(user_api_client, category):
     """
     child = Category.objects.create(
         name='child', slug='chi-ld', parent=category)
-    variables = json.dumps({'level': 0})
+    variables = {'level': 0}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']
@@ -214,7 +211,7 @@ def test_category_level(user_api_client, category):
         }
     }
     """
-    variables = json.dumps({'level': 1})
+    variables = {'level': 1}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -33,7 +33,7 @@ def test_category_query(user_api_client, product):
         }
     }
     ''' % {'category_pk': graphene.Node.to_global_id('Category', category.pk)}
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     category_data = content['data']['category']
     assert category_data is not None
@@ -83,8 +83,7 @@ def test_category_create_mutation(admin_api_client):
     variables = json.dumps({
         'name': category_name, 'description': category_description,
         'slug': category_slug})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
     assert data['errors'] == []
@@ -97,8 +96,7 @@ def test_category_create_mutation(admin_api_client):
     variables = json.dumps({
         'name': category_name, 'description': category_description,
         'parentId': parent_id, 'slug': category_slug})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
     assert data['errors'] == []
@@ -143,8 +141,7 @@ def test_category_update_mutation(admin_api_client, category):
     variables = json.dumps({
         'name': category_name, 'description': category_description,
         'id': category_id, 'slug': category_slug})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryUpdate']
     assert data['errors'] == []
@@ -172,8 +169,7 @@ def test_category_delete_mutation(admin_api_client, category):
     """
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Category', category.id)})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['categoryDelete']
     assert data['category']['name'] == category.name
@@ -199,8 +195,7 @@ def test_category_level(user_api_client, category):
     child = Category.objects.create(
         name='child', slug='chi-ld', parent=category)
     variables = json.dumps({'level': 0})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']
     assert category_data['name'] == category.name
@@ -221,8 +216,7 @@ def test_category_level(user_api_client, category):
     }
     """
     variables = json.dumps({'level': 1})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']
     assert category_data['name'] == child.name

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -33,7 +33,7 @@ def test_category_query(user_api_client, product):
         }
     }
     ''' % {'category_pk': graphene.Node.to_global_id('Category', category.pk)}
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     category_data = content['data']['category']
     assert category_data is not None
@@ -84,7 +84,7 @@ def test_category_create_mutation(admin_api_client):
         'name': category_name, 'description': category_description,
         'slug': category_slug})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
     assert data['errors'] == []
@@ -98,7 +98,7 @@ def test_category_create_mutation(admin_api_client):
         'name': category_name, 'description': category_description,
         'parentId': parent_id, 'slug': category_slug})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']
     assert data['errors'] == []
@@ -144,7 +144,7 @@ def test_category_update_mutation(admin_api_client, category):
         'name': category_name, 'description': category_description,
         'id': category_id, 'slug': category_slug})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['categoryUpdate']
     assert data['errors'] == []
@@ -173,7 +173,7 @@ def test_category_delete_mutation(admin_api_client, category):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Category', category.id)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['categoryDelete']
     assert data['category']['name'] == category.name
@@ -200,7 +200,7 @@ def test_category_level(user_api_client, category):
         name='child', slug='chi-ld', parent=category)
     variables = json.dumps({'level': 0})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']
     assert category_data['name'] == category.name
@@ -222,7 +222,7 @@ def test_category_level(user_api_client, category):
     """
     variables = json.dumps({'level': 1})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     category_data = content['data']['categories']['edges'][0]['node']
     assert category_data['name'] == child.name

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -35,7 +35,7 @@ def test_user_error_field_name_for_related_object(admin_api_client):
         }
     }
     """
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']['category']
     assert data is None
@@ -79,7 +79,7 @@ def test_mutation_returns_error_field_in_camel_case(admin_api_client, variant):
         'id': graphene.Node.to_global_id('ProductVariant', variant.id),
         'cost': 12.1234})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     error = content['data']['productVariantUpdate']['errors'][0]
     assert error['field'] == 'costPrice'

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import Mock
 
 import graphene
@@ -73,9 +72,9 @@ def test_mutation_returns_error_field_in_camel_case(admin_api_client, variant):
         }
     }
     """
-    variables = json.dumps({
+    variables = {
         'id': graphene.Node.to_global_id('ProductVariant', variant.id),
-        'cost': 12.1234})
+        'cost': 12.1234}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     error = content['data']['productVariantUpdate']['errors'][0]

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -35,7 +35,7 @@ def test_user_error_field_name_for_related_object(admin_api_client):
         }
     }
     """
-    response = admin_api_client.post({'query': query})
+    response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['categoryCreate']['category']
     assert data is None
@@ -78,8 +78,7 @@ def test_mutation_returns_error_field_in_camel_case(admin_api_client, variant):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('ProductVariant', variant.id),
         'cost': 12.1234})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     error = content['data']['productVariantUpdate']['errors'][0]
     assert error['field'] == 'costPrice'

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -2,12 +2,10 @@ import json
 from unittest.mock import Mock
 
 import graphene
-from django.shortcuts import reverse
-from tests.api.utils import get_graphql_content
-
 from saleor.graphql.core.utils import clean_seo_fields, snake_to_camel_case
 from saleor.graphql.product import types as product_types
 from saleor.graphql.utils import get_database_id
+from tests.api.utils import get_graphql_content
 
 
 def test_clean_seo_fields():

--- a/tests/api/test_discount.py
+++ b/tests/api/test_discount.py
@@ -1,14 +1,12 @@
 import json
 
-import graphene
 import pytest
-from django.shortcuts import reverse
-from tests.api.utils import get_graphql_content
 
-from saleor.discount import (
-    DiscountValueType, VoucherType)
+import graphene
+from saleor.discount import DiscountValueType, VoucherType
 from saleor.graphql.discount.types import (
     DiscountValueTypeEnum, VoucherTypeEnum)
+from tests.api.utils import get_graphql_content
 
 from .utils import assert_no_permission
 

--- a/tests/api/test_discount.py
+++ b/tests/api/test_discount.py
@@ -27,14 +27,14 @@ def test_voucher_permissions(
     }
     """
     # Query to ensure user with no permissions can't see vouchers
-    response = staff_api_client.post({'query': query})
+    response = staff_api_client.post_graphql(query)
     assert_no_permission(response)
 
     # Give staff user proper permissions
     staff_user.user_permissions.add(permission_manage_discounts)
 
     # Query again
-    response = staff_api_client.post({'query': query})
+    response = staff_api_client.post_graphql(query)
     get_graphql_content(response)
 
 
@@ -58,7 +58,7 @@ def test_voucher_query(
         }
     }
     """
-    response = admin_api_client.post({'query': query})
+    response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['vouchers']['edges'][0]['node']
     assert data['type'] == voucher.type.upper()
@@ -87,7 +87,7 @@ def test_sale_query(
             }
         }
         """
-    response = admin_api_client.post({'query': query})
+    response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['sales']['edges'][0]['node']
     assert data['type'] == sale.type.upper()
@@ -129,12 +129,10 @@ def test_create_voucher(user_api_client, admin_api_client):
         'discountValueType': DiscountValueTypeEnum.FIXED.name,
         'discountValue': 10.12,
         'minAmountSpent': 1.12})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['voucherCreate']['voucher']
     assert data['type'] == VoucherType.VALUE.upper()
@@ -170,12 +168,10 @@ def test_update_voucher(user_api_client, admin_api_client, voucher):
         'code': 'testcode123',
         'discountValueType': DiscountValueTypeEnum.PERCENTAGE.name})
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['voucherUpdate']['voucher']
     assert data['code'] == 'testcode123'
@@ -200,12 +196,10 @@ def test_voucher_delete_mutation(user_api_client, admin_api_client, voucher):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Voucher', voucher.id)})
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['voucherDelete']
     assert data['voucher']['name'] == voucher.name
@@ -234,12 +228,10 @@ def test_create_sale(user_api_client, admin_api_client):
         'name': 'test sale',
         'type': DiscountValueTypeEnum.FIXED.name,
         'value': '10.12'})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['saleCreate']['sale']
     assert data['type'] == DiscountValueType.FIXED.upper()
@@ -268,13 +260,11 @@ def test_update_sale(user_api_client, admin_api_client, sale):
         'id': graphene.Node.to_global_id('Sale', sale.id),
         'type': DiscountValueTypeEnum.PERCENTAGE.name})
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
 
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['saleUpdate']['sale']
     assert data['type'] == DiscountValueType.PERCENTAGE.upper()
@@ -298,12 +288,10 @@ def test_sale_delete_mutation(user_api_client, admin_api_client, sale):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Sale', sale.id)})
 
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['saleDelete']
     assert data['sale']['name'] == sale.name
@@ -334,8 +322,7 @@ def test_validate_voucher(voucher, admin_api_client):
         variables = json.dumps({
             'type': voucher_type.name,
             'id': graphene.Node.to_global_id('Voucher', voucher.id)})
-        response = admin_api_client.post(
-            {'query': query, 'variables': variables})
+        response = admin_api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         data = content['data']['voucherUpdate']['errors'][0]
         assert data['field'] == field_name

--- a/tests/api/test_discount.py
+++ b/tests/api/test_discount.py
@@ -27,14 +27,14 @@ def test_voucher_permissions(
     }
     """
     # Query to ensure user with no permissions can't see vouchers
-    response = staff_api_client.post(reverse('api'), {'query': query})
+    response = staff_api_client.post({'query': query})
     assert_no_permission(response)
 
     # Give staff user proper permissions
     staff_user.user_permissions.add(permission_manage_discounts)
 
     # Query again
-    response = staff_api_client.post(reverse('api'), {'query': query})
+    response = staff_api_client.post({'query': query})
     get_graphql_content(response)
 
 
@@ -58,7 +58,7 @@ def test_voucher_query(
         }
     }
     """
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['vouchers']['edges'][0]['node']
     assert data['type'] == voucher.type.upper()
@@ -87,7 +87,7 @@ def test_sale_query(
             }
         }
         """
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['sales']['edges'][0]['node']
     assert data['type'] == sale.type.upper()
@@ -130,11 +130,11 @@ def test_create_voucher(user_api_client, admin_api_client):
         'discountValue': 10.12,
         'minAmountSpent': 1.12})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['voucherCreate']['voucher']
     assert data['type'] == VoucherType.VALUE.upper()
@@ -171,11 +171,11 @@ def test_update_voucher(user_api_client, admin_api_client, voucher):
         'discountValueType': DiscountValueTypeEnum.PERCENTAGE.name})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['voucherUpdate']['voucher']
     assert data['code'] == 'testcode123'
@@ -201,11 +201,11 @@ def test_voucher_delete_mutation(user_api_client, admin_api_client, voucher):
         'id': graphene.Node.to_global_id('Voucher', voucher.id)})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['voucherDelete']
     assert data['voucher']['name'] == voucher.name
@@ -235,11 +235,11 @@ def test_create_sale(user_api_client, admin_api_client):
         'type': DiscountValueTypeEnum.FIXED.name,
         'value': '10.12'})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['saleCreate']['sale']
     assert data['type'] == DiscountValueType.FIXED.upper()
@@ -269,12 +269,12 @@ def test_update_sale(user_api_client, admin_api_client, sale):
         'type': DiscountValueTypeEnum.PERCENTAGE.name})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
 
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['saleUpdate']['sale']
     assert data['type'] == DiscountValueType.PERCENTAGE.upper()
@@ -299,11 +299,11 @@ def test_sale_delete_mutation(user_api_client, admin_api_client, sale):
         'id': graphene.Node.to_global_id('Sale', sale.id)})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['saleDelete']
     assert data['sale']['name'] == sale.name
@@ -335,7 +335,7 @@ def test_validate_voucher(voucher, admin_api_client):
             'type': voucher_type.name,
             'id': graphene.Node.to_global_id('Voucher', voucher.id)})
         response = admin_api_client.post(
-            reverse('api'), {'query': query, 'variables': variables})
+            {'query': query, 'variables': variables})
         content = get_graphql_content(response)
         data = content['data']['voucherUpdate']['errors'][0]
         assert data['field'] == field_name

--- a/tests/api/test_discount.py
+++ b/tests/api/test_discount.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -120,13 +118,13 @@ def test_create_voucher(user_api_client, admin_api_client):
             }
         }
     """
-    variables = json.dumps({
+    variables = {
         'name': 'test voucher',
         'type': VoucherTypeEnum.VALUE.name,
         'code': 'testcode123',
         'discountValueType': DiscountValueTypeEnum.FIXED.name,
         'discountValue': 10.12,
-        'minAmountSpent': 1.12})
+        'minAmountSpent': 1.12}
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
@@ -161,10 +159,10 @@ def test_update_voucher(user_api_client, admin_api_client, voucher):
     voucher.discount_value_type = DiscountValueType.FIXED
     voucher.save()
     assert voucher.code != 'testcode123'
-    variables = json.dumps({
+    variables = {
         'id': graphene.Node.to_global_id('Voucher', voucher.id),
         'code': 'testcode123',
-        'discountValueType': DiscountValueTypeEnum.PERCENTAGE.name})
+        'discountValueType': DiscountValueTypeEnum.PERCENTAGE.name}
 
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
@@ -191,8 +189,7 @@ def test_voucher_delete_mutation(user_api_client, admin_api_client, voucher):
               }
             }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Voucher', voucher.id)})
+    variables = {'id': graphene.Node.to_global_id('Voucher', voucher.id)}
 
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
@@ -222,10 +219,10 @@ def test_create_sale(user_api_client, admin_api_client):
             }
         }
     """
-    variables = json.dumps({
+    variables = {
         'name': 'test sale',
         'type': DiscountValueTypeEnum.FIXED.name,
-        'value': '10.12'})
+        'value': '10.12'}
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
@@ -254,9 +251,9 @@ def test_update_sale(user_api_client, admin_api_client, sale):
     # Set discount value type to 'fixed' and change it in mutation
     sale.type = DiscountValueType.FIXED
     sale.save()
-    variables = json.dumps({
+    variables = {
         'id': graphene.Node.to_global_id('Sale', sale.id),
-        'type': DiscountValueTypeEnum.PERCENTAGE.name})
+        'type': DiscountValueTypeEnum.PERCENTAGE.name}
 
     response = user_api_client.post_graphql(query, variables)
 
@@ -283,8 +280,7 @@ def test_sale_delete_mutation(user_api_client, admin_api_client, sale):
               }
             }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Sale', sale.id)})
+    variables = {'id': graphene.Node.to_global_id('Sale', sale.id)}
 
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
@@ -317,9 +313,9 @@ def test_validate_voucher(voucher, admin_api_client):
         (VoucherTypeEnum.PRODUCT, 'products'),
         (VoucherTypeEnum.COLLECTION, 'collections'))
     for voucher_type, field_name in fields:
-        variables = json.dumps({
+        variables = {
             'type': voucher_type.name,
-            'id': graphene.Node.to_global_id('Voucher', voucher.id)})
+            'id': graphene.Node.to_global_id('Voucher', voucher.id)}
         response = admin_api_client.post_graphql(query, variables)
         content = get_graphql_content(response)
         data = content['data']['voucherUpdate']['errors'][0]

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -1,12 +1,11 @@
 import json
 
-import graphene
 import pytest
-from django.shortcuts import reverse
-from tests.api.utils import get_graphql_content
 
+import graphene
 from saleor.order import OrderEvents, OrderEventsEmails
 from saleor.order.models import FulfillmentStatus
+from tests.api.utils import get_graphql_content
 
 CREATE_FULFILLMENT_QUERY = """
     mutation fulfillOrder(

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -43,10 +41,10 @@ def test_create_fulfillment(admin_api_client, order_with_lines, admin_user):
     order_line_id = graphene.Node.to_global_id('OrderLine', order_line.id)
     tracking = 'Flames tracking'
     assert not order.events.all()
-    variables = json.dumps(
-        {'order': order_id,
-         'lines': [{'orderLineId': order_line_id, 'quantity': 1}],
-         'tracking': tracking, 'notify': True})
+    variables = {
+        'order': order_id,
+        'lines': [{'orderLineId': order_line_id, 'quantity': 1}],
+        'tracking': tracking, 'notify': True}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']['fulfillment']
@@ -79,9 +77,9 @@ def test_create_fulfillment_not_sufficient_quantity(
     query = CREATE_FULFILLMENT_QUERY
     order_line = order_with_lines.lines.first()
     order_line_id = graphene.Node.to_global_id('OrderLine', order_line.id)
-    variables = json.dumps({
+    variables = {
         'order': graphene.Node.to_global_id('Order', order_with_lines.id),
-        'lines': [{'orderLineId': order_line_id, 'quantity': quantity}]})
+        'lines': [{'orderLineId': order_line_id, 'quantity': quantity}]}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']
@@ -103,8 +101,7 @@ def test_fulfillment_update_tracking(admin_api_client, fulfillment):
     """
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
     tracking = 'stationary tracking'
-    variables = json.dumps(
-        {'id': fulfillment_id, 'tracking': tracking})
+    variables = {'id': fulfillment_id, 'tracking': tracking}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentUpdateTracking']['fulfillment']
@@ -123,7 +120,7 @@ def test_cancel_fulfillment_restock_items(
         }
     """
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
-    variables = json.dumps({'id': fulfillment_id, 'restock': True})
+    variables = {'id': fulfillment_id, 'restock': True}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']
@@ -147,7 +144,7 @@ def test_cancel_fulfillment(admin_api_client, fulfillment, admin_user):
         }
     """
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
-    variables = json.dumps({'id': fulfillment_id, 'restock': False})
+    variables = {'id': fulfillment_id, 'restock': False}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -49,7 +49,7 @@ def test_create_fulfillment(admin_api_client, order_with_lines, admin_user):
          'lines': [{'orderLineId': order_line_id, 'quantity': 1}],
          'tracking': tracking, 'notify': True})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']['fulfillment']
     assert data['fulfillmentOrder'] == 1
@@ -85,7 +85,7 @@ def test_create_fulfillment_not_sufficient_quantity(
         'order': graphene.Node.to_global_id('Order', order_with_lines.id),
         'lines': [{'orderLineId': order_line_id, 'quantity': quantity}]})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']
     assert data['errors']
@@ -109,7 +109,7 @@ def test_fulfillment_update_tracking(admin_api_client, fulfillment):
     variables = json.dumps(
         {'id': fulfillment_id, 'tracking': tracking})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentUpdateTracking']['fulfillment']
     assert data['trackingNumber'] == tracking
@@ -129,7 +129,7 @@ def test_cancel_fulfillment_restock_items(
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
     variables = json.dumps({'id': fulfillment_id, 'restock': True})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']
     assert data['status'] == FulfillmentStatus.CANCELED.upper()
@@ -154,7 +154,7 @@ def test_cancel_fulfillment(admin_api_client, fulfillment, admin_user):
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
     variables = json.dumps({'id': fulfillment_id, 'restock': False})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']
     assert data['status'] == FulfillmentStatus.CANCELED.upper()

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -48,8 +48,7 @@ def test_create_fulfillment(admin_api_client, order_with_lines, admin_user):
         {'order': order_id,
          'lines': [{'orderLineId': order_line_id, 'quantity': 1}],
          'tracking': tracking, 'notify': True})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']['fulfillment']
     assert data['fulfillmentOrder'] == 1
@@ -84,8 +83,7 @@ def test_create_fulfillment_not_sufficient_quantity(
     variables = json.dumps({
         'order': graphene.Node.to_global_id('Order', order_with_lines.id),
         'lines': [{'orderLineId': order_line_id, 'quantity': quantity}]})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']
     assert data['errors']
@@ -108,8 +106,7 @@ def test_fulfillment_update_tracking(admin_api_client, fulfillment):
     tracking = 'stationary tracking'
     variables = json.dumps(
         {'id': fulfillment_id, 'tracking': tracking})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentUpdateTracking']['fulfillment']
     assert data['trackingNumber'] == tracking
@@ -128,8 +125,7 @@ def test_cancel_fulfillment_restock_items(
     """
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
     variables = json.dumps({'id': fulfillment_id, 'restock': True})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']
     assert data['status'] == FulfillmentStatus.CANCELED.upper()
@@ -153,8 +149,7 @@ def test_cancel_fulfillment(admin_api_client, fulfillment, admin_user):
     """
     fulfillment_id = graphene.Node.to_global_id('Fulfillment', fulfillment.id)
     variables = json.dumps({'id': fulfillment_id, 'restock': False})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCancel']['fulfillment']
     assert data['status'] == FulfillmentStatus.CANCELED.upper()

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import Mock, patch
 
 import pytest
@@ -176,12 +175,12 @@ def test_real_query(user_api_client, product):
         __typename
     }
     """
-    variables = json.dumps({
+    variables = {
         'categoryId': graphene.Node.to_global_id(
             'Category', category.id),
         'sortBy': 'name',
         'first': 1,
-        'attributesFilter': [filter_by]})
+        'attributesFilter': [filter_by]}
     response = user_api_client.post_graphql(query, variables)
     get_graphql_content(response)
 

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -176,17 +176,14 @@ def test_real_query(user_api_client, product):
         __typename
     }
     '''
-    response = user_api_client.post(
-        {
-            'query': query,
-            'variables': json.dumps(
-                {
-                    'categoryId': graphene.Node.to_global_id(
-                        'Category', category.id),
-                    'sortBy': 'name',
-                    'first': 1,
-                    'attributesFilter': [filter_by]})})
-    content = get_graphql_content(response)
+    variables = json.dumps({
+        'categoryId': graphene.Node.to_global_id(
+            'Category', category.id),
+        'sortBy': 'name',
+        'first': 1,
+        'attributesFilter': [filter_by]})
+    response = user_api_client.post_graphql(query, variables)
+    get_graphql_content(response)
 
 
 def test_get_nodes(product_list):

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -33,7 +33,8 @@ def test_jwt_middleware(admin_user):
 
     # test request with proper JWT token authorizes the request to API
     token = get_token(admin_user)
-    request = rf.get(reverse('api'), **{'HTTP_AUTHORIZATION': 'JWT %s' % token})
+    request = rf.get(
+        reverse('api'), **{'HTTP_AUTHORIZATION': 'JWT %s' % token})
     assert not hasattr(request, 'user')
     middleware(request)
     assert request.user == admin_user
@@ -176,7 +177,7 @@ def test_real_query(user_api_client, product):
     }
     '''
     response = user_api_client.post(
-        reverse('api'), {
+        {
             'query': query,
             'variables': json.dumps(
                 {

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -45,7 +45,7 @@ def test_real_query(user_api_client, product):
     category = product.category
     attr_value = product_attr.values.first()
     filter_by = '%s:%s' % (product_attr.slug, attr_value.slug)
-    query = '''
+    query = """
     query Root($categoryId: ID!, $sortBy: String, $first: Int, $attributesFilter: [AttributeScalar], $minPrice: Float, $maxPrice: Float) {
         category(id: $categoryId) {
             ...CategoryPageFragmentQuery
@@ -175,7 +175,7 @@ def test_real_query(user_api_client, product):
         }
         __typename
     }
-    '''
+    """
     variables = json.dumps({
         'categoryId': graphene.Node.to_global_id(
             'Category', category.id),

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -1,8 +1,9 @@
 import json
 from unittest.mock import Mock, patch
 
-import graphene
 import pytest
+
+import graphene
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Q
 from django.http import HttpResponse
@@ -10,12 +11,11 @@ from django.shortcuts import reverse
 from django.test import RequestFactory
 from graphql_jwt.shortcuts import get_token
 from graphql_relay import to_global_id
-from tests.api.utils import get_graphql_content
-
 from saleor.graphql.middleware import jwt_middleware
 from saleor.graphql.product.types import Product
 from saleor.graphql.utils import (
     filter_by_query_param, generate_query_argument_description, get_nodes)
+from tests.api.utils import get_graphql_content
 
 
 def test_jwt_middleware(admin_user):

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from saleor.graphql.menu.mutations import NavigationType
 from tests.api.utils import get_graphql_content
 

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -21,23 +21,20 @@ def test_menu_query(user_api_client, menu):
 
     # test query by name
     variables = json.dumps({'menu_name': menu.name})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
     # test query by id
     menu_id = graphene.Node.to_global_id('Menu', menu.id)
     variables = json.dumps({'id': menu_id})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
     # test query by invalid name returns null
     variables = json.dumps({'menu_name': 'not-a-menu'})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not content['data']['menu']
 
@@ -70,8 +67,7 @@ def test_menus_query(user_api_client, menu, menu_item):
     menu.save()
     menu_name = menu.name
     variables = json.dumps({'menu_name': menu_name})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     menu_data = content['data']['menus']['edges'][0]['node']
     assert menu_data['name'] == menu.name
@@ -107,8 +103,7 @@ def test_menu_items_query(user_api_client, menu_item, collection):
     menu_item.save()
     variables = json.dumps(
         {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItem']
     assert data['name'] == menu_item.name
@@ -138,8 +133,7 @@ def test_menu_item_query_static_url(user_api_client, menu_item):
     menu_item.save()
     variables = json.dumps(
         {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItem']
     assert data['name'] == menu_item.name
@@ -181,8 +175,7 @@ def test_create_menu(admin_api_client, collection, category, page):
     variables = json.dumps({
         'name': 'test-menu', 'collection': collection_id,
         'category': category_id, 'page': page_id, 'url': url})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuCreate']['menu']['name'] == 'test-menu'
 
@@ -200,8 +193,7 @@ def test_update_menu(admin_api_client, menu):
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     name = 'Blue oyster menu'
     variables = json.dumps({'id': menu_id, 'name': name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuUpdate']['menu']['name'] == name
 
@@ -218,8 +210,7 @@ def test_delete_menu(admin_api_client, menu):
         """
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     variables = json.dumps({'id': menu_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuDelete']['menu']['name'] == menu.name
     with pytest.raises(menu._meta.model.DoesNotExist):
@@ -244,8 +235,7 @@ def test_create_menu_item(admin_api_client, menu):
     url = 'http://www.example.com'
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     variables = json.dumps({'name': name, 'url': url, 'menu_id': menu_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemCreate']['menuItem']
     assert data['name'] == name
@@ -271,8 +261,7 @@ def test_update_menu_item(admin_api_client, menu, menu_item, page):
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     page_id = graphene.Node.to_global_id('Page', page.pk)
     variables = json.dumps({'id': menu_item_id, 'page': page_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['menuItem']
     assert data['page']['id'] == page_id
@@ -290,8 +279,7 @@ def test_delete_menu_item(admin_api_client, menu_item):
         """
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     variables = json.dumps({'id': menu_item_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemDelete']['menuItem']
     assert data['name'] == menu_item.name
@@ -318,8 +306,7 @@ def test_add_more_than_one_item(admin_api_client, menu, menu_item, page):
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     page_id = graphene.Node.to_global_id('Page', page.pk)
     variables = json.dumps({'id': menu_item_id, 'page': page_id, 'url': url})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['errors'][0]
     assert data['field'] == 'items'
@@ -347,16 +334,14 @@ def test_assign_menu(
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     variables = json.dumps({
         'menu': menu_id, 'navigationType': NavigationType.MAIN.name})
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
     staff_api_client.user.user_permissions.add(permission_manage_menus)
     staff_api_client.user.user_permissions.add(permission_manage_settings)
 
     # test assigning main menu
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['assignNavigation']['menu']['name'] == menu.name
     site_settings.refresh_from_db()
@@ -365,8 +350,7 @@ def test_assign_menu(
     # test assigning secondary menu
     variables = json.dumps({
         'menu': menu_id, 'navigationType': NavigationType.SECONDARY.name})
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['assignNavigation']['menu']['name'] == menu.name
     site_settings.refresh_from_db()
@@ -375,8 +359,7 @@ def test_assign_menu(
     # test unasigning menu
     variables = json.dumps({
         'id': None, 'navigationType': NavigationType.MAIN.name})
-    response = staff_api_client.post(
-        {'query': query, 'variables': variables})
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not content['data']['assignNavigation']['menu']
     site_settings.refresh_from_db()

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -22,7 +22,7 @@ def test_menu_query(user_api_client, menu):
     # test query by name
     variables = json.dumps({'menu_name': menu.name})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
@@ -30,14 +30,14 @@ def test_menu_query(user_api_client, menu):
     menu_id = graphene.Node.to_global_id('Menu', menu.id)
     variables = json.dumps({'id': menu_id})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
     # test query by invalid name returns null
     variables = json.dumps({'menu_name': 'not-a-menu'})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert not content['data']['menu']
 
@@ -71,7 +71,7 @@ def test_menus_query(user_api_client, menu, menu_item):
     menu_name = menu.name
     variables = json.dumps({'menu_name': menu_name})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     menu_data = content['data']['menus']['edges'][0]['node']
     assert menu_data['name'] == menu.name
@@ -108,7 +108,7 @@ def test_menu_items_query(user_api_client, menu_item, collection):
     variables = json.dumps(
         {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItem']
     assert data['name'] == menu_item.name
@@ -139,7 +139,7 @@ def test_menu_item_query_static_url(user_api_client, menu_item):
     variables = json.dumps(
         {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItem']
     assert data['name'] == menu_item.name
@@ -182,7 +182,7 @@ def test_create_menu(admin_api_client, collection, category, page):
         'name': 'test-menu', 'collection': collection_id,
         'category': category_id, 'page': page_id, 'url': url})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['menuCreate']['menu']['name'] == 'test-menu'
 
@@ -201,7 +201,7 @@ def test_update_menu(admin_api_client, menu):
     name = 'Blue oyster menu'
     variables = json.dumps({'id': menu_id, 'name': name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['menuUpdate']['menu']['name'] == name
 
@@ -219,7 +219,7 @@ def test_delete_menu(admin_api_client, menu):
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     variables = json.dumps({'id': menu_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['menuDelete']['menu']['name'] == menu.name
     with pytest.raises(menu._meta.model.DoesNotExist):
@@ -245,7 +245,7 @@ def test_create_menu_item(admin_api_client, menu):
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     variables = json.dumps({'name': name, 'url': url, 'menu_id': menu_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItemCreate']['menuItem']
     assert data['name'] == name
@@ -272,7 +272,7 @@ def test_update_menu_item(admin_api_client, menu, menu_item, page):
     page_id = graphene.Node.to_global_id('Page', page.pk)
     variables = json.dumps({'id': menu_item_id, 'page': page_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['menuItem']
     assert data['page']['id'] == page_id
@@ -291,7 +291,7 @@ def test_delete_menu_item(admin_api_client, menu_item):
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     variables = json.dumps({'id': menu_item_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItemDelete']['menuItem']
     assert data['name'] == menu_item.name
@@ -319,7 +319,7 @@ def test_add_more_than_one_item(admin_api_client, menu, menu_item, page):
     page_id = graphene.Node.to_global_id('Page', page.pk)
     variables = json.dumps({'id': menu_item_id, 'page': page_id, 'url': url})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['errors'][0]
     assert data['field'] == 'items'
@@ -348,7 +348,7 @@ def test_assign_menu(
     variables = json.dumps({
         'menu': menu_id, 'navigationType': NavigationType.MAIN.name})
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
     staff_api_client.user.user_permissions.add(permission_manage_menus)
@@ -356,7 +356,7 @@ def test_assign_menu(
 
     # test assigning main menu
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['assignNavigation']['menu']['name'] == menu.name
     site_settings.refresh_from_db()
@@ -366,7 +366,7 @@ def test_assign_menu(
     variables = json.dumps({
         'menu': menu_id, 'navigationType': NavigationType.SECONDARY.name})
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['assignNavigation']['menu']['name'] == menu.name
     site_settings.refresh_from_db()
@@ -376,7 +376,7 @@ def test_assign_menu(
     variables = json.dumps({
         'id': None, 'navigationType': NavigationType.MAIN.name})
     response = staff_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert not content['data']['assignNavigation']['menu']
     site_settings.refresh_from_db()

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -19,20 +17,20 @@ def test_menu_query(user_api_client, menu):
     """
 
     # test query by name
-    variables = json.dumps({'menu_name': menu.name})
+    variables = {'menu_name': menu.name}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
     # test query by id
     menu_id = graphene.Node.to_global_id('Menu', menu.id)
-    variables = json.dumps({'id': menu_id})
+    variables = {'id': menu_id}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menu']['name'] == menu.name
 
     # test query by invalid name returns null
-    variables = json.dumps({'menu_name': 'not-a-menu'})
+    variables = {'menu_name': 'not-a-menu'}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not content['data']['menu']
@@ -65,7 +63,7 @@ def test_menus_query(user_api_client, menu, menu_item):
     menu.items.add(menu_item)
     menu.save()
     menu_name = menu.name
-    variables = json.dumps({'menu_name': menu_name})
+    variables = {'menu_name': menu_name}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     menu_data = content['data']['menus']['edges'][0]['node']
@@ -100,8 +98,7 @@ def test_menu_items_query(user_api_client, menu_item, collection):
     menu_item.collection = collection
     menu_item.url = None
     menu_item.save()
-    variables = json.dumps(
-        {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
+    variables = {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItem']
@@ -130,8 +127,7 @@ def test_menu_item_query_static_url(user_api_client, menu_item):
     """
     menu_item.url = "http://example.com"
     menu_item.save()
-    variables = json.dumps(
-        {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)})
+    variables = {'id': graphene.Node.to_global_id('MenuItem', menu_item.pk)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItem']
@@ -171,9 +167,9 @@ def test_create_menu(admin_api_client, collection, category, page):
     page_id = graphene.Node.to_global_id('Page', page.pk)
     url = 'http://www.example.com'
 
-    variables = json.dumps({
+    variables = {
         'name': 'test-menu', 'collection': collection_id,
-        'category': category_id, 'page': page_id, 'url': url})
+        'category': category_id, 'page': page_id, 'url': url}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuCreate']['menu']['name'] == 'test-menu'
@@ -191,7 +187,7 @@ def test_update_menu(admin_api_client, menu):
     """
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
     name = 'Blue oyster menu'
-    variables = json.dumps({'id': menu_id, 'name': name})
+    variables = {'id': menu_id, 'name': name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuUpdate']['menu']['name'] == name
@@ -208,7 +204,7 @@ def test_delete_menu(admin_api_client, menu):
         }
         """
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
-    variables = json.dumps({'id': menu_id})
+    variables = {'id': menu_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['menuDelete']['menu']['name'] == menu.name
@@ -233,7 +229,7 @@ def test_create_menu_item(admin_api_client, menu):
     name = 'item menu'
     url = 'http://www.example.com'
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
-    variables = json.dumps({'name': name, 'url': url, 'menu_id': menu_id})
+    variables = {'name': name, 'url': url, 'menu_id': menu_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemCreate']['menuItem']
@@ -259,7 +255,7 @@ def test_update_menu_item(admin_api_client, menu, menu_item, page):
     assert not menu_item.page
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     page_id = graphene.Node.to_global_id('Page', page.pk)
-    variables = json.dumps({'id': menu_item_id, 'page': page_id})
+    variables = {'id': menu_item_id, 'page': page_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['menuItem']
@@ -277,7 +273,7 @@ def test_delete_menu_item(admin_api_client, menu_item):
         }
         """
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
-    variables = json.dumps({'id': menu_item_id})
+    variables = {'id': menu_item_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemDelete']['menuItem']
@@ -304,7 +300,7 @@ def test_add_more_than_one_item(admin_api_client, menu, menu_item, page):
     url = 'http://www.example.com'
     menu_item_id = graphene.Node.to_global_id('MenuItem', menu_item.pk)
     page_id = graphene.Node.to_global_id('Page', page.pk)
-    variables = json.dumps({'id': menu_item_id, 'page': page_id, 'url': url})
+    variables = {'id': menu_item_id, 'page': page_id, 'url': url}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['menuItemUpdate']['errors'][0]
@@ -331,8 +327,7 @@ def test_assign_menu(
 
     # test mutations fails without proper permissions
     menu_id = graphene.Node.to_global_id('Menu', menu.pk)
-    variables = json.dumps({
-        'menu': menu_id, 'navigationType': NavigationType.MAIN.name})
+    variables = {'menu': menu_id, 'navigationType': NavigationType.MAIN.name}
     response = staff_api_client.post_graphql(query, variables)
     assert_no_permission(response)
 
@@ -347,8 +342,8 @@ def test_assign_menu(
     assert site_settings.top_menu.name == menu.name
 
     # test assigning secondary menu
-    variables = json.dumps({
-        'menu': menu_id, 'navigationType': NavigationType.SECONDARY.name})
+    variables = {
+        'menu': menu_id, 'navigationType': NavigationType.SECONDARY.name}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['assignNavigation']['menu']['name'] == menu.name
@@ -356,8 +351,7 @@ def test_assign_menu(
     assert site_settings.bottom_menu.name == menu.name
 
     # test unasigning menu
-    variables = json.dumps({
-        'id': None, 'navigationType': NavigationType.MAIN.name})
+    variables = {'id': None, 'navigationType': NavigationType.MAIN.name}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert not content['data']['assignNavigation']['menu']

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -47,7 +47,7 @@ def test_orderline_query(admin_api_client, fulfilled_order):
     line.save()
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     order_data = content['data']['orders']['edges'][0]['node']
     lines_data = order_data['lines']['edges']
@@ -109,7 +109,7 @@ def test_order_query(admin_api_client, fulfilled_order, shipping_zone):
     }
     """
     response = admin_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     order_data = content['data']['orders']['edges'][0]['node']
     assert order_data['number'] == str(order.pk)
@@ -176,7 +176,7 @@ def test_order_events_query(admin_api_client, fulfilled_order, admin_user):
             'quantity': '10',
             'composed_id': '10-10'})
     response = admin_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     data = content['data']['orders']['edges'][0]['node']['events'][0]
     assert data['message'] == event.parameters['message']
@@ -203,7 +203,7 @@ def test_non_staff_user_can_only_see_his_order(user_api_client, order):
     ID = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': ID})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     order_data = content['data']['order']
     assert order_data['number'] == str(order.pk)
@@ -211,7 +211,7 @@ def test_non_staff_user_can_only_see_his_order(user_api_client, order):
     order.user = None
     order.save()
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     order_data = content['data']['order']
     assert not order_data
@@ -277,7 +277,7 @@ def test_draft_order_create(
             'lines': variant_list, 'shippingAddress': shipping_address,
             'shippingMethod': shipping_id, 'voucher': voucher_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderCreate']['order']
     assert data['status'] == OrderStatus.DRAFT.upper()
@@ -310,7 +310,7 @@ def test_draft_order_update(admin_api_client, order_with_lines):
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id, 'email': email})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderUpdate']['order']
     assert data['userEmail'] == email
@@ -330,7 +330,7 @@ def test_draft_order_delete(admin_api_client, order_with_lines):
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     with pytest.raises(order._meta.model.DoesNotExist):
         order.refresh_from_db()
 
@@ -376,7 +376,7 @@ def test_draft_order_complete(admin_api_client, admin_user, draft_order):
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderComplete']['order']
     order.refresh_from_db()
@@ -430,14 +430,12 @@ def test_draft_order_line_create(
 
     # mutation should fail without proper permissions
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_CREATE_MUTATION, 'variables': variables})
     assert_no_permission(response)
 
     # assign permissions
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_CREATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineCreate']
@@ -448,7 +446,6 @@ def test_draft_order_line_create(
     variables = json.dumps({
         'orderId': order_id, 'variantId': variant_id, 'quantity': 0})
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_CREATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineCreate']
@@ -466,7 +463,6 @@ def test_require_draft_order_when_creating_lines(
     variables = json.dumps({
         'orderId': order_id, 'variantId': variant_id, 'quantity': 1})
     response = admin_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_CREATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineCreate']
@@ -506,14 +502,12 @@ def test_draft_order_line_update(
 
     # mutation should fail without proper permissions
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_UPDATE_MUTATION, 'variables': variables})
     assert_no_permission(response)
 
     # assign permissions
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_UPDATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
@@ -522,7 +516,6 @@ def test_draft_order_line_update(
     # mutation should fail when quantity is lower than 1
     variables = json.dumps({'lineId': line_id, 'quantity': 0})
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_UPDATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
@@ -537,7 +530,6 @@ def test_require_draft_order_when_updating_lines(
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
     variables = json.dumps({'lineId': line_id, 'quantity': 1})
     response = admin_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_UPDATE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
@@ -571,14 +563,12 @@ def test_draft_order_line_remove(
 
     # mutation should fail without proper permissions
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_DELETE_MUTATION, 'variables': variables})
     assert_no_permission(response)
 
     # assign permissions
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_DELETE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineDelete']
@@ -593,7 +583,6 @@ def test_require_draft_order_when_removing_lines(
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
     variables = json.dumps({'id': line_id})
     response = admin_api_client.post(
-        reverse('api'),
         {'query': DRAFT_ORDER_LINE_DELETE_MUTATION, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineDelete']
@@ -633,7 +622,7 @@ def test_order_update(admin_api_client, order_with_lines):
         {'id': order_id, 'email': email, 'first_name': first_name,
          'last_name': last_name, 'country_code': 'PL'})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdate']['order']
     assert data['userEmail'] == email
@@ -669,7 +658,7 @@ def test_order_add_note(admin_api_client, order_with_lines, admin_user):
     message = 'nuclear note'
     variables = json.dumps({'id': order_id, 'message': message})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderAddNote']
 
@@ -702,7 +691,7 @@ def test_order_cancel_and_restock(admin_api_client, order_with_lines):
     quantity = order.get_total_quantity()
     variables = json.dumps({'id': order_id, 'restock': restock})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderCancel']['order']
     order.refresh_from_db()
@@ -719,7 +708,7 @@ def test_order_cancel(admin_api_client, order_with_lines):
     restock = False
     variables = json.dumps({'id': order_id, 'restock': restock})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderCancel']['order']
     order.refresh_from_db()
@@ -747,7 +736,7 @@ def test_order_capture(admin_api_client, payment_preauth, admin_user):
     amount = float(payment_preauth.get_total().gross.amount)
     variables = json.dumps({'id': order_id, 'amount': amount})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderCapture']['order']
     order.refresh_from_db()
@@ -788,7 +777,7 @@ def test_paid_order_mark_as_paid(
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     errors = content['data']['orderMarkAsPaid']['errors']
     msg = 'Orders with payments can not be manually marked as paid.'
@@ -816,7 +805,7 @@ def test_order_mark_as_paid(
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderMarkAsPaid']['order']
     order.refresh_from_db()
@@ -841,7 +830,7 @@ def test_order_release(admin_api_client, payment_preauth, admin_user):
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'id': order_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderRelease']['order']
     assert data['paymentStatus'] == PaymentStatusEnum.REFUNDED.name
@@ -867,7 +856,7 @@ def test_order_refund(admin_api_client, payment_confirmed):
     amount = float(payment_confirmed.get_total().gross.amount)
     variables = json.dumps({'id': order_id, 'amount': amount})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderRefund']['order']
     order.refresh_from_db()
@@ -959,7 +948,7 @@ def test_order_update_shipping(
         'ShippingMethod', shipping_method.id)
     variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
     assert data['order']['id'] == order_id
@@ -983,7 +972,7 @@ def test_order_update_shipping_clear_shipping_method(
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'order': order_id, 'shippingMethod': None})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
     assert data['order']['id'] == order_id
@@ -1001,7 +990,7 @@ def test_order_update_shipping_shipping_required(
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = json.dumps({'order': order_id, 'shippingMethod': None})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
     assert data['errors'][0]['field'] == 'shippingMethod'
@@ -1020,7 +1009,7 @@ def test_order_update_shipping_no_shipping_address(
         'ShippingMethod', shipping_method.id)
     variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
     assert data['errors'][0]['field'] == 'order'
@@ -1042,7 +1031,7 @@ def test_order_update_shipping_incorrect_shipping_method(
         'ShippingMethod', shipping_method.id)
     variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
     assert data['errors'][0]['field'] == 'shippingMethod'

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -197,7 +196,7 @@ def test_non_staff_user_can_only_see_his_order(user_api_client, order):
     }
     """
     ID = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': ID})
+    variables = {'id': ID}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     order_data = content['data']['order']
@@ -265,11 +264,10 @@ def test_draft_order_create(
     shipping_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.id)
     voucher_id = graphene.Node.to_global_id('Voucher', voucher.id)
-    variables = json.dumps(
-        {
-            'user': user_id, 'discount': discount,
-            'lines': variant_list, 'shippingAddress': shipping_address,
-            'shippingMethod': shipping_id, 'voucher': voucher_id})
+    variables = {
+        'user': user_id, 'discount': discount,
+        'lines': variant_list, 'shippingAddress': shipping_address,
+        'shippingMethod': shipping_id, 'voucher': voucher_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderCreate']['order']
@@ -301,7 +299,7 @@ def test_draft_order_update(admin_api_client, order_with_lines):
         """
     email = 'not_default@example.com'
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id, 'email': email})
+    variables = {'id': order_id, 'email': email}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderUpdate']['order']
@@ -320,7 +318,7 @@ def test_draft_order_delete(admin_api_client, order_with_lines):
         }
         """
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id})
+    variables = {'id': order_id}
     response = admin_api_client.post_graphql(query, variables)
     with pytest.raises(order._meta.model.DoesNotExist):
         order.refresh_from_db()
@@ -365,7 +363,7 @@ def test_draft_order_complete(admin_api_client, admin_user, draft_order):
     assert line_2.variant.quantity_available < line_2.quantity
 
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id})
+    variables = {'id': order_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderComplete']['order']
@@ -416,8 +414,8 @@ def test_draft_order_line_create(
     quantity = 1
     order_id = graphene.Node.to_global_id('Order', order.id)
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.id)
-    variables = json.dumps({
-        'orderId': order_id, 'variantId': variant_id, 'quantity': quantity})
+    variables = {
+        'orderId': order_id, 'variantId': variant_id, 'quantity': quantity}
 
     # mutation should fail without proper permissions
     response = staff_api_client.post_graphql(query, variables)
@@ -432,8 +430,7 @@ def test_draft_order_line_create(
     assert data['orderLine']['quantity'] == old_quantity + quantity
 
     # mutation should fail when quantity is lower than 1
-    variables = json.dumps({
-        'orderId': order_id, 'variantId': variant_id, 'quantity': 0})
+    variables = {'orderId': order_id, 'variantId': variant_id, 'quantity': 0}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineCreate']
@@ -449,8 +446,7 @@ def test_require_draft_order_when_creating_lines(
     variant = line.variant
     order_id = graphene.Node.to_global_id('Order', order.id)
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.id)
-    variables = json.dumps({
-        'orderId': order_id, 'variantId': variant_id, 'quantity': 1})
+    variables = {'orderId': order_id, 'variantId': variant_id, 'quantity': 1}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineCreate']
@@ -487,7 +483,7 @@ def test_draft_order_line_update(
     line = order.lines.first()
     new_quantity = 1
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = json.dumps({'lineId': line_id, 'quantity': new_quantity})
+    variables = {'lineId': line_id, 'quantity': new_quantity}
 
     # mutation should fail without proper permissions
     response = staff_api_client.post_graphql(query, variables)
@@ -501,7 +497,7 @@ def test_draft_order_line_update(
     assert data['orderLine']['quantity'] == new_quantity
 
     # mutation should fail when quantity is lower than 1
-    variables = json.dumps({'lineId': line_id, 'quantity': 0})
+    variables = {'lineId': line_id, 'quantity': 0}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
@@ -515,7 +511,7 @@ def test_require_draft_order_when_updating_lines(
     order = order_with_lines
     line = order.lines.first()
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = json.dumps({'lineId': line_id, 'quantity': 1})
+    variables = {'lineId': line_id, 'quantity': 1}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
@@ -546,7 +542,7 @@ def test_draft_order_line_remove(
     order = draft_order
     line = order.lines.first()
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = json.dumps({'id': line_id})
+    variables = {'id': line_id}
 
     # mutation should fail without proper permissions
     response = staff_api_client.post_graphql(query, variables)
@@ -567,7 +563,7 @@ def test_require_draft_order_when_removing_lines(
     order = order_with_lines
     line = order.lines.first()
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = json.dumps({'id': line_id})
+    variables = {'id': line_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineDelete']
@@ -603,9 +599,9 @@ def test_order_update(admin_api_client, order_with_lines):
     assert not order.shipping_address.first_name == first_name
     assert not order.billing_address.last_name == last_name
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps(
-        {'id': order_id, 'email': email, 'first_name': first_name,
-         'last_name': last_name, 'country_code': 'PL'})
+    variables = {
+        'id': order_id, 'email': email, 'first_name': first_name,
+        'last_name': last_name, 'country_code': 'PL'}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdate']['order']
@@ -640,7 +636,7 @@ def test_order_add_note(admin_api_client, order_with_lines, admin_user):
     assert not order.events.all()
     order_id = graphene.Node.to_global_id('Order', order.id)
     message = 'nuclear note'
-    variables = json.dumps({'id': order_id, 'message': message})
+    variables = {'id': order_id, 'message': message}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderAddNote']
@@ -672,7 +668,7 @@ def test_order_cancel_and_restock(admin_api_client, order_with_lines):
     order_id = graphene.Node.to_global_id('Order', order.id)
     restock = True
     quantity = order.get_total_quantity()
-    variables = json.dumps({'id': order_id, 'restock': restock})
+    variables = {'id': order_id, 'restock': restock}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderCancel']['order']
@@ -688,7 +684,7 @@ def test_order_cancel(admin_api_client, order_with_lines):
     query = CANCEL_ORDER_QUERY
     order_id = graphene.Node.to_global_id('Order', order.id)
     restock = False
-    variables = json.dumps({'id': order_id, 'restock': restock})
+    variables = {'id': order_id, 'restock': restock}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderCancel']['order']
@@ -715,7 +711,7 @@ def test_order_capture(admin_api_client, payment_preauth, admin_user):
     """
     order_id = graphene.Node.to_global_id('Order', order.id)
     amount = float(payment_preauth.get_total().gross.amount)
-    variables = json.dumps({'id': order_id, 'amount': amount})
+    variables = {'id': order_id, 'amount': amount}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderCapture']['order']
@@ -755,7 +751,7 @@ def test_paid_order_mark_as_paid(
             }
         """
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id})
+    variables = {'id': order_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     errors = content['data']['orderMarkAsPaid']['errors']
@@ -782,7 +778,7 @@ def test_order_mark_as_paid(
         """
     assert not order.is_fully_paid()
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id})
+    variables = {'id': order_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderMarkAsPaid']['order']
@@ -806,7 +802,7 @@ def test_order_release(admin_api_client, payment_preauth, admin_user):
             }
         """
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'id': order_id})
+    variables = {'id': order_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderRelease']['order']
@@ -831,7 +827,7 @@ def test_order_refund(admin_api_client, payment_confirmed):
     """
     order_id = graphene.Node.to_global_id('Order', order.id)
     amount = float(payment_confirmed.get_total().gross.amount)
-    variables = json.dumps({'id': order_id, 'amount': amount})
+    variables = {'id': order_id, 'amount': amount}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderRefund']['order']
@@ -922,7 +918,7 @@ def test_order_update_shipping(
     order_id = graphene.Node.to_global_id('Order', order.id)
     method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.id)
-    variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
+    variables = {'order': order_id, 'shippingMethod': method_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
@@ -945,7 +941,7 @@ def test_order_update_shipping_clear_shipping_method(
 
     query = ORDER_UPDATE_SHIPPING_QUERY
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'order': order_id, 'shippingMethod': None})
+    variables = {'order': order_id, 'shippingMethod': None}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
@@ -962,7 +958,7 @@ def test_order_update_shipping_shipping_required(
     order = order_with_lines
     query = ORDER_UPDATE_SHIPPING_QUERY
     order_id = graphene.Node.to_global_id('Order', order.id)
-    variables = json.dumps({'order': order_id, 'shippingMethod': None})
+    variables = {'order': order_id, 'shippingMethod': None}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
@@ -980,7 +976,7 @@ def test_order_update_shipping_no_shipping_address(
     order_id = graphene.Node.to_global_id('Order', order.id)
     method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.id)
-    variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
+    variables = {'order': order_id, 'shippingMethod': method_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']
@@ -1001,7 +997,7 @@ def test_order_update_shipping_incorrect_shipping_method(
     order_id = graphene.Node.to_global_id('Order', order.id)
     method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.id)
-    variables = json.dumps({'order': order_id, 'shippingMethod': method_id})
+    variables = {'order': order_id, 'shippingMethod': method_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['orderUpdateShipping']

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from payments import PaymentStatus
 from saleor.account.models import Address
 from saleor.core.utils.taxes import ZERO_TAXED_MONEY

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -20,8 +20,7 @@ def test_page_query(user_api_client, page):
     """
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Page', page.id)})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     page_data = content['data']['page']
     assert page_data['title'] == page.title
@@ -60,8 +59,7 @@ def test_page_create_mutation(admin_api_client):
     variables = json.dumps({
         'title': page_title, 'content': page_content,
         'isVisible': page_isVisible, 'slug': page_slug})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['pageCreate']
     assert data['errors'] == []
@@ -88,8 +86,7 @@ def test_page_delete_mutation(admin_api_client, page):
     """
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Page', page.id)})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['pageDelete']
     assert data['page']['title'] == page.title
@@ -124,8 +121,7 @@ def test_paginate_pages(user_api_client, page):
             }
         }
         """
-    response = user_api_client.post(
-        {'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     pages_data = content['data']['pages']
     assert len(pages_data['edges']) == 2

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -17,8 +15,7 @@ def test_page_query(user_api_client, page):
         }
     }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Page', page.id)})
+    variables = {'id': graphene.Node.to_global_id('Page', page.id)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     page_data = content['data']['page']
@@ -55,9 +52,9 @@ def test_page_create_mutation(admin_api_client):
     page_isVisible = True
 
     # test creating root page
-    variables = json.dumps({
+    variables = {
         'title': page_title, 'content': page_content,
-        'isVisible': page_isVisible, 'slug': page_slug})
+        'isVisible': page_isVisible, 'slug': page_slug}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['pageCreate']
@@ -83,8 +80,7 @@ def test_page_delete_mutation(admin_api_client, page):
               }
             }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('Page', page.id)})
+    variables = {'id': graphene.Node.to_global_id('Page', page.id)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['pageDelete']

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -21,7 +21,7 @@ def test_page_query(user_api_client, page):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Page', page.id)})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     page_data = content['data']['page']
     assert page_data['title'] == page.title
@@ -61,7 +61,7 @@ def test_page_create_mutation(admin_api_client):
         'title': page_title, 'content': page_content,
         'isVisible': page_isVisible, 'slug': page_slug})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['pageCreate']
     assert data['errors'] == []
@@ -89,7 +89,7 @@ def test_page_delete_mutation(admin_api_client, page):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('Page', page.id)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['pageDelete']
     assert data['page']['title'] == page.title
@@ -125,7 +125,7 @@ def test_paginate_pages(user_api_client, page):
         }
         """
     response = user_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     pages_data = content['data']['pages']
     assert len(pages_data['edges']) == 2

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from saleor.page.models import Page
 from tests.api.utils import get_graphql_content
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -4,7 +4,6 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from django.utils.text import slugify
 from graphql_relay import to_global_id
 from prices import Money

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1,4 +1,3 @@
-import json
 from unittest.mock import MagicMock, Mock
 
 import pytest
@@ -153,9 +152,9 @@ def test_query_product_image_by_id(user_api_client, product_with_image):
         }
     }
     """
-    variables = json.dumps({
+    variables = {
         'productId': graphene.Node.to_global_id('Product', product_with_image.pk),
-        'imageId': graphene.Node.to_global_id('ProductImage', image.pk)})
+        'imageId': graphene.Node.to_global_id('ProductImage', image.pk)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
 
@@ -178,7 +177,7 @@ def test_product_with_collections(admin_api_client, product, collection):
     product.save()
     product_id = graphene.Node.to_global_id('Product', product.id)
 
-    variables = json.dumps({'productID': product_id})
+    variables = {'productID': product_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['product']
@@ -199,8 +198,8 @@ def test_filter_product_by_category(user_api_client, product):
         }
     }
     """
-    variables = json.dumps({
-        'categoryId': graphene.Node.to_global_id('Category', category.id)})
+    variables = {
+        'categoryId': graphene.Node.to_global_id('Category', category.id)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     product_data = content['data']['products']['edges'][0]['node']
@@ -217,8 +216,8 @@ def test_fetch_product_by_id(user_api_client, product):
         }
     }
     """
-    variables = json.dumps({
-        'productId': graphene.Node.to_global_id('Product', product.id)})
+    variables = {
+        'productId': graphene.Node.to_global_id('Product', product.id)}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     product_data = content['data']['node']
@@ -370,7 +369,7 @@ def test_create_product(
     non_existent_attr_value = 'The cake is a lie'
 
     # test creating root product
-    variables = json.dumps({
+    variables = {
         'productTypeId': product_type_id,
         'categoryId': category_id,
         'name': product_name,
@@ -381,7 +380,7 @@ def test_create_product(
         'price': product_price,
         'attributes': [
             {'slug': color_attr_slug, 'value': color_value_slug},
-            {'slug': size_attr_slug, 'value': non_existent_attr_value}]})
+            {'slug': size_attr_slug, 'value': non_existent_attr_value}]}
 
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -467,7 +466,7 @@ def test_update_product(
     product_taxRate = 'STANDARD'
     product_price = "33.12"
 
-    variables = json.dumps({
+    variables = {
         'productId': product_id,
         'categoryId': category_id,
         'name': product_name,
@@ -475,7 +474,7 @@ def test_update_product(
         'isPublished': product_isPublished,
         'chargeTaxes': product_chargeTaxes,
         'taxRate': product_taxRate,
-        'price': product_price})
+        'price': product_price}
 
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -505,7 +504,7 @@ def test_delete_product(admin_api_client, product):
             }
     """
     node_id = graphene.Node.to_global_id('Product', product.id)
-    variables = json.dumps({'id': node_id})
+    variables = {'id': node_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productDelete']
@@ -564,8 +563,8 @@ def test_product_type_query(
     no_products = Product.objects.count()
     product.is_published = False
     product.save()
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('ProductType', product_type.id)})
+    variables = {
+        'id': graphene.Node.to_global_id('ProductType', product_type.id)}
 
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -629,12 +628,12 @@ def test_product_type_create_mutation(admin_api_client, product_type):
         graphene.Node.to_global_id('Attribute', att.id) for att in
         variant_attributes]
 
-    variables = json.dumps({
+    variables = {
         'name': product_type_name, 'hasVariants': has_variants,
         'taxRate': 'STANDARD',
         'isShippingRequired': require_shipping,
         'productAttributes': product_attributes_ids,
-        'variantAttributes': variant_attributes_ids})
+        'variantAttributes': variant_attributes_ids}
     initial_count = ProductType.objects.count()
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
@@ -705,11 +704,11 @@ def test_product_type_update_mutation(admin_api_client, product_type):
         product_attributes]
     variant_attributes = product_type.variant_attributes.all()
 
-    variables = json.dumps({
+    variables = {
         'id': product_type_id, 'name': product_type_name,
         'hasVariants': has_variants,
         'isShippingRequired': require_shipping,
-        'productAttributes': product_attributes_ids})
+        'productAttributes': product_attributes_ids}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productTypeUpdate']['productType']
@@ -731,8 +730,8 @@ def test_product_type_delete_mutation(admin_api_client, product_type):
             }
         }
     """
-    variables = json.dumps({
-        'id': graphene.Node.to_global_id('ProductType', product_type.id)})
+    variables = {
+        'id': graphene.Node.to_global_id('ProductType', product_type.id)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productTypeDelete']
@@ -804,9 +803,9 @@ def test_product_image_update_mutation(admin_api_client, product_with_image):
     """
     image_obj = product_with_image.images.first()
     alt = 'damage alt'
-    variables = json.dumps({
+    variables = {
         'alt': alt,
-        'imageId': graphene.Node.to_global_id('ProductImage', image_obj.id)})
+        'imageId': graphene.Node.to_global_id('ProductImage', image_obj.id)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['productImageUpdate']['image']['alt'] == alt
@@ -958,8 +957,8 @@ def test_update_collection(admin_api_client, collection):
     collection_id = to_global_id('Collection', collection.id)
     name = 'new-name'
     slug = 'new-slug'
-    variables = json.dumps(
-        {'name': name, 'slug': slug, 'id': collection_id, 'isPublished': True})
+    variables = {
+        'name': name, 'slug': slug, 'id': collection_id, 'isPublished': True}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['collectionUpdate']['collection']
@@ -978,7 +977,7 @@ def test_delete_collection(admin_api_client, collection):
         }
     """
     collection_id = to_global_id('Collection', collection.id)
-    variables = json.dumps({'id': collection_id})
+    variables = {'id': collection_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['collectionDelete']['collection']
@@ -1005,8 +1004,7 @@ def test_add_products_to_collection(
     product_ids = [
         to_global_id('Product', product.pk) for product in product_list]
     no_products_before = collection.products.count()
-    variables = json.dumps(
-        {'id': collection_id, 'products': product_ids})
+    variables = {'id': collection_id, 'products': product_ids}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['collectionAddProducts']['collection']
@@ -1033,8 +1031,7 @@ def test_remove_products_from_collection(
     product_ids = [
         to_global_id('Product', product.pk) for product in product_list]
     no_products_before = collection.products.count()
-    variables = json.dumps(
-        {'id': collection_id, 'products': product_ids})
+    variables = {'id': collection_id, 'products': product_ids}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['collectionRemoveProducts']['collection']
@@ -1060,9 +1057,9 @@ def test_assign_variant_image(
     variant = product_with_image.variants.first()
     image = product_with_image.images.first()
 
-    variables = json.dumps({
+    variables = {
         'variantId': to_global_id('ProductVariant', variant.pk),
-        'imageId': to_global_id('ProductImage', image.pk)})
+        'imageId': to_global_id('ProductImage', image.pk)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     variant.refresh_from_db()
@@ -1073,9 +1070,9 @@ def test_assign_variant_image(
     product_with_image.save()
 
     image_2 = ProductImage.objects.create(product=product_with_image)
-    variables = json.dumps({
+    variables = {
         'variantId': to_global_id('ProductVariant', variant.pk),
-        'imageId': to_global_id('ProductImage', image_2.pk)})
+        'imageId': to_global_id('ProductImage', image_2.pk)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['variantImageAssign']['errors'][0]['field'] == 'imageId'
@@ -1105,9 +1102,9 @@ def test_unassign_variant_image(
     }
     """
 
-    variables = json.dumps({
+    variables = {
         'variantId': to_global_id('ProductVariant', variant.pk),
-        'imageId': to_global_id('ProductImage', image.pk)})
+        'imageId': to_global_id('ProductImage', image.pk)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     variant.refresh_from_db()
@@ -1115,9 +1112,9 @@ def test_unassign_variant_image(
 
     # check that unsassigning a not assigned image throws error
     image_2 = ProductImage.objects.create(product=product_with_image)
-    variables = json.dumps({
+    variables = {
         'variantId': to_global_id('ProductVariant', variant.pk),
-        'imageId': to_global_id('ProductImage', image_2.pk)})
+        'imageId': to_global_id('ProductImage', image_2.pk)}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['variantImageUnassign']['errors'][0]['field'] == 'imageId'
@@ -1160,11 +1157,11 @@ def test_product_type_update_changes_variant_name(
     variant_attributes_ids = [
         graphene.Node.to_global_id('Attribute', att.id) for att in
         variant_attributes]
-    variables = json.dumps({
+    variables = {
         'id': product_type_id,
         'hasVariants': has_variants,
         'isShippingRequired': require_shipping,
-        'variantAttributes': variant_attributes_ids})
+        'variantAttributes': variant_attributes_ids}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     product.refresh_from_db()
@@ -1195,7 +1192,7 @@ def test_product_variants_by_ids(user_api_client, variant):
         """
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.id)
 
-    variables = json.dumps({'ids': [variant_id]})
+    variables = {'ids': [variant_id]}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariants']
@@ -1236,7 +1233,7 @@ def test_category_image_query(user_api_client, non_default_category):
             }
         }
     """
-    variables = json.dumps({'id': category_id})
+    variables = {'id': category_id}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['category']
@@ -1258,7 +1255,7 @@ def test_collection_image_query(user_api_client, collection):
             }
         }
     """
-    variables = json.dumps({'id': collection_id})
+    variables = {'id': collection_id}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['collection']
@@ -1302,8 +1299,7 @@ def test_product_variant_price(
         }
         """
     product_id = graphene.Node.to_global_id('Product', variant.product.id)
-    variables = json.dumps({'id': product_id})
-
+    variables = {'id': product_id}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['product']

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -18,7 +18,7 @@ from .utils import assert_no_permission, get_multipart_request_body
 
 
 def test_fetch_all_products(user_api_client, product):
-    query = '''
+    query = """
     query {
         products {
             totalCount
@@ -29,7 +29,7 @@ def test_fetch_all_products(user_api_client, product):
             }
         }
     }
-    '''
+    """
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     num_products = Product.objects.count()
@@ -40,7 +40,7 @@ def test_fetch_all_products(user_api_client, product):
 @pytest.mark.djangodb
 def test_fetch_unavailable_products(user_api_client, product):
     Product.objects.update(is_published=False)
-    query = '''
+    query = """
     query {
         products {
             totalCount
@@ -51,7 +51,7 @@ def test_fetch_unavailable_products(user_api_client, product):
             }
         }
     }
-    '''
+    """
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     assert content['data']['products']['totalCount'] == 0
@@ -61,7 +61,7 @@ def test_fetch_unavailable_products(user_api_client, product):
 def test_product_query(admin_api_client, product):
     category = Category.objects.first()
     product = category.products.first()
-    query = '''
+    query = """
     query {
         category(id: "%(category_id)s") {
             products {
@@ -121,7 +121,7 @@ def test_product_query(admin_api_client, product):
             }
         }
     }
-    ''' % {'category_id': graphene.Node.to_global_id('Category', category.id)}
+    """ % {'category_id': graphene.Node.to_global_id('Category', category.id)}
     response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     assert content['data']['category'] is not None
@@ -144,7 +144,7 @@ def test_product_query(admin_api_client, product):
 
 def test_query_product_image_by_id(user_api_client, product_with_image):
     image = product_with_image.images.first()
-    query = '''
+    query = """
     query productImageById($imageId: ID!, $productId: ID!) {
         product(id: $productId) {
             imageById(id: $imageId) {
@@ -153,7 +153,7 @@ def test_query_product_image_by_id(user_api_client, product_with_image):
             }
         }
     }
-    '''
+    """
     variables = json.dumps({
         'productId': graphene.Node.to_global_id('Product', product_with_image.pk),
         'imageId': graphene.Node.to_global_id('ProductImage', image.pk)})
@@ -162,7 +162,7 @@ def test_query_product_image_by_id(user_api_client, product_with_image):
 
 
 def test_product_with_collections(admin_api_client, product, collection):
-    query = '''
+    query = """
         query getProduct($productID: ID!) {
             product(id: $productID) {
                 collections(first: 1) {
@@ -174,7 +174,7 @@ def test_product_with_collections(admin_api_client, product, collection):
                 }
             }
         }
-        '''
+        """
     product.collections.add(collection)
     product.save()
     product_id = graphene.Node.to_global_id('Product', product.id)
@@ -189,7 +189,7 @@ def test_product_with_collections(admin_api_client, product, collection):
 
 def test_filter_product_by_category(user_api_client, product):
     category = product.category
-    query = '''
+    query = """
     query getProducts($categoryId: ID) {
         products(category: $categoryId) {
             edges {
@@ -199,7 +199,7 @@ def test_filter_product_by_category(user_api_client, product):
             }
         }
     }
-    '''
+    """
     variables = json.dumps({
         'categoryId': graphene.Node.to_global_id('Category', category.id)})
     response = user_api_client.post_graphql(query, variables)
@@ -209,7 +209,7 @@ def test_filter_product_by_category(user_api_client, product):
 
 
 def test_fetch_product_by_id(user_api_client, product):
-    query = '''
+    query = """
     query ($productId: ID!) {
         node(id: $productId) {
             ... on Product {
@@ -217,7 +217,7 @@ def test_fetch_product_by_id(user_api_client, product):
             }
         }
     }
-    '''
+    """
     variables = json.dumps({
         'productId': graphene.Node.to_global_id('Product', product.id)})
     response = user_api_client.post_graphql(query, variables)
@@ -231,7 +231,7 @@ def test_filter_product_by_attributes(user_api_client, product):
     category = product.category
     attr_value = product_attr.values.first()
     filter_by = '%s:%s' % (product_attr.slug, attr_value.slug)
-    query = '''
+    query = """
     query {
         category(id: "%(category_id)s") {
             products(attributes: ["%(filter_by)s"]) {
@@ -243,7 +243,7 @@ def test_filter_product_by_attributes(user_api_client, product):
             }
         }
     }
-    ''' % {
+    """ % {
         'category_id': graphene.Node.to_global_id('Category', category.id),
         'filter_by': filter_by}
     response = user_api_client.post_graphql(query)
@@ -262,7 +262,7 @@ def test_sort_products(user_api_client, product):
     product.price = Money('20.00', 'USD')
     product.save()
 
-    query = '''
+    query = """
     query {
         products(sortBy: "%(sort_by)s") {
             edges {
@@ -274,7 +274,7 @@ def test_sort_products(user_api_client, product):
             }
         }
     }
-    '''
+    """
 
     asc_price_query = query % {'sort_by': 'price'}
     response = user_api_client.post_graphql(asc_price_query)
@@ -1183,7 +1183,7 @@ def test_update_variants_changed_does_nothing_with_no_attributes():
 
 
 def test_product_variants_by_ids(user_api_client, variant):
-    query = '''
+    query = """
         query getProduct($ids: [ID!]) {
             productVariants(ids: $ids) {
                 edges {
@@ -1193,7 +1193,7 @@ def test_product_variants_by_ids(user_api_client, variant):
                 }
             }
         }
-        '''
+        """
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.id)
 
     variables = json.dumps({'ids': [variant_id]})
@@ -1205,7 +1205,7 @@ def test_product_variants_by_ids(user_api_client, variant):
 
 
 def test_product_variants_no_ids_list(user_api_client, variant):
-    query = '''
+    query = """
         query getProductVariants {
             productVariants(first: 10) {
                 edges {
@@ -1215,7 +1215,7 @@ def test_product_variants_no_ids_list(user_api_client, variant):
                 }
             }
         }
-        '''
+        """
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['productVariants']
@@ -1287,7 +1287,7 @@ def test_product_variant_price(
     # Drop other variants
     # product.variants.exclude(id=variant.pk).delete()
 
-    query = '''
+    query = """
         query getProductVariants($id: ID!) {
             product(id: $id) {
                 variants {
@@ -1301,7 +1301,7 @@ def test_product_variant_price(
                 }
             }
         }
-        '''
+        """
     product_id = graphene.Node.to_global_id('Product', variant.product.id)
     variables = json.dumps({'id': product_id})
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -30,7 +30,7 @@ def test_fetch_all_products(user_api_client, product):
         }
     }
     '''
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     num_products = Product.objects.count()
     assert content['data']['products']['totalCount'] == num_products
@@ -52,7 +52,7 @@ def test_fetch_unavailable_products(user_api_client, product):
         }
     }
     '''
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     assert content['data']['products']['totalCount'] == 0
     assert not content['data']['products']['edges']
@@ -122,7 +122,7 @@ def test_product_query(admin_api_client, product):
         }
     }
     ''' % {'category_id': graphene.Node.to_global_id('Category', category.id)}
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     assert content['data']['category'] is not None
     product_edges_data = content['data']['category']['products']['edges']
@@ -158,7 +158,7 @@ def test_query_product_image_by_id(user_api_client, product_with_image):
         'productId': graphene.Node.to_global_id('Product', product_with_image.pk),
         'imageId': graphene.Node.to_global_id('ProductImage', image.pk)})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
 
 
@@ -182,7 +182,7 @@ def test_product_with_collections(admin_api_client, product, collection):
 
     variables = json.dumps({'productID': product_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['product']
     assert data['collections']['edges'][0]['node']['name'] == collection.name
@@ -203,7 +203,6 @@ def test_filter_product_by_category(user_api_client, product):
     }
     '''
     response = user_api_client.post(
-        reverse('api'),
         {
             'query': query,
             'variables': json.dumps(
@@ -227,7 +226,6 @@ def test_fetch_product_by_id(user_api_client, product):
     }
     '''
     response = user_api_client.post(
-        reverse('api'),
         {
             'query': query,
             'variables': json.dumps(
@@ -259,7 +257,7 @@ def test_filter_product_by_attributes(user_api_client, product):
     ''' % {
         'category_id': graphene.Node.to_global_id('Category', category.id),
         'filter_by': filter_by}
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     product_data = content['data']['category']['products']['edges'][0]['node']
     assert product_data['name'] == product.name
@@ -290,7 +288,7 @@ def test_sort_products(user_api_client, product):
     '''
 
     asc_price_query = query % {'sort_by': 'price'}
-    response = user_api_client.post(reverse('api'), {'query': asc_price_query})
+    response = user_api_client.post({'query': asc_price_query})
     content = get_graphql_content(response)
     product_data = content['data']['products']['edges'][0]['node']
     price_0 = content['data']['products']['edges'][0]['node']['price']['amount']
@@ -298,7 +296,7 @@ def test_sort_products(user_api_client, product):
     assert price_0 < price_1
 
     desc_price_query = query % {'sort_by': '-price'}
-    response = user_api_client.post(reverse('api'), {'query': desc_price_query})
+    response = user_api_client.post({'query': desc_price_query})
     content = get_graphql_content(response)
     price_0 = content['data']['products']['edges'][0]['node']['price']['amount']
     price_1 = content['data']['products']['edges'][1]['node']['price']['amount']
@@ -398,7 +396,7 @@ def test_create_product(
             {'slug': size_attr_slug, 'value': non_existent_attr_value}]})
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productCreate']
     assert data['errors'] == []
@@ -493,7 +491,7 @@ def test_update_product(
         'price': product_price})
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productUpdate']
     assert data['errors'] == []
@@ -523,7 +521,7 @@ def test_delete_product(admin_api_client, product):
     node_id = graphene.Node.to_global_id('Product', product.id)
     variables = json.dumps({'id': node_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productDelete']
     assert data['product']['name'] == product.name
@@ -553,7 +551,7 @@ def test_product_type(user_api_client, product_type):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     no_product_types = ProductType.objects.count()
     assert content['data']['productTypes']['totalCount'] == no_product_types
@@ -585,13 +583,13 @@ def test_product_type_query(
         'id': graphene.Node.to_global_id('ProductType', product_type.id)})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']
     assert data['productType']['products']['totalCount'] == no_products - 1
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']
     assert data['productType']['products']['totalCount'] == no_products
@@ -656,7 +654,7 @@ def test_product_type_create_mutation(admin_api_client, product_type):
         'variantAttributes': variant_attributes_ids})
     initial_count = ProductType.objects.count()
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert ProductType.objects.count() == initial_count + 1
     data = content['data']['productTypeCreate']['productType']
@@ -731,7 +729,7 @@ def test_product_type_update_mutation(admin_api_client, product_type):
         'isShippingRequired': require_shipping,
         'productAttributes': product_attributes_ids})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productTypeUpdate']['productType']
     assert data['name'] == product_type_name
@@ -755,7 +753,7 @@ def test_product_type_delete_mutation(admin_api_client, product_type):
     variables = json.dumps({
         'id': graphene.Node.to_global_id('ProductType', product_type.id)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productTypeDelete']
     assert data['productType']['name'] == product_type.name
@@ -778,7 +776,7 @@ def test_product_image_create_mutation(admin_api_client, product):
         'product': graphene.Node.to_global_id('Product', product.id),
         'image': image_name}
     body = get_multipart_request_body(query, variables, image_file, image_name)
-    response = admin_api_client.post_multipart(reverse('api'), body)
+    response = admin_api_client.post_multipart(body)
     content = get_graphql_content(response)
     product.refresh_from_db()
     assert product.images.first().image.file
@@ -805,7 +803,7 @@ def test_invalid_product_image_create_mutation(admin_api_client, product):
         'product': graphene.Node.to_global_id('Product', product.id),
         'image': image_name}
     body = get_multipart_request_body(query, variables, image_file, image_name)
-    response = admin_api_client.post_multipart(reverse('api'), body)
+    response = admin_api_client.post_multipart(body)
     content = get_graphql_content(response)
     assert content['data']['productImageCreate']['errors'] == [{
         'field': 'image',
@@ -830,7 +828,7 @@ def test_product_image_update_mutation(admin_api_client, product_with_image):
         'alt': alt,
         'imageId': graphene.Node.to_global_id('ProductImage', image_obj.id)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['productImageUpdate']['image']['alt'] == alt
 
@@ -851,7 +849,7 @@ def test_product_image_delete(admin_api_client, product_with_image):
     node_id = graphene.Node.to_global_id('ProductImage', image_obj.id)
     variables = {'id': node_id}
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productImageDelete']
     assert data['image']['url'] == image_obj.image.url
@@ -881,7 +879,7 @@ def test_reorder_images(admin_api_client, product_with_images):
     variables = {
         'product_id': product_id, 'images_ids': [image_1_id, image_0_id]}
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
 
     # Check if order has been changed
@@ -914,7 +912,7 @@ def test_collections_query(
     """
 
     # query public collections only as regular user
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     edges = content['data']['collections']['edges']
     assert len(edges) == 1
@@ -926,7 +924,7 @@ def test_collections_query(
 
     # query all collections only as a staff user with proper permissions
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post(reverse('api'), {'query': query})
+    response = staff_api_client.post({'query': query})
     content = get_graphql_content(response)
     edges = content['data']['collections']['edges']
     assert len(edges) == 2
@@ -957,7 +955,7 @@ def test_create_collection(admin_api_client, product_list):
         'name': name, 'slug': slug, 'products': product_ids,
         'backgroundImage': image_name, 'isPublished': True}
     body = get_multipart_request_body(query, variables, image_file, image_name)
-    response = admin_api_client.post_multipart(reverse('api'), body)
+    response = admin_api_client.post_multipart(body)
     content = get_graphql_content(response)
     data = content['data']['collectionCreate']['collection']
     assert data['name'] == name
@@ -986,7 +984,7 @@ def test_update_collection(admin_api_client, collection):
     variables = json.dumps(
         {'name': name, 'slug': slug, 'id': collection_id, 'isPublished': True})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['collectionUpdate']['collection']
     assert data['name'] == name
@@ -1006,7 +1004,7 @@ def test_delete_collection(admin_api_client, collection):
     collection_id = to_global_id('Collection', collection.id)
     variables = json.dumps({'id': collection_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['collectionDelete']['collection']
     assert data['name'] == collection.name
@@ -1035,7 +1033,7 @@ def test_add_products_to_collection(
     variables = json.dumps(
         {'id': collection_id, 'products': product_ids})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['collectionAddProducts']['collection']
     assert data[
@@ -1064,7 +1062,7 @@ def test_remove_products_from_collection(
     variables = json.dumps(
         {'id': collection_id, 'products': product_ids})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['collectionRemoveProducts']['collection']
     assert data[
@@ -1093,7 +1091,7 @@ def test_assign_variant_image(
         'variantId': to_global_id('ProductVariant', variant.pk),
         'imageId': to_global_id('ProductImage', image.pk)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     variant.refresh_from_db()
     assert variant.images.first() == image
@@ -1107,13 +1105,13 @@ def test_assign_variant_image(
         'variantId': to_global_id('ProductVariant', variant.pk),
         'imageId': to_global_id('ProductImage', image_2.pk)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['variantImageAssign']['errors'][0]['field'] == 'imageId'
 
     # check permissions
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
 
@@ -1141,7 +1139,7 @@ def test_unassign_variant_image(
         'variantId': to_global_id('ProductVariant', variant.pk),
         'imageId': to_global_id('ProductImage', image.pk)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     variant.refresh_from_db()
     assert variant.images.count() == 0
@@ -1152,13 +1150,13 @@ def test_unassign_variant_image(
         'variantId': to_global_id('ProductVariant', variant.pk),
         'imageId': to_global_id('ProductImage', image_2.pk)})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['variantImageUnassign']['errors'][0]['field'] == 'imageId'
 
     # check permissions
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     assert_no_permission(response)
 
 
@@ -1201,7 +1199,7 @@ def test_product_type_update_changes_variant_name(
         'isShippingRequired': require_shipping,
         'variantAttributes': variant_attributes_ids})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     product.refresh_from_db()
     variant = product.variants.first()
@@ -1233,7 +1231,7 @@ def test_product_variants_by_ids(user_api_client, variant):
 
     variables = json.dumps({'ids': [variant_id]})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productVariants']
     assert data['edges'][0]['node']['id'] == variant_id
@@ -1253,7 +1251,7 @@ def test_product_variants_no_ids_list(user_api_client, variant):
         }
         '''
     response = user_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     data = content['data']['productVariants']
     assert len(data['edges']) == ProductVariant.objects.count()
@@ -1276,7 +1274,7 @@ def test_category_image_query(user_api_client, non_default_category):
     """
     variables = json.dumps({'id': category_id})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['category']
     thumbnail_url = category.background_image.thumbnail['120x120'].url
@@ -1299,7 +1297,7 @@ def test_collection_image_query(user_api_client, collection):
     """
     variables = json.dumps({'id': collection_id})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['collection']
     thumbnail_url = collection.background_image.thumbnail['120x120'].url
@@ -1345,7 +1343,7 @@ def test_product_variant_price(
     variables = json.dumps({'id': product_id})
 
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['product']
     variant_price = data['variants']['edges'][0]['node']['price']

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -92,7 +92,7 @@ def test_shipping_zone_query(user_api_client, shipping_zone):
     ID = graphene.Node.to_global_id('ShippingZone', shipping.id)
     variables = json.dumps({'id': ID})
     response = user_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
 
     shipping_data = content['data']['shippingZone']
@@ -116,7 +116,7 @@ def test_shipping_zones_query(user_api_client, shipping_zone):
     num_of_shippings = shipping_zone._meta.model.objects.count()
 
     response = user_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     assert content['data']['shippingZones']['totalCount'] == num_of_shippings
 
@@ -148,7 +148,7 @@ def test_create_shipping_zone(admin_api_client):
     variables = json.dumps(
         {'name': 'test shipping', 'countries': ['PL']})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert not data['errors']
@@ -163,7 +163,7 @@ def test_create_default_shipping_zone(admin_api_client):
     variables = json.dumps(
         {'default': True, 'name': 'test shipping', 'countries': ['PL']})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert not data['errors']
@@ -182,7 +182,7 @@ def test_create_duplicated_default_shipping_zone(
     variables = json.dumps(
         {'default': True, 'name': 'test shipping', 'countries': ['PL']})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert data['errors']
@@ -216,7 +216,7 @@ def test_update_shipping_zone(admin_api_client, shipping_zone):
     shipping_id = graphene.Node.to_global_id('ShippingZone', shipping_zone.pk)
     variables = json.dumps({'id': shipping_id, 'name': name, 'countries': []})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
     assert not data['errors']
@@ -237,7 +237,7 @@ def test_update_shipping_zone_default_exists(
     variables = json.dumps(
         {'id': shipping_id, 'name': 'Name', 'countries': [], 'default': True})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
     assert data['errors']
@@ -260,7 +260,7 @@ def test_delete_shipping_zone(admin_api_client, shipping_zone):
         'ShippingZone', shipping_zone.pk)
     variables = json.dumps({'id': shipping_zone_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingZoneDelete']['shippingZone']
     assert data['name'] == shipping_zone.name
@@ -286,7 +286,7 @@ def test_create_shipping_method(
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
         'type': ShippingMethodTypeEnum.PRICE.name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
     assert 'errors' not in data
@@ -314,7 +314,7 @@ def test_create_weight_based_shipping_method(
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
         'type': ShippingMethodTypeEnum.WEIGHT.name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
     assert data['minimumOrderWeight'] == expected_min_weight
@@ -343,7 +343,7 @@ def test_create_weight_shipping_method_errors(
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
         'type': ShippingMethodTypeEnum.WEIGHT.name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
     assert data['errors'][0] == expected_error
@@ -371,7 +371,7 @@ def test_create_price_shipping_method_errors(
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
         'type': ShippingMethodTypeEnum.PRICE.name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
     assert data['errors'][0] == expected_error
@@ -417,7 +417,7 @@ def test_update_shipping_method(admin_api_client, shipping_zone):
             'minimumOrderPrice': 12.00,
             'type': ShippingMethodTypeEnum.PRICE.name})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceUpdate']['shippingMethod']
     assert data['price']['amount'] == float(price)
@@ -439,7 +439,7 @@ def test_delete_shipping_method(admin_api_client, shipping_method):
         'ShippingMethod', shipping_method.pk)
     variables = json.dumps({'id': shipping_method_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shippingPriceDelete']['shippingMethod']
     assert data['price']['amount'] == float(shipping_method.price.amount)

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -3,7 +3,6 @@ import json
 import pytest
 
 import graphene
-from django.shortcuts import reverse
 from saleor.graphql.shipping.types import ShippingMethodTypeEnum
 from tests.api.utils import get_graphql_content
 

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -89,7 +87,7 @@ def test_shipping_zone_query(user_api_client, shipping_zone):
     }
     """
     ID = graphene.Node.to_global_id('ShippingZone', shipping.id)
-    variables = json.dumps({'id': ID})
+    variables = {'id': ID}
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
 
@@ -142,8 +140,7 @@ CREATE_SHIPPING_ZONE_QUERY = """
 
 def test_create_shipping_zone(admin_api_client):
     query = CREATE_SHIPPING_ZONE_QUERY
-    variables = json.dumps(
-        {'name': 'test shipping', 'countries': ['PL']})
+    variables = {'name': 'test shipping', 'countries': ['PL']}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
@@ -156,8 +153,7 @@ def test_create_shipping_zone(admin_api_client):
 
 def test_create_default_shipping_zone(admin_api_client):
     query = CREATE_SHIPPING_ZONE_QUERY
-    variables = json.dumps(
-        {'default': True, 'name': 'test shipping', 'countries': ['PL']})
+    variables = {'default': True, 'name': 'test shipping', 'countries': ['PL']}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
@@ -174,8 +170,7 @@ def test_create_duplicated_default_shipping_zone(
     shipping_zone.save()
 
     query = CREATE_SHIPPING_ZONE_QUERY
-    variables = json.dumps(
-        {'default': True, 'name': 'test shipping', 'countries': ['PL']})
+    variables = {'default': True, 'name': 'test shipping', 'countries': ['PL']}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
@@ -208,7 +203,7 @@ def test_update_shipping_zone(admin_api_client, shipping_zone):
     query = UPDATE_SHIPPING_ZONE_QUERY
     name = 'Parabolic name'
     shipping_id = graphene.Node.to_global_id('ShippingZone', shipping_zone.pk)
-    variables = json.dumps({'id': shipping_id, 'name': name, 'countries': []})
+    variables = {'id': shipping_id, 'name': name, 'countries': []}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
@@ -227,8 +222,8 @@ def test_update_shipping_zone_default_exists(
     shipping_zone = shipping_zone.__class__.objects.filter(default=False).get()
 
     shipping_id = graphene.Node.to_global_id('ShippingZone', shipping_zone.pk)
-    variables = json.dumps(
-        {'id': shipping_id, 'name': 'Name', 'countries': [], 'default': True})
+    variables = {
+        'id': shipping_id, 'name': 'Name', 'countries': [], 'default': True}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
@@ -250,7 +245,7 @@ def test_delete_shipping_zone(admin_api_client, shipping_zone):
     """
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
-    variables = json.dumps({'id': shipping_zone_id})
+    variables = {'id': shipping_zone_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneDelete']['shippingZone']
@@ -272,10 +267,10 @@ def test_create_shipping_method(
     price = 12.34
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
-    variables = json.dumps({
+    variables = {
         'shippingZone': shipping_zone_id, 'name': name, 'price': price,
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
-        'type': ShippingMethodTypeEnum.PRICE.name})
+        'type': ShippingMethodTypeEnum.PRICE.name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
@@ -299,10 +294,10 @@ def test_create_weight_based_shipping_method(
     query = weight_based_shipping_query
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
-    variables = json.dumps({
+    variables = {
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
-        'type': ShippingMethodTypeEnum.WEIGHT.name})
+        'type': ShippingMethodTypeEnum.WEIGHT.name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
@@ -327,10 +322,10 @@ def test_create_weight_shipping_method_errors(
     query = weight_based_shipping_query
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
-    variables = json.dumps({
+    variables = {
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
-        'type': ShippingMethodTypeEnum.WEIGHT.name})
+        'type': ShippingMethodTypeEnum.WEIGHT.name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
@@ -354,10 +349,10 @@ def test_create_price_shipping_method_errors(
     query = price_based_shipping_query
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
-    variables = json.dumps({
+    variables = {
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
-        'type': ShippingMethodTypeEnum.PRICE.name})
+        'type': ShippingMethodTypeEnum.PRICE.name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
@@ -396,13 +391,12 @@ def test_update_shipping_method(admin_api_client, shipping_zone):
         'ShippingZone', shipping_zone.pk)
     shipping_method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.pk)
-    variables = json.dumps(
-        {
-            'shippingZone': shipping_zone_id,
-            'price': price,
-            'id': shipping_method_id,
-            'minimumOrderPrice': 12.00,
-            'type': ShippingMethodTypeEnum.PRICE.name})
+    variables = {
+        'shippingZone': shipping_zone_id,
+        'price': price,
+        'id': shipping_method_id,
+        'minimumOrderPrice': 12.00,
+        'type': ShippingMethodTypeEnum.PRICE.name}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceUpdate']['shippingMethod']
@@ -423,7 +417,7 @@ def test_delete_shipping_method(admin_api_client, shipping_method):
         """
     shipping_method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.pk)
-    variables = json.dumps({'id': shipping_method_id})
+    variables = {'id': shipping_method_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceDelete']['shippingMethod']

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -91,8 +91,7 @@ def test_shipping_zone_query(user_api_client, shipping_zone):
     """
     ID = graphene.Node.to_global_id('ShippingZone', shipping.id)
     variables = json.dumps({'id': ID})
-    response = user_api_client.post(
-        {'query': query, 'variables': variables})
+    response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
 
     shipping_data = content['data']['shippingZone']
@@ -115,8 +114,7 @@ def test_shipping_zones_query(user_api_client, shipping_zone):
     """
     num_of_shippings = shipping_zone._meta.model.objects.count()
 
-    response = user_api_client.post(
-        {'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     assert content['data']['shippingZones']['totalCount'] == num_of_shippings
 
@@ -147,8 +145,7 @@ def test_create_shipping_zone(admin_api_client):
     query = CREATE_SHIPPING_ZONE_QUERY
     variables = json.dumps(
         {'name': 'test shipping', 'countries': ['PL']})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert not data['errors']
@@ -162,8 +159,7 @@ def test_create_default_shipping_zone(admin_api_client):
     query = CREATE_SHIPPING_ZONE_QUERY
     variables = json.dumps(
         {'default': True, 'name': 'test shipping', 'countries': ['PL']})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert not data['errors']
@@ -181,8 +177,7 @@ def test_create_duplicated_default_shipping_zone(
     query = CREATE_SHIPPING_ZONE_QUERY
     variables = json.dumps(
         {'default': True, 'name': 'test shipping', 'countries': ['PL']})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneCreate']
     assert data['errors']
@@ -215,8 +210,7 @@ def test_update_shipping_zone(admin_api_client, shipping_zone):
     name = 'Parabolic name'
     shipping_id = graphene.Node.to_global_id('ShippingZone', shipping_zone.pk)
     variables = json.dumps({'id': shipping_id, 'name': name, 'countries': []})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
     assert not data['errors']
@@ -236,8 +230,7 @@ def test_update_shipping_zone_default_exists(
     shipping_id = graphene.Node.to_global_id('ShippingZone', shipping_zone.pk)
     variables = json.dumps(
         {'id': shipping_id, 'name': 'Name', 'countries': [], 'default': True})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneUpdate']
     assert data['errors']
@@ -259,8 +252,7 @@ def test_delete_shipping_zone(admin_api_client, shipping_zone):
     shipping_zone_id = graphene.Node.to_global_id(
         'ShippingZone', shipping_zone.pk)
     variables = json.dumps({'id': shipping_zone_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingZoneDelete']['shippingZone']
     assert data['name'] == shipping_zone.name
@@ -285,8 +277,7 @@ def test_create_shipping_method(
         'shippingZone': shipping_zone_id, 'name': name, 'price': price,
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
         'type': ShippingMethodTypeEnum.PRICE.name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
     assert 'errors' not in data
@@ -313,8 +304,7 @@ def test_create_weight_based_shipping_method(
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
         'type': ShippingMethodTypeEnum.WEIGHT.name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']['shippingMethod']
     assert data['minimumOrderWeight'] == expected_min_weight
@@ -342,8 +332,7 @@ def test_create_weight_shipping_method_errors(
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderWeight': min_weight, 'maximumOrderWeight': max_weight,
         'type': ShippingMethodTypeEnum.WEIGHT.name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
     assert data['errors'][0] == expected_error
@@ -370,8 +359,7 @@ def test_create_price_shipping_method_errors(
         'shippingZone': shipping_zone_id, 'name': 'DHL', 'price': 12.34,
         'minimumOrderPrice': min_price, 'maximumOrderPrice': max_price,
         'type': ShippingMethodTypeEnum.PRICE.name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceCreate']
     assert data['errors'][0] == expected_error
@@ -416,8 +404,7 @@ def test_update_shipping_method(admin_api_client, shipping_zone):
             'id': shipping_method_id,
             'minimumOrderPrice': 12.00,
             'type': ShippingMethodTypeEnum.PRICE.name})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceUpdate']['shippingMethod']
     assert data['price']['amount'] == float(price)
@@ -438,8 +425,7 @@ def test_delete_shipping_method(admin_api_client, shipping_method):
     shipping_method_id = graphene.Node.to_global_id(
         'ShippingMethod', shipping_method.pk)
     variables = json.dumps({'id': shipping_method_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shippingPriceDelete']['shippingMethod']
     assert data['price']['amount'] == float(shipping_method.price.amount)

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -1,5 +1,3 @@
-import json
-
 import graphene
 from django.conf import settings
 from django_countries import countries
@@ -175,12 +173,10 @@ def test_shop_settings_mutation(admin_api_client, site_settings):
             }
         }
     """
-    variables = json.dumps({
+    variables = {
         'input': {
             'includeTaxesInPrices': False,
-            'headerText': 'Lorem ipsum'
-        }
-    })
+            'headerText': 'Lorem ipsum'}}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shopSettingsUpdate']['shop']
@@ -204,10 +200,10 @@ def test_shop_domain_update(admin_api_client):
         }
     """
     new_name = 'saleor test store'
-    variables = json.dumps({
+    variables = {
         'input': {
             'domain': 'lorem-ipsum.com',
-            'name': new_name}})
+            'name': new_name}}
     site = Site.objects.get_current()
     assert site.domain != 'lorem-ipsum.com'
     response = admin_api_client.post_graphql(query, variables)
@@ -234,9 +230,7 @@ def test_homepage_collection_update(admin_api_client, collection):
         }
     """
     collection_id = graphene.Node.to_global_id('Collection', collection.id)
-    variables = json.dumps({
-        'collection': collection_id
-    })
+    variables = {'collection': collection_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['homepageCollectionUpdate']['shop']

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -23,13 +23,13 @@ def test_query_authorization_keys(
         }
     }
     """
-    response = admin_api_client.post({'query': query})
+    response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['authorizationKeys'][0]['name'] == authorization_key.name
     assert data['authorizationKeys'][0]['key'] == authorization_key.key
 
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     assert_no_permission(response)
 
 
@@ -44,7 +44,7 @@ def test_query_countries(user_api_client):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['countries']) == len(countries)
@@ -59,7 +59,7 @@ def test_query_currencies(user_api_client):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['currencies']) == len(settings.AVAILABLE_CURRENCIES)
@@ -75,7 +75,7 @@ def test_query_name(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['description'] == site_settings.description
@@ -94,7 +94,7 @@ def test_query_domain(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['domain']['host'] == site_settings.site.domain
@@ -113,7 +113,7 @@ def test_query_languages(settings, user_api_client):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['languages']) == len(settings.LANGUAGES)
@@ -130,7 +130,7 @@ def test_query_permissions(admin_api_client, user_api_client):
         }
     }
     """
-    response = admin_api_client.post({'query': query})
+    response = admin_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']
     permissions = data['permissions']
@@ -139,7 +139,7 @@ def test_query_permissions(admin_api_client, user_api_client):
     for code in permissions_codes:
         assert code in MODELS_PERMISSIONS
 
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     assert_no_permission(response)
 
 
@@ -158,7 +158,7 @@ def test_query_navigation(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     navigation_data = content['data']['shop']['navigation']
     assert navigation_data['main']['name'] == site_settings.top_menu.name
@@ -182,8 +182,7 @@ def test_shop_settings_mutation(admin_api_client, site_settings):
             'headerText': 'Lorem ipsum'
         }
     })
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shopSettingsUpdate']['shop']
     assert data['includeTaxesInPrices'] == False
@@ -212,8 +211,7 @@ def test_shop_domain_update(admin_api_client):
             'name': new_name}})
     site = Site.objects.get_current()
     assert site.domain != 'lorem-ipsum.com'
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['shopDomainUpdate']['shop']
     assert data['domain']['host'] == 'lorem-ipsum.com'
@@ -240,8 +238,7 @@ def test_homepage_collection_update(admin_api_client, collection):
     variables = json.dumps({
         'collection': collection_id
     })
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['homepageCollectionUpdate']['shop']
     assert data['homepageCollection']['id'] == collection_id
@@ -262,7 +259,7 @@ def test_query_default_country(user_api_client, settings):
         }
     }
     """
-    response = user_api_client.post({'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']['defaultCountry']
     assert data['code'] == settings.DEFAULT_COUNTRY
@@ -282,14 +279,13 @@ def test_query_geolocalization(user_api_client):
         }
     """
     GERMAN_IP = '79.222.222.22'
-    response = user_api_client.post(
-        {'query': query}, HTTP_X_FORWARDED_FOR=GERMAN_IP)
+    response = user_api_client.post_graphql(
+        query, HTTP_X_FORWARDED_FOR=GERMAN_IP)
     content = get_graphql_content(response)
     data = content['data']['shop']['geolocalization']
     assert data['country']['code'] == 'DE'
 
-    response = user_api_client.post(
-        {'query': query})
+    response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content['data']['shop']['geolocalization']
     assert data['country'] is None

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -23,13 +23,13 @@ def test_query_authorization_keys(
         }
     }
     """
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['authorizationKeys'][0]['name'] == authorization_key.name
     assert data['authorizationKeys'][0]['key'] == authorization_key.key
 
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     assert_no_permission(response)
 
 
@@ -44,7 +44,7 @@ def test_query_countries(user_api_client):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['countries']) == len(countries)
@@ -59,7 +59,7 @@ def test_query_currencies(user_api_client):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['currencies']) == len(settings.AVAILABLE_CURRENCIES)
@@ -75,7 +75,7 @@ def test_query_name(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['description'] == site_settings.description
@@ -94,7 +94,7 @@ def test_query_domain(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert data['domain']['host'] == site_settings.site.domain
@@ -113,7 +113,7 @@ def test_query_languages(settings, user_api_client):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     assert len(data['languages']) == len(settings.LANGUAGES)
@@ -130,7 +130,7 @@ def test_query_permissions(admin_api_client, user_api_client):
         }
     }
     """
-    response = admin_api_client.post(reverse('api'), {'query': query})
+    response = admin_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']
     permissions = data['permissions']
@@ -139,7 +139,7 @@ def test_query_permissions(admin_api_client, user_api_client):
     for code in permissions_codes:
         assert code in MODELS_PERMISSIONS
 
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     assert_no_permission(response)
 
 
@@ -158,7 +158,7 @@ def test_query_navigation(user_api_client, site_settings):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     navigation_data = content['data']['shop']['navigation']
     assert navigation_data['main']['name'] == site_settings.top_menu.name
@@ -183,7 +183,7 @@ def test_shop_settings_mutation(admin_api_client, site_settings):
         }
     })
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shopSettingsUpdate']['shop']
     assert data['includeTaxesInPrices'] == False
@@ -213,7 +213,7 @@ def test_shop_domain_update(admin_api_client):
     site = Site.objects.get_current()
     assert site.domain != 'lorem-ipsum.com'
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['shopDomainUpdate']['shop']
     assert data['domain']['host'] == 'lorem-ipsum.com'
@@ -241,7 +241,7 @@ def test_homepage_collection_update(admin_api_client, collection):
         'collection': collection_id
     })
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['homepageCollectionUpdate']['shop']
     assert data['homepageCollection']['id'] == collection_id
@@ -262,7 +262,7 @@ def test_query_default_country(user_api_client, settings):
         }
     }
     """
-    response = user_api_client.post(reverse('api'), {'query': query})
+    response = user_api_client.post({'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']['defaultCountry']
     assert data['code'] == settings.DEFAULT_COUNTRY
@@ -283,13 +283,13 @@ def test_query_geolocalization(user_api_client):
     """
     GERMAN_IP = '79.222.222.22'
     response = user_api_client.post(
-        reverse('api'), {'query': query}, HTTP_X_FORWARDED_FOR=GERMAN_IP)
+        {'query': query}, HTTP_X_FORWARDED_FOR=GERMAN_IP)
     content = get_graphql_content(response)
     data = content['data']['shop']['geolocalization']
     assert data['country']['code'] == 'DE'
 
     response = user_api_client.post(
-        reverse('api'), {'query': query})
+        {'query': query})
     content = get_graphql_content(response)
     data = content['data']['shop']['geolocalization']
     assert data['country'] is None

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -2,7 +2,6 @@ import json
 
 import graphene
 from django.conf import settings
-from django.shortcuts import reverse
 from django_countries import countries
 from saleor.core.permissions import MODELS_PERMISSIONS
 from saleor.site.models import Site

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -53,9 +53,8 @@ def test_fetch_variant(admin_api_client, product):
 
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
-    variables = json.dumps({ 'id': variant_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    variables = json.dumps({'id': variant_id})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariant']
     assert data['name'] == variant.name
@@ -133,8 +132,7 @@ def test_create_variant(admin_api_client, product, product_type):
         'attributes': [
             {'slug': variant_slug, 'value': variant_value}],
         'trackInventory': True})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariantCreate']['productVariant']
     assert data['name'] == variant_value
@@ -179,8 +177,7 @@ def test_create_product_variant_not_all_attributes(
         'productId': product_id,
         'sku': sku,
         'attributes': [{'slug': variant_slug, 'value': variant_value}]})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['productVariantCreate']['errors']
     assert content['data']['productVariantCreate']['errors'][0]['field'] == 'attributes:color'
@@ -230,8 +227,7 @@ def test_update_product_variant(admin_api_client, product):
         'costPrice': cost_price,
         'trackInventory': True})
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content['data']['productVariantUpdate']['productVariant']
@@ -274,8 +270,7 @@ def test_update_product_variant_not_all_attributes(
         'sku': sku,
         'attributes': [{'slug': variant_slug, 'value': variant_value}]})
 
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     variant.refresh_from_db()
     content = get_graphql_content(response)
     assert content['data']['productVariantUpdate']['errors']
@@ -297,8 +292,7 @@ def test_delete_variant(admin_api_client, product):
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
     variables = json.dumps({'id': variant_id})
-    response = admin_api_client.post(
-        {'query': query, 'variables': variables})
+    response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariantDelete']
     assert data['productVariant']['sku'] == variant.sku

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 import graphene
@@ -53,7 +51,7 @@ def test_fetch_variant(admin_api_client, product):
 
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
-    variables = json.dumps({'id': variant_id})
+    variables = {'id': variant_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariant']
@@ -122,7 +120,7 @@ def test_create_variant(admin_api_client, product, product_type):
     variant_slug = product_type.variant_attributes.first().slug
     variant_value = 'test-value'
 
-    variables = json.dumps({
+    variables = {
         'productId': product_id,
         'sku': sku,
         'quantity': quantity,
@@ -131,7 +129,7 @@ def test_create_variant(admin_api_client, product, product_type):
         'weight': weight,
         'attributes': [
             {'slug': variant_slug, 'value': variant_value}],
-        'trackInventory': True})
+        'trackInventory': True}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariantCreate']['productVariant']
@@ -173,10 +171,10 @@ def test_create_product_variant_not_all_attributes(
     variant_value = 'test-value'
     product_type.variant_attributes.add(color_attribute)
 
-    variables = json.dumps({
+    variables = {
         'productId': product_id,
         'sku': sku,
-        'attributes': [{'slug': variant_slug, 'value': variant_value}]})
+        'attributes': [{'slug': variant_slug, 'value': variant_value}]}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     assert content['data']['productVariantCreate']['errors']
@@ -220,12 +218,12 @@ def test_update_product_variant(admin_api_client, product):
     cost_price = 3.3
     quantity = 123
 
-    variables = json.dumps({
+    variables = {
         'id': variant_id,
         'sku': sku,
         'quantity': quantity,
         'costPrice': cost_price,
-        'trackInventory': True})
+        'trackInventory': True}
 
     response = admin_api_client.post_graphql(query, variables)
     variant.refresh_from_db()
@@ -265,10 +263,10 @@ def test_update_product_variant_not_all_attributes(
     variant_value = 'test-value'
     product_type.variant_attributes.add(color_attribute)
 
-    variables = json.dumps({
+    variables = {
         'id': variant_id,
         'sku': sku,
-        'attributes': [{'slug': variant_slug, 'value': variant_value}]})
+        'attributes': [{'slug': variant_slug, 'value': variant_value}]}
 
     response = admin_api_client.post_graphql(query, variables)
     variant.refresh_from_db()
@@ -291,7 +289,7 @@ def test_delete_variant(admin_api_client, product):
     """
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
-    variables = json.dumps({'id': variant_id})
+    variables = {'id': variant_id}
     response = admin_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['productVariantDelete']

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -1,8 +1,8 @@
 import json
 
-import graphene
 import pytest
-from django.shortcuts import reverse
+
+import graphene
 from tests.api.utils import get_graphql_content
 
 

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -55,7 +55,7 @@ def test_fetch_variant(admin_api_client, product):
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
     variables = json.dumps({ 'id': variant_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productVariant']
     assert data['name'] == variant.name
@@ -134,7 +134,7 @@ def test_create_variant(admin_api_client, product, product_type):
             {'slug': variant_slug, 'value': variant_value}],
         'trackInventory': True})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productVariantCreate']['productVariant']
     assert data['name'] == variant_value
@@ -180,7 +180,7 @@ def test_create_product_variant_not_all_attributes(
         'sku': sku,
         'attributes': [{'slug': variant_slug, 'value': variant_value}]})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     assert content['data']['productVariantCreate']['errors']
     assert content['data']['productVariantCreate']['errors'][0]['field'] == 'attributes:color'
@@ -231,7 +231,7 @@ def test_update_product_variant(admin_api_client, product):
         'trackInventory': True})
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     variant.refresh_from_db()
     content = get_graphql_content(response)
     data = content['data']['productVariantUpdate']['productVariant']
@@ -275,7 +275,7 @@ def test_update_product_variant_not_all_attributes(
         'attributes': [{'slug': variant_slug, 'value': variant_value}]})
 
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     variant.refresh_from_db()
     content = get_graphql_content(response)
     assert content['data']['productVariantUpdate']['errors']
@@ -298,7 +298,7 @@ def test_delete_variant(admin_api_client, product):
     variant_id = graphene.Node.to_global_id('ProductVariant', variant.pk)
     variables = json.dumps({'id': variant_id})
     response = admin_api_client.post(
-        reverse('api'), {'query': query, 'variables': variables})
+        {'query': query, 'variables': variables})
     content = get_graphql_content(response)
     data = content['data']['productVariantDelete']
     assert data['productVariant']['sku'] == variant.sku

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -31,7 +31,7 @@ def get_multipart_request_body(query, variables, file, file_name):
     of additional 'operations' and 'map' keys.
     """
     return {
-        'operations': json.dumps({'query': query, 'variables': variables}),
+        'operations': json.dumps(query, variables),
         'map': json.dumps({file_name: ['variables.file']}), file_name: file}
 
 

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -31,7 +31,7 @@ def get_multipart_request_body(query, variables, file, file_name):
     of additional 'operations' and 'map' keys.
     """
     return {
-        'operations': json.dumps(query, variables),
+        'operations': json.dumps({'query': query, 'variables': variables}),
         'map': json.dumps({file_name: ['variables.file']}), file_name: file}
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from django.contrib.sites.models import Site
 from django.core.files import File
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.forms import ModelForm
+from django.shortcuts import reverse
 from django.test.client import MULTIPART_CONTENT, Client
 from django.utils.encoding import smart_text
 from django_countries import countries
@@ -31,12 +32,13 @@ from saleor.order.models import Order
 from saleor.order.utils import recalculate_order
 from saleor.page.models import Page
 from saleor.product.models import (
-    AttributeValue, Category, Collection, Product, Attribute,
-    AttributeTranslation, ProductImage, ProductTranslation, ProductType,
-    ProductVariant)
+    Attribute, AttributeTranslation, AttributeValue, Category, Collection,
+    Product, ProductImage, ProductTranslation, ProductType, ProductVariant)
 from saleor.shipping.models import (
     ShippingMethod, ShippingMethodType, ShippingZone)
 from saleor.site.models import AuthorizationKey, SiteSettings
+
+API_PATH = reverse('api')
 
 
 class ApiClient(Client):
@@ -53,7 +55,7 @@ class ApiClient(Client):
         environ.update({'HTTP_AUTHORIZATION': 'JWT %s' % self.token})
         return environ
 
-    def post(self, path, data=None, **kwargs):
+    def post(self, data=None, **kwargs):
         """Send a POST request.
 
         This wrapper sets the `application/json` content type which is
@@ -63,7 +65,7 @@ class ApiClient(Client):
         if data:
             data = json.dumps(data)
         kwargs['content_type'] = 'application/json'
-        return super().post(path, data, **kwargs)
+        return super().post(API_PATH, data, **kwargs)
 
     def post_multipart(self, *args, **kwargs):
         """Send a multipart POST request.
@@ -72,7 +74,7 @@ class ApiClient(Client):
         uploading files.
         """
         kwargs['content_type'] = MULTIPART_CONTENT
-        return super().post(*args, **kwargs)
+        return super().post(API_PATH, *args, **kwargs)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,11 +68,16 @@ class ApiClient(Client):
         return super().post(API_PATH, data, **kwargs)
 
     def post_graphql(self, query=None, variables=None, **kwargs):
+        """Dedicated helper for posting GraphQL queries.
+
+        Sets the `application/json` content type and json.dumps the variables
+        if present.
+        """
         data = {}
         if query is not None:
             data['query'] = query
         if variables is not None:
-            data['variables'] = variables
+            data['variables'] = json.dumps(variables)
         if data:
             data = json.dumps(data)
         kwargs['content_type'] = 'application/json'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,17 @@ class ApiClient(Client):
         kwargs['content_type'] = 'application/json'
         return super().post(API_PATH, data, **kwargs)
 
+    def post_graphql(self, query=None, variables=None, **kwargs):
+        data = {}
+        if query is not None:
+            data['query'] = query
+        if variables is not None:
+            data['variables'] = variables
+        if data:
+            data = json.dumps(data)
+        kwargs['content_type'] = 'application/json'
+        return super().post(API_PATH, data, **kwargs)
+
     def post_multipart(self, *args, **kwargs):
         """Send a multipart POST request.
 


### PR DESCRIPTION
The first part of changes described in #3003 
- Introduced new Client's method `post_graphql` which takes `variables` and `query` arguments. 
I think it's more readable that overriding the default `post` method.
- Calls `json.dumps` on `variables` inside of `post_graphql` method instead of in each test individually
- API posts to api url by default (no need to specify the url in every test)