### PR TITLE
Fix the redundant PROCESSES os environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,11 @@ RUN \
 FROM python:3.6-slim
 
 ARG STATIC_URL
-ENV STATIC_URL ${STATIC_URL:-/static/}
+
+ENV STATIC_URL=${STATIC_URL:-/static/} \
+    UWSGI_PORT=8000 \
+    UWSGI_PROCESSES=4 \
+    PYTHONUNBUFFERED=1
 
 RUN \
   apt-get update && \
@@ -66,10 +70,6 @@ RUN useradd --system saleor && \
 
 USER saleor
 
-
 EXPOSE 8000
-ENV PORT 8000
 
-ENV PYTHONUNBUFFERED 1
-ENV PROCESSES 4
 CMD ["uwsgi", "/app/saleor/wsgi/uwsgi.ini"]

--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -1,11 +1,11 @@
 [uwsgi]
 die-on-term = true
-http-socket = :$(PORT)
+http-socket = :$(UWSGI_PORT)
 log-format = UWSGI uwsgi "%(method) %(uri) %(proto)" %(status) %(size) %(msecs)ms [PID:%(pid):Worker-%(wid)] [RSS:%(rssM)MB]
 master = true
 max-requests = 100
 memory-report = true
 module = saleor.wsgi:application
-processes = 4
+processes = $(UWSGI_PROCESSES)
 static-map = /static=/app/static
 mimefile = /etc/mime.types


### PR DESCRIPTION
What does this commit/MR/PR do?

- Fix the redundant PROCESSES os environment variable
- Collects all ENV variables into one location in final docker image

Why is this commit/MR/PR needed?

- To enable reconfiguration of the number of processes or uwsgi workers

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
