### PR TITLE
Return absolute image paths in API

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -128,8 +128,9 @@ class OrderLine(CountableDjangoObjectType):
             return None
         if not size:
             size = 255
-        return get_thumbnail(
+        url = get_thumbnail(
             self.variant.get_first_image(), size, method='thumbnail')
+        return info.context.build_absolute_uri(url)
 
     @staticmethod
     def resolve_unit_price(obj, info):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -207,8 +207,10 @@ class Image(graphene.ObjectType):
 
     def resolve_url(self, info, size=None):
         if size:
-            return get_thumbnail(self, size, method='thumbnail')
-        return self.url
+            url = get_thumbnail(self, size, method='thumbnail')
+        else:
+            url = self.url
+        return info.context.build_absolute_uri(url)
 
 
 class Product(CountableDjangoObjectType):
@@ -250,7 +252,8 @@ class Product(CountableDjangoObjectType):
     def resolve_thumbnail_url(self, info, *, size=None):
         if not size:
             size = 255
-        return get_thumbnail(self.get_first_image(), size, method='thumbnail')
+        url = get_thumbnail(self.get_first_image(), size, method='thumbnail')
+        return info.context.build_absolute_uri(url)
 
     def resolve_url(self, info):
         return self.get_absolute_url()
@@ -437,5 +440,7 @@ class ProductImage(CountableDjangoObjectType):
 
     def resolve_url(self, info, *, size=None):
         if size:
-            return get_thumbnail(self.image, size, method='thumbnail')
-        return self.image.url
+            url = get_thumbnail(self.image, size, method='thumbnail')
+        else:
+            url = self.image.url
+        return info.context.build_absolute_uri(url)

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -49,7 +49,7 @@ def test_orderline_query(
     thumbnails = [l['thumbnailUrl'] for l in order_data['lines']]
     assert len(thumbnails) == 2
     assert None in thumbnails
-    assert '/static/images/placeholder540x540.png' in thumbnails
+    assert '/static/images/placeholder540x540.png' in thumbnails[1]
 
 
 def test_order_query(

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -893,7 +893,7 @@ def test_product_image_delete(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
     data = content['data']['productImageDelete']
-    assert data['image']['url'] == image_obj.image.url
+    assert image_obj.image.url in data['image']['url']
     with pytest.raises(image_obj._meta.model.DoesNotExist):
         image_obj.refresh_from_db()
     assert node_id == data['image']['id']

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1356,7 +1356,7 @@ def test_category_image_query(user_api_client, non_default_category):
     content = get_graphql_content(response)
     data = content['data']['category']
     thumbnail_url = category.background_image.thumbnail['120x120'].url
-    assert data['backgroundImage']['url'] == thumbnail_url
+    assert thumbnail_url in data['backgroundImage']['url']
 
 
 def test_category_image_query_without_associated_file(
@@ -1400,7 +1400,7 @@ def test_collection_image_query(user_api_client, collection):
     content = get_graphql_content(response)
     data = content['data']['collection']
     thumbnail_url = collection.background_image.thumbnail['120x120'].url
-    assert data['backgroundImage']['url'] == thumbnail_url
+    assert thumbnail_url in data['backgroundImage']['url']
 
 
 def test_collection_image_query_without_associated_file(


### PR DESCRIPTION
This PR changes relative image URLs returned by API to absolute ones, so that any client application won't have to assemble them manually.

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
