### PR TITLE
Remove comparing string in address-form-panel template

### DIFF
--- a/templates/checkout/snippets/addresses_form.html
+++ b/templates/checkout/snippets/addresses_form.html
@@ -2,13 +2,13 @@
 <div class="panel-group" id="accordion" role="tablist" aria-multiselectable="true">
   {% if addresses_form.SHIPPING_ADDRESS %}
     {% trans "Same as shipping" context "Checkout addresses form label" as same_as_shipping %}
-    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" radio_name=addresses_form.address.html_name radio_value=addresses_form.SHIPPING_ADDRESS label=same_as_shipping value=addresses_form.address.value only %}
+    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" address_show=False radio_name=addresses_form.address.html_name radio_value=addresses_form.SHIPPING_ADDRESS label=same_as_shipping value=addresses_form.address.value only %}
   {% endif %}
   {% for address in addresses %}
-    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" radio_name=addresses_form.address.html_name radio_value=address.id label=address value=addresses_form.address.value address=address only %}
+    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" address_show=False radio_name=addresses_form.address.html_name radio_value=address.id label=address value=addresses_form.address.value address=address only %}
   {% endfor %}
   {% if addresses_form.NEW_ADDRESS and address_form %}
     {% trans "Enter a new address" context "Checkout addresses form label" as enter_a_new_address %}
-    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" radio_name=addresses_form.address.html_name radio_value=addresses_form.NEW_ADDRESS label=enter_a_new_address value=addresses_form.address.value address_form=address_form only %}
+    {% include "checkout/snippets/addresses_form_panel.html" with parent_element_id="accordion" address_show=True radio_name=addresses_form.address.html_name radio_value=addresses_form.NEW_ADDRESS label=enter_a_new_address value=addresses_form.address.value address_form=address_form only %}
   {% endif %}
 </div>

--- a/templates/checkout/snippets/addresses_form_panel.html
+++ b/templates/checkout/snippets/addresses_form_panel.html
@@ -1,5 +1,5 @@
  {% load i18n_address_tags %}
- <div class="radio {% if address or label == _('Same as shipping') %} address_hide{% else %} address_show{% endif %}">
+ <div class="radio {% if not address_show %} address_hide{% else %} address_show{% endif %}">
   <label>
     <input type="radio" name="{{ radio_name }}" value="{{ radio_value }}" id="address_{{ radio_value }}" {% if radio_value == value %}checked{% endif %}>
     {% if address %}


### PR DESCRIPTION
I want to merge this change because it resolve #1585 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
