### PR TITLE
Remove custom services names in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       dockerfile: ./Dockerfile
       args:
         STATIC_URL: '/static/'
-    container_name: saleor-web
     restart: unless-stopped
     networks:
       - saleor-backend-tier
@@ -24,7 +23,6 @@ services:
 
   db:
     image: library/postgres:latest
-    container_name: saleor-postgres
     restart: unless-stopped
     networks:
       - saleor-backend-tier
@@ -38,7 +36,6 @@ services:
 
   redis:
     image: library/redis:latest
-    container_name: saleor-redis
     restart: unless-stopped
     networks:
       - saleor-backend-tier
@@ -53,7 +50,6 @@ services:
       dockerfile: ./Dockerfile
       args:
         STATIC_URL: '/static/'
-    container_name: saleor-celery
     command: celery -A saleor worker --app=saleor.celeryconf:app --loglevel=info
     restart: unless-stopped
     networks:
@@ -66,7 +62,6 @@ services:
 
   search:
     image: elasticsearch:5.4.3
-    container_name: saleor-elasticsearch
     restart: unless-stopped
     networks:
       - saleor-backend-tier


### PR DESCRIPTION
Remove custom services names in docker-compose to let Docker Compose generate default ones, based on the stack name. To allow having more than one Saleor stack at the same time on the same machine.

Otherwise, Docker Compose doesn't allow having the services on the second stack.

Currently, with custom names, each service gets a fixed name. Running:

```bash
docker-compose up -d
```

creates services / containers:

```
saleor-postgres
saleor-elasticsearch
saleor-redis
saleor-celery
saleor-web
```

After this change, if the base directory is `saleor`, it will create services / containers:

```
saleor_search_1
saleor_redis_1
saleor_db_1
saleor_celery_1
saleor_web_1
```

but if the directory was named `my-puppy-store`, the service names would be:

```
my-puppy-store_search_1
my-puppy-store_redis_1
my-puppy-store_db_1
my-puppy-store_celery_1
my-puppy-store_web_1
```

## I want to merge this change because...

This would allow having more than one Docker Compose based Saleor project. And simplify the current `docker-compose.yml` file.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [n/a] Privileged views and APIs are guarded by proper permission checks.
1. [n/a] All visible strings are translated with proper context.
1. [n/a] All data-formatting is locale-aware (dates, numbers, and so on).
1. [n/a] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [n/a] The code is documented (docstrings, project documentation).
1. [n/a] GraphQL schema and type definitions are up to date.
