### PR TITLE
Do not collect unnecessary static files

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -123,7 +123,8 @@ STATICFILES_DIRS = [
     ('assets', os.path.join(PROJECT_ROOT, 'saleor', 'static', 'assets')),
     ('favicons', os.path.join(PROJECT_ROOT, 'saleor', 'static', 'favicons')),
     ('images', os.path.join(PROJECT_ROOT, 'saleor', 'static', 'images')),
-    ('dashboard', os.path.join(PROJECT_ROOT, 'saleor', 'static', 'dashboard'))]
+    ('dashboard_images', os.path.join(
+        PROJECT_ROOT, 'saleor', 'static', 'dashboard', 'images'))]
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder']


### PR DESCRIPTION
As mentioned in https://github.com/mirumee/saleor/pull/3047#issuecomment-427364593, unnecessary static files are collected by collectstatic.

It will be more elegant to move to frontend's source files to such as ```/src```, but this sounds like a big refactor and many existed pull requests needs to rebase.

So this PR fixed this issue tempararily.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
