### PR TITLE
Installing dev packages in docker since tests are needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install pipenv
 ADD Pipfile /app/
 ADD Pipfile.lock /app/
 WORKDIR /app
-RUN pipenv install --system --deploy
+RUN pipenv install --system --deploy --dev
 
 ### Build static assets
 FROM node:10 as build-nodejs


### PR DESCRIPTION
Fixed https://github.com/mirumee/saleor/pull/3076#issuecomment-428112618

Sorry, I don't know there are tests running insider the docker container in circle Ci. Dev packages should be installed insider of it by ```pipenv install --dev```

@maarcingebala 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
