### PR TITLE
Fix file not found error on populatedb when CWD is not the project root

### DIFF
--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -55,8 +55,7 @@ class Command(BaseCommand):
         create_images = not options['withoutimages']
         for msg in create_shipping_zones():
             self.stdout.write(msg)
-        create_products_by_schema(
-            self.placeholders_dir, create_images, stdout=self.stdout)
+        create_products_by_schema(self.placeholders_dir, create_images)
         self.stdout.write('Created products')
         for msg in create_product_sales(5):
             self.stdout.write(msg)

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -195,8 +195,9 @@ def create_product_variants(variants_data):
         ProductVariant.objects.update_or_create(pk=pk, defaults=defaults)
 
 
-def create_products_by_schema(placeholder_dir, create_images, stdout=None):
-    with open('saleor/static/db.json') as f:
+def create_products_by_schema(placeholder_dir, create_images):
+    path = os.path.join(settings.PROJECT_ROOT, 'saleor', 'static', 'db.json')
+    with open(path) as f:
         db_items = json.load(f, object_hook=object_hook)
     types = defaultdict(list)
     # Sort db objects by its model

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -121,7 +121,7 @@ def test_create_fake_order(db, monkeypatch, product_image):
         pass
     for _ in random_data.create_users(3):
         pass
-        random_data.create_products_by_schema('/', 10, False)
+        random_data.create_products_by_schema('/', 10)
     how_many = 5
     for _ in random_data.create_orders(how_many):
         pass


### PR DESCRIPTION
If the current working directory was not the project root directory, Saleor was crashing with:
```
    def create_products_by_schema(placeholder_dir, create_images, stdout=None):
>       with open('saleor/static/db.json') as f:
E       FileNotFoundError: [Errno 2] No such file or directory: 'saleor/static/db.json'
```

In addition, we should not use `/` in paths as there may lead to issues on Windows.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
