### PR TITLE
Remove duplicated field in Order type

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -143,8 +143,9 @@ class Order(CountableDjangoObjectType):
             description='List of shipments for the order.'),
         model_field='fulfillments')
     lines = gql_optimizer.field(
-        PrefetchingConnectionField(
-            lambda: OrderLine, description='List of order lines.'),
+        graphene.List(
+            lambda: OrderLine, required=True,
+            description='List of order lines.'),
         model_field='lines')
     is_paid = graphene.Boolean(
         description='Informs if an order is fully paid.')
@@ -174,9 +175,6 @@ class Order(CountableDjangoObjectType):
     available_shipping_methods = graphene.List(
         ShippingMethod, required=False,
         description='Shipping methods that can be used with this order.')
-    lines = graphene.List(
-        OrderLine, required=True,
-        description='List of order lines for the order')
 
     class Meta:
         description = 'Represents an order in the shop.'


### PR DESCRIPTION
This PR removes duplicated `lines` field in the `Order` type, which was introduced by a mistake during a rebase.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
