### PR TITLE
Add .gitattributes file to hide generated files diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,18 +1,12 @@
 # Package manager lock files
-Pipfile.lock linguist-generated
-package-lock.json linguist-generated
-
-# Generated GraphQL schemas
-*.graphql linguist-generated
-
-# Generated GraphQL types
-gql-types.ts linguist-generated
+Pipfile.lock linguist-generated -diff -merge
+package-lock.json linguist-generated -diff -merge
 
 # Generated django migration files
 *_auto_*.py linguist-generated
 
 # Generated locale pot files
-*.po linguist-generated
+*.po -merge
 
 # Software made SVG files
 *.svg linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,21 @@
+# Package manager lock files
+Pipfile.lock linguist-generated
+package-lock.json linguist-generated
+
+# Generated GraphQL schemas
+*.graphql linguist-generated
+
+# Generated GraphQL types
+gql-types.ts linguist-generated
+
+# Generated django migration files
+*_auto_*.py linguist-generated
+
+# Generated locale pot files
+*.po linguist-generated
+
+# Software made SVG files
+*.svg linguist-generated
+
+# Precompiled emails templates
+*.mjml linguist-generated


### PR DESCRIPTION
Closes #2673.

This hides diffs from:
- Pipenv lock files;
- GraphQL generated files (types and schemas);
- mjml precompiled files;
- django generated migration files;
- pot files;
- svg files.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
