### PR TITLE
Add validation error code to API

### DIFF
--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -44,8 +44,7 @@ class CountableDjangoObjectType(DjangoObjectType):
     def __init_subclass_with_meta__(cls, *args, **kwargs):
         # Force it to use the countable connection
         countable_conn = CountableConnection.create_type(
-            "{}CountableConnection".format(cls.__name__),
-            node=cls)
+            "{}CountableConnection".format(cls.__name__), node=cls)
         super().__init_subclass_with_meta__(
             *args, connection=countable_conn, **kwargs)
 
@@ -54,8 +53,10 @@ class Error(graphene.ObjectType):
     field = graphene.String(
         description="""Name of a field that caused the error. A value of
         `null` indicates that the error isn't associated with a particular
-        field.""", required=False)
+        field.""",
+        required=False)
     message = graphene.String(description='The error message.')
+    code = graphene.String(description='The error code.')
 
     class Meta:
         description = 'Represents an error in the input of a mutation.'
@@ -67,9 +68,8 @@ class LanguageDisplay(graphene.ObjectType):
 
 
 PermissionEnum = graphene.Enum(
-    'PermissionEnum', [
-        (str_to_enum(codename.split('.')[1]), codename)
-        for codename in MODELS_PERMISSIONS])
+    'PermissionEnum', [(str_to_enum(codename.split('.')[1]), codename)
+                       for codename in MODELS_PERMISSIONS])
 
 
 class PermissionDisplay(graphene.ObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -479,6 +479,7 @@ type DraftOrderUpdate {
 type Error {
   field: String
   message: String
+  code: String
 }
 
 type Fulfillment implements Node {

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -261,16 +261,16 @@ export interface SiteDomainInput {
 
 export interface StaffCreateInput {
   email?: string | null;
-  note?: string | null;
   isActive?: boolean | null;
+  note?: string | null;
   permissions?: (string | null)[] | null;
   sendPasswordEmail?: boolean | null;
 }
 
 export interface StaffInput {
   email?: string | null;
-  note?: string | null;
   isActive?: boolean | null;
+  note?: string | null;
   permissions?: (string | null)[] | null;
 }
 


### PR DESCRIPTION
I want to merge this change because it adds error codes to API.

Example: 
```
mutation {
  categoryUpdate(id:"Q2F0ZWdvcnk6Ng==", input:{slug:"a b"}) {
    errors{
      field
      message
      code
    }
  }
}
```
outputs
```
{
  "data": {
    "categoryUpdate": {
      "errors": [
        {
          "field": "slug",
          "message": "Wpisz poprawną uproszczoną nazwę zawierającą jedynie litery, cyfry, podkreślenia i myślniki.",
          "code": "invalid"
        }
      ]
    }
  }
}
```

TODO:
1. [ ] Use enum as `code` instead of string
2. [ ] Ensure that all custom errors in various mutations have `code` property 

It allows front end to format its own messages instead of relying on API output.

<!-- Please mention all relevant issue numbers. -->


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
