### PR TITLE
Docker compose override

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,15 @@
+version: '2'
+
+services:
+  web:
+    ports:
+      - 8000:8000
+  db:
+    ports:
+      - 5432:5432
+  redis:
+    ports:
+      - 6379:6379
+  search:
+    ports:
+      - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    ports:
-      - 8000:8000
     volumes:
       - .:/app:Z
     env_file: common.env
@@ -30,8 +28,6 @@ services:
       - saleor-backend-tier
     volumes:
       - saleor-db:/var/lib/postgresql
-    ports:
-      - 5432:5432
     environment:
       - POSTGRES_USER=saleor
       - POSTGRES_PASSWORD=saleor
@@ -44,8 +40,6 @@ services:
       - saleor-backend-tier
     volumes:
       - saleor-redis:/data
-    ports:
-      - 6379:6379
 
   celery:
     build:
@@ -72,8 +66,6 @@ services:
       - saleor-backend-tier
     volumes:
       - saleor-search:/usr/share/elasticsearch/
-    ports:
-      - 9200:9200
     # See https://github.com/docker/compose/issues/4513 if updating to version '3'
     mem_limit: 512m
     environment:

--- a/docs/customization/docker.rst
+++ b/docs/customization/docker.rst
@@ -18,7 +18,7 @@ You will need to install Docker and `docker-compose <https://docs.docker.com/com
 
 .. note::
 
-   Our configuration uses a ``docker-compose.override.yml`` that exposes PostgreSQL, Redis and Elasticsearch ports. If you don't want to expose the ports you can tell Docker Compose to do not include the additional configurations (ports) in the ``docker-compose.override.yml`` file by specifying ``docker-compose.yml`` with the ``-f`` option, as in ``docker-compose -f docker-compose.yml up -d``.
+   Our configuration uses a ``docker-compose.override.yml`` that exposes PostgreSQL, Redis and Elasticsearch ports. If you don't want to expose the ports you can tell Docker Compose to not include the additional configurations (ports) in the ``docker-compose.override.yml`` file by specifying ``docker-compose.yml`` with the ``-f`` option, as in ``docker-compose -f docker-compose.yml up -d``.
 
 
 Usage

--- a/docs/customization/docker.rst
+++ b/docs/customization/docker.rst
@@ -18,7 +18,7 @@ You will need to install Docker and `docker-compose <https://docs.docker.com/com
 
 .. note::
 
-   Our configuration exposes PostgreSQL, Redis and Elasticsearch ports. If you have problems running this docker file because of port conflicts, you can remove ``ports`` section from ``docker-compose.yml``.
+   Our configuration uses a ``docker-compose.override.yml`` that exposes PostgreSQL, Redis and Elasticsearch ports. If you don't want to expose the ports you can tell Docker Compose to do not include the additional configurations (ports) in the ``docker-compose.override.yml`` file by specifying ``docker-compose.yml`` with the ``-f`` option, as in ``docker-compose -f docker-compose.yml up -d``.
 
 
 Usage


### PR DESCRIPTION
Include a `docker-compose.override.yml` file for the local development overrides as it is [read by default by Docker Compose](https://docs.docker.com/compose/extends/). 

This allows having the same configuration and current development experience, but the original `docker-compose.yml` file can be kept without exposing the ports, for example, to be used during deployments.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [n/a] Privileged views and APIs are guarded by proper permission checks.
1. [n/a] All visible strings are translated with proper context.
1. [n/a] All data-formatting is locale-aware (dates, numbers, and so on).
1. [n/a] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [n/a] The code is documented (docstrings, project documentation).
1. [n/a] GraphQL schema and type definitions are up to date.
