### PR TITLE
allow uwsgi logging to be configurable via os_env variable

### DIFF
--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -9,3 +9,11 @@ module = saleor.wsgi:application
 processes = 4
 static-map = /static=/app/static
 mimefile = /etc/mime.types
+
+if-env = UWSGI_ENABLE_LOGGING
+disable-logging = $(UWSGI_ENABLE_LOGGING)
+endif =
+if-not-env = UWSGI_ENABLE_LOGGING
+disable-logging = True
+endif =
+


### PR DESCRIPTION
What does this commit/MR/PR do?

- allow uwsgi logging to be configurable via os_env variable
- include a default fallback where the port has not been set

Why is this commit/MR/PR needed?

- Allow uwsgi logging parameter to be configurable

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
