### PR TITLE
Change connection to a list in API

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -1,11 +1,9 @@
 import graphene
-import graphene_django_optimizer as gql_optimizer
 from django.contrib.auth import get_user_model
 from graphene import relay
 
 from ...account import models
 from ...core.permissions import get_permissions
-from ..core.fields import PrefetchingConnectionField
 from ..core.types.common import (
     CountableDjangoObjectType, CountryDisplay, PermissionDisplay)
 from ..utils import format_permissions_for_display
@@ -43,10 +41,8 @@ class Address(CountableDjangoObjectType):
 class User(CountableDjangoObjectType):
     permissions = graphene.List(
         PermissionDisplay, description='List of user\'s permissions.')
-    addresses = gql_optimizer.field(
-        PrefetchingConnectionField(
-            Address, description='List of all user\'s addresses.'),
-        model_field='addresses')
+    addresses = graphene.List(
+        Address, description='List of all user\'s addresses.')
 
     class Meta:
         exclude_fields = ['password', 'is_superuser', 'OrderEvent_set']

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -1,4 +1,5 @@
 import graphene
+import graphene_django_optimizer as gql_optimizer
 from django.contrib.auth import get_user_model
 from graphene import relay
 
@@ -41,8 +42,10 @@ class Address(CountableDjangoObjectType):
 class User(CountableDjangoObjectType):
     permissions = graphene.List(
         PermissionDisplay, description='List of user\'s permissions.')
-    addresses = graphene.List(
-        Address, description='List of all user\'s addresses.')
+    addresses = gql_optimizer.field(
+        graphene.List(
+            Address, description='List of all user\'s addresses.'),
+        model_field='addresses')
 
     class Meta:
         exclude_fields = ['password', 'is_superuser', 'OrderEvent_set']

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -39,10 +39,12 @@ class Checkout(CountableDjangoObjectType):
         description='Shipping methods that can be used with this order.')
     is_shipping_required = graphene.Boolean(
         description='Returns True, if checkout requires shipping.')
-    lines = graphene.List(
-        CheckoutLine, description=(
-            'A list of checkout lines, each containing information about '
-            'an item in the checkout.'))
+    lines = gql_optimizer.field(
+        graphene.List(
+            CheckoutLine, description=(
+                'A list of checkout lines, each containing information about '
+                'an item in the checkout.')),
+        model_field='lines')
     payments = gql_optimizer.field(
         graphene.List(
             Payment, description='List of payments for the checkout'),

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1,10 +1,12 @@
 import graphene
+import graphene_django_optimizer as gql_optimizer
 
 from ...checkout import models
 from ...core.utils.taxes import get_taxes_for_address
 from ..core.types.common import CountableDjangoObjectType
 from ..core.types.money import TaxedMoney
 from ..order.resolvers import resolve_shipping_methods
+from ..payment.types import Payment
 from ..shipping.types import ShippingMethod
 
 
@@ -32,33 +34,40 @@ class CheckoutLine(CountableDjangoObjectType):
 
 
 class Checkout(CountableDjangoObjectType):
-    total_price = graphene.Field(
-        TaxedMoney,
-        description=(
-            'The sum of the the checkout line prices, with all the taxes,'
-            'shipping costs, and discounts included.'))
-    subtotal_price = graphene.Field(
-        TaxedMoney,
-        description=(
-            'The price of the checkout before shipping, with taxes included.'))
-    shipping_price = graphene.Field(
-        TaxedMoney,
-        description='The price of the shipping, with all the taxes included.')
-    lines = graphene.List(
-        CheckoutLine, description=(
-            'A list of checkout lines, each containing information about '
-            'an item in the checkout.'))
     available_shipping_methods = graphene.List(
         ShippingMethod, required=False,
         description='Shipping methods that can be used with this order.')
     is_shipping_required = graphene.Boolean(
         description='Returns True, if checkout requires shipping.')
+    lines = graphene.List(
+        CheckoutLine, description=(
+            'A list of checkout lines, each containing information about '
+            'an item in the checkout.'))
+    payments = gql_optimizer.field(
+        graphene.List(
+            Payment, description='List of payments for the checkout'),
+        model_field='payments')
+    shipping_price = graphene.Field(
+        TaxedMoney,
+        description='The price of the shipping, with all the taxes included.')
+    subtotal_price = graphene.Field(
+        TaxedMoney,
+        description=(
+            'The price of the checkout before shipping, with taxes included.'))
+    total_price = graphene.Field(
+        TaxedMoney,
+        description=(
+            'The sum of the the checkout line prices, with all the taxes,'
+            'shipping costs, and discounts included.'))
 
     class Meta:
         description = 'Checkout object'
         model = models.Cart
         interfaces = [graphene.relay.Node]
         filter_fields = ['token']
+
+    def resolve_payments(self, info):
+        return self.payments.all()
 
     def resolve_total_price(self, info):
         taxes = get_taxes_for_address(self.shipping_address)

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -6,7 +6,6 @@ from ...core.utils.taxes import get_taxes_for_address
 from ..core.types.common import CountableDjangoObjectType
 from ..core.types.money import TaxedMoney
 from ..order.resolvers import resolve_shipping_methods
-from ..payment.types import Payment
 from ..shipping.types import ShippingMethod
 
 
@@ -45,10 +44,6 @@ class Checkout(CountableDjangoObjectType):
                 'A list of checkout lines, each containing information about '
                 'an item in the checkout.')),
         model_field='lines')
-    payments = gql_optimizer.field(
-        graphene.List(
-            Payment, description='List of payments for the checkout'),
-        model_field='payments')
     shipping_price = graphene.Field(
         TaxedMoney,
         description='The price of the shipping, with all the taxes included.')
@@ -63,13 +58,11 @@ class Checkout(CountableDjangoObjectType):
             'shipping costs, and discounts included.'))
 
     class Meta:
+        exclude_fields = ['payments']
         description = 'Checkout object'
         model = models.Cart
         interfaces = [graphene.relay.Node]
         filter_fields = ['token']
-
-    def resolve_payments(self, info):
-        return self.payments.all()
 
     def resolve_total_price(self, info):
         taxes = get_taxes_for_address(self.shipping_address)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -5,7 +5,6 @@ from graphene import relay
 from ...order import OrderEvents, OrderEventsEmails, models
 from ...product.templatetags.product_images import get_thumbnail
 from ..account.types import User
-from ..core.fields import PrefetchingConnectionField
 from ..core.types.common import CountableDjangoObjectType
 from ..core.types.money import Money, TaxedMoney
 from ..payment.types import OrderAction, PaymentChargeStatusEnum

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -91,7 +91,7 @@ class Fulfillment(CountableDjangoObjectType):
     lines = gql_optimizer.field(
         graphene.List(
             FulfillmentLine,
-            description='List of fulfillment lines for the fulfillment'),
+            description='List of lines for the fulfillment'),
         model_field='lines')
     status_display = graphene.String(
         description='User-friendly fulfillment status.')

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -74,10 +74,24 @@ class OrderEvent(CountableDjangoObjectType):
         return self.order_id
 
 
+class FulfillmentLine(CountableDjangoObjectType):
+    order_line = graphene.Field(lambda: OrderLine)
+
+    class Meta:
+        description = 'Represents line of the fulfillment.'
+        interfaces = [relay.Node]
+        model = models.FulfillmentLine
+        exclude_fields = ['fulfillment']
+
+    @gql_optimizer.resolver_hints(prefetch_related='order_line')
+    def resolve_order_line(self, info):
+        return self.order_line
+
+
 class Fulfillment(CountableDjangoObjectType):
-    lines = gql_optimizer.field(
-        PrefetchingConnectionField(lambda: FulfillmentLine),
-        model_field='lines')
+    lines = graphene.List(
+        FulfillmentLine,
+        description='List of fulfillment lines for the fulfillment')
     status_display = graphene.String(
         description='User-friendly fulfillment status.')
 
@@ -92,20 +106,6 @@ class Fulfillment(CountableDjangoObjectType):
 
     def resolve_status_display(self, info):
         return self.get_status_display()
-
-
-class FulfillmentLine(CountableDjangoObjectType):
-    order_line = graphene.Field(lambda: OrderLine)
-
-    class Meta:
-        description = 'Represents line of the fulfillment.'
-        interfaces = [relay.Node]
-        model = models.FulfillmentLine
-        exclude_fields = ['fulfillment']
-
-    @gql_optimizer.resolver_hints(prefetch_related='order_line')
-    def resolve_order_line(self, info):
-        return self.order_line
 
 
 class OrderLine(CountableDjangoObjectType):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -275,9 +275,18 @@ class Product(CountableDjangoObjectType):
             graphene.ID, description='ID of a product image.'),
         description='Get a single product image by ID')
     variants = gql_optimizer.field(
-        PrefetchingConnectionField(ProductVariant), model_field='variants')
+        graphene.List(
+            ProductVariant, description='List of varinats for the product'),
+        model_field='variants')
     images = gql_optimizer.field(
-        PrefetchingConnectionField(lambda: ProductImage), model_field='images')
+        graphene.List(
+            ProductImage, description='List of images for the product'),
+        model_field='images')
+    collections = gql_optimizer.field(
+        graphene.List(
+            lambda: Collection,
+            description='List of collections for the product'),
+        model_field='collections')
 
     class Meta:
         description = dedent("""Represents an individual item for sale in the
@@ -334,6 +343,9 @@ class Product(CountableDjangoObjectType):
 
     def resolve_variants(self, info, **kwargs):
         return self.variants.all()
+
+    def resolve_collections(self, info):
+        return self.collections.all()
 
 
 def prefetch_products(info, *args, **kwargs):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -284,6 +284,7 @@ class Product(CountableDjangoObjectType):
         storefront.""")
         interfaces = [relay.Node]
         model = models.Product
+        exclude_fields = ['voucher_set', 'sale_set']
 
     @gql_optimizer.resolver_hints(prefetch_related='images')
     def resolve_thumbnail_url(self, info, *, size=None):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -18,17 +18,6 @@ type Address implements Node {
   phone: String
 }
 
-type AddressCountableConnection {
-  pageInfo: PageInfo!
-  edges: [AddressCountableEdge!]!
-  totalCount: Int
-}
-
-type AddressCountableEdge {
-  node: Address!
-  cursor: String!
-}
-
 type AddressCreate {
   errors: [Error]
   address: Address
@@ -295,13 +284,13 @@ type Checkout implements Node {
   translatedDiscountName: String
   voucherCode: String
   lines: [CheckoutLine]
-  payments(before: String, after: String, first: Int, last: Int, id: ID): PaymentCountableConnection
+  payments: [Payment]
   id: ID!
-  totalPrice: TaxedMoney
-  subtotalPrice: TaxedMoney
-  shippingPrice: TaxedMoney
   availableShippingMethods: [ShippingMethod]
   isShippingRequired: Boolean
+  shippingPrice: TaxedMoney
+  subtotalPrice: TaxedMoney
+  totalPrice: TaxedMoney
 }
 
 type CheckoutBillingAddressUpdate {
@@ -624,7 +613,7 @@ type Fulfillment implements Node {
   status: FulfillmentStatus!
   trackingNumber: String!
   shippingDate: DateTime!
-  lines(before: String, after: String, first: Int, last: Int): FulfillmentLineCountableConnection
+  lines: [FulfillmentLine]
   statusDisplay: String
 }
 
@@ -654,17 +643,6 @@ type FulfillmentLine implements Node {
   id: ID!
   orderLine: OrderLine
   quantity: Int!
-}
-
-type FulfillmentLineCountableConnection {
-  pageInfo: PageInfo!
-  edges: [FulfillmentLineCountableEdge!]!
-  totalCount: Int
-}
-
-type FulfillmentLineCountableEdge {
-  node: FulfillmentLine!
-  cursor: String!
 }
 
 input FulfillmentLineInput {
@@ -983,7 +961,7 @@ type Order implements Node {
   lines: [OrderLine]!
   fulfillments: [Fulfillment]!
   events: [OrderEvent]
-  payments(before: String, after: String, first: Int, last: Int, id: ID): PaymentCountableConnection
+  payments: [Payment]
   actions: [OrderAction]!
   availableShippingMethods: [ShippingMethod]
   number: String
@@ -1330,11 +1308,9 @@ type Product implements Node {
   chargeTaxes: Boolean!
   taxRate: String!
   weight: Weight
-  voucherSet(before: String, after: String, first: Int, last: Int): VoucherCountableConnection
-  saleSet(before: String, after: String, first: Int, last: Int): SaleCountableConnection
-  variants(before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
-  images(before: String, after: String, first: Int, last: Int): ProductImageCountableConnection
-  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  variants: [ProductVariant]
+  images: [ProductImage]
+  collections: [Collection]
   url: String!
   thumbnailUrl(size: Int): String
   availability: ProductAvailability
@@ -1395,17 +1371,6 @@ type ProductImage implements Node {
   id: ID!
   alt: String!
   url(size: Int): String!
-}
-
-type ProductImageCountableConnection {
-  pageInfo: PageInfo!
-  edges: [ProductImageCountableEdge!]!
-  totalCount: Int
-}
-
-type ProductImageCountableEdge {
-  node: ProductImage!
-  cursor: String!
 }
 
 type ProductImageCreate {
@@ -1517,7 +1482,7 @@ type ProductVariant implements Node {
   priceOverride: Money
   product: Product!
   attributes: [SelectedAttribute!]!
-  images(before: String, after: String, first: Int, last: Int): ProductImageCountableConnection
+  images: [ProductImage]
   trackInventory: Boolean!
   quantity: Int!
   quantityAllocated: Int!
@@ -1951,7 +1916,7 @@ type User implements Node {
   id: ID!
   lastLogin: DateTime
   email: String!
-  addresses(before: String, after: String, first: Int, last: Int): AddressCountableConnection
+  addresses: [Address]
   isStaff: Boolean!
   token: UUID!
   isActive: Boolean!

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -284,7 +284,6 @@ type Checkout implements Node {
   translatedDiscountName: String
   voucherCode: String
   lines: [CheckoutLine]
-  payments: [Payment]
   id: ID!
   availableShippingMethods: [ShippingMethod]
   isShippingRequired: Boolean

--- a/saleor/static/dashboard-next/orders/components/OrderFulfillment/OrderFulfillment.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderFulfillment/OrderFulfillment.tsx
@@ -60,7 +60,7 @@ const OrderFulfillment = decorate<OrderFulfillmentProps>(
     onOrderFulfillmentCancel,
     onTrackingCodeAdd
   }) => {
-    const lines = maybe(() => fulfillment.lines.edges.map(edge => edge.node));
+    const lines = maybe(() => fulfillment.lines);
     const status = maybe(() => fulfillment.status);
     return (
       <Card>
@@ -179,14 +179,13 @@ const OrderFulfillment = decorate<OrderFulfillmentProps>(
             )}
           </TableBody>
         </Table>
-        {status === FulfillmentStatus.FULFILLED &&
-          !fulfillment.trackingNumber && (
-            <CardActions>
-              <Button color="secondary" onClick={onTrackingCodeAdd}>
-                {i18n.t("Add tracking")}
-              </Button>
-            </CardActions>
-          )}
+        {status === FulfillmentStatus.FULFILLED && !fulfillment.trackingNumber && (
+          <CardActions>
+            <Button color="secondary" onClick={onTrackingCodeAdd}>
+              {i18n.t("Add tracking")}
+            </Button>
+          </CardActions>
+        )}
       </Card>
     );
   }

--- a/saleor/static/dashboard-next/orders/fixtures.ts
+++ b/saleor/static/dashboard-next/orders/fixtures.ts
@@ -818,41 +818,35 @@ export const order = (placeholder: string): OrderDetails_order => ({
       __typename: "Fulfillment",
       fulfillmentOrder: 2,
       id: "RnVsZmlsbG1lbnQ6MjQ=",
-      lines: {
-        __typename: "FulfillmentLineCountableConnection",
-        edges: [
-          {
-            __typename: "FulfillmentLineCountableEdge",
-            node: {
-              __typename: "FulfillmentLine",
-              id: "RnVsZmlsbG1lbnRMaW5lOjM5",
-              orderLine: {
-                __typename: "OrderLine",
-                id: "T3JkZXJMaW5lOjIz",
-                productName: "Williams, Garcia and Walker (XS)",
-                productSku: "5-1337",
-                quantity: 2,
-                quantityFulfilled: 2,
-                thumbnailUrl: placeholder,
-                unitPrice: {
-                  __typename: "TaxedMoney",
-                  gross: {
-                    __typename: "Money",
-                    amount: 79.71,
-                    currency: "USD"
-                  },
-                  net: {
-                    __typename: "Money",
-                    amount: 79.71,
-                    currency: "USD"
-                  }
-                }
+      lines: [
+        {
+          __typename: "FulfillmentLine",
+          id: "RnVsZmlsbG1lbnRMaW5lOjM5",
+          orderLine: {
+            __typename: "OrderLine",
+            id: "T3JkZXJMaW5lOjIz",
+            productName: "Williams, Garcia and Walker (XS)",
+            productSku: "5-1337",
+            quantity: 2,
+            quantityFulfilled: 2,
+            thumbnailUrl: placeholder,
+            unitPrice: {
+              __typename: "TaxedMoney",
+              gross: {
+                __typename: "Money",
+                amount: 79.71,
+                currency: "USD"
               },
-              quantity: 1
+              net: {
+                __typename: "Money",
+                amount: 79.71,
+                currency: "USD"
+              }
             }
-          }
-        ]
-      },
+          },
+          quantity: 1
+        }
+      ],
       status: FulfillmentStatus.FULFILLED,
       trackingNumber: ""
     },
@@ -860,41 +854,35 @@ export const order = (placeholder: string): OrderDetails_order => ({
       __typename: "Fulfillment",
       fulfillmentOrder: 1,
       id: "RnVsZmlsbG1lbnQ6OQ==",
-      lines: {
-        __typename: "FulfillmentLineCountableConnection",
-        edges: [
-          {
-            __typename: "FulfillmentLineCountableEdge",
-            node: {
-              __typename: "FulfillmentLine",
-              id: "RnVsZmlsbG1lbnRMaW5lOjE1",
-              orderLine: {
-                __typename: "OrderLine",
-                id: "T3JkZXJMaW5lOjIz",
-                productName: "Williams, Garcia and Walker (XS)",
-                productSku: "5-1337",
-                quantity: 2,
-                quantityFulfilled: 2,
-                thumbnailUrl: placeholder,
-                unitPrice: {
-                  __typename: "TaxedMoney",
-                  gross: {
-                    __typename: "Money",
-                    amount: 79.71,
-                    currency: "USD"
-                  },
-                  net: {
-                    __typename: "Money",
-                    amount: 79.71,
-                    currency: "USD"
-                  }
-                }
+      lines: [
+        {
+          __typename: "FulfillmentLine",
+          id: "RnVsZmlsbG1lbnRMaW5lOjE1",
+          orderLine: {
+            __typename: "OrderLine",
+            id: "T3JkZXJMaW5lOjIz",
+            productName: "Williams, Garcia and Walker (XS)",
+            productSku: "5-1337",
+            quantity: 2,
+            quantityFulfilled: 2,
+            thumbnailUrl: placeholder,
+            unitPrice: {
+              __typename: "TaxedMoney",
+              gross: {
+                __typename: "Money",
+                amount: 79.71,
+                currency: "USD"
               },
-              quantity: 1
+              net: {
+                __typename: "Money",
+                amount: 79.71,
+                currency: "USD"
+              }
             }
-          }
-        ]
-      },
+          },
+          quantity: 1
+        }
+      ],
       status: FulfillmentStatus.FULFILLED,
       trackingNumber: ""
     }

--- a/saleor/static/dashboard-next/orders/queries.ts
+++ b/saleor/static/dashboard-next/orders/queries.ts
@@ -81,14 +81,10 @@ export const fragmentOrderDetails = gql`
     fulfillments {
       id
       lines {
-        edges {
-          node {
-            id
-            quantity
-            orderLine {
-              ...OrderLineFragment
-            }
-          }
+        id
+        quantity
+        orderLine {
+          ...OrderLineFragment
         }
       }
       fulfillmentOrder
@@ -234,14 +230,10 @@ export const orderVariantSearchQuery = gql`
           id
           name
           variants {
-            edges {
-              node {
-                id
-                name
-                sku
-                stockQuantity
-              }
-            }
+            id
+            name
+            sku
+            stockQuantity
           }
         }
       }

--- a/saleor/static/dashboard-next/orders/types/OrderCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCancel.ts
@@ -47,56 +47,46 @@ export interface OrderCancel_orderCancel_order_events {
   user: OrderCancel_orderCancel_order_events_user | null;
 }
 
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderCancel_orderCancel_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderCancel_orderCancel_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges_node {
+export interface OrderCancel_orderCancel_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderCancel_orderCancel_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderCancel_orderCancel_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderCancel_orderCancel_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderCancel_orderCancel_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderCancel_orderCancel_order_fulfillments_lines_edges[];
+  orderLine: OrderCancel_orderCancel_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderCancel_orderCancel_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderCancel_orderCancel_order_fulfillments_lines | null;
+  lines: (OrderCancel_orderCancel_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderCapture.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCapture.ts
@@ -53,56 +53,46 @@ export interface OrderCapture_orderCapture_order_events {
   user: OrderCapture_orderCapture_order_events_user | null;
 }
 
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderCapture_orderCapture_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderCapture_orderCapture_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges_node {
+export interface OrderCapture_orderCapture_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderCapture_orderCapture_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderCapture_orderCapture_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderCapture_orderCapture_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderCapture_orderCapture_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderCapture_orderCapture_order_fulfillments_lines_edges[];
+  orderLine: OrderCapture_orderCapture_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderCapture_orderCapture_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderCapture_orderCapture_order_fulfillments_lines | null;
+  lines: (OrderCapture_orderCapture_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderCreateFulfillment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCreateFulfillment.ts
@@ -53,56 +53,46 @@ export interface OrderCreateFulfillment_orderFulfillmentCreate_order_events {
   user: OrderCreateFulfillment_orderFulfillmentCreate_order_events_user | null;
 }
 
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node {
+export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_edges[];
+  orderLine: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines | null;
+  lines: (OrderCreateFulfillment_orderFulfillmentCreate_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderDetails.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetails.ts
@@ -47,56 +47,46 @@ export interface OrderDetails_order_events {
   user: OrderDetails_order_events_user | null;
 }
 
-export interface OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderDetails_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderDetails_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderDetails_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderDetails_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderDetails_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderDetails_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderDetails_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderDetails_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderDetails_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderDetails_order_fulfillments_lines_edges_node {
+export interface OrderDetails_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderDetails_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderDetails_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderDetails_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderDetails_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderDetails_order_fulfillments_lines_edges[];
+  orderLine: OrderDetails_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderDetails_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderDetails_order_fulfillments_lines | null;
+  lines: (OrderDetails_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
@@ -47,56 +47,46 @@ export interface OrderDetailsFragment_events {
   user: OrderDetailsFragment_events_user | null;
 }
 
-export interface OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderDetailsFragment_fulfillments_lines_edges_node_orderLine {
+export interface OrderDetailsFragment_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderDetailsFragment_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderDetailsFragment_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderDetailsFragment_fulfillments_lines_edges_node {
+export interface OrderDetailsFragment_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderDetailsFragment_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderDetailsFragment_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderDetailsFragment_fulfillments_lines_edges_node;
-}
-
-export interface OrderDetailsFragment_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderDetailsFragment_fulfillments_lines_edges[];
+  orderLine: OrderDetailsFragment_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderDetailsFragment_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderDetailsFragment_fulfillments_lines | null;
+  lines: (OrderDetailsFragment_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderDraftCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftCancel.ts
@@ -47,56 +47,46 @@ export interface OrderDraftCancel_draftOrderDelete_order_events {
   user: OrderDraftCancel_draftOrderDelete_order_events_user | null;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node {
+export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderDraftCancel_draftOrderDelete_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_edges[];
+  orderLine: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderDraftCancel_draftOrderDelete_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderDraftCancel_draftOrderDelete_order_fulfillments_lines | null;
+  lines: (OrderDraftCancel_draftOrderDelete_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderDraftFinalize.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftFinalize.ts
@@ -53,56 +53,46 @@ export interface OrderDraftFinalize_draftOrderComplete_order_events {
   user: OrderDraftFinalize_draftOrderComplete_order_events_user | null;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node {
+export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_edges[];
+  orderLine: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderDraftFinalize_draftOrderComplete_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines | null;
+  lines: (OrderDraftFinalize_draftOrderComplete_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderDraftUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftUpdate.ts
@@ -53,56 +53,46 @@ export interface OrderDraftUpdate_draftOrderUpdate_order_events {
   user: OrderDraftUpdate_draftOrderUpdate_order_events_user | null;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node {
+export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_edges[];
+  orderLine: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderDraftUpdate_draftOrderUpdate_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines | null;
+  lines: (OrderDraftUpdate_draftOrderUpdate_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderFulfillmentCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderFulfillmentCancel.ts
@@ -53,56 +53,46 @@ export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_events {
   user: OrderFulfillmentCancel_orderFulfillmentCancel_order_events_user | null;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node {
+export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_edges[];
+  orderLine: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines | null;
+  lines: (OrderFulfillmentCancel_orderFulfillmentCancel_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -53,56 +53,46 @@ export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_o
   user: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_events_user | null;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node {
+export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_edges[];
+  orderLine: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines | null;
+  lines: (OrderFulfillmentUpdateTracking_orderFulfillmentUpdateTracking_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderLineAdd.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineAdd.ts
@@ -53,56 +53,46 @@ export interface OrderLineAdd_draftOrderLineCreate_order_events {
   user: OrderLineAdd_draftOrderLineCreate_order_events_user | null;
 }
 
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node {
+export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_edges[];
+  orderLine: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderLineAdd_draftOrderLineCreate_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines | null;
+  lines: (OrderLineAdd_draftOrderLineCreate_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderLineDelete.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineDelete.ts
@@ -53,56 +53,46 @@ export interface OrderLineDelete_draftOrderLineDelete_order_events {
   user: OrderLineDelete_draftOrderLineDelete_order_events_user | null;
 }
 
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node {
+export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_edges[];
+  orderLine: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderLineDelete_draftOrderLineDelete_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines | null;
+  lines: (OrderLineDelete_draftOrderLineDelete_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderLineUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineUpdate.ts
@@ -53,56 +53,46 @@ export interface OrderLineUpdate_draftOrderLineUpdate_order_events {
   user: OrderLineUpdate_draftOrderLineUpdate_order_events_user | null;
 }
 
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node {
+export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_edges[];
+  orderLine: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderLineUpdate_draftOrderLineUpdate_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines | null;
+  lines: (OrderLineUpdate_draftOrderLineUpdate_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderMarkAsPaid.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderMarkAsPaid.ts
@@ -53,56 +53,46 @@ export interface OrderMarkAsPaid_orderMarkAsPaid_order_events {
   user: OrderMarkAsPaid_orderMarkAsPaid_order_events_user | null;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node {
+export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_edges[];
+  orderLine: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines | null;
+  lines: (OrderMarkAsPaid_orderMarkAsPaid_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderRefund.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderRefund.ts
@@ -53,56 +53,46 @@ export interface OrderRefund_orderRefund_order_events {
   user: OrderRefund_orderRefund_order_events_user | null;
 }
 
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderRefund_orderRefund_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderRefund_orderRefund_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges_node {
+export interface OrderRefund_orderRefund_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderRefund_orderRefund_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderRefund_orderRefund_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderRefund_orderRefund_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderRefund_orderRefund_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderRefund_orderRefund_order_fulfillments_lines_edges[];
+  orderLine: OrderRefund_orderRefund_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderRefund_orderRefund_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderRefund_orderRefund_order_fulfillments_lines | null;
+  lines: (OrderRefund_orderRefund_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/types/OrderVariantSearch.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderVariantSearch.ts
@@ -5,7 +5,7 @@
 // GraphQL query operation: OrderVariantSearch
 // ====================================================
 
-export interface OrderVariantSearch_products_edges_node_variants_edges_node {
+export interface OrderVariantSearch_products_edges_node_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
@@ -13,21 +13,11 @@ export interface OrderVariantSearch_products_edges_node_variants_edges_node {
   stockQuantity: number;
 }
 
-export interface OrderVariantSearch_products_edges_node_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: OrderVariantSearch_products_edges_node_variants_edges_node;
-}
-
-export interface OrderVariantSearch_products_edges_node_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: OrderVariantSearch_products_edges_node_variants_edges[];
-}
-
 export interface OrderVariantSearch_products_edges_node {
   __typename: "Product";
   id: string;
   name: string;
-  variants: OrderVariantSearch_products_edges_node_variants | null;
+  variants: (OrderVariantSearch_products_edges_node_variants | null)[] | null;
 }
 
 export interface OrderVariantSearch_products_edges {

--- a/saleor/static/dashboard-next/orders/types/OrderVoid.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderVoid.ts
@@ -47,56 +47,46 @@ export interface OrderVoid_orderVoid_order_events {
   user: OrderVoid_orderVoid_order_events_user | null;
 }
 
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross {
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice_gross {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice_net {
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice_net {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice {
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice {
   __typename: "TaxedMoney";
-  gross: OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice_gross;
-  net: OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice_net;
+  gross: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice_gross;
+  net: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice_net;
 }
 
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine {
+export interface OrderVoid_orderVoid_order_fulfillments_lines_orderLine {
   __typename: "OrderLine";
   id: string;
   productName: string;
   productSku: string;
   quantity: number;
   quantityFulfilled: number;
-  unitPrice: OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine_unitPrice | null;
+  unitPrice: OrderVoid_orderVoid_order_fulfillments_lines_orderLine_unitPrice | null;
   thumbnailUrl: string | null;
 }
 
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges_node {
+export interface OrderVoid_orderVoid_order_fulfillments_lines {
   __typename: "FulfillmentLine";
   id: string;
   quantity: number;
-  orderLine: OrderVoid_orderVoid_order_fulfillments_lines_edges_node_orderLine | null;
-}
-
-export interface OrderVoid_orderVoid_order_fulfillments_lines_edges {
-  __typename: "FulfillmentLineCountableEdge";
-  node: OrderVoid_orderVoid_order_fulfillments_lines_edges_node;
-}
-
-export interface OrderVoid_orderVoid_order_fulfillments_lines {
-  __typename: "FulfillmentLineCountableConnection";
-  edges: OrderVoid_orderVoid_order_fulfillments_lines_edges[];
+  orderLine: OrderVoid_orderVoid_order_fulfillments_lines_orderLine | null;
 }
 
 export interface OrderVoid_orderVoid_order_fulfillments {
   __typename: "Fulfillment";
   id: string;
-  lines: OrderVoid_orderVoid_order_fulfillments_lines | null;
+  lines: (OrderVoid_orderVoid_order_fulfillments_lines | null)[] | null;
   fulfillmentOrder: number;
   status: FulfillmentStatus;
   trackingNumber: string;

--- a/saleor/static/dashboard-next/orders/views/OrderDetails/index.tsx
+++ b/saleor/static/dashboard-next/orders/views/OrderDetails/index.tsx
@@ -398,12 +398,6 @@ export const OrderDetails: React.StatelessComponent<OrderDetailsProps> = ({
                                     variants={maybe(() =>
                                       variantSearchOpts.data.products.edges
                                         .map(edge => edge.node)
-                                        .map(product => ({
-                                          ...product,
-                                          variants: product.variants.edges.map(
-                                            edge => edge.node
-                                          )
-                                        }))
                                         .map(product =>
                                           product.variants.map(variant => ({
                                             ...variant,
@@ -603,12 +597,6 @@ export const OrderDetails: React.StatelessComponent<OrderDetailsProps> = ({
                                     variants={maybe(() =>
                                       variantSearchOpts.data.products.edges
                                         .map(edge => edge.node)
-                                        .map(product => ({
-                                          ...product,
-                                          variants: product.variants.edges.map(
-                                            edge => edge.node
-                                          )
-                                        }))
                                         .map(product =>
                                           product.variants.map(variant => ({
                                             ...variant,

--- a/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
@@ -13,11 +13,11 @@ import CardTitle from "../../../components/CardTitle";
 import ImageTile from "../../../components/ImageTile";
 import Toggle from "../../../components/Toggle";
 import i18n from "../../../i18n";
-import { ProductDetails_product_images_edges_node } from "../../types/ProductDetails";
+import { ProductDetails_product_images } from "../../types/ProductDetails";
 
 interface ProductImagesProps {
   placeholderImage?: string;
-  images: ProductDetails_product_images_edges_node[];
+  images: ProductDetails_product_images[];
   loading?: boolean;
   onImageDelete: (id: string) => () => void;
   onImageEdit: (id: string) => () => void;

--- a/saleor/static/dashboard-next/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -12,8 +12,8 @@ import i18n from "../../../i18n";
 import { UserError } from "../../../types";
 import {
   ProductDetails_product,
-  ProductDetails_product_images_edges_node,
-  ProductDetails_product_variants_edges_node_priceOverride
+  ProductDetails_product_images,
+  ProductDetails_product_variants_priceOverride
 } from "../../types/ProductDetails";
 import ProductAvailabilityForm from "../ProductAvailabilityForm";
 import ProductDetailsForm from "../ProductDetailsForm";
@@ -43,11 +43,11 @@ interface ProductUpdateProps {
     id: string;
     sku: string;
     name: string;
-    priceOverride?: ProductDetails_product_variants_edges_node_priceOverride;
+    priceOverride?: ProductDetails_product_variants_priceOverride;
     stockQuantity: number;
     margin: number;
   }>;
-  images?: ProductDetails_product_images_edges_node[];
+  images?: ProductDetails_product_images[];
   product?: ProductDetails_product;
   header: string;
   saveButtonBarState?: SaveButtonBarState;

--- a/saleor/static/dashboard-next/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantCreatePage/ProductVariantCreatePage.tsx
@@ -72,7 +72,7 @@ const ProductVariantCreatePage = decorate<ProductVariantCreatePageProps>(
         }))
       ),
       costPrice: "",
-      images: maybe(() => product.images.edges.map(edge => edge.node.id)),
+      images: maybe(() => product.images.map(image => image.id)),
       priceOverride: "",
       quantity: 0,
       sku: ""
@@ -92,11 +92,7 @@ const ProductVariantCreatePage = decorate<ProductVariantCreatePageProps>(
                 <div className={classes.root}>
                   <div>
                     <ProductVariantNavigation
-                      variants={
-                        product && product.variants && product.variants.edges
-                          ? product.variants.edges.map(edge => edge.node)
-                          : undefined
-                      }
+                      variants={maybe(() => product.variants)}
                       onRowClick={(variantId: string) => {
                         if (product && product.variants) {
                           return onVariantClick(variantId);

--- a/saleor/static/dashboard-next/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
@@ -11,22 +11,12 @@ import CardTitle from "../../../components/CardTitle";
 import Skeleton from "../../../components/Skeleton";
 import TableCellAvatar from "../../../components/TableCellAvatar";
 import i18n from "../../../i18n";
-import { renderCollection } from "../../../misc";
+import { maybe, renderCollection } from "../../../misc";
+import { ProductVariantDetails_productVariant } from "../../types/ProductVariantDetails";
 
 interface ProductVariantNavigationProps {
   current?: string;
-  variants?: Array<{
-    id: string;
-    name: string;
-    sku: string;
-    image?: {
-      edges?: Array<{
-        node?: {
-          url: string;
-        };
-      }>;
-    };
-  }>;
+  variants: ProductVariantDetails_productVariant[];
   onRowClick: (variantId: string) => void;
 }
 
@@ -70,17 +60,7 @@ const ProductVariantNavigation = decorate<ProductVariantNavigationProps>(
                   className={classNames({
                     [classes.tabActive]: variant && variant.id === current
                   })}
-                  thumbnail={
-                    variant &&
-                    variant.image &&
-                    variant.image.edges !== undefined
-                      ? variant.image.edges.length > 0
-                        ? variant.image.edges[0] &&
-                          variant.image.edges[0].node &&
-                          variant.image.edges[0].node.url
-                        : null
-                      : undefined
-                  }
+                  thumbnail={maybe(() => variant.images[0].url)}
                 />
                 <TableCell className={classes.textLeft}>
                   {variant ? variant.name || variant.sku : <Skeleton />}

--- a/saleor/static/dashboard-next/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantNavigation/ProductVariantNavigation.tsx
@@ -12,11 +12,14 @@ import Skeleton from "../../../components/Skeleton";
 import TableCellAvatar from "../../../components/TableCellAvatar";
 import i18n from "../../../i18n";
 import { maybe, renderCollection } from "../../../misc";
+import { ProductVariantCreateData_product_variants } from "../../types/ProductVariantCreateData";
 import { ProductVariantDetails_productVariant } from "../../types/ProductVariantDetails";
 
 interface ProductVariantNavigationProps {
   current?: string;
-  variants: ProductVariantDetails_productVariant[];
+  variants:
+    | ProductVariantDetails_productVariant[]
+    | ProductVariantCreateData_product_variants[];
   onRowClick: (variantId: string) => void;
 }
 

--- a/saleor/static/dashboard-next/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -8,6 +8,7 @@ import SaveButtonBar, {
   SaveButtonBarState
 } from "../../../components/SaveButtonBar";
 import Toggle from "../../../components/Toggle";
+import { maybe } from "../../../misc";
 import { UserError } from "../../../types";
 import { ProductVariant } from "../../types/ProductVariant";
 import ProductVariantAttributes from "../ProductVariantAttributes";
@@ -58,13 +59,11 @@ const ProductVariantPage = decorate<ProductVariantPageProps>(
     onSubmit,
     onVariantClick
   }) => {
-    const variantImages = variant
-      ? variant.images.edges.map(edge => edge.node.id)
-      : [];
+    const variantImages = variant ? variant.images.map(image => image.id) : [];
     const productImages = variant
-      ? variant.product.images.edges
-          .map(edge => edge.node)
-          .sort((prev, next) => (prev.sortOrder > next.sortOrder ? 1 : -1))
+      ? variant.product.images.sort((prev, next) =>
+          prev.sortOrder > next.sortOrder ? 1 : -1
+        )
       : undefined;
     const images = productImages
       ? productImages

--- a/saleor/static/dashboard-next/products/components/ProductVariantPage/ProductVariantPage.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantPage/ProductVariantPage.tsx
@@ -106,13 +106,7 @@ const ProductVariantPage = decorate<ProductVariantPageProps>(
                       <div>
                         <ProductVariantNavigation
                           current={variant ? variant.id : undefined}
-                          variants={
-                            variant
-                              ? variant.product.variants.edges.map(
-                                  edge => edge.node
-                                )
-                              : undefined
-                          }
+                          variants={maybe(() => variant.product.variants)}
                           onRowClick={(variantId: string) => {
                             if (variant) {
                               return onVariantClick(variantId);
@@ -181,11 +175,9 @@ const ProductVariantPage = decorate<ProductVariantPageProps>(
                   onImageSelect={onImageSelect}
                   open={isImageSelectModalActive}
                   images={productImages}
-                  selectedImages={
-                    variant && variant.images && variant.images.edges
-                      ? variant.images.edges.map(edge => edge.node.id)
-                      : undefined
-                  }
+                  selectedImages={maybe(() =>
+                    variant.images.map(image => image.id)
+                  )}
                 />
               </>
             )}

--- a/saleor/static/dashboard-next/products/containers/ProductImagesReorder.tsx
+++ b/saleor/static/dashboard-next/products/containers/ProductImagesReorder.tsx
@@ -53,13 +53,7 @@ const ProductImagesReorderProvider: React.StatelessComponent<
               product: {
                 __typename: "Product",
                 id: props.productId,
-                images: {
-                  __typename: "ProductImageCountableConnection",
-                  edges: productImages.map(image => ({
-                    __typename: "ProductImageCountableEdge",
-                    node: image
-                  }))
-                }
+                images: productImages
               }
             }
           };

--- a/saleor/static/dashboard-next/products/containers/ProductUpdateOperations.tsx
+++ b/saleor/static/dashboard-next/products/containers/ProductUpdateOperations.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 
+import { maybe } from "../../misc";
 import {
   MutationProviderProps,
   MutationProviderRenderProps,
@@ -150,11 +151,7 @@ const ProductUpdateOperations: React.StatelessComponent<
       {updateProduct => (
         <ProductImagesReorderProvider
           productId={productId}
-          productImages={
-            product && product.images && product.images.edges
-              ? product.images.edges.map(edge => edge.node)
-              : []
-          }
+          productImages={maybe(() => product.images, [])}
           onError={onError}
           onSuccess={onImageReorder}
         >

--- a/saleor/static/dashboard-next/products/fixtures.ts
+++ b/saleor/static/dashboard-next/products/fixtures.ts
@@ -2258,19 +2258,23 @@ export const variant = (placeholderImage: string): ProductVariant => ({
   images: [
     {
       __typename: "ProductImage",
-      id: "img1"
+      id: "img1",
+      url: placeholderImage
     },
     {
       __typename: "ProductImage",
-      id: "img2"
+      id: "img2",
+      url: placeholderImage
     },
     {
       __typename: "ProductImage",
-      id: "img7"
+      id: "img7",
+      url: placeholderImage
     },
     {
       __typename: "ProductImage",
-      id: "img8"
+      id: "img8",
+      url: placeholderImage
     }
   ],
   name: "Extended Hard",

--- a/saleor/static/dashboard-next/products/fixtures.ts
+++ b/saleor/static/dashboard-next/products/fixtures.ts
@@ -125,77 +125,53 @@ export const product: (
   availableOn: "2018-08-25T18:45:54.125Z",
   category: { __typename: "Category", id: "Q2F0ZWdvcnk6MQ==", name: "Apparel" },
   chargeTaxes: true,
-  collections: {
-    __typename: "CollectionCountableConnection",
-    edges: [
-      {
-        __typename: "CollectionCountableEdge",
-        node: {
-          __typename: "Collection",
-          id: "Q29sbGVjdGlvbjoy",
-          name: "Winter sale"
-        }
-      }
-    ]
-  },
+  collections: [
+    {
+      __typename: "Collection",
+      id: "Q29sbGVjdGlvbjoy",
+      name: "Winter sale"
+    }
+  ],
   description:
     "Omnis rerum ea. Fugit dignissimos modi est rerum. Qui corrupti expedita et. Dolorem dolorum illo doloremque. Officia perspiciatis facilis ab maxime voluptatem eligendi ipsam. Quisquam impedit repudiandae eos. Id sit dolores adipisci qui omnis dolores qui. Illo deleniti mollitia perspiciatis.",
   id: "p10171",
-  images: {
-    __typename: "ProductImageCountableConnection",
-    edges: [
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          alt: "Id sit dolores adipisci",
-          id: "UHJvZHVjdEltYWdlOjE=",
-          sortOrder: 0,
-          url: placeholderImage
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          alt: "Id sit dolores adipisci",
-          id: "UHJvZHVjdEltYWdlOaE=",
-          sortOrder: 2,
-          url: placeholderImage
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          alt: "Id sit dolores adipisci",
-          id: "UPJvZHVjdEltYWdlOjV=",
-          sortOrder: 1,
-          url: placeholderImage
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          alt: "Id sit dolores adipisci",
-          id: "UHJvZHVjdEltYHdlOjX=",
-          sortOrder: 3,
-          url: placeholderImage
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          alt: "Id sit dolores adipisci",
-          id: "UHJvZHVjdIlnYWdlOjX=",
-          sortOrder: 4,
-          url: placeholderImage
-        }
-      }
-    ]
-  },
+  images: [
+    {
+      __typename: "ProductImage",
+      alt: "Id sit dolores adipisci",
+      id: "UHJvZHVjdEltYWdlOjE=",
+      sortOrder: 0,
+      url: placeholderImage
+    },
+    {
+      __typename: "ProductImage",
+      alt: "Id sit dolores adipisci",
+      id: "UHJvZHVjdEltYWdlOaE=",
+      sortOrder: 2,
+      url: placeholderImage
+    },
+    {
+      __typename: "ProductImage",
+      alt: "Id sit dolores adipisci",
+      id: "UPJvZHVjdEltYWdlOjV=",
+      sortOrder: 1,
+      url: placeholderImage
+    },
+    {
+      __typename: "ProductImage",
+      alt: "Id sit dolores adipisci",
+      id: "UHJvZHVjdEltYHdlOjX=",
+      sortOrder: 3,
+      url: placeholderImage
+    },
+    {
+      __typename: "ProductImage",
+      alt: "Id sit dolores adipisci",
+      id: "UHJvZHVjdIlnYWdlOjX=",
+      sortOrder: 4,
+      url: placeholderImage
+    }
+  ],
   isFeatured: false,
   isPublished: true,
   margin: { __typename: "Margin", start: 2, stop: 7 },
@@ -259,89 +235,54 @@ export const product: (
   sku: "59661-34207",
   thumbnailUrl: placeholderImage,
   url: "/example-url",
-  variants: {
-    __typename: "ProductVariantCountableConnection",
-    edges: [
-      {
-        __typename: "ProductVariantCountableEdge",
-        node: {
-          __typename: "ProductVariant",
-          id: "pv75934",
-          image: {
-            __typename: "ProductImageCountableConnection",
-            edges: [
-              {
-                __typename: "ProductImageCountableEdge",
-                node: {
-                  __typename: "ProductImage",
-                  id: "pi92837",
-                  url: placeholderImage
-                }
-              }
-            ]
-          },
-          images: {
-            edges: [
-              {
-                node: {
-                  url: placeholderImage
-                }
-              },
-              {
-                node: {
-                  url: placeholderImage
-                }
-              }
-            ]
-          },
-          margin: 2,
-          name: "Cordoba Oro",
-          priceOverride: {
-            __typename: "Money",
-            amount: 678.78,
-            currency: "USD",
-            localized: "678.78 USD"
-          },
-          sku: "87192-94370",
-          stockQuantity: 48
+  variants: [
+    {
+      __typename: "ProductVariant",
+      id: "pv75934",
+      images: [
+        {
+          __typename: "ProductImage",
+          id: "pi92837",
+          url: placeholderImage
+        },
+        {
+          __typename: "ProductImage",
+          id: "pi92838",
+          url: placeholderImage
         }
+      ],
+      margin: 2,
+      name: "Cordoba Oro",
+      priceOverride: {
+        __typename: "Money",
+        amount: 678.78,
+        currency: "USD"
       },
-      {
-        __typename: "ProductVariantCountableEdge",
-        node: {
-          __typename: "ProductVariant",
-          id: "pv68615",
-          image: {
-            __typename: "ProductImageCountableConnection",
-            edges: [
-              {
-                __typename: "ProductImageCountableEdge",
-                node: {
-                  __typename: "ProductImage",
-                  id: "pi81234",
-                  url: placeholderImage
-                }
-              }
-            ]
-          },
-          images: {
-            edges: [
-              {
-                node: {
-                  url: placeholderImage
-                }
-              }
-            ]
-          },
-          margin: 7,
-          name: "silver",
-          priceOverride: null,
-          sku: "69055-15190",
-          stockQuantity: 14
+      sku: "87192-94370",
+      stockQuantity: 48
+    },
+    {
+      __typename: "ProductVariant",
+      id: "pv68615",
+      images: [
+        {
+          __typename: "ProductImage",
+          id: "pi81234",
+          url: placeholderImage
+        },
+        {
+          __typename: "ProductImage",
+          id: "pi1236912",
+          url: placeholderImage
         }
-      }
-    ]
-  }
+      ],
+      margin: 7,
+      name: "silver",
+      priceOverride: null,
+      sku: "69055-15190",
+      stockQuantity: 14
+    }
+  ]
 });
 export const products = (placeholderImage: string) => [
   {
@@ -2308,45 +2249,30 @@ export const variant = (placeholderImage: string): ProductVariant => ({
       }
     }
   ],
-  costPrice:{
-    __typename:"Money",
+  costPrice: {
+    __typename: "Money",
     amount: 12,
-    currency: "USD",
+    currency: "USD"
   },
   id: "var1",
-  images: {
-    __typename: "ProductImageCountableConnection",
-    edges: [
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          id: "img1"
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          id: "img2"
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          id: "img7"
-        }
-      },
-      {
-        __typename: "ProductImageCountableEdge",
-        node: {
-          __typename: "ProductImage",
-          id: "img8"
-        }
-      }
-    ]
-  },
+  images: [
+    {
+      __typename: "ProductImage",
+      id: "img1"
+    },
+    {
+      __typename: "ProductImage",
+      id: "img2"
+    },
+    {
+      __typename: "ProductImage",
+      id: "img7"
+    },
+    {
+      __typename: "ProductImage",
+      id: "img8"
+    }
+  ],
   name: "Extended Hard",
   priceOverride: {
     __typename: "Money",
@@ -2356,206 +2282,135 @@ export const variant = (placeholderImage: string): ProductVariant => ({
   product: {
     __typename: "Product",
     id: "prod1",
-    images: {
-      __typename: "ProductImageCountableConnection",
-      edges: [
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Front",
-            id: "img1",
-            sortOrder: 1,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Back",
-            id: "img2",
-            sortOrder: 4,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Right side",
-            id: "img3",
-            sortOrder: 2,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Left side",
-            id: "img4",
-            sortOrder: 3,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Paper",
-            id: "img5",
-            sortOrder: 0,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Hard cover",
-            id: "img6",
-            sortOrder: 1,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Extended version",
-            id: "img7",
-            sortOrder: 0,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Cut version",
-            id: "img8",
-            sortOrder: 2,
-            url: placeholderImage
-          }
-        },
-        {
-          __typename: "ProductImageCountableEdge",
-          node: {
-            __typename: "ProductImage",
-            alt: "Soft cover",
-            id: "img9",
-            sortOrder: 2,
-            url: placeholderImage
-          }
-        }
-      ]
-    },
+    images: [
+      {
+        __typename: "ProductImage",
+        alt: "Front",
+        id: "img1",
+        sortOrder: 1,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Back",
+        id: "img2",
+        sortOrder: 4,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Right side",
+        id: "img3",
+        sortOrder: 2,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Left side",
+        id: "img4",
+        sortOrder: 3,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Paper",
+        id: "img5",
+        sortOrder: 0,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Hard cover",
+        id: "img6",
+        sortOrder: 1,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Extended version",
+        id: "img7",
+        sortOrder: 0,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Cut version",
+        id: "img8",
+        sortOrder: 2,
+        url: placeholderImage
+      },
+      {
+        __typename: "ProductImage",
+        alt: "Soft cover",
+        id: "img9",
+        sortOrder: 2,
+        url: placeholderImage
+      }
+    ],
     name: "Our Awesome Book",
     thumbnailUrl: placeholderImage,
-    variants: {
-      __typename: "ProductVariantCountableConnection",
-      edges: [
-        {
-          __typename: "ProductVariantCountableEdge",
-          node: {
-            __typename: "ProductVariant",
-            id: "var1",
-            image: {
-              __typename: "ProductImageCountableConnection",
-              edges: [
-                {
-                  __typename: "ProductImageCountableEdge",
-                  node: {
-                    __typename: "ProductImage",
-                    id: "23123",
-                    url: placeholderImage
-                  }
-                }
-              ]
-            },
-            name: "Extended Hard",
-            sku: "13-1337"
+    variants: [
+      {
+        __typename: "ProductVariant",
+        id: "var1",
+        images: [
+          {
+            __typename: "ProductImage",
+            id: "23123",
+            url: placeholderImage
           }
-        },
-        {
-          __typename: "ProductVariantCountableEdge",
-          node: {
-            __typename: "ProductVariant",
-            id: "var2",
-            image: {
-              __typename: "ProductImageCountableConnection",
-              edges: [
-                {
-                  __typename: "ProductImageCountableEdge",
-                  node: {
-                    __typename: "ProductImage",
-                    id: "23123",
-                    url: placeholderImage
-                  }
-                }
-              ]
-            },
-            name: "Extended Soft",
-            sku: "13-1338"
+        ],
+        name: "Extended Hard",
+        sku: "13-1337"
+      },
+      {
+        __typename: "ProductVariant",
+        id: "var2",
+        images: [
+          {
+            __typename: "ProductImage",
+            id: "23123",
+            url: placeholderImage
           }
-        },
-        {
-          __typename: "ProductVariantCountableEdge",
-          node: {
-            __typename: "ProductVariant",
-            id: "var3",
-            image: {
-              __typename: "ProductImageCountableConnection",
-              edges: [
-                {
-                  __typename: "ProductImageCountableEdge",
-                  node: {
-                    __typename: "ProductImage",
-                    id: "23123",
-                    url: placeholderImage
-                  }
-                }
-              ]
-            },
-            name: "Normal Hard",
-            sku: "13-1339"
+        ],
+        name: "Extended Soft",
+        sku: "13-1338"
+      },
+      {
+        __typename: "ProductVariant",
+        id: "var3",
+        images: [
+          {
+            __typename: "ProductImage",
+            id: "23123",
+            url: placeholderImage
           }
-        },
-        {
-          __typename: "ProductVariantCountableEdge",
-          node: {
-            __typename: "ProductVariant",
-            id: "var4",
-            image: {
-              __typename: "ProductImageCountableConnection",
-              edges: [
-                {
-                  __typename: "ProductImageCountableEdge",
-                  node: {
-                    __typename: "ProductImage",
-                    id: "23123",
-                    url: placeholderImage
-                  }
-                }
-              ]
-            },
-            name: "Normal Soft",
-            sku: "13-1340"
+        ],
+        name: "Normal Hard",
+        sku: "13-1339"
+      },
+      {
+        __typename: "ProductVariant",
+        id: "var4",
+        images: [
+          {
+            __typename: "ProductImage",
+            id: "23123",
+            url: placeholderImage
           }
-        }
-      ],
-      totalCount: 11
-    }
+        ],
+        name: "Normal Soft",
+        sku: "13-1340"
+      }
+    ]
   },
   quantity: 19,
   quantityAllocated: 12,
-  sku: "1230959124123",
-  
+  sku: "1230959124123"
 });
 export const variantImages = (placeholderImage: string) =>
-  variant(placeholderImage).images.edges.map(edge => edge.node);
+  variant(placeholderImage).images;
 export const variantProductImages = (placeholderImage: string) =>
-  variant(placeholderImage).product.images.edges.map(edge => edge.node);
+  variant(placeholderImage).product.images;
 export const variantSiblings = (placeholderImage: string) =>
-  variant(placeholderImage).product.variants.edges.map(edge => edge.node);
+  variant(placeholderImage).product.variants;

--- a/saleor/static/dashboard-next/products/mutations.ts
+++ b/saleor/static/dashboard-next/products/mutations.ts
@@ -81,14 +81,10 @@ export const productImagesReorder = gql`
       product {
         id
         images {
-          edges {
-            node {
-              id
-              alt
-              sortOrder
-              url
-            }
-          }
+          id
+          alt
+          sortOrder
+          url
         }
       }
     }
@@ -283,11 +279,7 @@ export const productImageDeleteMutation = gql`
       product {
         id
         images {
-          edges {
-            node {
-              id
-            }
-          }
+          id
         }
       }
     }

--- a/saleor/static/dashboard-next/products/queries.ts
+++ b/saleor/static/dashboard-next/products/queries.ts
@@ -50,12 +50,8 @@ export const fragmentProduct = gql`
       name
     }
     collections {
-      edges {
-        node {
-          id
-          name
-        }
-      }
+      id
+      name
     }
     price {
       ...Money
@@ -107,25 +103,17 @@ export const fragmentProduct = gql`
       }
     }
     images {
-      edges {
-        node {
-          ...ProductImageFragment
-        }
-      }
+      ...ProductImageFragment
     }
     variants {
-      edges {
-        node {
-          id
-          sku
-          name
-          priceOverride {
-            ...Money
-          }
-          stockQuantity
-          margin
-        }
+      id
+      sku
+      name
+      priceOverride {
+        ...Money
       }
+      stockQuantity
+      margin
     }
     productType {
       id
@@ -162,11 +150,7 @@ export const fragmentVariant = gql`
       ...Money
     }
     images {
-      edges {
-        node {
-          id
-        }
-      }
+      id
     }
     name
     priceOverride {
@@ -175,30 +159,17 @@ export const fragmentVariant = gql`
     product {
       id
       images {
-        edges {
-          node {
-            ...ProductImageFragment
-          }
-        }
+        ...ProductImageFragment
       }
       name
       thumbnailUrl
       variants {
-        totalCount
-        edges {
-          node {
-            id
-            name
-            sku
-            image: images(first: 1) {
-              edges {
-                node {
-                  id
-                  url
-                }
-              }
-            }
-          }
+        id
+        name
+        sku
+        images {
+          id
+          url
         }
       }
     }
@@ -346,13 +317,9 @@ const productVariantCreateQuery = gql`
     product(id: $id) {
       id
       images {
-        edges {
-          node {
-            id
-            sortOrder
-            url
-          }
-        }
+        id
+        sortOrder
+        url
       }
       productType {
         id
@@ -369,20 +336,12 @@ const productVariantCreateQuery = gql`
         }
       }
       variants {
-        edges {
-          node {
-            id
-            name
-            sku
-            image: images(first: 1) {
-              edges {
-                node {
-                  id
-                  url
-                }
-              }
-            }
-          }
+        id
+        name
+        sku
+        images {
+          id
+          url
         }
       }
     }
@@ -403,18 +362,8 @@ const productImageQuery = gql`
         url
       }
       images {
-        edges {
-          node {
-            id
-            url(size: 48)
-          }
-        }
-        pageInfo {
-          hasPreviousPage
-          hasNextPage
-          startCursor
-          endCursor
-        }
+        id
+        url(size: 48)
       }
     }
   }

--- a/saleor/static/dashboard-next/products/queries.ts
+++ b/saleor/static/dashboard-next/products/queries.ts
@@ -151,6 +151,7 @@ export const fragmentVariant = gql`
     }
     images {
       id
+      url
     }
     name
     priceOverride {

--- a/saleor/static/dashboard-next/products/types/Product.ts
+++ b/saleor/static/dashboard-next/products/types/Product.ts
@@ -11,20 +11,10 @@ export interface Product_category {
   name: string;
 }
 
-export interface Product_collections_edges_node {
+export interface Product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface Product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: Product_collections_edges_node;
-}
-
-export interface Product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: Product_collections_edges[];
 }
 
 export interface Product_price {
@@ -118,7 +108,7 @@ export interface Product_availability {
   priceRange: Product_availability_priceRange | null;
 }
 
-export interface Product_images_edges_node {
+export interface Product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -126,40 +116,20 @@ export interface Product_images_edges_node {
   url: string;
 }
 
-export interface Product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: Product_images_edges_node;
-}
-
-export interface Product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: Product_images_edges[];
-}
-
-export interface Product_variants_edges_node_priceOverride {
+export interface Product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface Product_variants_edges_node {
+export interface Product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: Product_variants_edges_node_priceOverride | null;
+  priceOverride: Product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface Product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: Product_variants_edges_node;
-}
-
-export interface Product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: Product_variants_edges[];
 }
 
 export interface Product_productType {
@@ -177,7 +147,7 @@ export interface Product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: Product_category;
-  collections: Product_collections | null;
+  collections: (Product_collections | null)[] | null;
   price: Product_price | null;
   margin: Product_margin | null;
   purchaseCost: Product_purchaseCost | null;
@@ -186,8 +156,8 @@ export interface Product {
   availableOn: any | null;
   attributes: Product_attributes[];
   availability: Product_availability | null;
-  images: Product_images | null;
-  variants: Product_variants | null;
+  images: (Product_images | null)[] | null;
+  variants: (Product_variants | null)[] | null;
   productType: Product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductCreate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductCreate.ts
@@ -19,20 +19,10 @@ export interface ProductCreate_productCreate_product_category {
   name: string;
 }
 
-export interface ProductCreate_productCreate_product_collections_edges_node {
+export interface ProductCreate_productCreate_product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface ProductCreate_productCreate_product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductCreate_productCreate_product_collections_edges_node;
-}
-
-export interface ProductCreate_productCreate_product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductCreate_productCreate_product_collections_edges[];
 }
 
 export interface ProductCreate_productCreate_product_price {
@@ -126,7 +116,7 @@ export interface ProductCreate_productCreate_product_availability {
   priceRange: ProductCreate_productCreate_product_availability_priceRange | null;
 }
 
-export interface ProductCreate_productCreate_product_images_edges_node {
+export interface ProductCreate_productCreate_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -134,40 +124,20 @@ export interface ProductCreate_productCreate_product_images_edges_node {
   url: string;
 }
 
-export interface ProductCreate_productCreate_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductCreate_productCreate_product_images_edges_node;
-}
-
-export interface ProductCreate_productCreate_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductCreate_productCreate_product_images_edges[];
-}
-
-export interface ProductCreate_productCreate_product_variants_edges_node_priceOverride {
+export interface ProductCreate_productCreate_product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface ProductCreate_productCreate_product_variants_edges_node {
+export interface ProductCreate_productCreate_product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: ProductCreate_productCreate_product_variants_edges_node_priceOverride | null;
+  priceOverride: ProductCreate_productCreate_product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface ProductCreate_productCreate_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductCreate_productCreate_product_variants_edges_node;
-}
-
-export interface ProductCreate_productCreate_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductCreate_productCreate_product_variants_edges[];
 }
 
 export interface ProductCreate_productCreate_product_productType {
@@ -185,7 +155,7 @@ export interface ProductCreate_productCreate_product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: ProductCreate_productCreate_product_category;
-  collections: ProductCreate_productCreate_product_collections | null;
+  collections: (ProductCreate_productCreate_product_collections | null)[] | null;
   price: ProductCreate_productCreate_product_price | null;
   margin: ProductCreate_productCreate_product_margin | null;
   purchaseCost: ProductCreate_productCreate_product_purchaseCost | null;
@@ -194,8 +164,8 @@ export interface ProductCreate_productCreate_product {
   availableOn: any | null;
   attributes: ProductCreate_productCreate_product_attributes[];
   availability: ProductCreate_productCreate_product_availability | null;
-  images: ProductCreate_productCreate_product_images | null;
-  variants: ProductCreate_productCreate_product_variants | null;
+  images: (ProductCreate_productCreate_product_images | null)[] | null;
+  variants: (ProductCreate_productCreate_product_variants | null)[] | null;
   productType: ProductCreate_productCreate_product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductDetails.ts
@@ -11,20 +11,10 @@ export interface ProductDetails_product_category {
   name: string;
 }
 
-export interface ProductDetails_product_collections_edges_node {
+export interface ProductDetails_product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface ProductDetails_product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductDetails_product_collections_edges_node;
-}
-
-export interface ProductDetails_product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductDetails_product_collections_edges[];
 }
 
 export interface ProductDetails_product_price {
@@ -118,7 +108,7 @@ export interface ProductDetails_product_availability {
   priceRange: ProductDetails_product_availability_priceRange | null;
 }
 
-export interface ProductDetails_product_images_edges_node {
+export interface ProductDetails_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -126,40 +116,20 @@ export interface ProductDetails_product_images_edges_node {
   url: string;
 }
 
-export interface ProductDetails_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductDetails_product_images_edges_node;
-}
-
-export interface ProductDetails_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductDetails_product_images_edges[];
-}
-
-export interface ProductDetails_product_variants_edges_node_priceOverride {
+export interface ProductDetails_product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface ProductDetails_product_variants_edges_node {
+export interface ProductDetails_product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: ProductDetails_product_variants_edges_node_priceOverride | null;
+  priceOverride: ProductDetails_product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface ProductDetails_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductDetails_product_variants_edges_node;
-}
-
-export interface ProductDetails_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductDetails_product_variants_edges[];
 }
 
 export interface ProductDetails_product_productType {
@@ -177,7 +147,7 @@ export interface ProductDetails_product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: ProductDetails_product_category;
-  collections: ProductDetails_product_collections | null;
+  collections: (ProductDetails_product_collections | null)[] | null;
   price: ProductDetails_product_price | null;
   margin: ProductDetails_product_margin | null;
   purchaseCost: ProductDetails_product_purchaseCost | null;
@@ -186,8 +156,8 @@ export interface ProductDetails_product {
   availableOn: any | null;
   attributes: ProductDetails_product_attributes[];
   availability: ProductDetails_product_availability | null;
-  images: ProductDetails_product_images | null;
-  variants: ProductDetails_product_variants | null;
+  images: (ProductDetails_product_images | null)[] | null;
+  variants: (ProductDetails_product_variants | null)[] | null;
   productType: ProductDetails_product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductImageById.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageById.ts
@@ -12,36 +12,17 @@ export interface ProductImageById_product_mainImage {
   url: string;
 }
 
-export interface ProductImageById_product_images_edges_node {
+export interface ProductImageById_product_images {
   __typename: "ProductImage";
   id: string;
   url: string;
-}
-
-export interface ProductImageById_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductImageById_product_images_edges_node;
-}
-
-export interface ProductImageById_product_images_pageInfo {
-  __typename: "PageInfo";
-  hasPreviousPage: boolean;
-  hasNextPage: boolean;
-  startCursor: string | null;
-  endCursor: string | null;
-}
-
-export interface ProductImageById_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductImageById_product_images_edges[];
-  pageInfo: ProductImageById_product_images_pageInfo;
 }
 
 export interface ProductImageById_product {
   __typename: "Product";
   id: string;
   mainImage: ProductImageById_product_mainImage | null;
-  images: ProductImageById_product_images | null;
+  images: (ProductImageById_product_images | null)[] | null;
 }
 
 export interface ProductImageById {

--- a/saleor/static/dashboard-next/products/types/ProductImageCreate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageCreate.ts
@@ -17,20 +17,10 @@ export interface ProductImageCreate_productImageCreate_product_category {
   name: string;
 }
 
-export interface ProductImageCreate_productImageCreate_product_collections_edges_node {
+export interface ProductImageCreate_productImageCreate_product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface ProductImageCreate_productImageCreate_product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductImageCreate_productImageCreate_product_collections_edges_node;
-}
-
-export interface ProductImageCreate_productImageCreate_product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductImageCreate_productImageCreate_product_collections_edges[];
 }
 
 export interface ProductImageCreate_productImageCreate_product_price {
@@ -124,7 +114,7 @@ export interface ProductImageCreate_productImageCreate_product_availability {
   priceRange: ProductImageCreate_productImageCreate_product_availability_priceRange | null;
 }
 
-export interface ProductImageCreate_productImageCreate_product_images_edges_node {
+export interface ProductImageCreate_productImageCreate_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -132,40 +122,20 @@ export interface ProductImageCreate_productImageCreate_product_images_edges_node
   url: string;
 }
 
-export interface ProductImageCreate_productImageCreate_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductImageCreate_productImageCreate_product_images_edges_node;
-}
-
-export interface ProductImageCreate_productImageCreate_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductImageCreate_productImageCreate_product_images_edges[];
-}
-
-export interface ProductImageCreate_productImageCreate_product_variants_edges_node_priceOverride {
+export interface ProductImageCreate_productImageCreate_product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface ProductImageCreate_productImageCreate_product_variants_edges_node {
+export interface ProductImageCreate_productImageCreate_product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: ProductImageCreate_productImageCreate_product_variants_edges_node_priceOverride | null;
+  priceOverride: ProductImageCreate_productImageCreate_product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface ProductImageCreate_productImageCreate_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductImageCreate_productImageCreate_product_variants_edges_node;
-}
-
-export interface ProductImageCreate_productImageCreate_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductImageCreate_productImageCreate_product_variants_edges[];
 }
 
 export interface ProductImageCreate_productImageCreate_product_productType {
@@ -183,7 +153,7 @@ export interface ProductImageCreate_productImageCreate_product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: ProductImageCreate_productImageCreate_product_category;
-  collections: ProductImageCreate_productImageCreate_product_collections | null;
+  collections: (ProductImageCreate_productImageCreate_product_collections | null)[] | null;
   price: ProductImageCreate_productImageCreate_product_price | null;
   margin: ProductImageCreate_productImageCreate_product_margin | null;
   purchaseCost: ProductImageCreate_productImageCreate_product_purchaseCost | null;
@@ -192,8 +162,8 @@ export interface ProductImageCreate_productImageCreate_product {
   availableOn: any | null;
   attributes: ProductImageCreate_productImageCreate_product_attributes[];
   availability: ProductImageCreate_productImageCreate_product_availability | null;
-  images: ProductImageCreate_productImageCreate_product_images | null;
-  variants: ProductImageCreate_productImageCreate_product_variants | null;
+  images: (ProductImageCreate_productImageCreate_product_images | null)[] | null;
+  variants: (ProductImageCreate_productImageCreate_product_variants | null)[] | null;
   productType: ProductImageCreate_productImageCreate_product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductImageDelete.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageDelete.ts
@@ -5,25 +5,15 @@
 // GraphQL mutation operation: ProductImageDelete
 // ====================================================
 
-export interface ProductImageDelete_productImageDelete_product_images_edges_node {
+export interface ProductImageDelete_productImageDelete_product_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface ProductImageDelete_productImageDelete_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductImageDelete_productImageDelete_product_images_edges_node;
-}
-
-export interface ProductImageDelete_productImageDelete_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductImageDelete_productImageDelete_product_images_edges[];
 }
 
 export interface ProductImageDelete_productImageDelete_product {
   __typename: "Product";
   id: string;
-  images: ProductImageDelete_productImageDelete_product_images | null;
+  images: (ProductImageDelete_productImageDelete_product_images | null)[] | null;
 }
 
 export interface ProductImageDelete_productImageDelete {

--- a/saleor/static/dashboard-next/products/types/ProductImageReorder.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageReorder.ts
@@ -11,7 +11,7 @@ export interface ProductImageReorder_productImageReorder_errors {
   message: string | null;
 }
 
-export interface ProductImageReorder_productImageReorder_product_images_edges_node {
+export interface ProductImageReorder_productImageReorder_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -19,20 +19,10 @@ export interface ProductImageReorder_productImageReorder_product_images_edges_no
   url: string;
 }
 
-export interface ProductImageReorder_productImageReorder_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductImageReorder_productImageReorder_product_images_edges_node;
-}
-
-export interface ProductImageReorder_productImageReorder_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductImageReorder_productImageReorder_product_images_edges[];
-}
-
 export interface ProductImageReorder_productImageReorder_product {
   __typename: "Product";
   id: string;
-  images: ProductImageReorder_productImageReorder_product_images | null;
+  images: (ProductImageReorder_productImageReorder_product_images | null)[] | null;
 }
 
 export interface ProductImageReorder_productImageReorder {

--- a/saleor/static/dashboard-next/products/types/ProductImageUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageUpdate.ts
@@ -17,20 +17,10 @@ export interface ProductImageUpdate_productImageUpdate_product_category {
   name: string;
 }
 
-export interface ProductImageUpdate_productImageUpdate_product_collections_edges_node {
+export interface ProductImageUpdate_productImageUpdate_product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductImageUpdate_productImageUpdate_product_collections_edges_node;
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductImageUpdate_productImageUpdate_product_collections_edges[];
 }
 
 export interface ProductImageUpdate_productImageUpdate_product_price {
@@ -124,7 +114,7 @@ export interface ProductImageUpdate_productImageUpdate_product_availability {
   priceRange: ProductImageUpdate_productImageUpdate_product_availability_priceRange | null;
 }
 
-export interface ProductImageUpdate_productImageUpdate_product_images_edges_node {
+export interface ProductImageUpdate_productImageUpdate_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -132,40 +122,20 @@ export interface ProductImageUpdate_productImageUpdate_product_images_edges_node
   url: string;
 }
 
-export interface ProductImageUpdate_productImageUpdate_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductImageUpdate_productImageUpdate_product_images_edges_node;
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductImageUpdate_productImageUpdate_product_images_edges[];
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_variants_edges_node_priceOverride {
+export interface ProductImageUpdate_productImageUpdate_product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface ProductImageUpdate_productImageUpdate_product_variants_edges_node {
+export interface ProductImageUpdate_productImageUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: ProductImageUpdate_productImageUpdate_product_variants_edges_node_priceOverride | null;
+  priceOverride: ProductImageUpdate_productImageUpdate_product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductImageUpdate_productImageUpdate_product_variants_edges_node;
-}
-
-export interface ProductImageUpdate_productImageUpdate_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductImageUpdate_productImageUpdate_product_variants_edges[];
 }
 
 export interface ProductImageUpdate_productImageUpdate_product_productType {
@@ -183,7 +153,7 @@ export interface ProductImageUpdate_productImageUpdate_product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: ProductImageUpdate_productImageUpdate_product_category;
-  collections: ProductImageUpdate_productImageUpdate_product_collections | null;
+  collections: (ProductImageUpdate_productImageUpdate_product_collections | null)[] | null;
   price: ProductImageUpdate_productImageUpdate_product_price | null;
   margin: ProductImageUpdate_productImageUpdate_product_margin | null;
   purchaseCost: ProductImageUpdate_productImageUpdate_product_purchaseCost | null;
@@ -192,8 +162,8 @@ export interface ProductImageUpdate_productImageUpdate_product {
   availableOn: any | null;
   attributes: ProductImageUpdate_productImageUpdate_product_attributes[];
   availability: ProductImageUpdate_productImageUpdate_product_availability | null;
-  images: ProductImageUpdate_productImageUpdate_product_images | null;
-  variants: ProductImageUpdate_productImageUpdate_product_variants | null;
+  images: (ProductImageUpdate_productImageUpdate_product_images | null)[] | null;
+  variants: (ProductImageUpdate_productImageUpdate_product_variants | null)[] | null;
   productType: ProductImageUpdate_productImageUpdate_product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductUpdate.ts
@@ -19,20 +19,10 @@ export interface ProductUpdate_productUpdate_product_category {
   name: string;
 }
 
-export interface ProductUpdate_productUpdate_product_collections_edges_node {
+export interface ProductUpdate_productUpdate_product_collections {
   __typename: "Collection";
   id: string;
   name: string;
-}
-
-export interface ProductUpdate_productUpdate_product_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductUpdate_productUpdate_product_collections_edges_node;
-}
-
-export interface ProductUpdate_productUpdate_product_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductUpdate_productUpdate_product_collections_edges[];
 }
 
 export interface ProductUpdate_productUpdate_product_price {
@@ -126,7 +116,7 @@ export interface ProductUpdate_productUpdate_product_availability {
   priceRange: ProductUpdate_productUpdate_product_availability_priceRange | null;
 }
 
-export interface ProductUpdate_productUpdate_product_images_edges_node {
+export interface ProductUpdate_productUpdate_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -134,40 +124,20 @@ export interface ProductUpdate_productUpdate_product_images_edges_node {
   url: string;
 }
 
-export interface ProductUpdate_productUpdate_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductUpdate_productUpdate_product_images_edges_node;
-}
-
-export interface ProductUpdate_productUpdate_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductUpdate_productUpdate_product_images_edges[];
-}
-
-export interface ProductUpdate_productUpdate_product_variants_edges_node_priceOverride {
+export interface ProductUpdate_productUpdate_product_variants_priceOverride {
   __typename: "Money";
   amount: number;
   currency: string;
 }
 
-export interface ProductUpdate_productUpdate_product_variants_edges_node {
+export interface ProductUpdate_productUpdate_product_variants {
   __typename: "ProductVariant";
   id: string;
   sku: string;
   name: string;
-  priceOverride: ProductUpdate_productUpdate_product_variants_edges_node_priceOverride | null;
+  priceOverride: ProductUpdate_productUpdate_product_variants_priceOverride | null;
   stockQuantity: number;
   margin: number | null;
-}
-
-export interface ProductUpdate_productUpdate_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductUpdate_productUpdate_product_variants_edges_node;
-}
-
-export interface ProductUpdate_productUpdate_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductUpdate_productUpdate_product_variants_edges[];
 }
 
 export interface ProductUpdate_productUpdate_product_productType {
@@ -185,7 +155,7 @@ export interface ProductUpdate_productUpdate_product {
   seoTitle: string | null;
   seoDescription: string | null;
   category: ProductUpdate_productUpdate_product_category;
-  collections: ProductUpdate_productUpdate_product_collections | null;
+  collections: (ProductUpdate_productUpdate_product_collections | null)[] | null;
   price: ProductUpdate_productUpdate_product_price | null;
   margin: ProductUpdate_productUpdate_product_margin | null;
   purchaseCost: ProductUpdate_productUpdate_product_purchaseCost | null;
@@ -194,8 +164,8 @@ export interface ProductUpdate_productUpdate_product {
   availableOn: any | null;
   attributes: ProductUpdate_productUpdate_product_attributes[];
   availability: ProductUpdate_productUpdate_product_availability | null;
-  images: ProductUpdate_productUpdate_product_images | null;
-  variants: ProductUpdate_productUpdate_product_variants | null;
+  images: (ProductUpdate_productUpdate_product_images | null)[] | null;
+  variants: (ProductUpdate_productUpdate_product_variants | null)[] | null;
   productType: ProductUpdate_productUpdate_product_productType;
   url: string;
 }

--- a/saleor/static/dashboard-next/products/types/ProductVariant.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariant.ts
@@ -42,6 +42,7 @@ export interface ProductVariant_costPrice {
 export interface ProductVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface ProductVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/ProductVariant.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariant.ts
@@ -39,19 +39,9 @@ export interface ProductVariant_costPrice {
   currency: string;
 }
 
-export interface ProductVariant_images_edges_node {
+export interface ProductVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface ProductVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariant_images_edges_node;
-}
-
-export interface ProductVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariant_images_edges[];
 }
 
 export interface ProductVariant_priceOverride {
@@ -60,7 +50,7 @@ export interface ProductVariant_priceOverride {
   currency: string;
 }
 
-export interface ProductVariant_product_images_edges_node {
+export interface ProductVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -68,58 +58,27 @@ export interface ProductVariant_product_images_edges_node {
   url: string;
 }
 
-export interface ProductVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariant_product_images_edges_node;
-}
-
-export interface ProductVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariant_product_images_edges[];
-}
-
-export interface ProductVariant_product_variants_edges_node_image_edges_node {
+export interface ProductVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface ProductVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface ProductVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface ProductVariant_product_variants_edges_node {
+export interface ProductVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: ProductVariant_product_variants_edges_node_image | null;
-}
-
-export interface ProductVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductVariant_product_variants_edges_node;
-}
-
-export interface ProductVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: ProductVariant_product_variants_edges[];
+  images: (ProductVariant_product_variants_images | null)[] | null;
 }
 
 export interface ProductVariant_product {
   __typename: "Product";
   id: string;
-  images: ProductVariant_product_images | null;
+  images: (ProductVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: ProductVariant_product_variants | null;
+  variants: (ProductVariant_product_variants | null)[] | null;
 }
 
 export interface ProductVariant {
@@ -127,7 +86,7 @@ export interface ProductVariant {
   id: string;
   attributes: ProductVariant_attributes[];
   costPrice: ProductVariant_costPrice | null;
-  images: ProductVariant_images | null;
+  images: (ProductVariant_images | null)[] | null;
   name: string;
   priceOverride: ProductVariant_priceOverride | null;
   product: ProductVariant_product;

--- a/saleor/static/dashboard-next/products/types/ProductVariantCreateData.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantCreateData.ts
@@ -5,21 +5,11 @@
 // GraphQL query operation: ProductVariantCreateData
 // ====================================================
 
-export interface ProductVariantCreateData_product_images_edges_node {
+export interface ProductVariantCreateData_product_images {
   __typename: "ProductImage";
   id: string;
   sortOrder: number;
   url: string;
-}
-
-export interface ProductVariantCreateData_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariantCreateData_product_images_edges_node;
-}
-
-export interface ProductVariantCreateData_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariantCreateData_product_images_edges[];
 }
 
 export interface ProductVariantCreateData_product_productType_variantAttributes_values {
@@ -44,46 +34,26 @@ export interface ProductVariantCreateData_product_productType {
   variantAttributes: (ProductVariantCreateData_product_productType_variantAttributes | null)[] | null;
 }
 
-export interface ProductVariantCreateData_product_variants_edges_node_image_edges_node {
+export interface ProductVariantCreateData_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface ProductVariantCreateData_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariantCreateData_product_variants_edges_node_image_edges_node;
-}
-
-export interface ProductVariantCreateData_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariantCreateData_product_variants_edges_node_image_edges[];
-}
-
-export interface ProductVariantCreateData_product_variants_edges_node {
+export interface ProductVariantCreateData_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: ProductVariantCreateData_product_variants_edges_node_image | null;
-}
-
-export interface ProductVariantCreateData_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductVariantCreateData_product_variants_edges_node;
-}
-
-export interface ProductVariantCreateData_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  edges: ProductVariantCreateData_product_variants_edges[];
+  images: (ProductVariantCreateData_product_variants_images | null)[] | null;
 }
 
 export interface ProductVariantCreateData_product {
   __typename: "Product";
   id: string;
-  images: ProductVariantCreateData_product_images | null;
+  images: (ProductVariantCreateData_product_images | null)[] | null;
   productType: ProductVariantCreateData_product_productType;
-  variants: ProductVariantCreateData_product_variants | null;
+  variants: (ProductVariantCreateData_product_variants | null)[] | null;
 }
 
 export interface ProductVariantCreateData {

--- a/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
@@ -39,19 +39,9 @@ export interface ProductVariantDetails_productVariant_costPrice {
   currency: string;
 }
 
-export interface ProductVariantDetails_productVariant_images_edges_node {
+export interface ProductVariantDetails_productVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface ProductVariantDetails_productVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariantDetails_productVariant_images_edges_node;
-}
-
-export interface ProductVariantDetails_productVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariantDetails_productVariant_images_edges[];
 }
 
 export interface ProductVariantDetails_productVariant_priceOverride {
@@ -60,7 +50,7 @@ export interface ProductVariantDetails_productVariant_priceOverride {
   currency: string;
 }
 
-export interface ProductVariantDetails_productVariant_product_images_edges_node {
+export interface ProductVariantDetails_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -68,58 +58,27 @@ export interface ProductVariantDetails_productVariant_product_images_edges_node 
   url: string;
 }
 
-export interface ProductVariantDetails_productVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariantDetails_productVariant_product_images_edges_node;
-}
-
-export interface ProductVariantDetails_productVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariantDetails_productVariant_product_images_edges[];
-}
-
-export interface ProductVariantDetails_productVariant_product_variants_edges_node_image_edges_node {
+export interface ProductVariantDetails_productVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface ProductVariantDetails_productVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: ProductVariantDetails_productVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface ProductVariantDetails_productVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: ProductVariantDetails_productVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface ProductVariantDetails_productVariant_product_variants_edges_node {
+export interface ProductVariantDetails_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: ProductVariantDetails_productVariant_product_variants_edges_node_image | null;
-}
-
-export interface ProductVariantDetails_productVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: ProductVariantDetails_productVariant_product_variants_edges_node;
-}
-
-export interface ProductVariantDetails_productVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: ProductVariantDetails_productVariant_product_variants_edges[];
+  images: (ProductVariantDetails_productVariant_product_variants_images | null)[] | null;
 }
 
 export interface ProductVariantDetails_productVariant_product {
   __typename: "Product";
   id: string;
-  images: ProductVariantDetails_productVariant_product_images | null;
+  images: (ProductVariantDetails_productVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: ProductVariantDetails_productVariant_product_variants | null;
+  variants: (ProductVariantDetails_productVariant_product_variants | null)[] | null;
 }
 
 export interface ProductVariantDetails_productVariant {
@@ -127,7 +86,7 @@ export interface ProductVariantDetails_productVariant {
   id: string;
   attributes: ProductVariantDetails_productVariant_attributes[];
   costPrice: ProductVariantDetails_productVariant_costPrice | null;
-  images: ProductVariantDetails_productVariant_images | null;
+  images: (ProductVariantDetails_productVariant_images | null)[] | null;
   name: string;
   priceOverride: ProductVariantDetails_productVariant_priceOverride | null;
   product: ProductVariantDetails_productVariant_product;

--- a/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
@@ -42,6 +42,7 @@ export interface ProductVariantDetails_productVariant_costPrice {
 export interface ProductVariantDetails_productVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface ProductVariantDetails_productVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/VariantCreate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantCreate.ts
@@ -50,6 +50,7 @@ export interface VariantCreate_productVariantCreate_productVariant_costPrice {
 export interface VariantCreate_productVariantCreate_productVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/VariantCreate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantCreate.ts
@@ -47,19 +47,9 @@ export interface VariantCreate_productVariantCreate_productVariant_costPrice {
   currency: string;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_images_edges_node {
+export interface VariantCreate_productVariantCreate_productVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantCreate_productVariantCreate_productVariant_images_edges_node;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantCreate_productVariantCreate_productVariant_images_edges[];
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_priceOverride {
@@ -68,7 +58,7 @@ export interface VariantCreate_productVariantCreate_productVariant_priceOverride
   currency: string;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_product_images_edges_node {
+export interface VariantCreate_productVariantCreate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -76,58 +66,27 @@ export interface VariantCreate_productVariantCreate_productVariant_product_image
   url: string;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantCreate_productVariantCreate_productVariant_product_images_edges_node;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantCreate_productVariantCreate_productVariant_product_images_edges[];
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image_edges_node {
+export interface VariantCreate_productVariantCreate_productVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_variants_edges_node {
+export interface VariantCreate_productVariantCreate_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: VariantCreate_productVariantCreate_productVariant_product_variants_edges_node_image | null;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: VariantCreate_productVariantCreate_productVariant_product_variants_edges_node;
-}
-
-export interface VariantCreate_productVariantCreate_productVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: VariantCreate_productVariantCreate_productVariant_product_variants_edges[];
+  images: (VariantCreate_productVariantCreate_productVariant_product_variants_images | null)[] | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant_product {
   __typename: "Product";
   id: string;
-  images: VariantCreate_productVariantCreate_productVariant_product_images | null;
+  images: (VariantCreate_productVariantCreate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: VariantCreate_productVariantCreate_productVariant_product_variants | null;
+  variants: (VariantCreate_productVariantCreate_productVariant_product_variants | null)[] | null;
 }
 
 export interface VariantCreate_productVariantCreate_productVariant {
@@ -135,7 +94,7 @@ export interface VariantCreate_productVariantCreate_productVariant {
   id: string;
   attributes: VariantCreate_productVariantCreate_productVariant_attributes[];
   costPrice: VariantCreate_productVariantCreate_productVariant_costPrice | null;
-  images: VariantCreate_productVariantCreate_productVariant_images | null;
+  images: (VariantCreate_productVariantCreate_productVariant_images | null)[] | null;
   name: string;
   priceOverride: VariantCreate_productVariantCreate_productVariant_priceOverride | null;
   product: VariantCreate_productVariantCreate_productVariant_product;

--- a/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
@@ -45,19 +45,9 @@ export interface VariantImageAssign_variantImageAssign_productVariant_costPrice 
   currency: string;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_images_edges_node {
+export interface VariantImageAssign_variantImageAssign_productVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageAssign_variantImageAssign_productVariant_images_edges_node;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageAssign_variantImageAssign_productVariant_images_edges[];
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_priceOverride {
@@ -66,7 +56,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_priceOverr
   currency: string;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_product_images_edges_node {
+export interface VariantImageAssign_variantImageAssign_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -74,58 +64,27 @@ export interface VariantImageAssign_variantImageAssign_productVariant_product_im
   url: string;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageAssign_variantImageAssign_productVariant_product_images_edges_node;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageAssign_variantImageAssign_productVariant_product_images_edges[];
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image_edges_node {
+export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node {
+export interface VariantImageAssign_variantImageAssign_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node_image | null;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: VariantImageAssign_variantImageAssign_productVariant_product_variants_edges_node;
-}
-
-export interface VariantImageAssign_variantImageAssign_productVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: VariantImageAssign_variantImageAssign_productVariant_product_variants_edges[];
+  images: (VariantImageAssign_variantImageAssign_productVariant_product_variants_images | null)[] | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_product {
   __typename: "Product";
   id: string;
-  images: VariantImageAssign_variantImageAssign_productVariant_product_images | null;
+  images: (VariantImageAssign_variantImageAssign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: VariantImageAssign_variantImageAssign_productVariant_product_variants | null;
+  variants: (VariantImageAssign_variantImageAssign_productVariant_product_variants | null)[] | null;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant {
@@ -133,7 +92,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant {
   id: string;
   attributes: VariantImageAssign_variantImageAssign_productVariant_attributes[];
   costPrice: VariantImageAssign_variantImageAssign_productVariant_costPrice | null;
-  images: VariantImageAssign_variantImageAssign_productVariant_images | null;
+  images: (VariantImageAssign_variantImageAssign_productVariant_images | null)[] | null;
   name: string;
   priceOverride: VariantImageAssign_variantImageAssign_productVariant_priceOverride | null;
   product: VariantImageAssign_variantImageAssign_productVariant_product;

--- a/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
@@ -48,6 +48,7 @@ export interface VariantImageAssign_variantImageAssign_productVariant_costPrice 
 export interface VariantImageAssign_variantImageAssign_productVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface VariantImageAssign_variantImageAssign_productVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
@@ -48,6 +48,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_costPr
 export interface VariantImageUnassign_variantImageUnassign_productVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
@@ -45,19 +45,9 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_costPr
   currency: string;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_images_edges_node {
+export interface VariantImageUnassign_variantImageUnassign_productVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageUnassign_variantImageUnassign_productVariant_images_edges_node;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageUnassign_variantImageUnassign_productVariant_images_edges[];
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_priceOverride {
@@ -66,7 +56,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_priceO
   currency: string;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_images_edges_node {
+export interface VariantImageUnassign_variantImageUnassign_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -74,58 +64,27 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant_produc
   url: string;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageUnassign_variantImageUnassign_productVariant_product_images_edges_node;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageUnassign_variantImageUnassign_productVariant_product_images_edges[];
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image_edges_node {
+export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node {
+export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node_image | null;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges_node;
-}
-
-export interface VariantImageUnassign_variantImageUnassign_productVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: VariantImageUnassign_variantImageUnassign_productVariant_product_variants_edges[];
+  images: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants_images | null)[] | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant_product {
   __typename: "Product";
   id: string;
-  images: VariantImageUnassign_variantImageUnassign_productVariant_product_images | null;
+  images: (VariantImageUnassign_variantImageUnassign_productVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: VariantImageUnassign_variantImageUnassign_productVariant_product_variants | null;
+  variants: (VariantImageUnassign_variantImageUnassign_productVariant_product_variants | null)[] | null;
 }
 
 export interface VariantImageUnassign_variantImageUnassign_productVariant {
@@ -133,7 +92,7 @@ export interface VariantImageUnassign_variantImageUnassign_productVariant {
   id: string;
   attributes: VariantImageUnassign_variantImageUnassign_productVariant_attributes[];
   costPrice: VariantImageUnassign_variantImageUnassign_productVariant_costPrice | null;
-  images: VariantImageUnassign_variantImageUnassign_productVariant_images | null;
+  images: (VariantImageUnassign_variantImageUnassign_productVariant_images | null)[] | null;
   name: string;
   priceOverride: VariantImageUnassign_variantImageUnassign_productVariant_priceOverride | null;
   product: VariantImageUnassign_variantImageUnassign_productVariant_product;

--- a/saleor/static/dashboard-next/products/types/VariantUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantUpdate.ts
@@ -50,6 +50,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_costPrice {
 export interface VariantUpdate_productVariantUpdate_productVariant_images {
   __typename: "ProductImage";
   id: string;
+  url: string;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_priceOverride {

--- a/saleor/static/dashboard-next/products/types/VariantUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantUpdate.ts
@@ -47,19 +47,9 @@ export interface VariantUpdate_productVariantUpdate_productVariant_costPrice {
   currency: string;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_images_edges_node {
+export interface VariantUpdate_productVariantUpdate_productVariant_images {
   __typename: "ProductImage";
   id: string;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantUpdate_productVariantUpdate_productVariant_images_edges_node;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantUpdate_productVariantUpdate_productVariant_images_edges[];
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_priceOverride {
@@ -68,7 +58,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant_priceOverride
   currency: string;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_product_images_edges_node {
+export interface VariantUpdate_productVariantUpdate_productVariant_product_images {
   __typename: "ProductImage";
   id: string;
   alt: string;
@@ -76,58 +66,27 @@ export interface VariantUpdate_productVariantUpdate_productVariant_product_image
   url: string;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_product_images_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantUpdate_productVariantUpdate_productVariant_product_images_edges_node;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_images {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantUpdate_productVariantUpdate_productVariant_product_images_edges[];
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image_edges_node {
+export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_images {
   __typename: "ProductImage";
   id: string;
   url: string;
 }
 
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image_edges {
-  __typename: "ProductImageCountableEdge";
-  node: VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image_edges_node;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image {
-  __typename: "ProductImageCountableConnection";
-  edges: VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image_edges[];
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node {
+export interface VariantUpdate_productVariantUpdate_productVariant_product_variants {
   __typename: "ProductVariant";
   id: string;
   name: string;
   sku: string;
-  image: VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node_image | null;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants_edges {
-  __typename: "ProductVariantCountableEdge";
-  node: VariantUpdate_productVariantUpdate_productVariant_product_variants_edges_node;
-}
-
-export interface VariantUpdate_productVariantUpdate_productVariant_product_variants {
-  __typename: "ProductVariantCountableConnection";
-  totalCount: number | null;
-  edges: VariantUpdate_productVariantUpdate_productVariant_product_variants_edges[];
+  images: (VariantUpdate_productVariantUpdate_productVariant_product_variants_images | null)[] | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant_product {
   __typename: "Product";
   id: string;
-  images: VariantUpdate_productVariantUpdate_productVariant_product_images | null;
+  images: (VariantUpdate_productVariantUpdate_productVariant_product_images | null)[] | null;
   name: string;
   thumbnailUrl: string | null;
-  variants: VariantUpdate_productVariantUpdate_productVariant_product_variants | null;
+  variants: (VariantUpdate_productVariantUpdate_productVariant_product_variants | null)[] | null;
 }
 
 export interface VariantUpdate_productVariantUpdate_productVariant {
@@ -135,7 +94,7 @@ export interface VariantUpdate_productVariantUpdate_productVariant {
   id: string;
   attributes: VariantUpdate_productVariantUpdate_productVariant_attributes[];
   costPrice: VariantUpdate_productVariantUpdate_productVariant_costPrice | null;
-  images: VariantUpdate_productVariantUpdate_productVariant_images | null;
+  images: (VariantUpdate_productVariantUpdate_productVariant_images | null)[] | null;
   name: string;
   priceOverride: VariantUpdate_productVariantUpdate_productVariant_priceOverride | null;
   product: VariantUpdate_productVariantUpdate_productVariant_product;

--- a/saleor/static/dashboard-next/products/views/ProductImage/index.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductImage/index.tsx
@@ -6,6 +6,7 @@ import ActionDialog from "../../../components/ActionDialog";
 import Messages from "../../../components/messages";
 import Navigator from "../../../components/Navigator";
 import i18n from "../../../i18n";
+import { maybe } from "../../../misc";
 import ProductImagePage from "../../components/ProductImagePage";
 import {
   TypedProductImageDeleteMutation,
@@ -81,16 +82,7 @@ export const ProductImage: React.StatelessComponent<ProductImageProps> = ({
                               <ProductImagePage
                                 disabled={loading}
                                 image={image || null}
-                                images={
-                                  data &&
-                                  data.product &&
-                                  data.product.images &&
-                                  data.product.images.edges
-                                    ? data.product.images.edges.map(
-                                        edge => edge.node
-                                      )
-                                    : undefined
-                                }
+                                images={maybe(() => data.product.images)}
                                 onBack={handleBack}
                                 onDelete={() =>
                                   navigate(

--- a/saleor/static/dashboard-next/products/views/ProductUpdate/index.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductUpdate/index.tsx
@@ -69,10 +69,6 @@ export const ProductUpdate: React.StatelessComponent<ProductUpdateProps> = ({
                     data && data.categories
                       ? data.categories.edges.map(edge => edge.node)
                       : [];
-                  const images =
-                    data && data.product
-                      ? data.product.images.edges.map(edge => edge.node)
-                      : undefined;
                   return (
                     <ProductUpdateOperations
                       product={product}
@@ -138,24 +134,14 @@ export const ProductUpdate: React.StatelessComponent<ProductUpdateProps> = ({
                               disabled={disableFormSave}
                               errors={errors}
                               saveButtonBarState={formSubmitState}
-                              images={images}
-                              header={product ? product.name : undefined}
+                              images={maybe(() => data.product.images)}
+                              header={maybe(() => product.name)}
                               placeholderImage={placeholderImg}
                               product={product}
-                              productCollections={
-                                product && product.collections
-                                  ? product.collections.edges.map(
-                                      edge => edge.node
-                                    )
-                                  : undefined
-                              }
-                              variants={
-                                product && product.variants
-                                  ? product.variants.edges.map(
-                                      edge => edge.node
-                                    )
-                                  : undefined
-                              }
+                              productCollections={maybe(
+                                () => product.collections
+                              )}
+                              variants={maybe(() => product.variants)}
                               onAttributesEdit={() =>
                                 navigate(
                                   productTypeUrl(
@@ -180,7 +166,9 @@ export const ProductUpdate: React.StatelessComponent<ProductUpdateProps> = ({
                               }}
                               onImageReorder={({ newIndex, oldIndex }) => {
                                 if (product) {
-                                  let ids = images.map(image => image.id);
+                                  let ids = product.images.map(
+                                    image => image.id
+                                  );
                                   ids = arrayMove(ids, oldIndex, newIndex);
                                   reorderProductImages.mutate({
                                     imagesIds: ids,

--- a/saleor/static/dashboard-next/products/views/ProductVariant/index.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductVariant/index.tsx
@@ -86,9 +86,8 @@ export const ProductVariant: React.StatelessComponent<ProductUpdateProps> = ({
                       if (variant) {
                         if (
                           variant.images &&
-                          variant.images.edges
-                            .map(edge => edge.node.id)
-                            .indexOf(id) !== -1
+                          variant.images.map(image => image.id).indexOf(id) !==
+                            -1
                         ) {
                           unassignImage.mutate({
                             imageId: id,

--- a/saleor/static/dashboard-next/storybook/stories/products/ProductCreatePage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/products/ProductCreatePage.tsx
@@ -16,7 +16,7 @@ storiesOf("Views / Products / Create product", module)
       disabled={false}
       errors={[]}
       header="Add product"
-      collections={product.collections.edges.map(edge => edge.node)}
+      collections={product.collections}
       productTypes={productTypes}
       categories={[product.category]}
       onAttributesEdit={undefined}
@@ -30,7 +30,7 @@ storiesOf("Views / Products / Create product", module)
       disabled={true}
       errors={[]}
       header="Add product"
-      collections={product.collections.edges.map(edge => edge.node)}
+      collections={product.collections}
       productTypes={productTypes}
       categories={[product.category]}
       onAttributesEdit={undefined}

--- a/saleor/static/dashboard-next/storybook/stories/products/ProductUpdatePage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/products/ProductUpdatePage.tsx
@@ -17,12 +17,12 @@ storiesOf("Views / Products / Product edit", module)
       onSubmit={() => undefined}
       product={product}
       header={product.name}
-      collections={product.collections.edges.map(edge => edge.node)}
+      collections={product.collections}
       categories={[product.category]}
       placeholderImage={placeholderImage}
-      images={product.images.edges.map(edge => edge.node)}
-      variants={product.variants.edges.map(edge => edge.node)}
-      productCollections={product.collections.edges.map(edge => edge.node)}
+      images={product.images}
+      variants={product.variants}
+      productCollections={product.collections}
       onAttributesEdit={undefined}
       onDelete={undefined}
       onProductShow={undefined}
@@ -38,12 +38,12 @@ storiesOf("Views / Products / Product edit", module)
       onSubmit={() => undefined}
       product={product}
       header={product.name}
-      collections={product.collections.edges.map(edge => edge.node)}
+      collections={product.collections}
       categories={[product.category]}
       placeholderImage={placeholderImage}
       images={[]}
-      variants={product.variants.edges.map(edge => edge.node)}
-      productCollections={product.collections.edges.map(edge => edge.node)}
+      variants={product.variants}
+      productCollections={product.collections}
       onAttributesEdit={undefined}
       onDelete={undefined}
       onProductShow={undefined}
@@ -64,12 +64,12 @@ storiesOf("Views / Products / Product edit", module)
         } as any
       }
       header={product.name}
-      collections={product.collections.edges.map(edge => edge.node)}
+      collections={product.collections}
       categories={[product.category]}
       placeholderImage={placeholderImage}
-      images={product.images.edges.map(edge => edge.node)}
-      variants={product.variants.edges.map(edge => edge.node)}
-      productCollections={product.collections.edges.map(edge => edge.node)}
+      images={product.images}
+      variants={product.variants}
+      productCollections={product.collections}
       onAttributesEdit={undefined}
       onDelete={undefined}
       onProductShow={undefined}

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -91,7 +91,7 @@ def test_query_user(staff_api_client, customer_user, permission_manage_users):
             isStaff
             isActive
             addresses {
-                totalCount
+                id
             }
             orders {
                 totalCount
@@ -125,7 +125,7 @@ def test_query_user(staff_api_client, customer_user, permission_manage_users):
     assert data['email'] == user.email
     assert data['isStaff'] == user.is_staff
     assert data['isActive'] == user.is_active
-    assert data['addresses']['totalCount'] == user.addresses.count()
+    assert len(data['addresses']) == user.addresses.count()
     assert data['orders']['totalCount'] == user.orders.count()
     address = data['defaultShippingAddress']
     user_address = user.default_shipping_address

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -554,9 +554,6 @@ def test_query_checkouts(
             edges {
                 node {
                     token
-                    payments{
-                        id
-                    }
                 }
             }
         }
@@ -568,7 +565,6 @@ def test_query_checkouts(
     content = get_graphql_content(response)
     received_checkout = content['data']['checkouts']['edges'][0]['node']
     assert str(checkout.token) == received_checkout['token']
-    assert len(received_checkout['payments']) == checkout.payments.count()
 
 
 def test_query_checkout_lines(

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -554,6 +554,9 @@ def test_query_checkouts(
             edges {
                 node {
                     token
+                    payments{
+                        id
+                    }
                 }
             }
         }
@@ -565,6 +568,7 @@ def test_query_checkouts(
     content = get_graphql_content(response)
     received_checkout = content['data']['checkouts']['edges'][0]['node']
     assert str(checkout.token) == received_checkout['token']
+    assert len(received_checkout['payments']) == checkout.payments.count()
 
 
 def test_query_checkout_lines(

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -25,7 +25,7 @@ CREATE_FULFILLMENT_QUERY = """
                 status
                 trackingNumber
             lines {
-                totalCount
+                id
             }
         }
     }
@@ -54,7 +54,7 @@ def test_create_fulfillment(
     assert data['fulfillmentOrder'] == 1
     assert data['status'] == FulfillmentStatus.FULFILLED.upper()
     assert data['trackingNumber'] == tracking
-    assert data['lines']['totalCount'] == 1
+    assert len(data['lines']) == 1
 
     event_fulfillment, event_email_sent = order.events.all()
     assert event_fulfillment.type == (

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -79,6 +79,9 @@ def test_order_query(
                     fulfillments {
                         fulfillmentOrder
                     }
+                    payments{
+                        id
+                    }
                     subtotal {
                         net {
                             amount
@@ -123,6 +126,7 @@ def test_order_query(
     fulfillment = order.fulfillments.first().fulfillment_order
     fulfillment_order = order_data['fulfillments'][0]['fulfillmentOrder']
     assert fulfillment_order == fulfillment
+    assert len(order_data['payments']) == order.payments.count()
 
     expected_methods = ShippingMethod.objects.applicable_shipping_methods(
         price=order.get_subtotal().gross.amount,

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -90,19 +90,11 @@ def test_product_query(staff_api_client, product, permission_manage_products):
                         url
                         thumbnailUrl
                         images {
-                            edges {
-                                node {
-                                    url
-                                }
-                            }
+                            url
                         }
                         variants {
-                            edges {
-                                node {
-                                    name
-                                    stockQuantity
-                                    }
-                                }
+                            name
+                            stockQuantity
                         }
                         availability {
                             available,
@@ -185,12 +177,8 @@ def test_product_with_collections(
     query = """
         query getProduct($productID: ID!) {
             product(id: $productID) {
-                collections(first: 1) {
-                    edges {
-                        node {
-                            name
-                        }
-                    }
+                collections {
+                    name
                 }
             }
         }
@@ -204,8 +192,8 @@ def test_product_with_collections(
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['product']
-    assert data['collections']['edges'][0]['node']['name'] == collection.name
-    assert len(data['collections']['edges']) == 1
+    assert data['collections'][0]['name'] == collection.name
+    assert len(data['collections']) == 1
 
 
 def test_filter_product_by_category(user_api_client, product):
@@ -1198,12 +1186,8 @@ def test_product_variant_price(
         query getProductVariants($id: ID!) {
             product(id: $id) {
                 variants {
-                    edges {
-                        node {
-                            price {
-                                amount
-                            }
-                        }
+                    price {
+                        amount
                     }
                 }
             }
@@ -1214,7 +1198,7 @@ def test_product_variant_price(
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content['data']['product']
-    variant_price = data['variants']['edges'][0]['node']['price']
+    variant_price = data['variants'][0]['price']
     assert variant_price['amount'] == api_variant_price
 
 

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -31,11 +31,7 @@ def test_fetch_variant(staff_api_client, product, permission_manage_products):
                 amount
             }
             images {
-                edges {
-                    node {
-                        id
-                    }
-                }
+                id
             }
             name
             priceOverride {


### PR DESCRIPTION
I want to merge this change because resolve #3012 #3011 #3008 

In API we should use lists instead of connections where pagination is not required. 

Related fields that I think should be changed to lists:
- [x] `Fulfillment.lines`
- [x] `User.addresses`
- [x] `Checkout.payments`
- [x] `Order.payments`
- [x] `ProductVariant.images`
- [x] `Product.collections`
- [x] `Product.images`
- [x] `Product.variants`


<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
