### PR TITLE
Fix missing DJANGO_SETTINGS_MODULE in pytest.ini

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -4,3 +4,4 @@ testpaths = tests
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
+DJANGO_SETTINGS_MODULE = tests.settings

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,6 @@ exclude_lines =
     raise NotImplementedError
     return NotImplemented
 
-[tool:pytest]
-testpaths = tests saleor
-DJANGO_SETTINGS_MODULE = tests.settings
-
 [flake8]
 exclude =
     .*/,


### PR DESCRIPTION
This adds back the `DJANGO_SETTINGS_MODULE` environment variable to pytest that was accidentally dropped in #3229. This issue caused #3233.

This also clean up the remains of the previous config.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
