### PR TITLE
Fix date formatting when timezone is missing

### DIFF
--- a/saleor/static/dashboard-next/components/DateFormatter/DateFormatter.tsx
+++ b/saleor/static/dashboard-next/components/DateFormatter/DateFormatter.tsx
@@ -14,6 +14,13 @@ interface DateFormatterProps {
 const DateFormatter: React.StatelessComponent<DateFormatterProps> = ({
   date
 }) => {
+  const getTitle = (value: string, locale?: string, tz?: string) => {
+    let date = moment(value).locale(locale);
+    if (tz !== undefined) {
+      date = date.tz(tz);
+    }
+    return date.toLocaleString();
+  };
   return (
     <LocaleConsumer>
       {locale => (
@@ -21,12 +28,7 @@ const DateFormatter: React.StatelessComponent<DateFormatterProps> = ({
           {tz => (
             <Consumer>
               {currentDate => (
-                <Tooltip
-                  title={moment(date)
-                    .locale(locale)
-                    .tz(tz)
-                    .toLocaleString()}
-                >
+                <Tooltip title={getTitle(date, locale, tz)}>
                   <ReactMoment from={currentDate} locale={locale} tz={tz}>
                     {date}
                   </ReactMoment>


### PR DESCRIPTION
This fixes the regression caused by merging #3028. Date formatting was failing when no particular timezone was enforced. Currently it defaults to the local timezone of the browser.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
