### PR TITLE
Add WORKDIR before calling pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN \
 RUN pip install pipenv
 ADD Pipfile /app/
 ADD Pipfile.lock /app/
+WORKDIR /app
 RUN pipenv install --system --deploy
 
 ### Build static assets


### PR DESCRIPTION
An attempt to fix the failing build on CircleCI by setting the WORKDIR before calling `pipenv`.
