### PR TITLE
Prevent tests from modifying real settings

### DIFF
--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -1,5 +1,4 @@
 import graphene
-from django.conf import settings
 from django_countries import countries
 from saleor.core.permissions import MODELS_PERMISSIONS
 from saleor.graphql.core.utils import str_to_enum
@@ -45,7 +44,7 @@ def test_query_countries(user_api_client):
     assert len(data['countries']) == len(countries)
 
 
-def test_query_currencies(user_api_client):
+def test_query_currencies(user_api_client, settings):
     query = """
     query {
         shop {
@@ -77,7 +76,7 @@ def test_query_name(user_api_client, site_settings):
     assert data['name'] == site_settings.site.name
 
 
-def test_query_domain(user_api_client, site_settings):
+def test_query_domain(user_api_client, site_settings, settings):
     query = """
     query {
         shop {

--- a/tests/dashboard/test_order.py
+++ b/tests/dashboard/test_order.py
@@ -2,7 +2,6 @@ import json
 from decimal import Decimal
 
 import pytest
-from django.conf import settings
 from django.urls import reverse
 from prices import Money
 from tests.utils import get_form_errors, get_redirect_location
@@ -39,7 +38,7 @@ def test_ajax_order_shipping_methods_list(
 
 
 def test_ajax_order_shipping_methods_list_different_country(
-        admin_client, order, shipping_zone):
+        admin_client, order, settings, shipping_zone):
     order.shipping_address = order.billing_address.get_copy()
     order.save()
     method = shipping_zone.shipping_methods.get()
@@ -617,7 +616,7 @@ def test_view_create_from_draft_order_not_draft_order(
 
 
 def test_view_create_from_draft_order_shipping_zone_not_valid(
-        admin_client, draft_order, shipping_zone):
+        admin_client, draft_order, settings, shipping_zone):
     method = shipping_zone.shipping_methods.create(
         name='DHL', price=Money(10, settings.DEFAULT_CURRENCY))
     shipping_zone.countries = ['DE']
@@ -779,7 +778,7 @@ def test_view_order_shipping_edit(
 
 
 def test_view_order_shipping_edit_not_draft_order(
-        admin_client, order_with_lines, shipping_zone):
+        admin_client, order_with_lines, settings, shipping_zone):
     method = shipping_zone.shipping_methods.create(
         price=Money(5, settings.DEFAULT_CURRENCY), name='DHL')
     url = reverse(
@@ -929,7 +928,7 @@ def test_remove_customer_from_order_do_not_remove_modified_addresses(
     assert order.shipping_address == old_shipping_address
 
 
-def test_view_order_voucher_edit(admin_client, draft_order, voucher):
+def test_view_order_voucher_edit(admin_client, draft_order, settings, voucher):
     total_before = draft_order.total
     url = reverse(
         'dashboard:order-voucher-edit', kwargs={'order_pk': draft_order.pk})
@@ -948,7 +947,7 @@ def test_view_order_voucher_edit(admin_client, draft_order, voucher):
     assert draft_order.total == total_before - discount_amount
 
 
-def test_view_order_voucher_remove(admin_client, draft_order, voucher):
+def test_view_order_voucher_remove(admin_client, draft_order, settings, voucher):
     increase_voucher_usage(voucher)
     draft_order.voucher = voucher
     discount_amount = Money(voucher.discount_value, settings.DEFAULT_CURRENCY)

--- a/tests/dashboard/test_product.py
+++ b/tests/dashboard/test_product.py
@@ -1,7 +1,6 @@
 import json
 from unittest.mock import MagicMock, Mock
 
-from django.conf import settings
 from django.forms import HiddenInput
 from django.forms.models import model_to_dict
 from django.urls import reverse
@@ -77,7 +76,7 @@ def test_view_product_list_with_filters_no_results(admin_client, product_list):
     assert list(response.context['filter_set'].qs) == []
 
 
-def test_view_product_list_pagination(admin_client, product_list):
+def test_view_product_list_pagination(admin_client, product_list, settings):
     settings.DASHBOARD_PAGINATE_BY = 1
     url = reverse('dashboard:product-list')
     data = {'page': '1'}
@@ -95,7 +94,8 @@ def test_view_product_list_pagination(admin_client, product_list):
     assert not response.context['filter_set'].is_bound_unsorted
 
 
-def test_view_product_list_pagination_with_filters(admin_client, product_list):
+def test_view_product_list_pagination_with_filters(
+        admin_client, product_list, settings):
     settings.DASHBOARD_PAGINATE_BY = 1
     url = reverse('dashboard:product-list')
     data = {
@@ -559,7 +559,8 @@ def test_view_variant_images(admin_client, product_with_image):
     assert variant.variant_images.filter(image=product_image).exists()
 
 
-def test_view_ajax_available_variants_list(admin_client, product, category):
+def test_view_ajax_available_variants_list(
+        admin_client, product, category, settings):
     unavailable_product = Product.objects.create(
         name='Test product', price=Money(10, settings.DEFAULT_CURRENCY),
         product_type=product.product_type,
@@ -1037,7 +1038,8 @@ def test_product_form_assign_collection_to_product(product):
     assert collection.products.first().name == product.name
 
 
-def test_product_form_sanitize_product_description(product_type, category):
+def test_product_form_sanitize_product_description(
+        product_type, category, settings):
     product = Product.objects.create(
         name='Test Product', price=Money(10, settings.DEFAULT_CURRENCY),
         description='', pk=10, product_type=product_type, category=category)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5,7 +5,6 @@ from urllib.parse import urljoin
 
 import pytest
 
-from django.conf import settings
 from django.db.models import Case, F, When
 from django.shortcuts import reverse
 from django.templatetags.static import static
@@ -238,21 +237,18 @@ def test_create_thumbnails(product_with_image, settings):
 
 
 @patch('storages.backends.s3boto3.S3Boto3Storage')
-@patch.object(settings, 'AWS_MEDIA_BUCKET_NAME', 'media-bucket')
-@patch.object(settings, 'AWS_MEDIA_CUSTOM_DOMAIN', 'media-bucket.example.org')
-def test_storages_set_s3_bucket_domain(*_patches):
-    assert settings.AWS_MEDIA_BUCKET_NAME == 'media-bucket'
-    assert settings.AWS_MEDIA_CUSTOM_DOMAIN == 'media-bucket.example.org'
+def test_storages_set_s3_bucket_domain(storage, settings):
+    settings.AWS_MEDIA_BUCKET_NAME = 'media-bucket'
+    settings.AWS_MEDIA_CUSTOM_DOMAIN = 'media-bucket.example.org'
     storage = S3MediaStorage()
     assert storage.bucket_name == 'media-bucket'
     assert storage.custom_domain == 'media-bucket.example.org'
 
 
 @patch('storages.backends.s3boto3.S3Boto3Storage')
-@patch.object(settings, 'AWS_MEDIA_BUCKET_NAME', 'media-bucket')
-def test_storages_not_setting_s3_bucket_domain(*_patches):
-    assert settings.AWS_MEDIA_BUCKET_NAME == 'media-bucket'
-    assert settings.AWS_MEDIA_CUSTOM_DOMAIN is None
+def test_storages_not_setting_s3_bucket_domain(storage, settings):
+    settings.AWS_MEDIA_BUCKET_NAME = 'media-bucket'
+    settings.AWS_MEDIA_CUSTOM_DOMAIN = None
     storage = S3MediaStorage()
     assert storage.bucket_name == 'media-bucket'
     assert storage.custom_domain is None
@@ -303,7 +299,7 @@ def test_convert_weight():
     assert convert_weight(weight, WeightUnits.GRAM) == expected_result
 
 
-def test_build_absolute_uri(site_settings):
+def test_build_absolute_uri(site_settings, settings):
     # Case when we are using external service for storing static files,
     # eg. Amazon s3
     url = 'https://example.com/static/images/image.jpg'

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -1,7 +1,6 @@
 from unittest import mock
 
 import pytest
-from django.conf import settings
 from django.templatetags.static import static
 from templated_email import get_connection
 
@@ -59,7 +58,7 @@ def test_collect_data_for_email(order):
     (emails.send_payment_confirmation, emails.CONFIRM_PAYMENT_TEMPLATE),
     (emails.send_order_confirmation, emails.CONFIRM_ORDER_TEMPLATE)])
 @mock.patch('saleor.order.emails.send_templated_mail')
-def test_send_emails(mocked_templated_email, order, template, send_email):
+def test_send_emails(mocked_templated_email, order, template, send_email, settings):
     send_email(order.pk)
     email_data = emails.collect_data_for_email(order.pk, template)
 
@@ -83,7 +82,8 @@ def test_send_emails(mocked_templated_email, order, template, send_email):
     (emails.send_fulfillment_update, emails.UPDATE_FULFILLMENT_TEMPLATE)])
 @mock.patch('saleor.order.emails.send_templated_mail')
 def test_send_fulfillment_emails(
-        mocked_templated_email, template, send_email, fulfilled_order):
+        mocked_templated_email, template, send_email, fulfilled_order,
+        settings):
     fulfillment = fulfilled_order.fulfillments.first()
     send_email(order_pk=fulfilled_order.pk, fulfillment_pk=fulfillment.pk)
     email_data = emails.collect_data_for_fullfillment_email(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -2,7 +2,6 @@ from decimal import Decimal
 
 import pytest
 
-from django.conf import settings
 from django.urls import reverse
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
@@ -360,7 +359,7 @@ def test_order_queryset_drafts(draft_order):
     assert all([order not in draft_orders for order in other_orders])
 
 
-def test_order_queryset_to_ship():
+def test_order_queryset_to_ship(settings):
     total = TaxedMoney(net=Money(10, 'USD'), gross=Money(15, 'USD'))
     orders_to_ship = [
         Order.objects.create(status=OrderStatus.UNFULFILLED, total=total),
@@ -436,7 +435,7 @@ def test_update_order_prices(order_with_lines):
 
 
 def test_order_payment_flow(
-        request_cart_with_item, client, address, shipping_zone):
+        request_cart_with_item, client, address, shipping_zone, settings):
     request_cart_with_item.shipping_address = address
     request_cart_with_item.billing_address = address.get_copy()
     request_cart_with_item.email = 'test@example.com'
@@ -456,12 +455,12 @@ def test_order_payment_flow(
     assert response.status_code == 200
     redirect_url = reverse(
         'order:payment',
-        kwargs={'token': order.token, 'gateway':settings.DUMMY})
+        kwargs={'token': order.token, 'gateway': settings.DUMMY})
     assert response.request['PATH_INFO'] == redirect_url
 
     # Go to payment details page, enter payment data
     data = {
-        'gateway':settings.DUMMY,
+        'gateway': settings.DUMMY,
         'is_active': True,
         'total': order.total.gross.amount,
         'currency': order.total.gross.currency,

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 
 import pytest
 
-from django.conf import settings
 from django.core import serializers
 from django.core.serializers.base import DeserializationError
 from django.urls import reverse
@@ -68,7 +67,7 @@ def test_product_preview(admin_client, client, product):
     assert response.status_code == 200
 
 
-def test_filtering_by_attribute(db, color_attribute, category):
+def test_filtering_by_attribute(db, color_attribute, category, settings):
     product_type_a = models.ProductType.objects.create(
         name='New class', has_variants=True)
     product_type_a.product_attributes.add(color_attribute)

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,10 +1,9 @@
-from django.conf import settings
 from django.urls import reverse, translate_url
 
 from saleor.core.utils import build_absolute_uri
 
 
-def test_sitemap(client, product):
+def test_sitemap(client, product, settings):
     product_url = build_absolute_uri(product.get_absolute_url())
     category_url = build_absolute_uri(
         product.category.get_absolute_url())


### PR DESCRIPTION
Currently some of our tests modify the actual settings object instead of the proxy provided by the pytest fixture. This means that some tests can fail depending on the order of execution.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
