### PR TITLE
Use CommonJS packages instead of UMD

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,8 +16,8 @@ var reactDomPath;
 if (process.env.NODE_ENV === 'production') {
   const baseStaticPath = process.env.STATIC_URL || '/static/';
   const publicPath = url.resolve(baseStaticPath, 'assets/');
-  reactPath = 'node_modules/react/umd/react.production.min.js';
-  reactDomPath = 'node_modules/react-dom/umd/react-dom.production.min.js';
+  reactPath = 'node_modules/react/cjs/react.production.min.js';
+  reactDomPath = 'node_modules/react-dom/cjs/react-dom.production.min.js';
   output = {
     path: resolve('saleor/static/assets/'),
     filename: '[name].[chunkhash].js',
@@ -30,8 +30,8 @@ if (process.env.NODE_ENV === 'production') {
     chunkFilename: '[id].[chunkhash].css'
   });
 } else {
-  reactPath = 'node_modules/react/umd/react.development.js';
-  reactDomPath = 'node_modules/react-dom/umd/react-dom.development.js';
+  reactPath = 'node_modules/react/cjs/react.development.js';
+  reactDomPath = 'node_modules/react-dom/cjs/react-dom.development.js';
   output = {
     path: resolve('saleor/static/assets/'),
     filename: '[name].js',


### PR DESCRIPTION
I want to merge this change because, after the latest changes to `ReactDOM` version, webpack didn't import this package properly.
Fixes #3127 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
