### PR TITLE
Make order line sorting stable

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -242,15 +242,15 @@ class Order(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_fulfillments(self, info):
-        return self.fulfillments.all()
+        return self.fulfillments.all().order_by('pk')
 
     @staticmethod
     def resolve_lines(self, info):
-        return self.lines.all()
+        return self.lines.all().order_by('pk')
 
     @staticmethod
     def resolve_events(self, info):
-        return self.events.all()
+        return self.events.all().order_by('pk')
 
     @staticmethod
     @gql_optimizer.resolver_hints(prefetch_related='payments')

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -289,6 +289,9 @@ class OrderLine(models.Model):
     tax_rate = models.DecimalField(
         max_digits=5, decimal_places=2, default=Decimal('0.0'))
 
+    class Meta:
+        ordering = ('pk',)
+
     def __str__(self):
         return self.product_name
 

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -48,7 +48,7 @@ def test_orderline_query(
     order_data = content['data']['orders']['edges'][0]['node']
     thumbnails = [l['thumbnailUrl'] for l in order_data['lines']]
     assert len(thumbnails) == 2
-    assert None in thumbnails
+    assert thumbnails[0] is None
     assert '/static/images/placeholder540x540.png' in thumbnails[1]
 
 


### PR DESCRIPTION
This fixes the randomly failing test and causes API to always respond with objects in the same order.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
