### PR TITLE
Separate parent variable from category input

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -42,7 +42,7 @@ class CategoryCreate(ModelMutation):
         cleaned_input = super().clean_input(info, instance, input, errors)
         if 'slug' not in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
-        parent_id = input['parent']
+        parent_id = input['parent_id']
         if parent_id:
             parent = cls.get_node_or_error(
                 info, parent_id, errors, field='parent', only_type=Category)
@@ -57,7 +57,7 @@ class CategoryCreate(ModelMutation):
     @classmethod
     def mutate(cls, root, info, **data):
         parent_id = data.pop('parent_id', None)
-        data['input']['parent'] = parent_id
+        data['input']['parent_id'] = parent_id
         return super().mutate(root, info, **data)
 
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -11,17 +11,14 @@ from ...core.types.money import TaxRateType
 from ...core.utils import clean_seo_fields
 from ...file_upload.types import Upload
 from ...shipping.types import WeightScalar
-from ..types import Collection, Product, ProductImage, ProductVariant
+from ..types import Category, Collection, Product, ProductImage, ProductVariant
 from ..utils import attributes_to_hstore, update_variants_names
 
 
 class CategoryInput(graphene.InputObjectType):
     description = graphene.String(description='Category description')
     name = graphene.String(description='Category name')
-    parent = graphene.ID(
-        description='''
-        ID of the parent category. If empty, category will be top level
-        category.''', name='parent')
+
     slug = graphene.String(description='Category slug')
     seo = SeoInput(description='Search engine optimization fields.')
     background_image = Upload(description='Background image file.')
@@ -31,6 +28,10 @@ class CategoryCreate(ModelMutation):
     class Arguments:
         input = CategoryInput(
             required=True, description='Fields required to create a category.')
+        parent_id = graphene.ID(
+            description='''
+                ID of the parent category. If empty, category will be top level
+                category.''', name='parent')
 
     class Meta:
         description = 'Creates a new category.'
@@ -41,12 +42,23 @@ class CategoryCreate(ModelMutation):
         cleaned_input = super().clean_input(info, instance, input, errors)
         if 'slug' not in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
+        parent_id = input['parent']
+        if parent_id:
+            parent = cls.get_node_or_error(
+                info, parent_id, errors, field='parent', only_type=Category)
+            cleaned_input['parent'] = parent
         clean_seo_fields(cleaned_input)
         return cleaned_input
 
     @classmethod
     def user_is_allowed(cls, user, input):
         return user.has_perm('product.manage_products')
+
+    @classmethod
+    def mutate(cls, root, info, **data):
+        parent_id = data.pop('parent_id', None)
+        data['input']['parent'] = parent_id
+        return super().mutate(root, info, **data)
 
 
 class CategoryUpdate(CategoryCreate):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -269,7 +269,6 @@ type CategoryDelete {
 input CategoryInput {
   description: String
   name: String
-  parent: ID
   slug: String
   seo: SeoInput
   backgroundImage: Upload
@@ -692,7 +691,7 @@ type Mutations {
   attributeValueCreate(attribute: ID!, input: AttributeValueCreateInput!): AttributeValueCreate
   attributeValueDelete(id: ID!): AttributeValueDelete
   attributeValueUpdate(id: ID!, input: AttributeValueCreateInput!): AttributeValueUpdate
-  categoryCreate(input: CategoryInput!): CategoryCreate
+  categoryCreate(input: CategoryInput!, parent: ID): CategoryCreate
   categoryDelete(id: ID!): CategoryDelete
   categoryUpdate(id: ID!, input: CategoryInput!): CategoryUpdate
   customerCreate(input: UserCreateInput!): CustomerCreate

--- a/saleor/static/dashboard-next/categories/mutations.ts
+++ b/saleor/static/dashboard-next/categories/mutations.ts
@@ -32,8 +32,8 @@ export const TypedCategoryDeleteMutation = TypedMutation<
 
 export const categoryCreateMutation = gql`
   ${categoryDetailsFragment}
-  mutation CategoryCreate($input: CategoryInput!) {
-    categoryCreate(input: $input) {
+  mutation CategoryCreate($parent: ID, $input: CategoryInput!) {
+    categoryCreate(parent: $parent, input: $input) {
       errors {
         field
         message

--- a/saleor/static/dashboard-next/categories/types/CategoryCreate.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryCreate.ts
@@ -25,7 +25,6 @@ export interface CategoryCreate_categoryCreate_category {
   description: string;
   seoDescription: string | null;
   seoTitle: string | null;
-  parent: CategoryCreate_categoryCreate_category_parent | null;
 }
 
 export interface CategoryCreate_categoryCreate {
@@ -39,5 +38,6 @@ export interface CategoryCreate {
 }
 
 export interface CategoryCreateVariables {
+  parent?: string | null;
   input: CategoryInput;
 }

--- a/saleor/static/dashboard-next/categories/types/CategoryUpdate.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryUpdate.ts
@@ -25,7 +25,6 @@ export interface CategoryUpdate_categoryUpdate_category {
   description: string;
   seoDescription: string | null;
   seoTitle: string | null;
-  parent: CategoryUpdate_categoryUpdate_category_parent | null;
 }
 
 export interface CategoryUpdate_categoryUpdate {

--- a/saleor/static/dashboard-next/categories/views/CategoryCreate.tsx
+++ b/saleor/static/dashboard-next/categories/views/CategoryCreate.tsx
@@ -43,12 +43,12 @@ export const CategoryCreateView: React.StatelessComponent<
                         input: {
                           description: formData.description,
                           name: formData.name,
-                          parent: parentId,
                           seo: {
                             description: formData.seoDescription,
                             title: formData.seoTitle
                           }
-                        }
+                        },
+                        parent: parentId
                       }
                     })
                   }

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -155,7 +155,6 @@ export interface AuthorizationKeyInput {
 export interface CategoryInput {
   description?: string | null;
   name?: string | null;
-  parent?: string | null;
   slug?: string | null;
   seo?: SeoInput | null;
 }

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -54,8 +54,8 @@ def test_category_create_mutation(
                     slug: $slug
                     description: $description
                     backgroundImage: $backgroundImage
-                    parent: $parentId
-                }
+                },
+                parent: $parentId
             ) {
                 category {
                     id

--- a/tests/api/test_core.py
+++ b/tests/api/test_core.py
@@ -22,7 +22,7 @@ def test_user_error_field_name_for_related_object(
         staff_api_client, permission_manage_products):
     query = """
     mutation {
-        categoryCreate(input: {name: "Test", parent: "123456"}) {
+        categoryCreate(input: {name: "Test"}, parent: "123456") {
             errors {
                 field
                 message


### PR DESCRIPTION
Hi, I left variable name as `parent` instead of `parentId` as mentioned in the #3122 - I think it is more intuitive, but I am not sure complies with the current convention. @dominik-zeglen @maarcingebala feel free to request change on that, or anything you consider suspicious.
Closes #3122

<!-- Please mention all relevant issue numbers. -->

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
