### PR TITLE
Remove --dev from pipenv install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install pipenv
 ADD Pipfile /app/
 ADD Pipfile.lock /app/
 WORKDIR /app
-RUN pipenv install --system --deploy --dev
+RUN pipenv install --system --deploy
 
 ### Build static assets
 FROM node:10 as build-nodejs


### PR DESCRIPTION
What does this PR do?

  - removes the flag `--dev` from `pipenv install`

Why is this PR needed?

  - the resultant docker image should not include dev deps

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
