### PR TITLE
Skip installing chromium to make deployment faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 !.github
 !.gitignore
 !.nvmrc
+!.npmrc
 !.pylintrc
 !.travis*
 !.tx

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+puppeteer_skip_chromium_download = true


### PR DESCRIPTION
Storybooks's addon snapshots requires ```puppeteer``` which requires downloading chromium. The size is around 100MB, which make deployement process slower.

This PR disable installing chromium, since it is not required for webpack building.

I'm not so familar with storybook. But I think it looks like it not required by ```jest``` for tests or udpating snapshots by ```jest --updateSnapshot```.

I'm glad anyone could tell me when will be chromium really required in storybook's developing process.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
