### PR TITLE
Remove django-graphene-jwt warnings

### DIFF
--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import AnonymousUser
 from django.shortcuts import reverse
+from graphene_django.settings import graphene_settings
 from graphql_jwt.middleware import JSONWebTokenMiddleware
 
 
@@ -11,7 +12,10 @@ def jwt_middleware(get_response):
     and authenticates the user
     with graphql_jwt.middleware.JSONWebTokenMiddleware.
     """
+    # Disable warnings for django-graphene-jwt
+    graphene_settings.MIDDLEWARE.append(JSONWebTokenMiddleware)
     jwt_middleware = JSONWebTokenMiddleware(get_response=get_response)
+    graphene_settings.MIDDLEWARE.remove(JSONWebTokenMiddleware)
 
     def middleware(request):
         if request.path == reverse('api'):


### PR DESCRIPTION
Since django-graphene-jwt is updated to latest version 0.2.0 which added GRAPHENE middleware and deprecated Django middleware in https://github.com/flavors/django-graphql-jwt/commit/783203d951b8a50184bf2806eb388a6b6252e075#diff-88b99bb28683bd5b7e3a204826ead112, there are a lot of warnings.

This PR removes these warnings.

```
saleor/graphql/middleware.py:14
  /home/travis/build/mirumee/saleor/saleor/graphql/middleware.py:14: UserWarning: You do not have 'graphql_jwt.middleware.JSONWebTokenMiddleware' in your GRAPHENE['MIDDLEWARE'] setting. Please see the documentation for more information: <https://github.com/flavors/django-graphql-jwt#installation>
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
