### PR TITLE
Make Meta.description required for BaseMutation

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -46,6 +46,12 @@ class BaseMutation(graphene.Mutation):
         abstract = True
 
     @classmethod
+    def __init_subclass_with_meta__(cls, description=None, **options):
+        if not description:
+            raise ImproperlyConfigured('No description provided in Meta')
+        super().__init_subclass_with_meta__(description=description, **options)
+
+    @classmethod
     def _update_mutation_arguments_and_fields(cls, arguments, fields):
         cls._meta.arguments.update(arguments)
         cls._meta.fields.update(fields)

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -31,6 +31,9 @@ class ShopSettingsUpdate(BaseMutation):
             description='Fields required to update shop settings.',
             required=True)
 
+    class Meta:
+        description = 'Updates shop settings'
+
     shop = graphene.Field(
         Shop, description='Updated Shop')
 
@@ -56,6 +59,9 @@ class ShopDomainUpdate(BaseMutation):
     class Arguments:
         input = SiteDomainInput(description='Fields required to update site')
 
+    class Meta:
+        description = 'Updates site domain of the shop'
+
     shop = graphene.Field(Shop, description='Updated Shop')
 
     @classmethod
@@ -80,6 +86,9 @@ class HomepageCollectionUpdate(BaseMutation):
     class Arguments:
         collection = graphene.ID(
             description='Collection displayed on homepage')
+
+    class Meta:
+        description = 'Updates homepage collection of the shop'
 
     shop = graphene.Field(
         Shop, description='Updated Shop')

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -1,4 +1,6 @@
 import graphene
+import pytest
+from django.core.exceptions import ImproperlyConfigured
 from saleor.graphql.core.mutations import BaseMutation
 from saleor.graphql.product import types as product_types
 
@@ -8,6 +10,9 @@ class Mutation(BaseMutation):
 
     class Arguments:
         product_id = graphene.ID(required=True)
+
+    class Meta:
+        description = 'Base mutation'
 
     @classmethod
     def mutate(cls, root, info, product_id):
@@ -26,6 +31,15 @@ class Mutations(graphene.ObjectType):
 schema = graphene.Schema(
     mutation=Mutations,
     types=[product_types.Product, product_types.ProductVariant])
+
+
+def test_mutation_without_description_raises_error():
+    with pytest.raises(ImproperlyConfigured) as exc_info:
+        class MutationNoDescription(BaseMutation):
+            name = graphene.Field(graphene.String)
+
+            class Arguments:
+                product_id = graphene.ID(required=True)
 
 
 def test_resolve_id(product):


### PR DESCRIPTION
I want to merge this change because...

closes #3031 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
