### PR TITLE
Remove DJANGO_SETTINGS_MODULE env in CI settings but use the one in setup.cfg

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,9 +28,8 @@ jobs:
           name: Run tests
           command: |
             docker run -d --name db -e POSTGRES_USER=saleor -e POSTGRES_PASSWORD=saleor postgres:9.6-alpine
-            docker run --network container:db --rm -e DATABASE_URL -e DJANGO_SETTINGS_MODULE -e SECRET_KEY mirumee/saleor:latest pytest
+            docker run --network container:db --rm -e DATABASE_URL -e SECRET_KEY mirumee/saleor:latest pytest
           environment:
-            DJANGO_SETTINGS_MODULE: tests.settings
             DATABASE_URL: postgres://saleor:saleor@localhost:5432/saleor
             SECRET_KEY: irrelevant
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,6 +30,7 @@ jobs:
             docker run -d --name db -e POSTGRES_USER=saleor -e POSTGRES_PASSWORD=saleor postgres:9.6-alpine
             docker run --network container:db --rm -e DATABASE_URL -e DJANGO_SETTINGS_MODULE -e SECRET_KEY mirumee/saleor:latest pytest
           environment:
+            DJANGO_SETTINGS_MODULE: tests.settings
             DATABASE_URL: postgres://saleor:saleor@localhost:5432/saleor
             SECRET_KEY: irrelevant
       - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,10 +26,9 @@ jobs:
           name: Run tests
           command: |
             docker run -d --name db -e POSTGRES_USER=saleor -e POSTGRES_PASSWORD=saleor postgres:9.6-alpine
-            docker run --network container:db --rm -e DATABASE_URL -e SECRET_KEY mirumee/saleor:latest pytest
+            docker run --network container:db --rm -e DATABASE_URL mirumee/saleor:latest pytest
           environment:
             DATABASE_URL: postgres://saleor:saleor@localhost:5432/saleor
-            SECRET_KEY: irrelevant
       - deploy:
           name: Push Docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ jobs:
               export SALEOR_VERSION=$(git describe --tags)
             fi
             sed -i.bak "s#'dev'#'$SALEOR_VERSION'#" saleor/__init__.py
-
-
       - run:
           name: Build application Docker image
           command: |
@@ -39,7 +37,6 @@ jobs:
             docker tag mirumee/saleor:latest mirumee/saleor:$CIRCLE_SHA1
             docker push mirumee/saleor:$CIRCLE_SHA1
             docker push mirumee/saleor:latest
-
       - run:
           name: Deploy saleor-demo
           command: |
@@ -50,7 +47,6 @@ jobs:
                 -d build_parameters[CIRCLE_JOB]=deploy \
                 https://circleci.com/api/v1.1/project/github/mirumee/saleor-demo/tree/master
             fi
-
       - run:
           name: Deploy saleor master
           command: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ script:
   - tox
 env:
   global:
-    - DATABASE_URL='postgres://postgres@localhost:5432/saleor'
+    - DATABASE_URL="postgres://postgres@localhost:5432/saleor"
+    - SECRET_KEY="irrelevant"
   matrix:
   - DJANGO="1.11"
   - DJANGO="2.1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ script:
   - tox
 env:
   global:
-    - DJANGO_SETTINGS_MODULE=tests.settings
     - DATABASE_URL='postgres://postgres@localhost:5432/saleor'
   matrix:
   - DJANGO="1.11"

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-addopts = -n auto --vcr-record-mode=none --cov --cov-report=
-testpaths = tests
-filterwarnings =
-    ignore::DeprecationWarning
-    ignore::PendingDeprecationWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,6 @@ exclude_lines =
 
 [tool:pytest]
 testpaths = tests saleor
-DJANGO_SETTINGS_MODULE = tests.settings
 
 [flake8]
 exclude =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,12 @@ exclude_lines =
     return NotImplemented
 
 [tool:pytest]
+addopts = -n auto --vcr-record-mode=none --cov --cov-report=
 testpaths = tests saleor
+filterwarnings =
+    ignore::DeprecationWarning
+    ignore::PendingDeprecationWarning
+DJANGO_SETTINGS_MODULE = tests.settings
 
 [flake8]
 exclude =

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv]
 passenv = 
     CODECOV_* TOXENV CI TRAVIS TRAVIS_*
-    DATABASE_URL
+    DATABASE_URL SECRET_KEY
 deps =
     -rrequirements.txt
     -rrequirements_dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 [testenv]
 passenv = 
     CODECOV_* TOXENV CI TRAVIS TRAVIS_*
-    DJANGO_SETTINGS_MODULE DATABASE_URL
+    DATABASE_URL
 deps =
     -rrequirements.txt
     -rrequirements_dev.txt


### PR DESCRIPTION
```DJANGO_SETTINGS_MODULE ``` is set in ```setup.cfg``` for testing and then there is no need to setup this env var in CI settings.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
