### PR TITLE
Remove runtime warning when product has discount

### DIFF
--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -130,7 +130,7 @@
         {% else %}
           <h2 class="product__info__price">
             <span>{% price_range availability.price_range %}</span>
-            {% if availability.discount %}
+            {% if availability.discount != None %}
               <small class="product__info__price__undiscounted">
                 {% price availability.price_range_undiscounted %}
               </small>


### PR DESCRIPTION
It is acutally a bug. It happens when product has discounts.

```
.local/share/virtualenvs/saleor-Ar4mgESs/lib/python3.6/site-packages/django/template/defaulttags.py:308: RuntimeWarning: `bool(taxed_money)` will always evaluate to True, consider replacing the test with explicit `if taxed_money is None` or `if taxed_money.gross`.
  if match:
```

It is because ```availability.discount``` can be ```None``` or ```TaxedMoney``` which is returned in ```get_availability```.

Anyway, this PR removes the annoying warning.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
