### PR TITLE
Remove quantity-allocated generation in populatedb script

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -302,7 +302,6 @@ def create_variant(product, **kwargs):
     defaults = {
         'product': product,
         'quantity': fake.random_int(1, 50),
-        'quantity_allocated': fake.random_int(1, 50),
         'weight': fake.weight() if random.randint(0, 1) else None}
     defaults.update(kwargs)
     variant = ProductVariant(**defaults)


### PR DESCRIPTION
I removed the quantity-allocated value generation from the create_variant function in the random_data.py data generation script.

Ref #2572

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
