### PR TITLE
Move django debug toolbar dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,8 @@ django-bootstrap4==0.0.7
 django-cache-url==3.0.0
 django-celery-results==1.0.1
 django-countries==5.3.2
+django-debug-toolbar-request-history==0.0.9
+django-debug-toolbar==1.10.1
 django-elasticsearch-dsl==0.5.0
 django-filter==2.0.0
 django-fsm==2.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,8 +7,6 @@ certifi==2018.8.24
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
-django-debug-toolbar-request-history==0.0.9
-django-debug-toolbar==1.10.1
 django-extensions==2.1.2
 django-silk==2.0.0
 django==2.1.1


### PR DESCRIPTION
I want to merge this change because...

close #3042 

Django debug toolbar dependencies are currently in `requirements_dev.txt` but they are required for the project to run and for the startup tutorial to work without issue. Moving packages to `requirements.txt`.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] The packages install successfully.
1. [ ] The changes are tested.
