### PR TITLE
Add new dashboard home page

### DIFF
--- a/saleor/static/dashboard-next/components/TableCellAvatar/TableCellAvatar.tsx
+++ b/saleor/static/dashboard-next/components/TableCellAvatar/TableCellAvatar.tsx
@@ -10,16 +10,10 @@ import NoPhoto from "../../icons/NoPhoto";
 interface TableCellAvatarProps {
   className?: string;
   thumbnail?: string;
+  avatarSize?: string;
 }
 
 const decorate = withStyles(theme => ({
-  avatar: {
-    background: "none",
-    border: "1px solid #eaeaea",
-    borderRadius: 2,
-    color: "#bdbdbd",
-    padding: theme.spacing.unit / 2
-  },
   root: {
     paddingLeft: theme.spacing.unit * 3,
     paddingRight: theme.spacing.unit * 3,
@@ -27,18 +21,18 @@ const decorate = withStyles(theme => ({
   }
 }));
 const TableCellAvatar = decorate<TableCellAvatarProps>(
-  ({ classes, className, thumbnail }) => (
+  ({ classes, className, thumbnail, avatarSize }) => (
     <TableCell className={classNames(classes.root, className)}>
       {thumbnail === undefined ? (
-        <Avatar className={classes.avatar}>
+        <Avatar className={classNames(avatarSize)}>
           <Cached />
         </Avatar>
       ) : thumbnail === null ? (
-        <Avatar className={classes.avatar}>
+        <Avatar className={classNames(avatarSize)}>
           <NoPhoto />
         </Avatar>
       ) : (
-        <Avatar className={classes.avatar} src={thumbnail} />
+        <Avatar className={classNames(avatarSize)} src={thumbnail} />
       )}
     </TableCell>
   )

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -8,6 +8,7 @@ import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
 import HomeNotificationTable from "../HomeNotificationTable";
 import HomeOrdersCard from "../HomeOrdersCard";
+import HomeProductListCard from "../HomeProductListCard";
 import HomeSalesCard from "../HomeSalesCard";
 
 interface MoneyType {
@@ -27,7 +28,16 @@ export interface DashboardProps {
     problems: number;
     productsOut: number;
   };
+  onRowClick: () => undefined;
   ownerName: string;
+  topProducts?: Array<{
+    id: string;
+    name: string;
+    orders: number;
+    price: MoneyType;
+    thumbnailUrl: string;
+    variant: string;
+  }>;
   toOrders: () => void;
   toPayments: () => void;
   toProblems: () => void;
@@ -63,7 +73,9 @@ const Dashboard = decorate<DashboardProps>(
     toOrders,
     toPayments,
     toProblems,
-    toProductsOut
+    toProductsOut,
+    topProducts,
+    onRowClick
   }) => {
     return (
       <Container width="md">
@@ -93,7 +105,11 @@ const Dashboard = decorate<DashboardProps>(
               toProductsOut={toProductsOut}
             />
             <CardSpacer />
-            <Card>ProductListCard</Card>
+            <HomeProductListCard
+              onRowClick={onRowClick}
+              disabled={false}
+              topProducts={topProducts}
+            />
             <CardSpacer />
           </div>
           <div>

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -1,0 +1,70 @@
+import Card from "@material-ui/core/Card";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import * as React from "react";
+import CardSpacer from "../../../components/CardSpacer";
+import Container from "../../../components/Container";
+import PageHeader from "../../../components/PageHeader";
+import i18n from "../../../i18n";
+interface MoneyType {
+  amount: number;
+  currency: string;
+}
+
+export interface DashboardProps {
+  ownerName: string;
+}
+
+const decorate = withStyles(theme => ({
+  displayBlock: {
+    display: "block"
+  },
+  flexbox: {
+    display: "flex"
+  },
+
+  root: {
+    display: "grid" as "grid",
+    gridColumnGap: `${theme.spacing.unit * 3}px`,
+    gridTemplateColumns: "2fr 1fr",
+    [theme.breakpoints.down("sm")]: {
+      gridColumnGap: `${theme.spacing.unit}px`
+    },
+    [theme.breakpoints.down("xs")]: {
+      gridTemplateColumns: "1fr"
+    }
+  }
+}));
+const Dashboard = decorate<DashboardProps>(({ ownerName, classes }) => {
+  return (
+    <Container width="md">
+      <PageHeader
+        className={classes.displayBlock}
+        title={i18n.t("Hello there, {{userName}}", { userName: ownerName })}
+      >
+        <Typography component="span">
+          {i18n.t("Here are some information we gathered about your store")}
+        </Typography>
+      </PageHeader>
+
+      <div className={classes.root}>
+        <div>
+          <div className={classes.flexbox}>
+            <Card>Sales</Card>
+            <Card>Orders</Card>
+          </div>
+
+          <CardSpacer />
+          <Card>Notification</Card>
+          <CardSpacer />
+          <Card>ProductListCard</Card>
+          <CardSpacer />
+        </div>
+        <div>
+          <Card>HomeActivityCard</Card>
+        </div>
+      </div>
+    </Container>
+  );
+});
+export default Dashboard;

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -1,4 +1,3 @@
-import Card from "@material-ui/core/Card";
 import { withStyles } from "@material-ui/core/styles";
 import Typography from "@material-ui/core/Typography";
 import * as React from "react";
@@ -6,6 +5,7 @@ import CardSpacer from "../../../components/CardSpacer";
 import Container from "../../../components/Container";
 import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
+import HomeActivityCard from "../HomeActivityCard";
 import HomeNotificationTable from "../HomeNotificationTable";
 import HomeOrdersCard from "../HomeOrdersCard";
 import HomeProductListCard from "../HomeProductListCard";
@@ -16,6 +16,15 @@ interface MoneyType {
   currency: string;
 }
 export interface DashboardProps {
+  activities?: Array<{
+    action?: string;
+    admin?: boolean;
+    date?: string;
+    elementName?: string;
+    id: string;
+    newElement?: string;
+    user?: string;
+  }>;
   daily: {
     orders: {
       amount: number;
@@ -30,7 +39,7 @@ export interface DashboardProps {
   };
   onRowClick: () => undefined;
   ownerName: string;
-  topProducts?: Array<{
+  topProducts: Array<{
     id: string;
     name: string;
     orders: number;
@@ -75,7 +84,8 @@ const Dashboard = decorate<DashboardProps>(
     toProblems,
     toProductsOut,
     topProducts,
-    onRowClick
+    onRowClick,
+    activities
   }) => {
     return (
       <Container width="md">
@@ -113,7 +123,7 @@ const Dashboard = decorate<DashboardProps>(
             <CardSpacer />
           </div>
           <div>
-            <Card>HomeActivityCard</Card>
+            <HomeActivityCard disabled={false} activities={activities} />
           </div>
         </div>
       </Container>

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -6,6 +6,8 @@ import CardSpacer from "../../../components/CardSpacer";
 import Container from "../../../components/Container";
 import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
+import HomeNotificationTable from "../HomeNotificationTable";
+import HomeOrdersCard from "../HomeOrdersCard";
 import HomeSalesCard from "../HomeSalesCard";
 
 interface MoneyType {
@@ -13,10 +15,23 @@ interface MoneyType {
   currency: string;
 }
 export interface DashboardProps {
-  daily?: {
-    sales?: MoneyType;
+  daily: {
+    orders: {
+      amount: number;
+    };
+    sales: MoneyType;
+  };
+  notifications: {
+    orders: number;
+    payments: number;
+    problems: number;
+    productsOut: number;
   };
   ownerName: string;
+  toOrders: () => void;
+  toPayments: () => void;
+  toProblems: () => void;
+  toProductsOut: () => void;
 }
 
 const decorate = withStyles(theme => ({
@@ -39,36 +54,54 @@ const decorate = withStyles(theme => ({
     }
   }
 }));
-const Dashboard = decorate<DashboardProps>(({ ownerName, classes, daily }) => {
-  return (
-    <Container width="md">
-      <PageHeader
-        className={classes.displayBlock}
-        title={i18n.t("Hello there, {{userName}}", { userName: ownerName })}
-      >
-        <Typography component="span">
-          {i18n.t("Here are some information we gathered about your store")}
-        </Typography>
-      </PageHeader>
+const Dashboard = decorate<DashboardProps>(
+  ({
+    ownerName,
+    classes,
+    daily,
+    notifications,
+    toOrders,
+    toPayments,
+    toProblems,
+    toProductsOut
+  }) => {
+    return (
+      <Container width="md">
+        <PageHeader
+          className={classes.displayBlock}
+          title={i18n.t("Hello there, {{userName}}", { userName: ownerName })}
+        >
+          <Typography component="span">
+            {i18n.t("Here are some information we gathered about your store")}
+          </Typography>
+        </PageHeader>
 
-      <div className={classes.root}>
-        <div>
-          <div className={classes.flexbox}>
-            <HomeSalesCard disabled={false} title={"Sales"} daily={daily} />
-            <Card>Orders</Card>
+        <div className={classes.root}>
+          <div>
+            <div className={classes.flexbox}>
+              <HomeSalesCard disabled={false} title={"Sales"} daily={daily} />
+              <HomeOrdersCard disabled={false} title={"Orders"} daily={daily} />
+            </div>
+
+            <CardSpacer />
+            <HomeNotificationTable
+              disabled={false}
+              notifications={notifications}
+              toOrders={toOrders}
+              toPayments={toPayments}
+              toProblems={toProblems}
+              toProductsOut={toProductsOut}
+            />
+            <CardSpacer />
+            <Card>ProductListCard</Card>
+            <CardSpacer />
           </div>
-
-          <CardSpacer />
-          <Card>Notification</Card>
-          <CardSpacer />
-          <Card>ProductListCard</Card>
-          <CardSpacer />
+          <div>
+            <Card>HomeActivityCard</Card>
+          </div>
         </div>
-        <div>
-          <Card>HomeActivityCard</Card>
-        </div>
-      </div>
-    </Container>
-  );
-});
+      </Container>
+    );
+  }
+);
 export default Dashboard;

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -6,7 +6,6 @@ import Container from "../../../components/Container";
 import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
 import HomeActivityCard from "../HomeActivityCard";
-import HomeNotificationTable from "../HomeNotificationTable";
 import HomeOrdersCard from "../HomeOrdersCard";
 import HomeProductListCard from "../HomeProductListCard";
 import HomeSalesCard from "../HomeSalesCard";
@@ -31,12 +30,6 @@ export interface DashboardProps {
     };
     sales: MoneyType;
   };
-  notifications: {
-    orders: number;
-    payments: number;
-    problems: number;
-    productsOut: number;
-  };
   onRowClick: () => undefined;
   ownerName: string;
   topProducts: Array<{
@@ -47,10 +40,6 @@ export interface DashboardProps {
     thumbnailUrl: string;
     variant: string;
   }>;
-  toOrders: () => void;
-  toPayments: () => void;
-  toProblems: () => void;
-  toProductsOut: () => void;
 }
 
 const decorate = withStyles(theme => ({
@@ -74,19 +63,7 @@ const decorate = withStyles(theme => ({
   }
 }));
 const Dashboard = decorate<DashboardProps>(
-  ({
-    ownerName,
-    classes,
-    daily,
-    notifications,
-    toOrders,
-    toPayments,
-    toProblems,
-    toProductsOut,
-    topProducts,
-    onRowClick,
-    activities
-  }) => {
+  ({ ownerName, classes, daily, topProducts, onRowClick, activities }) => {
     return (
       <Container width="md">
         <PageHeader
@@ -105,15 +82,6 @@ const Dashboard = decorate<DashboardProps>(
               <HomeOrdersCard disabled={false} title={"Orders"} daily={daily} />
             </div>
 
-            <CardSpacer />
-            <HomeNotificationTable
-              disabled={false}
-              notifications={notifications}
-              toOrders={toOrders}
-              toPayments={toPayments}
-              toProblems={toProblems}
-              toProductsOut={toProductsOut}
-            />
             <CardSpacer />
             <HomeProductListCard
               onRowClick={onRowClick}

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -6,8 +6,16 @@ import CardSpacer from "../../../components/CardSpacer";
 import Container from "../../../components/Container";
 import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
+import HomeSalesCard from "../HomeSalesCard";
 
+interface MoneyType {
+  amount: number;
+  currency: string;
+}
 export interface DashboardProps {
+  daily?: {
+    sales?: MoneyType;
+  };
   ownerName: string;
 }
 
@@ -31,7 +39,7 @@ const decorate = withStyles(theme => ({
     }
   }
 }));
-const Dashboard = decorate<DashboardProps>(({ ownerName, classes }) => {
+const Dashboard = decorate<DashboardProps>(({ ownerName, classes, daily }) => {
   return (
     <Container width="md">
       <PageHeader
@@ -46,7 +54,7 @@ const Dashboard = decorate<DashboardProps>(({ ownerName, classes }) => {
       <div className={classes.root}>
         <div>
           <div className={classes.flexbox}>
-            <Card>Sales</Card>
+            <HomeSalesCard disabled={false} title={"Sales"} daily={daily} />
             <Card>Orders</Card>
           </div>
 

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -6,10 +6,6 @@ import CardSpacer from "../../../components/CardSpacer";
 import Container from "../../../components/Container";
 import PageHeader from "../../../components/PageHeader";
 import i18n from "../../../i18n";
-interface MoneyType {
-  amount: number;
-  currency: string;
-}
 
 export interface DashboardProps {
   ownerName: string;

--- a/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/Dashbaord.tsx
@@ -17,13 +17,13 @@ interface MoneyType {
 }
 export interface DashboardProps {
   activities?: Array<{
-    action?: string;
-    admin?: boolean;
-    date?: string;
+    action: string;
+    admin: boolean;
+    date: string;
     elementName?: string;
     id: string;
-    newElement?: string;
-    user?: string;
+    newElement: string;
+    user: string;
   }>;
   daily: {
     orders: {

--- a/saleor/static/dashboard-next/home/components/Dashbaord/index.ts
+++ b/saleor/static/dashboard-next/home/components/Dashbaord/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./Dashbaord";
+export * from "./Dashbaord";

--- a/saleor/static/dashboard-next/home/components/HomeActivityCard/HomeActivityCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeActivityCard/HomeActivityCard.tsx
@@ -1,0 +1,88 @@
+import Card from "@material-ui/core/Card";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemText from "@material-ui/core/ListItemText";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import * as React from "react";
+import Moment from "react-moment";
+import CardTitle from "../../../components/CardTitle";
+import Skeleton from "../../../components/Skeleton";
+import i18n from "../../../i18n";
+import { renderCollection } from "../../../misc";
+
+interface HomeProductListCardProps {
+  activities?: Array<{
+    action?: string;
+    admin?: boolean;
+    date?: string;
+    elementName?: string;
+    id?: string;
+    newElement?: string;
+    user?: string;
+  }>;
+  disabled: boolean;
+}
+
+const decorate = withStyles({
+  noProducts: {
+    paddingBottom: "18px",
+    paddingTop: "18px"
+  }
+});
+
+const HomeProductListCard = decorate<HomeProductListCardProps>(
+  ({ classes, activities }) => {
+    return (
+      <Card>
+        <CardTitle title={i18n.t("Activity")} />
+        <List dense={true}>
+          {renderCollection(
+            activities,
+            activity => (
+              <ListItem key={activity ? activity.id : "skeleton"}>
+                {activity ? (
+                  <ListItemText
+                    primary={
+                      <Typography
+                        dangerouslySetInnerHTML={{
+                          __html: activity.admin
+                            ? i18n.t(`Saleor shop admin 
+                        ${activity.action} ${activity.newElement}: 
+                        ${activity.user}`)
+                            : i18n.t(`
+                        ${activity.user} ${activity.action} a 
+                        ${activity.newElement}: ${activity.elementName}
+                        `)
+                        }}
+                      />
+                    }
+                    secondary={
+                      <Moment format="MMM D, YYYY [at] HH:mm ">
+                        {activity.date}
+                      </Moment>
+                    }
+                  />
+                ) : (
+                  <ListItemText>
+                    <Skeleton />
+                  </ListItemText>
+                )}
+              </ListItem>
+            ),
+            () => (
+              <ListItem dense={false} className={classes.noProducts}>
+                <ListItemText
+                  primary={
+                    <Typography>{i18n.t("No products found")}</Typography>
+                  }
+                />
+              </ListItem>
+            )
+          )}
+        </List>
+      </Card>
+    );
+  }
+);
+export default HomeProductListCard;

--- a/saleor/static/dashboard-next/home/components/HomeActivityCard/HomeActivityCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeActivityCard/HomeActivityCard.tsx
@@ -13,13 +13,13 @@ import { renderCollection } from "../../../misc";
 
 interface HomeProductListCardProps {
   activities?: Array<{
-    action?: string;
-    admin?: boolean;
-    date?: string;
+    action: string;
+    admin: boolean;
+    date: string;
     elementName?: string;
-    id?: string;
-    newElement?: string;
-    user?: string;
+    id: string;
+    newElement: string;
+    user: string;
   }>;
   disabled: boolean;
 }

--- a/saleor/static/dashboard-next/home/components/HomeActivityCard/index.ts
+++ b/saleor/static/dashboard-next/home/components/HomeActivityCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HomeActivityCard";
+export * from "./HomeActivityCard";

--- a/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -10,6 +10,18 @@ import * as React from "react";
 import Skeleton from "../../../components/Skeleton";
 import i18n from "../../../i18n";
 
+// component implementation
+{
+  /* <HomeNotificationTable
+disabled={false}
+notifications={notifications}
+toOrders={toOrders}
+toPayments={toPayments}
+toProblems={toProblems}
+toProductsOut={toProductsOut}
+/> */
+}
+
 interface HomeNotificationTableProps {
   disabled: boolean;
   notifications: {

--- a/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -1,0 +1,153 @@
+import Card from "@material-ui/core/Card";
+import { withStyles } from "@material-ui/core/styles";
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
+import Typography from "@material-ui/core/Typography";
+import KeyboardArrowRight from "@material-ui/icons/KeyboardArrowRight";
+import * as React from "react";
+import Skeleton from "../../../components/Skeleton";
+import i18n from "../../../i18n";
+
+interface HomeNotificationTableProps {
+  disabled: boolean;
+  notifications?: {
+    id?: number;
+    orders?: number;
+    payments?: number;
+    problems?: number;
+    productsOut?: number;
+  };
+  toOrders?();
+  toPayments?();
+  toProblems?();
+  toProductsOut?();
+}
+
+const decorate = withStyles(theme => ({
+  arrowIcon: {
+    width: theme.spacing.unit * 4
+  },
+  tableRowPointer: {
+    cursor: "pointer" as "pointer"
+  }
+}));
+const HomeNotificationTable = decorate<HomeNotificationTableProps>(
+  ({
+    classes,
+    notifications,
+    toOrders,
+    toPayments,
+    toProblems,
+    toProductsOut
+  }) => {
+    return (
+      <Card>
+        <Table>
+          <TableBody className={classes.tableRowPointer}>
+            <TableRow
+              hover={true}
+              onClick={!!notifications ? toOrders() : undefined}
+            >
+              <TableCell>
+                {notifications === undefined ? (
+                  <Skeleton />
+                ) : notifications && notifications.orders === 0 ? (
+                  <Typography>{i18n.t("No orders to fulfill")}</Typography>
+                ) : (
+                  <Typography
+                    dangerouslySetInnerHTML={{
+                      __html: i18n.t(
+                        "<b>{{orders}} Orders</b> are ready to fulfill",
+                        { orders: notifications.orders }
+                      )
+                    }}
+                  />
+                )}
+              </TableCell>
+              <TableCell className={classes.arrowIcon}>
+                <KeyboardArrowRight />
+              </TableCell>
+            </TableRow>
+            <TableRow
+              hover={true}
+              onClick={!!notifications ? toPayments() : undefined}
+            >
+              <TableCell>
+                {notifications === undefined ? (
+                  <Skeleton />
+                ) : notifications.payments === 0 ? (
+                  <Typography>
+                    {i18n.t("No payments waiting for capture")}
+                  </Typography>
+                ) : (
+                  <Typography
+                    dangerouslySetInnerHTML={{
+                      __html: i18n.t(
+                        "<b>{{payments}} Payments </b>to capture",
+                        { payments: notifications.payments }
+                      )
+                    }}
+                  />
+                )}
+              </TableCell>
+              <TableCell className={classes.arrowIcon}>
+                <KeyboardArrowRight />
+              </TableCell>
+            </TableRow>
+            <TableRow
+              hover={true}
+              onClick={!!notifications ? toProblems() : undefined}
+            >
+              <TableCell>
+                {notifications === undefined ? (
+                  <Skeleton />
+                ) : notifications.problems === 0 ? (
+                  <Typography>{i18n.t("No problem with orders")}</Typography>
+                ) : (
+                  <Typography
+                    dangerouslySetInnerHTML={{
+                      __html: i18n.t(
+                        "<b>{{problems}} Problems</b>  with orders",
+                        { problems: notifications.problems }
+                      )
+                    }}
+                  />
+                )}
+              </TableCell>
+              <TableCell className={classes.arrowIcon}>
+                <KeyboardArrowRight />
+              </TableCell>
+            </TableRow>
+            <TableRow
+              hover={true}
+              onClick={!!notifications ? toProductsOut() : undefined}
+            >
+              <TableCell>
+                {notifications === undefined ? (
+                  <Skeleton />
+                ) : notifications.productsOut === 0 ? (
+                  <Typography>{i18n.t("No out of stock products")}</Typography>
+                ) : (
+                  <Typography
+                    dangerouslySetInnerHTML={{
+                      __html: i18n.t(
+                        "<b>{{productsOut}} Products </b>out of stock",
+                        { productsOut: notifications.productsOut }
+                      )
+                    }}
+                  />
+                )}
+              </TableCell>
+              <TableCell className={classes.arrowIcon}>
+                <KeyboardArrowRight />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </Card>
+    );
+  }
+);
+export default HomeNotificationTable;

--- a/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeNotificationTable/HomeNotificationTable.tsx
@@ -12,17 +12,16 @@ import i18n from "../../../i18n";
 
 interface HomeNotificationTableProps {
   disabled: boolean;
-  notifications?: {
-    id?: number;
-    orders?: number;
-    payments?: number;
-    problems?: number;
-    productsOut?: number;
+  notifications: {
+    orders: number;
+    payments: number;
+    problems: number;
+    productsOut: number;
   };
-  toOrders?();
-  toPayments?();
-  toProblems?();
-  toProductsOut?();
+  toOrders();
+  toPayments();
+  toProblems();
+  toProductsOut();
 }
 
 const decorate = withStyles(theme => ({

--- a/saleor/static/dashboard-next/home/components/HomeNotificationTable/index.ts
+++ b/saleor/static/dashboard-next/home/components/HomeNotificationTable/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HomeNotificationTable";
+export * from "./HomeNotificationTable";

--- a/saleor/static/dashboard-next/home/components/HomeOrdersCard/HomeOrdersCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeOrdersCard/HomeOrdersCard.tsx
@@ -40,6 +40,7 @@ const decorate = withStyles(theme => ({
     [theme.breakpoints.down("sm")]: {
       marginLeft: `${theme.spacing.unit * 0.5}px`
     },
+    overflow: "initial" as "initial",
     width: "100%"
   },
   icon: {
@@ -70,7 +71,7 @@ const HomeOrdersCard = decorate<HomeOrdersCardProps>(
             >
               {i18n.t("Today")}
             </Typography>
-            <Typography color={"textPrimary"} variant="display1">
+            <Typography color={"textPrimary"} variant="headline">
               {daily && daily.orders ? daily.orders.amount : <Skeleton />}
             </Typography>
           </div>

--- a/saleor/static/dashboard-next/home/components/HomeOrdersCard/HomeOrdersCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeOrdersCard/HomeOrdersCard.tsx
@@ -1,0 +1,85 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import LocalShipping from "@material-ui/icons/LocalShipping";
+import * as React from "react";
+import Skeleton from "../../../components/Skeleton";
+import i18n from "../../../i18n";
+
+interface HomeOrdersCardProps {
+  disabled: boolean;
+  title: string;
+  daily: {
+    orders: {
+      amount: number;
+    };
+  };
+}
+
+const decorate = withStyles(theme => ({
+  cardContent: {
+    "&:last-child": {
+      paddingBottom: 16
+    },
+    display: "grid" as "grid",
+    gridColumnGap: theme.spacing.unit * 1 + "px",
+    gridTemplateColumns: "minmax(min-content, 5fr) 70px"
+  },
+  cardSubtitle: {
+    color: theme.palette.text.secondary,
+    fontSize: ".65rem",
+    height: "16px",
+    lineHeight: 0.5
+  },
+  cardTitle: {
+    fontWeight: "bold" as "bold"
+  },
+  fullWidth: {
+    marginLeft: `${theme.spacing.unit * 1.5}px`,
+    [theme.breakpoints.down("sm")]: {
+      marginLeft: `${theme.spacing.unit * 0.5}px`
+    },
+    width: "100%"
+  },
+  icon: {
+    color: theme.palette.primary.contrastText,
+    fontSize: 54,
+    margin: ".5rem .3rem"
+  },
+  iconBackground: {
+    alignSelf: "center",
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: "5px",
+    justifySelf: "center"
+  }
+}));
+const HomeOrdersCard = decorate<HomeOrdersCardProps>(
+  ({ classes, title, daily }) => {
+    return (
+      <Card className={classes.fullWidth}>
+        <CardContent className={classes.cardContent}>
+          <div>
+            <Typography className={classes.cardTitle} variant="subheading">
+              {title}
+            </Typography>
+            <Typography
+              className={classes.cardSubtitle}
+              variant="caption"
+              color="textSecondary"
+            >
+              {i18n.t("Today")}
+            </Typography>
+            <Typography color={"textPrimary"} variant="display1">
+              {daily && daily.orders ? daily.orders.amount : <Skeleton />}
+            </Typography>
+          </div>
+          <div className={classes.iconBackground}>
+            <LocalShipping className={classes.icon} />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+);
+export default HomeOrdersCard;

--- a/saleor/static/dashboard-next/home/components/HomeOrdersCard/index.ts
+++ b/saleor/static/dashboard-next/home/components/HomeOrdersCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HomeOrdersCard";
+export * from "./HomeOrdersCard";

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
@@ -18,7 +18,7 @@ interface MoneyType {
   currency: string;
 }
 interface HomeProductListProps {
-  topProducts?: Array<{
+  topProducts: Array<{
     id: string;
     name: string;
     orders: number;

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
@@ -1,0 +1,112 @@
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import * as classNames from "classnames";
+import * as React from "react";
+import Money from "../../../components/Money";
+import Skeleton from "../../../components/Skeleton";
+import i18n from "../../../i18n";
+import { renderCollection } from "../../../misc";
+
+import Table from "@material-ui/core/Table";
+import TableBody from "@material-ui/core/TableBody";
+import TableCell from "@material-ui/core/TableCell";
+import TableRow from "@material-ui/core/TableRow";
+import TableCellAvatar from "../../../components/TableCellAvatar";
+
+interface MoneyType {
+  amount: number;
+  currency: string;
+}
+interface HomeProductListProps {
+  topProducts?: Array<{
+    id: string;
+    name: string;
+    orders: number;
+    price: MoneyType;
+    thumbnailUrl: string;
+    variant: string;
+  }>;
+  onRowClick: (id: string) => () => void;
+  disabled: boolean;
+}
+
+const decorate = withStyles(theme => ({
+  tableRowPointer: {
+    cursor: "pointer" as "pointer"
+  },
+  tableRowSize: {
+    paddingBottom: theme.spacing.unit * 2,
+    paddingTop: theme.spacing.unit * 2
+  }
+}));
+
+export const HomeProductList = decorate<HomeProductListProps>(
+  ({ classes, topProducts, onRowClick }) => (
+    <Table>
+      <TableBody>
+        {renderCollection(
+          topProducts,
+          product => (
+            <TableRow
+              key={product ? product.id : "skeleton"}
+              hover={!!product}
+              className={classNames({
+                [classes.tableRowPointer]: !!product
+              })}
+              onClick={!!product ? onRowClick(product.id) : undefined}
+            >
+              <TableCellAvatar
+                className={classes.tableRowSize}
+                thumbnail={product && product.thumbnailUrl}
+              />
+              {product ? (
+                <TableCell>
+                  <Typography color={"primary"} variant="body1">
+                    {product.name}
+                  </Typography>
+                  <Typography color={"textSecondary"} variant="body1">
+                    {product.variant}
+                  </Typography>
+                  <Typography color={"textSecondary"} variant="body1">
+                    {i18n.t("{{ordersCount}} Orders", {
+                      ordersCount: product.orders
+                    })}
+                  </Typography>
+                </TableCell>
+              ) : (
+                <Skeleton />
+              )}
+
+              <TableCell>
+                <Typography variant="body1" align={"right"}>
+                  {product &&
+                  product.price !== undefined &&
+                  product.price.amount !== undefined &&
+                  product.price.currency !== undefined ? (
+                    <Money
+                      amount={product.price.amount}
+                      currency={product.price.currency}
+                    />
+                  ) : (
+                    <Skeleton />
+                  )}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          ),
+          () => (
+            <TableRow>
+              <TableCell>
+                <Typography variant="body1">
+                  {i18n.t("No products found")}
+                </Typography>
+              </TableCell>
+            </TableRow>
+          )
+        )}
+      </TableBody>
+    </Table>
+  )
+);
+
+export default HomeProductList;

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductList.tsx
@@ -31,6 +31,10 @@ interface HomeProductListProps {
 }
 
 const decorate = withStyles(theme => ({
+  avatarSize: {
+    height: "64px",
+    width: "64px"
+  },
   tableRowPointer: {
     cursor: "pointer" as "pointer"
   },
@@ -58,6 +62,7 @@ export const HomeProductList = decorate<HomeProductListProps>(
               <TableCellAvatar
                 className={classes.tableRowSize}
                 thumbnail={product && product.thumbnailUrl}
+                avatarSize={classes.avatarSize}
               />
               {product ? (
                 <TableCell>

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductListCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductListCard.tsx
@@ -1,0 +1,43 @@
+import Card from "@material-ui/core/Card";
+import { withStyles } from "@material-ui/core/styles";
+// import Container from "../../../components/Container";
+import * as React from "react";
+import CardTitle from "../../../components/CardTitle";
+// import PageHeader from "../../../components/PageHeader";
+import i18n from "../../../i18n";
+// import CardSpacer from "../../../components/CardSpacer";
+import HomeProductList from "./HomeProductList";
+
+interface MoneyType {
+  amount: number;
+  currency: string;
+}
+interface HomeProductListCardProps {
+  disabled: boolean;
+  topProducts?: Array<{
+    id: string;
+    name: string;
+    orders: number;
+    price: MoneyType;
+    thumbnailUrl: string;
+    variant: string;
+  }>;
+  onRowClick: (id: string) => () => void;
+}
+
+const decorate = withStyles({});
+const HomeProductListCard = decorate<HomeProductListCardProps>(
+  ({ topProducts, onRowClick }) => {
+    return (
+      <Card>
+        <CardTitle title={i18n.t("Top products")} />
+        <HomeProductList
+          disabled={false}
+          topProducts={topProducts}
+          onRowClick={onRowClick}
+        />
+      </Card>
+    );
+  }
+);
+export default HomeProductListCard;

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductListCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/HomeProductListCard.tsx
@@ -14,7 +14,7 @@ interface MoneyType {
 }
 interface HomeProductListCardProps {
   disabled: boolean;
-  topProducts?: Array<{
+  topProducts: Array<{
     id: string;
     name: string;
     orders: number;

--- a/saleor/static/dashboard-next/home/components/HomeProductListCard/index.ts
+++ b/saleor/static/dashboard-next/home/components/HomeProductListCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HomeProductListCard";
+export * from "./HomeProductListCard";

--- a/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
@@ -1,0 +1,100 @@
+import Card from "@material-ui/core/Card";
+import CardContent from "@material-ui/core/CardContent";
+import { withStyles } from "@material-ui/core/styles";
+import Typography from "@material-ui/core/Typography";
+import i18n from "../../../i18n";
+
+import Dollar from "@material-ui/icons/AttachMoney";
+import * as React from "react";
+
+import Money from "../../../components/Money";
+import Skeleton from "../../../components/Skeleton";
+
+interface MoneyType {
+  amount: number;
+  currency: string;
+}
+
+interface HomeSalesCardProps {
+  disabled: boolean;
+  title: string;
+  daily?: {
+    sales?: MoneyType;
+  };
+}
+
+const decorate = withStyles(theme => ({
+  cardContent: {
+    "&:last-child": {
+      paddingBottom: 16
+    },
+    display: "grid" as "grid",
+    gridColumnGap: theme.spacing.unit * 1 + "px",
+    gridTemplateColumns: "minmax(min-content, 5fr) 70px",
+    minHeight: "0",
+    minWidth: "0"
+  },
+
+  cardSubtitle: {
+    color: theme.palette.text.secondary,
+    fontSize: ".65rem",
+    height: "16px",
+    lineHeight: 0.5
+  },
+  cardTitle: {
+    fontWeight: "bold" as "bold"
+  },
+  fullWidth: {
+    marginRight: `${theme.spacing.unit * 1.5}px`,
+    [theme.breakpoints.down("sm")]: {
+      marginRight: `${theme.spacing.unit * 0.5}px`
+    },
+    width: "100%"
+  },
+  icon: {
+    color: theme.palette.primary.contrastText,
+    fontSize: 54,
+    margin: ".5rem .3rem"
+  },
+  iconBackground: {
+    alignSelf: "center",
+    backgroundColor: theme.palette.primary.main,
+    borderRadius: "5px",
+    justifySelf: "center"
+  }
+}));
+const HomeSalesCard = decorate<HomeSalesCardProps>(
+  ({ classes, title, daily }) => {
+    return (
+      <Card className={classes.fullWidth}>
+        <CardContent className={classes.cardContent}>
+          <div>
+            <Typography className={classes.cardTitle} variant="subheading">
+              {title}
+            </Typography>
+            <Typography className={classes.cardSubtitle} variant="caption">
+              {i18n.t("Today")}
+            </Typography>
+            <Typography color={"textPrimary"} variant="display1">
+              {daily &&
+              daily.sales &&
+              daily.sales.amount !== undefined &&
+              daily.sales.currency !== undefined ? (
+                <Money
+                  amount={daily.sales.amount}
+                  currency={daily.sales.currency}
+                />
+              ) : (
+                <Skeleton />
+              )}
+            </Typography>
+          </div>
+          <div className={classes.iconBackground}>
+            <Dollar className={classes.icon} />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+);
+export default HomeSalesCard;

--- a/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
@@ -30,9 +30,7 @@ const decorate = withStyles(theme => ({
     },
     display: "grid" as "grid",
     gridColumnGap: theme.spacing.unit * 1 + "px",
-    gridTemplateColumns: "minmax(min-content, 5fr) 70px",
-    minHeight: "0",
-    minWidth: "0"
+    gridTemplateColumns: "minmax(min-content, 5fr) 70px"
   },
 
   cardSubtitle: {
@@ -49,6 +47,7 @@ const decorate = withStyles(theme => ({
     [theme.breakpoints.down("sm")]: {
       marginRight: `${theme.spacing.unit * 0.5}px`
     },
+    overflow: "initial" as "initial",
     width: "100%"
   },
   icon: {
@@ -75,7 +74,7 @@ const HomeSalesCard = decorate<HomeSalesCardProps>(
             <Typography className={classes.cardSubtitle} variant="caption">
               {i18n.t("Today")}
             </Typography>
-            <Typography color={"textPrimary"} variant="display1">
+            <Typography color={"textPrimary"} variant="headline">
               {daily &&
               daily.sales &&
               daily.sales.amount !== undefined &&

--- a/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
+++ b/saleor/static/dashboard-next/home/components/HomeSalesCard/HomeSalesCard.tsx
@@ -18,8 +18,8 @@ interface MoneyType {
 interface HomeSalesCardProps {
   disabled: boolean;
   title: string;
-  daily?: {
-    sales?: MoneyType;
+  daily: {
+    sales: MoneyType;
   };
 }
 

--- a/saleor/static/dashboard-next/home/components/HomeSalesCard/index.ts
+++ b/saleor/static/dashboard-next/home/components/HomeSalesCard/index.ts
@@ -1,0 +1,2 @@
+export { default } from "./HomeSalesCard";
+export * from "./HomeSalesCard";

--- a/saleor/static/dashboard-next/home/fixtures.ts
+++ b/saleor/static/dashboard-next/home/fixtures.ts
@@ -1,0 +1,101 @@
+export const shop = (placeholderImage: string) => ({
+  activities: [
+    {
+      action: "published",
+      admin: false,
+      date: "2018-09-17T13:22:24.376193+00:00",
+      elementName: "Tępa Podkowa",
+      id: "1",
+      newElement: "collection",
+      user: "Maćko z Bogdańca"
+    },
+    {
+      action: "published",
+      admin: false,
+      date: "2018-09-18T13:22:24.376193+00:00",
+      elementName: "Porwania",
+      id: "2",
+      newElement: "category",
+      user: "Danusia Jurandówna"
+    },
+    {
+      action: "created",
+      admin: false,
+      date: "2018-09-19T13:22:24.376193+00:00",
+      elementName: "Legiony polskie",
+      id: "3",
+      newElement: "collection",
+      user: "Ksiądz Robak"
+    },
+    {
+      action: "added",
+      admin: true,
+      date: "2018-09-20T13:22:24.376193+00:00",
+      id: "4",
+      newElement: "user",
+      user: "Tadeusz Soplica"
+    }
+  ],
+  daily: {
+    orders: {
+      amount: 1223
+    },
+    sales: {
+      amount: 125,
+      currency: "PLN"
+    }
+  },
+  notifications: {
+    orders: 12,
+    payments: 10,
+    problems: 69,
+    productsOut: 2
+  },
+  ownerName: "Zbyszko z Bogdańca",
+  topProducts: [
+    {
+      id: "1",
+      name: "Lake Success",
+      orders: 123,
+      price: {
+        amount: 54,
+        currency: "PLN"
+      },
+      thumbnailUrl: placeholderImage,
+      variant: "Hardcover"
+    },
+    {
+      id: "2",
+      name: "The Sadness of Beautiful Things",
+      orders: 111,
+      price: {
+        amount: 23,
+        currency: "PLN"
+      },
+      thumbnailUrl: placeholderImage,
+      variant: "Softcover"
+    },
+    {
+      id: "3",
+      name: "The Messy Middle",
+      orders: 93,
+      price: {
+        amount: 112,
+        currency: "PLN"
+      },
+      thumbnailUrl: placeholderImage,
+      variant: "Softcover"
+    },
+    {
+      id: "4",
+      name: "Everything's Trash",
+      orders: 32,
+      price: {
+        amount: 15,
+        currency: "PLN"
+      },
+      thumbnailUrl: placeholderImage,
+      variant: "Hardcover"
+    }
+  ]
+});

--- a/saleor/static/dashboard-next/storybook/config.js
+++ b/saleor/static/dashboard-next/storybook/config.js
@@ -99,6 +99,9 @@ function loadStories() {
   // Site settings
   require("./stories/siteSettings/SiteSettingsKeyDialog");
   require("./stories/siteSettings/SiteSettingsPage");
+
+  // Homepage
+  require("./stories/home/dashboard");
 }
 
 configure(loadStories, module);

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -8,11 +8,12 @@ import Decorator from "../../Decorator";
 const shop = shopFixture(placeholderImage);
 
 const dashboardProps: DashboardProps = {
+  daily: shop.daily,
   ownerName: shop.ownerName
 };
 
 storiesOf("Views / Home / Dashboard", module)
   .addDecorator(Decorator)
   .add("default", () => <Dashbaord {...dashboardProps} />)
-  .add("loading", () => <Dashbaord {...dashboardProps} />)
+  .add("loading", () => <Dashbaord {...dashboardProps} daily={undefined} />)
   .add("no data", () => <Dashbaord {...dashboardProps} />);

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -8,6 +8,7 @@ import Decorator from "../../Decorator";
 const shop = shopFixture(placeholderImage);
 
 const dashboardProps: DashboardProps = {
+  activities: shop.activities,
   daily: shop.daily,
   notifications: shop.notifications,
   onRowClick: () => undefined,
@@ -28,6 +29,7 @@ storiesOf("Views / Home / Dashboard", module)
       topProducts={undefined}
       daily={undefined}
       notifications={undefined}
+      activities={undefined}
     />
   ))
   .add("no data", () => (
@@ -40,5 +42,6 @@ storiesOf("Views / Home / Dashboard", module)
         problems: 0,
         productsOut: 0
       }}
+      activities={[]}
     />
   ));

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -9,11 +9,32 @@ const shop = shopFixture(placeholderImage);
 
 const dashboardProps: DashboardProps = {
   daily: shop.daily,
-  ownerName: shop.ownerName
+  ownerName: shop.ownerName,
+  notifications: shop.notifications,
+  toOrders: () => undefined,
+  toPayments: () => undefined,
+  toProblems: () => undefined,
+  toProductsOut: () => undefined
 };
 
 storiesOf("Views / Home / Dashboard", module)
   .addDecorator(Decorator)
   .add("default", () => <Dashbaord {...dashboardProps} />)
-  .add("loading", () => <Dashbaord {...dashboardProps} daily={undefined} />)
-  .add("no data", () => <Dashbaord {...dashboardProps} />);
+  .add("loading", () => (
+    <Dashbaord
+      {...dashboardProps}
+      daily={undefined}
+      notifications={undefined}
+    />
+  ))
+  .add("no data", () => (
+    <Dashbaord
+      {...dashboardProps}
+      notifications={{
+        orders: 0,
+        payments: 0,
+        problems: 0,
+        productsOut: 0
+      }}
+    />
+  ));

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -9,12 +9,14 @@ const shop = shopFixture(placeholderImage);
 
 const dashboardProps: DashboardProps = {
   daily: shop.daily,
-  ownerName: shop.ownerName,
   notifications: shop.notifications,
+  onRowClick: () => undefined,
+  ownerName: shop.ownerName,
   toOrders: () => undefined,
   toPayments: () => undefined,
   toProblems: () => undefined,
-  toProductsOut: () => undefined
+  toProductsOut: () => undefined,
+  topProducts: shop.topProducts
 };
 
 storiesOf("Views / Home / Dashboard", module)
@@ -23,6 +25,7 @@ storiesOf("Views / Home / Dashboard", module)
   .add("loading", () => (
     <Dashbaord
       {...dashboardProps}
+      topProducts={undefined}
       daily={undefined}
       notifications={undefined}
     />
@@ -30,6 +33,7 @@ storiesOf("Views / Home / Dashboard", module)
   .add("no data", () => (
     <Dashbaord
       {...dashboardProps}
+      topProducts={[]}
       notifications={{
         orders: 0,
         payments: 0,

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -1,0 +1,18 @@
+import { storiesOf } from "@storybook/react";
+import * as React from "react";
+import * as placeholderImage from "../../../../images/placeholder60x60.png";
+import Dashbaord, { DashboardProps } from "../../../home/components/Dashbaord";
+import { shop as shopFixture } from "../../../home/fixtures";
+import Decorator from "../../Decorator";
+
+const shop = shopFixture(placeholderImage);
+
+const dashboardProps: DashboardProps = {
+  ownerName: shop.ownerName
+};
+
+storiesOf("Views / Home / Dashboard", module)
+  .addDecorator(Decorator)
+  .add("default", () => <Dashbaord {...dashboardProps} />)
+  .add("loading", () => <Dashbaord {...dashboardProps} />)
+  .add("no data", () => <Dashbaord {...dashboardProps} />);

--- a/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/home/dashboard.tsx
@@ -10,13 +10,8 @@ const shop = shopFixture(placeholderImage);
 const dashboardProps: DashboardProps = {
   activities: shop.activities,
   daily: shop.daily,
-  notifications: shop.notifications,
   onRowClick: () => undefined,
   ownerName: shop.ownerName,
-  toOrders: () => undefined,
-  toPayments: () => undefined,
-  toProblems: () => undefined,
-  toProductsOut: () => undefined,
   topProducts: shop.topProducts
 };
 
@@ -28,20 +23,9 @@ storiesOf("Views / Home / Dashboard", module)
       {...dashboardProps}
       topProducts={undefined}
       daily={undefined}
-      notifications={undefined}
       activities={undefined}
     />
   ))
   .add("no data", () => (
-    <Dashbaord
-      {...dashboardProps}
-      topProducts={[]}
-      notifications={{
-        orders: 0,
-        payments: 0,
-        problems: 0,
-        productsOut: 0
-      }}
-      activities={[]}
-    />
+    <Dashbaord {...dashboardProps} topProducts={[]} activities={[]} />
   ));

--- a/saleor/static/dashboard-next/theme.ts
+++ b/saleor/static/dashboard-next/theme.ts
@@ -1,4 +1,5 @@
 import { createMuiTheme } from "@material-ui/core/styles";
+import spacing from "@material-ui/core/styles/spacing";
 
 const createShadow = (pv, pb, ps, uv, ub, us, av, ab, as) =>
   [
@@ -16,6 +17,17 @@ export const ICONBUTTON_SIZE = 48;
 
 export default createMuiTheme({
   overrides: {
+    MuiAvatar: {
+      colorDefault: {
+        backgroundColor: "none",
+        color: "#bdbdbd"
+      },
+      root: {
+        border: "1px solid #eaeaea",
+        borderRadius: 2,
+        padding: spacing.unit / 2
+      }
+    },
     MuiButton: {
       label: {
         fontWeight: 600


### PR DESCRIPTION
## This pull request will add new dashboard page. 

### Things to do: 
- [x] Add basic layout
- [x] Add sales card
- [x] Add orders card
- [x] Add notifications table (there is no API for it right now. It is created and can be used in the future)
- [x] Add top products table
- [x] Add Activities table
- [ ] Connect to the API
- [ ] Think about Orders/Sales cards behaviour when the numbers are big (overflow problem)