### PR TITLE
Make product variant attributes non-nullable

### DIFF
--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -135,7 +135,7 @@ class ProductVariant(CountableDjangoObjectType):
         price is used."""))
     price = graphene.Field(Money, description="Price of the product variant.")
     attributes = graphene.List(
-        SelectedAttribute,
+        graphene.NonNull(SelectedAttribute), required=True,
         description='List of attributes assigned to this variant.')
     cost_price = graphene.Field(
         Money, description='Cost price of the variant.')

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1507,7 +1507,7 @@ type ProductVariant implements Node {
   name: String!
   priceOverride: Money
   product: Product!
-  attributes: [SelectedAttribute]
+  attributes: [SelectedAttribute!]!
   images(before: String, after: String, first: Int, last: Int): ProductImageCountableConnection
   trackInventory: Boolean!
   quantity: Int!

--- a/saleor/static/dashboard-next/home/types/Home.ts
+++ b/saleor/static/dashboard-next/home/types/Home.ts
@@ -72,7 +72,7 @@ export interface Home_productTopToday_edges_node {
   __typename: "ProductVariant";
   id: string;
   revenue: Home_productTopToday_edges_node_revenue | null;
-  attributes: (Home_productTopToday_edges_node_attributes | null)[] | null;
+  attributes: Home_productTopToday_edges_node_attributes[];
   product: Home_productTopToday_edges_node_product;
   quantityOrdered: number | null;
 }

--- a/saleor/static/dashboard-next/products/types/ProductVariant.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariant.ts
@@ -125,7 +125,7 @@ export interface ProductVariant_product {
 export interface ProductVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (ProductVariant_attributes | null)[] | null;
+  attributes: ProductVariant_attributes[];
   costPrice: ProductVariant_costPrice | null;
   images: ProductVariant_images | null;
   name: string;

--- a/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
@@ -125,7 +125,7 @@ export interface ProductVariantDetails_productVariant_product {
 export interface ProductVariantDetails_productVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (ProductVariantDetails_productVariant_attributes | null)[] | null;
+  attributes: ProductVariantDetails_productVariant_attributes[];
   costPrice: ProductVariantDetails_productVariant_costPrice | null;
   images: ProductVariantDetails_productVariant_images | null;
   name: string;

--- a/saleor/static/dashboard-next/products/types/VariantCreate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantCreate.ts
@@ -133,7 +133,7 @@ export interface VariantCreate_productVariantCreate_productVariant_product {
 export interface VariantCreate_productVariantCreate_productVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (VariantCreate_productVariantCreate_productVariant_attributes | null)[] | null;
+  attributes: VariantCreate_productVariantCreate_productVariant_attributes[];
   costPrice: VariantCreate_productVariantCreate_productVariant_costPrice | null;
   images: VariantCreate_productVariantCreate_productVariant_images | null;
   name: string;

--- a/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
@@ -131,7 +131,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product {
 export interface VariantImageAssign_variantImageAssign_productVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (VariantImageAssign_variantImageAssign_productVariant_attributes | null)[] | null;
+  attributes: VariantImageAssign_variantImageAssign_productVariant_attributes[];
   costPrice: VariantImageAssign_variantImageAssign_productVariant_costPrice | null;
   images: VariantImageAssign_variantImageAssign_productVariant_images | null;
   name: string;

--- a/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
@@ -131,7 +131,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
 export interface VariantImageUnassign_variantImageUnassign_productVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (VariantImageUnassign_variantImageUnassign_productVariant_attributes | null)[] | null;
+  attributes: VariantImageUnassign_variantImageUnassign_productVariant_attributes[];
   costPrice: VariantImageUnassign_variantImageUnassign_productVariant_costPrice | null;
   images: VariantImageUnassign_variantImageUnassign_productVariant_images | null;
   name: string;

--- a/saleor/static/dashboard-next/products/types/VariantUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantUpdate.ts
@@ -133,7 +133,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product {
 export interface VariantUpdate_productVariantUpdate_productVariant {
   __typename: "ProductVariant";
   id: string;
-  attributes: (VariantUpdate_productVariantUpdate_productVariant_attributes | null)[] | null;
+  attributes: VariantUpdate_productVariantUpdate_productVariant_attributes[];
   costPrice: VariantUpdate_productVariantUpdate_productVariant_costPrice | null;
   images: VariantUpdate_productVariantUpdate_productVariant_images | null;
   name: string;


### PR DESCRIPTION
This fixes the schema to indicate the server is supposed to always provide a list of attributes when requested.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
