### PR TITLE
Disable deprecated warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+addopts = -n auto --vcr-record-mode=none --cov --cov-report=
+testpaths = tests
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning


### PR DESCRIPTION
Try to do same thing as https://github.com/mirumee/saleor/pull/3211 which still have a lot of deprecated warnings.

I believe the derecated warnings in third-party packages won't be removed recently, and maybe it is better to just disable them at all just as many open source project did.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
