### PR TITLE
Fix wrong file name in populatedb thumbnails

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -719,4 +719,4 @@ def get_product_list_images_dir(placeholder_dir):
 
 def get_image(image_dir, image_name):
     img_path = os.path.join(image_dir, image_name)
-    return File(open(img_path, 'rb'))
+    return File(open(img_path, 'rb'), name=image_name)


### PR DESCRIPTION
This fixes a forgotten issue that was raised by #2694. Populatedb was passing as image file name the (full) absolute path instead of the file name, which makes django create a whole bunch of sub directories in the media directories, which is not the expected behavior from Saleor.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
