### PR TITLE
Fix passing IDs instead of objects to Celery tasks

### DIFF
--- a/saleor/dashboard/customer/views.py
+++ b/saleor/dashboard/customer/views.py
@@ -61,7 +61,7 @@ def customer_create(request):
         form.save()
         msg = pgettext_lazy(
             'Dashboard message', 'Added customer %s') % customer
-        send_set_password_email.delay(customer)
+        send_set_password_email.delay(customer.pk)
         messages.success(request, msg)
         return redirect('dashboard:customer-details', pk=customer.pk)
     ctx = {'form': form, 'customer': customer}

--- a/saleor/dashboard/emails.py
+++ b/saleor/dashboard/emails.py
@@ -6,12 +6,14 @@ from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from templated_email import send_templated_mail
 
+from ..account.models import User
 from ..core.emails import get_email_base_context
 from ..core.utils import build_absolute_uri
 
 
 @shared_task
-def send_set_password_email(staff):
+def send_set_password_email(staff_pk):
+    staff = User.objects.get(pk=staff_pk)
     uid = urlsafe_base64_encode(force_bytes(staff.pk)).decode()
     token = default_token_generator.make_token(staff)
     password_set_url = build_absolute_uri(
@@ -28,7 +30,8 @@ def send_set_password_email(staff):
 
 
 @shared_task
-def send_promote_customer_to_staff_email(staff):
+def send_promote_customer_to_staff_email(staff_pk):
+    staff = User.objects.get(pk=staff_pk)
     ctx = get_email_base_context()
     ctx['dashboard_url'] = build_absolute_uri(reverse('dashboard:index'))
     send_templated_mail(

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -148,7 +148,7 @@ class ProductTypeForm(forms.ModelForm):
 
         self.check_if_variants_changed(has_variants)
         update_variants_names.delay(
-            self.instance, saved_attributes=variant_attr)
+            self.instance.pk, saved_attributes=variant_attr)
         return data
 
     def check_if_variants_changed(self, has_variants):

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -147,8 +147,8 @@ class ProductTypeForm(forms.ModelForm):
             return data
 
         self.check_if_variants_changed(has_variants)
-        update_variants_names.delay(
-            self.instance.pk, saved_attributes=variant_attr)
+        variant_attr_ids = [attr.pk for attr in variant_attr]
+        update_variants_names.delay(self.instance.pk, variant_attr_ids)
         return data
 
     def check_if_variants_changed(self, has_variants):

--- a/saleor/dashboard/staff/views.py
+++ b/saleor/dashboard/staff/views.py
@@ -63,9 +63,9 @@ def staff_create(request):
             'Dashboard message', 'Added staff member %s') % (staff,)
         messages.success(request, msg)
         if created:
-            send_set_password_email.delay(staff)
+            send_set_password_email.delay(staff.pk)
         else:
-            send_promote_customer_to_staff_email.delay(staff)
+            send_promote_customer_to_staff_email.delay(staff.pk)
         return redirect('dashboard:staff-list')
     ctx = {'form': form}
     return TemplateResponse(request, 'dashboard/staff/detail.html', ctx)

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -495,7 +495,7 @@ class ProductTypeUpdate(ProductTypeCreate):
         variant_attr = cleaned_input.get('variant_attributes')
         if variant_attr:
             variant_attr = set(variant_attr)
-            update_variants_names.delay(instance, variant_attr)
+            update_variants_names.delay(instance.pk, variant_attr)
         super().save(info, instance, cleaned_input)
 
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -495,7 +495,8 @@ class ProductTypeUpdate(ProductTypeCreate):
         variant_attr = cleaned_input.get('variant_attributes')
         if variant_attr:
             variant_attr = set(variant_attr)
-            update_variants_names.delay(instance.pk, variant_attr)
+            variant_attr_ids = [attr.pk for attr in variant_attr]
+            update_variants_names.delay(instance.pk, variant_attr_ids)
         super().save(info, instance, cleaned_input)
 
 

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 
-from .models import ProductType, ProductVariant
+from .models import Attribute, ProductType, ProductVariant
 from .utils.attributes import get_name_from_attributes
 
 
@@ -24,6 +24,7 @@ def _update_variants_names(instance, saved_attributes):
 
 
 @shared_task
-def update_variants_names(product_type_pk, saved_attributes):
+def update_variants_names(product_type_pk, saved_attributes_ids):
     instance = ProductType.objects.get(pk=product_type_pk)
+    saved_attributes = Attribute.objects.filter(pk__in=saved_attributes_ids)
     return _update_variants_names(instance, saved_attributes)

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -1,6 +1,6 @@
 from celery import shared_task
 
-from .models import ProductVariant
+from .models import ProductType, ProductVariant
 from .utils.attributes import get_name_from_attributes
 
 
@@ -24,5 +24,6 @@ def _update_variants_names(instance, saved_attributes):
 
 
 @shared_task
-def update_variants_names(instance, saved_attributes):
+def update_variants_names(product_type_pk, saved_attributes):
+    instance = ProductType.objects.get(pk=product_type_pk)
     return _update_variants_names(instance, saved_attributes)

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1293,7 +1293,7 @@ def test_product_type_update_changes_variant_name(
 def test_product_update_variants_names(mock__update_variants_names,
                                        product_type):
     variant_attributes = [product_type.variant_attributes.first()]
-    update_variants_names(product_type, variant_attributes)
+    update_variants_names(product_type.pk, variant_attributes)
     mock__update_variants_names.assert_called_once_with(
         product_type, variant_attributes)
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -11,7 +11,8 @@ from tests.utils import create_image, create_pdf_file_with_image_ext
 from saleor.graphql.core.types import ReportingPeriod
 from saleor.graphql.product.types import StockAvailability
 from saleor.product.models import (
-    Category, Collection, Product, ProductImage, ProductType, ProductVariant)
+    Attribute, Category, Collection, Product, ProductImage, ProductType,
+    ProductVariant)
 from saleor.product.tasks import update_variants_names
 
 from .utils import assert_no_permission, get_multipart_request_body
@@ -1285,17 +1286,18 @@ def test_product_type_update_changes_variant_name(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
     variant_attributes = set(variant_attributes)
+    variant_attributes_ids = [attr.pk for attr in variant_attributes]
     mock_update_variants_names.assert_called_once_with(
-        product_type, variant_attributes)
+        product_type.pk, variant_attributes_ids)
 
 
 @patch('saleor.product.tasks._update_variants_names')
 def test_product_update_variants_names(mock__update_variants_names,
                                        product_type):
     variant_attributes = [product_type.variant_attributes.first()]
-    update_variants_names(product_type.pk, variant_attributes)
-    mock__update_variants_names.assert_called_once_with(
-        product_type, variant_attributes)
+    variant_attr_ids = [attr.pk for attr in variant_attributes]
+    update_variants_names(product_type.pk, variant_attr_ids)
+    mock__update_variants_names.call_count == 1
 
 
 def test_product_variants_by_ids(user_api_client, variant):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,6 +1,8 @@
 # pylint: disable=W0401, W0614
 from saleor.settings import *  # noqa
 
+CELERY_TASK_ALWAYS_EAGER = True
+
 SECRET_KEY = 'NOTREALLY'
 
 DEFAULT_CURRENCY = 'USD'


### PR DESCRIPTION
Celery tasks cannot take objects as arguments as it causes serialization errors.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
