### PR TITLE
Improve documentation for Heroku app deployment

### DIFF
--- a/docs/deployment/heroku.rst
+++ b/docs/deployment/heroku.rst
@@ -4,10 +4,13 @@ Heroku
 Configuration
 -------------
 
+Within the repo, git should already be initialized. All you have to do now is add the `heroku` remote with your `app-name`
+
 .. code-block:: console
 
- $ heroku create --buildpack https://github.com/heroku/heroku-buildpack-nodejs.git
- $ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-python.git
+ $ heroku git:remote -a 'app-name'
+ $ heroku buildpacks:set heroku/nodejs
+ $ heroku buildpacks:add heroku/python
  $ heroku addons:create heroku-postgresql:hobby-dev
  $ heroku addons:create heroku-redis:hobby-dev
  $ heroku addons:create sendgrid:starter


### PR DESCRIPTION
I want to merge this change because I wish to include the step for adding the Heroku remote. And also setting the Heroku NodeJS and Python buildpacks. 

Only the start of my effort to improve Saleor documentation during Hacktoberfest. :)