### PR TITLE
Use DJANGO_SETTINGS_MODULE with pytest on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           name: Run tests
           command: |
             docker run -d --name db -e POSTGRES_USER=saleor -e POSTGRES_PASSWORD=saleor postgres:9.6-alpine
-            docker run --network container:db --rm -e DATABASE_URL -e SECRET_KEY mirumee/saleor:latest pytest
+            docker run --network container:db --rm -e DATABASE_URL -e DJANGO_SETTINGS_MODULE -e SECRET_KEY mirumee/saleor:latest pytest
           environment:
             DATABASE_URL: postgres://saleor:saleor@localhost:5432/saleor
             SECRET_KEY: irrelevant


### PR DESCRIPTION
Build on CircleCI are failing due to missing `DJANGO_SETTINGS_MODULE`. I've set this variable through CircleCI configuration interface, but it also has to be added in the `pytest` command.

Partially reverts [this commit](https://github.com/mirumee/saleor/commit/5d634976865238f757f8f1a58cc35571fb0cac37).

I tested this command by connecting to the Docker instance on CI and running it manually, it worked.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
