### PR TITLE
Issue 2749, added alt text to cart icon so that it will say Items if …

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -149,7 +149,7 @@
                   {% trans "Your Cart" context "Main navigation item" %}
                 </span>
                 <div class="navbar__brand__cart__icon">
-                  <svg data-src="{% static "images/cart.svg" %}" width="35" height="30"/>
+                  <svg data-src="{% static "images/cart.svg" %}" width="35" height="30" alt="Items"/>
                 </div>
                 <span class="badge {% if not cart_counter %}empty{% endif %}">
                   {% if cart_counter %}


### PR DESCRIPTION

I want to merge this change because...

Issue 2749 suggests that there should be a text alternative in case the cart icon doesn't load. I added a text default to "Items" in case the icon doesn't load.

Fixes #2749

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
