### PR TITLE
Hide shipping from dashboard order details...

### DIFF
--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -337,6 +337,7 @@
                   <p>
                     {% trans "Subtotal" context "Order subtotal" %}
                   </p>
+                  {% if order.is_shipping_required or order.shipping_method %}
                   <p>
                     {% if order.is_draft %}
                       <a href="#base-modal" data-href="{% url 'dashboard:order-shipping-edit' order_pk=order.pk %}"
@@ -359,6 +360,7 @@
                       {% endif %}
                     {% endif %}
                   </p>
+                  {% endif %}
                   <p>
                     {% if order.display_gross_prices %}
                       {% trans "Taxes (included)" context "Order total taxes" %}
@@ -410,9 +412,11 @@
                   <p>
                     {% price order.get_subtotal display_gross=order.display_gross_prices %}
                   </p>
+                  {% if order.is_shipping_required or order.shipping_method %}
                   <p>
                     {% price order.shipping_price display_gross=order.display_gross_prices %}
                   </p>
+                  {% endif %}
                   <p>{% price order.total.tax %}</p>
                   {% if order.is_draft or order.discount_amount %}
                     <p>{% discount_as_negative order.discount_amount html=True %}</p>


### PR DESCRIPTION
unless there are shippable items or shipping on the order.

I want to merge this change because it fixes #2935 

Decided to leave shipping address in case somebody needs it to be the registered owners address or similar. Happy to hide it as well if desirable?

Decided to leave shipping editable if present, e.g. shippable product removed after shipping added, as otherwise the order would not add up and user would need to re-add a shippable to rectify.

I did not fix the indents in the template as wanted to keep changes 100% obvious at least for first review of this change.

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/791747/46891757-e0e4ad80-ce62-11e8-9cce-2edbbc8ac61c.png)

After:
![image](https://user-images.githubusercontent.com/791747/46891650-6ddb3700-ce62-11e8-9396-5125117e26f3.png)
![image](https://user-images.githubusercontent.com/791747/46891665-83e8f780-ce62-11e8-96bc-791ba4652fe1.png)
![image](https://user-images.githubusercontent.com/791747/46891683-9b27e500-ce62-11e8-85da-aeddcf207c3e.png)
![image](https://user-images.githubusercontent.com/791747/46891710-b561c300-ce62-11e8-8f5f-70817368ca89.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
