### PR TITLE
Fixed tons of deprecated warnings using latest pytest

### DIFF
--- a/saleor/core/templatetags/placeholder.py
+++ b/saleor/core/templatetags/placeholder.py
@@ -1,4 +1,4 @@
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.template import Library
 
 register = Library()

--- a/saleor/core/templatetags/placeholder.py
+++ b/saleor/core/templatetags/placeholder.py
@@ -1,5 +1,5 @@
-from django.templatetags.static import static
 from django.template import Library
+from django.templatetags.static import static
 
 register = Library()
 

--- a/saleor/dashboard/order/urls.py
+++ b/saleor/dashboard/order/urls.py
@@ -58,6 +58,6 @@ urlpatterns = [
     url(r'^(?P<order_pk>\d+)/mark-as-paid/$',
         views.mark_order_as_paid, name='order-mark-as-paid'),
 
-    url('^(?P<order_pk>\d+)/ajax/shipping-methods/$',
+    url(r'^(?P<order_pk>\d+)/ajax/shipping-methods/$',
         views.ajax_order_shipping_methods_list,
         name='ajax-order-shipping-methods')]

--- a/saleor/dashboard/templatetags/utils.py
+++ b/saleor/dashboard/templatetags/utils.py
@@ -2,7 +2,7 @@ from json import dumps
 from urllib.parse import urlencode
 
 from django import forms
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.template import Library
 from django_filters.fields import RangeField
 from versatileimagefield.widgets import VersatileImagePPOIClickWidget

--- a/saleor/dashboard/templatetags/utils.py
+++ b/saleor/dashboard/templatetags/utils.py
@@ -2,8 +2,8 @@ from json import dumps
 from urllib.parse import urlencode
 
 from django import forms
-from django.templatetags.static import static
 from django.template import Library
+from django.templatetags.static import static
 from django_filters.fields import RangeField
 from versatileimagefield.widgets import VersatileImagePPOIClickWidget
 

--- a/saleor/product/templatetags/product_images.py
+++ b/saleor/product/templatetags/product_images.py
@@ -4,7 +4,7 @@ import warnings
 
 from django import template
 from django.conf import settings
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 logger = logging.getLogger(__name__)
 register = template.Library()

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -257,7 +257,7 @@ if DEBUG:
         'debug_toolbar.panels.profiling.ProfilingPanel',
     ]
     DEBUG_TOOLBAR_CONFIG = {
-        'RESULTS_STORE_SIZE': 100}
+        'RESULTS_CACHE_SIZE': 100}
 
 ENABLE_SILK = get_bool_from_env('ENABLE_SILK', False)
 if ENABLE_SILK:

--- a/templates/account/account_delete_prompt.html
+++ b/templates/account/account_delete_prompt.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% load bootstrap_form from bootstrap4 %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load placeholder %}
 

--- a/templates/account/details.html
+++ b/templates/account/details.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load i18n_address_tags %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 {% block title %}{% trans "Your profile" context "User profile page title" %} — {{ block.super }}{% endblock %}

--- a/templates/account/login.html
+++ b/templates/account/login.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block title %}{% trans "Log in" context "Login page title" %} — {{ block.super }}{% endblock %}

--- a/templates/account/partials/login_form.html
+++ b/templates/account/partials/login_form.html
@@ -1,6 +1,6 @@
 {% load bootstrap_form from bootstrap4 %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 <form method="post" action="{% url 'account:login' %}" novalidate>
   {% csrf_token %}

--- a/templates/account/password_reset.html
+++ b/templates/account/password_reset.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap_form from bootstrap4 %}
 
 {% block title %}{% trans "Password reset" context "Password reset page title" %} — {{ block.super }}{% endblock %}

--- a/templates/account/password_reset_done.html
+++ b/templates/account/password_reset_done.html
@@ -1,7 +1,7 @@
 {% extends "account/password_reset_base.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Password Reset" context "Password reset done page title" %}{% endblock %}
 

--- a/templates/account/password_reset_from_key.html
+++ b/templates/account/password_reset_from_key.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load bootstrap_form from bootstrap4 %}
-{% load staticfiles %}
+{% load static %}
 {% block head_title %}{% trans "Change Password" context "Password reset from key page title" %}{% endblock %}
 
 {% block form %}

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load bootstrap_form from bootstrap4 %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 
 {% block title %}{% trans "Sign Up" context "Signup page title" %} — {{ block.super }}{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,7 +3,7 @@
 {% load menu from shop %}
 {% load placeholder %}
 {% load render_bundle from webpack_loader %}
-{% load staticfiles %}
+{% load static %}
 {% load translate_url from urls %}
 
 <html lang="{{ LANGUAGE_CODE }}" class="no-js" data-shipping-options-url="{% url 'cart:shipping-options' %}" data-cart-summary-url="{% url 'cart:summary' %}">

--- a/templates/cart_dropdown.html
+++ b/templates/cart_dropdown.html
@@ -2,7 +2,7 @@
 {% load get_thumbnail from product_images %}
 {% load placeholder %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 
 <div class="container">
   {% if quantity > 0 %}

--- a/templates/category/index.html
+++ b/templates/category/index.html
@@ -1,6 +1,6 @@
 {% extends "product/product_list_base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block breadcrumb_part %}
   <li>

--- a/templates/checkout/details.html
+++ b/templates/checkout/details.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Checkout" context "Checkout page title" %} — {{ block.super }}{% endblock %}
 

--- a/templates/checkout/index.html
+++ b/templates/checkout/index.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load get_thumbnail from product_images %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Your cart" context "Cart page title" %} — {{ block.super }}{% endblock %}
 

--- a/templates/checkout/login.html
+++ b/templates/checkout/login.html
@@ -1,5 +1,5 @@
 {% extends "checkout/details.html" %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load placeholder %}
 

--- a/templates/collection/index.html
+++ b/templates/collection/index.html
@@ -1,6 +1,6 @@
 {% extends "product/product_list_base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block breadcrumb_part %}
   <li>

--- a/templates/dashboard/base.html
+++ b/templates/dashboard/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% load render_bundle from webpack_loader %}
 {% load version %}
 {% load serialize_messages from utils %}

--- a/templates/dashboard/category/detail.html
+++ b/templates/dashboard/category/detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load mptt_tags %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}{% trans "Categories" context "Category list page title" %} -

--- a/templates/dashboard/category/form.html
+++ b/templates/dashboard/category/form.html
@@ -2,7 +2,7 @@
 {% load materializecss %}
 {% load i18n %}
 {% load mptt_tags %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if category.pk %}

--- a/templates/dashboard/category/list.html
+++ b/templates/dashboard/category/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load mptt_tags %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/collection/detail.html
+++ b/templates/dashboard/collection/detail.html
@@ -1,7 +1,7 @@
 {% extends 'dashboard/base.html' %}
 {% load materializecss %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 {% block title %}

--- a/templates/dashboard/collection/list.html
+++ b/templates/dashboard/collection/list.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 {% load utils %}
 

--- a/templates/dashboard/customer/detail.html
+++ b/templates/dashboard/customer/detail.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load materializecss %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 {% block title %}

--- a/templates/dashboard/customer/form.html
+++ b/templates/dashboard/customer/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load materializecss %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if customer.pk %}

--- a/templates/dashboard/customer/list.html
+++ b/templates/dashboard/customer/list.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/discount/sale/form.html
+++ b/templates/dashboard/discount/sale/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if sale.pk %}

--- a/templates/dashboard/discount/sale/list.html
+++ b/templates/dashboard/discount/sale/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load materializecss %}
 {% load static %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/discount/voucher/form.html
+++ b/templates/dashboard/discount/voucher/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if voucher.pk %}

--- a/templates/dashboard/includes/_address.html
+++ b/templates/dashboard/includes/_address.html
@@ -1,5 +1,5 @@
 {% load i18n_address_tags %}
-{% load staticfiles %}
+{% load static %}
 
 <div class="address">
 	{% format_address address include_phone=False latin=True %}

--- a/templates/dashboard/includes/_menu_items.html
+++ b/templates/dashboard/includes/_menu_items.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load utils %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 <div class="card">

--- a/templates/dashboard/includes/_pagination.html
+++ b/templates/dashboard/includes/_pagination.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% load utils %}
-{% load staticfiles %}
+{% load static %}
 
 
 {% if page_obj.paginator.num_pages > 1 %}

--- a/templates/dashboard/menu/detail.html
+++ b/templates/dashboard/menu/detail.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}{% trans "Navigation" context "Menu list page title" %} -

--- a/templates/dashboard/menu/form.html
+++ b/templates/dashboard/menu/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load materializecss %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if menu.pk %}

--- a/templates/dashboard/menu/item/detail.html
+++ b/templates/dashboard/menu/item/detail.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}{% trans "Menu items" context "Menu item list page title" %} -

--- a/templates/dashboard/menu/item/form.html
+++ b/templates/dashboard/menu/item/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load materializecss %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if menu_item.pk %}

--- a/templates/dashboard/menu/list.html
+++ b/templates/dashboard/menu/list.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load mptt_tags %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/next.html
+++ b/templates/dashboard/next.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% load render_bundle from webpack_loader %}
 {% load version %}
 {% load serialize_messages from utils %}

--- a/templates/dashboard/order/address_form.html
+++ b/templates/dashboard/order/address_form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% trans "Edit address" context "" %} - {% trans "Orders" context "Dashboard orders list" %} - {{ block.super }}

--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -4,7 +4,7 @@
 {% load i18n_address_tags %}
 {% load materializecss %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 {% load voucher %}
 

--- a/templates/dashboard/order/fulfillment.html
+++ b/templates/dashboard/order/fulfillment.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load i18n_address_tags %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 {% block title %}

--- a/templates/dashboard/order/list.html
+++ b/templates/dashboard/order/list.html
@@ -4,7 +4,7 @@
 {% load prices_i18n %}
 {% load status %}
 {% load utils %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}{% trans "Orders" context "Dashboard orders list" %} - {{ block.super }}{% endblock %}
 

--- a/templates/dashboard/page/detail.html
+++ b/templates/dashboard/page/detail.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 {% load utils %}
 

--- a/templates/dashboard/page/form.html
+++ b/templates/dashboard/page/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if page.pk %}

--- a/templates/dashboard/page/list.html
+++ b/templates/dashboard/page/list.html
@@ -1,6 +1,6 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 {% load utils %}
 

--- a/templates/dashboard/product/attribute/detail.html
+++ b/templates/dashboard/product/attribute/detail.html
@@ -1,7 +1,7 @@
 {% extends 'dashboard/base.html' %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {{ attribute }} - {{ block.super }}

--- a/templates/dashboard/product/attribute/form.html
+++ b/templates/dashboard/product/attribute/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if attribute.pk %}

--- a/templates/dashboard/product/attribute/list.html
+++ b/templates/dashboard/product/attribute/list.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/product/attribute/values/form.html
+++ b/templates/dashboard/product/attribute/values/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if attribute.pk %}

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 {% load utils %}
 

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if product.pk %}

--- a/templates/dashboard/product/list.html
+++ b/templates/dashboard/product/list.html
@@ -3,7 +3,7 @@
 {% load materializecss %}
 {% load price from taxed_prices %}
 {% load get_thumbnail from product_images %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/product/product_image/form.html
+++ b/templates/dashboard/product/product_image/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if product_image.pk %}

--- a/templates/dashboard/product/product_image/list.html
+++ b/templates/dashboard/product/product_image/list.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% trans "Images" %} - {{ block.super }}

--- a/templates/dashboard/product/product_type/form.html
+++ b/templates/dashboard/product/product_type/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if product_type.pk %}

--- a/templates/dashboard/product/product_type/list.html
+++ b/templates/dashboard/product/product_type/list.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/product/product_type/modal/confirm_delete.html
+++ b/templates/dashboard/product/product_type/modal/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base_modal.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block form_class %}{% endblock %}
 

--- a/templates/dashboard/product/product_variant/detail.html
+++ b/templates/dashboard/product/product_variant/detail.html
@@ -2,7 +2,7 @@
 
 {% load i18n %}
 {% load price from taxed_prices %}
-{% load staticfiles %}
+{% load static %}
 {% load status %}
 
 {% block title %}

--- a/templates/dashboard/product/product_variant/form.html
+++ b/templates/dashboard/product/product_variant/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if variant.pk %}

--- a/templates/dashboard/product/product_variant/modal/confirm_delete.html
+++ b/templates/dashboard/product/product_variant/modal/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base_modal.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block form_class %}{% endblock %}
 

--- a/templates/dashboard/search/results.html
+++ b/templates/dashboard/search/results.html
@@ -3,7 +3,7 @@
 {% load materializecss %}
 {% load price from taxed_prices %}
 {% load get_thumbnail from product_images %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% trans "Search results" context "Search page title" %} - {{ block.super }}

--- a/templates/dashboard/shipping/form.html
+++ b/templates/dashboard/shipping/form.html
@@ -2,7 +2,7 @@
 {% load materializecss %}
 {% load i18n %}
 {% load mptt_tags %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if shipping_zone.pk %}

--- a/templates/dashboard/shipping/methods/form.html
+++ b/templates/dashboard/shipping/methods/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if method.pk %}

--- a/templates/dashboard/shipping/modal/confirm_delete.html
+++ b/templates/dashboard/shipping/modal/confirm_delete.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base_modal.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block form_class %}{% endblock %}
 

--- a/templates/dashboard/sites/authorization_keys/form.html
+++ b/templates/dashboard/sites/authorization_keys/form.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if site.pk %}

--- a/templates/dashboard/sites/detail.html
+++ b/templates/dashboard/sites/detail.html
@@ -1,7 +1,7 @@
 {% extends 'dashboard/base.html' %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {{ site_settings }} - {{ block.super }}

--- a/templates/dashboard/staff/detail.html
+++ b/templates/dashboard/staff/detail.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load materializecss %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% if staff_member %}

--- a/templates/dashboard/staff/list.html
+++ b/templates/dashboard/staff/list.html
@@ -1,7 +1,7 @@
 {% extends "dashboard/base.html" %}
 {% load i18n %}
 {% load materializecss %}
-{% load staticfiles %}
+{% load static %}
 {% load utils %}
 
 {% block title %}

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load staticfiles i18n %}
+{% load static i18n %}
 {% load render_bundle from webpack_loader %}
 
 <html lang="{{ LANGUAGE_CODE }}" class="no-js">

--- a/templates/dashboard/taxes/details.html
+++ b/templates/dashboard/taxes/details.html
@@ -2,7 +2,7 @@
 
 {% load get_country_by_code from dashboard %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% get_country_by_code tax.country_code as country_name %}

--- a/templates/dashboard/taxes/form.html
+++ b/templates/dashboard/taxes/form.html
@@ -1,5 +1,5 @@
 {% extends 'dashboard/base.html' %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load materializecss %}
 

--- a/templates/order/checkout_success.html
+++ b/templates/order/checkout_success.html
@@ -1,7 +1,7 @@
 {% extends 'checkout/details.html' %}
 
 {% load bootstrap_form from bootstrap4 %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load placeholder %}
 

--- a/templates/order/checkout_success_anonymous.html
+++ b/templates/order/checkout_success_anonymous.html
@@ -1,7 +1,7 @@
 {% extends 'checkout/details.html' %}
 
 {% load bootstrap_form from bootstrap4 %}
-{% load staticfiles %}
+{% load static %}
 {% load i18n %}
 {% load placeholder %}
 

--- a/templates/order/details.html
+++ b/templates/order/details.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap_form from bootstrap4 %}
 
 {% block title %}

--- a/templates/order/payment.html
+++ b/templates/order/payment.html
@@ -2,7 +2,7 @@
 
 {% load bootstrap_form from bootstrap4 %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 {% block title %}
   {% blocktrans trimmed context "Payment details page title" %}

--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 
 <div class="product-filters">
   <div class="product-filters__title">

--- a/templates/product/_items.html
+++ b/templates/product/_items.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load taxed_prices %}
 {% load get_thumbnail from product_images %}
 {% load placeholder %}

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -7,7 +7,7 @@
 {% load i18n %}
 {% load markdown from markdown %}
 {% load placeholder %}
-{% load staticfiles %}
+{% load static %}
 {% load taxed_prices %}
 
 {% block title %}

--- a/templates/product/product_list_base.html
+++ b/templates/product/product_list_base.html
@@ -4,7 +4,7 @@
 {% load get_object_properties from attributes %}
 {% load i18n %}
 {% load shop %}
-{% load staticfiles %}
+{% load static %}
 
 {% block footer_scripts %}
   {{ block.super }}

--- a/templates/search/results.html
+++ b/templates/search/results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap_pagination from bootstrap4 %}
 
 {% block title %}{% trans "Search results" context "Search page title" %} {{ block.super }}{% endblock %}

--- a/templates/styleguide.html
+++ b/templates/styleguide.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load i18n %}
-{% load staticfiles %}
+{% load static %}
 {% load bootstrap_form from bootstrap4 %}
 
 {% block title %}Style guide — {{ block.super }}{% endblock %}

--- a/templates/templated_email/source/shared/header.mjml
+++ b/templates/templated_email/source/shared/header.mjml
@@ -1,5 +1,5 @@
 <mj-raw>
-  {% load staticfiles %}
+  {% load static %}
 </mj-raw>
 <mj-section>
   <mj-column>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
-import django
 from django.contrib.auth.models import Permission
 from django.contrib.sites.models import Site
 from django.core.files import File
@@ -35,33 +34,6 @@ from saleor.product.models import (
 from saleor.shipping.models import (
     ShippingMethod, ShippingMethodType, ShippingZone)
 from saleor.site.models import AuthorizationKey, SiteSettings
-
-
-def pytest_collection_modifyitems(items):
-    for item in items:
-        # Enable deprecation warning which is disabled by Python automatically
-        # This is to make sure having same behaviour with pytest
-        item.add_marker(
-            pytest.mark.filterwarnings('default::DeprecationWarning'))
-        item.add_marker(
-            pytest.mark.filterwarnings('default::PendingDeprecationWarning'))
-
-        # Ignore from_db_value deprecation warning in Django 2.X 
-        # since it is not used in saleor, but may used in third-party packages
-        if django.VERSION[0] == 2:
-            item.add_marker(pytest.mark.filterwarnings(
-                'ignore:'
-                '.*from_db_value.*:'
-                'django.utils.deprecation.RemovedInDjango30Warning'))
-        
-        # Ignore is_authenticated() deprecation warning in Django 1.X 
-        # in django-impersonate package
-        if django.VERSION[0] == 1:
-            item.add_marker(pytest.mark.filterwarnings(
-                'ignore:'
-                '.*is_authenticated.*:'
-                'django.utils.deprecation.RemovedInDjango20Warning:'
-                'impersonate.helpers'))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
+import django
 from django.contrib.auth.models import Permission
 from django.contrib.sites.models import Site
 from django.core.files import File
@@ -34,6 +35,33 @@ from saleor.product.models import (
 from saleor.shipping.models import (
     ShippingMethod, ShippingMethodType, ShippingZone)
 from saleor.site.models import AuthorizationKey, SiteSettings
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # Enable deprecation warning which is disabled by Python automatically
+        # This is to make sure having same behaviour with pytest
+        item.add_marker(
+            pytest.mark.filterwarnings('default::DeprecationWarning'))
+        item.add_marker(
+            pytest.mark.filterwarnings('default::PendingDeprecationWarning'))
+
+        # Ignore from_db_value deprecation warning in Django 2.X 
+        # since it is not used in saleor, but may used in third-party packages
+        if django.VERSION[0] == 2:
+            item.add_marker(pytest.mark.filterwarnings(
+                'ignore:'
+                '.*from_db_value.*:'
+                'django.utils.deprecation.RemovedInDjango30Warning'))
+        
+        # Ignore is_authenticated() deprecation warning in Django 1.X 
+        # in django-impersonate package
+        if django.VERSION[0] == 1:
+            item.add_marker(pytest.mark.filterwarnings(
+                'ignore:'
+                '.*is_authenticated.*:'
+                'django.utils.deprecation.RemovedInDjango20Warning:'
+                'impersonate.helpers'))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_product_tags.py
+++ b/tests/test_product_tags.py
@@ -1,6 +1,6 @@
 from unittest.mock import Mock, patch
 
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 from django.test import override_settings
 
 from saleor.product.templatetags.product_images import (


### PR DESCRIPTION
After https://github.com/mirumee/saleor/pull/2430 pytest is updated to latest version. Since pytest 3.8.0, ```DeprecationWarning``` and ```PendingDeprecationWarning``` are now shown by default if no other warning filter is configured. https://github.com/pytest-dev/pytest/blob/master/CHANGELOG.rst#features. This makes the test in CI having tons of deprecated warning messages.

This PR ignores deprecation warning for third-party packages and update saleor to remove the deprecated warnings.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
