### PR TITLE
Only display each Python warning once on CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist = py{35,36,37}-django{111,21,_master}
 skipsdist = True
 
 [testenv]
-passenv = 
+passenv =
     CODECOV_* TOXENV CI TRAVIS TRAVIS_*
     DJANGO_SETTINGS_MODULE DATABASE_URL
 deps =
@@ -14,7 +14,7 @@ commands =
     django21: pip install "django>=2.1a1,<2.2" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput
-    pytest -n auto --vcr-record-mode=none --cov --cov-report=
+    pytest -n auto --vcr-record-mode=none --cov --cov-report= -Wonce
     codecov
 
 [travis]


### PR DESCRIPTION
This brings the number of logged warnings from thousands down to a couple dozen.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
