### PR TITLE
Set homepage collection to None in api if input field is null

### DIFF
--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -93,10 +93,12 @@ class HomepageCollectionUpdate(BaseMutation):
 
     @classmethod
     @permission_required('site.manage_settings')
-    def mutate(cls, root, info, collection):
+    def mutate(cls, root, info, collection=None):
         errors = []
-        new_collection = cls.get_node_or_error(
-            info, collection, errors, 'collection', Collection)
+        new_collection = None
+        if collection:
+            new_collection = cls.get_node_or_error(
+                info, collection, errors, 'collection', Collection)
         if errors:
             return HomepageCollectionUpdate(errors=errors)
         site_settings = info.context.site.settings

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -242,6 +242,32 @@ def test_homepage_collection_update(
     assert site.settings.homepage_collection == collection
 
 
+def test_homepage_collection_update_set_null(
+        staff_api_client, collection, site_settings,
+        permission_manage_settings):
+    query = """
+        mutation homepageCollectionUpdate($collection: ID) {
+            homepageCollectionUpdate(collection: $collection) {
+                shop {
+                    homepageCollection {
+                        id
+                    }
+                }
+            }
+        }
+    """
+    site_settings.homepage_collection = collection
+    site_settings.save()
+    variables = {'collection': None}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_settings])
+    content = get_graphql_content(response)
+    data = content['data']['homepageCollectionUpdate']['shop']
+    assert data['homepageCollection'] is None
+    site_settings.refresh_from_db()
+    assert site_settings.homepage_collection is None
+
+
 def test_query_default_country(user_api_client, settings):
     settings.DEFAULT_COUNTRY = 'US'
     query = """


### PR DESCRIPTION
I want to merge this change because...

closes #3138 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
