### PR TITLE
Refactor logged in user query

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -14,16 +14,6 @@ USER_SEARCH_FIELDS = (
     'default_shipping_address__country')
 
 
-def resolve_user(info, id):
-    logged_user = info.context.user
-    if not id:
-        return logged_user
-    user = graphene.Node.get_node_from_global_id(info, id, User)
-    if logged_user.has_perm('account.manage_users') or user == logged_user:
-        return user
-    return None
-
-
 def resolve_customers(info, query):
     qs = models.User.objects.filter(
         Q(is_staff=False) | (Q(is_staff=True) & Q(orders__isnull=False)))

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -1,4 +1,3 @@
-import graphene
 import graphene_django_optimizer as gql_optimizer
 from django.db.models import Q
 from i18naddress import get_validation_rules
@@ -6,7 +5,7 @@ from i18naddress import get_validation_rules
 from ...account import models
 from ...core.utils import get_client_ip, get_country_by_ip
 from ..utils import filter_by_query_param
-from .types import AddressValidationData, ChoiceValue, User
+from .types import AddressValidationData, ChoiceValue
 
 USER_SEARCH_FIELDS = (
     'email', 'default_shipping_address__first_name',

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,5 +1,5 @@
 import graphene
-from graphql_jwt.decorators import login_required, permission_required
+from graphql_jwt.decorators import permission_required
 
 from ..core.fields import PrefetchingConnectionField
 from ..descriptions import DESCRIPTIONS
@@ -9,8 +9,7 @@ from .mutations import (
     LoggedUserUpdate, PasswordReset, SetPassword, StaffCreate, StaffDelete,
     StaffUpdate)
 from .resolvers import (
-    resolve_address_validator, resolve_customers, resolve_staff_users,
-    resolve_user)
+    resolve_address_validator, resolve_customers, resolve_staff_users)
 from .types import AddressValidationData, AddressValidationInput, User
 
 
@@ -39,9 +38,9 @@ class AccountQueries(graphene.ObjectType):
     def resolve_staff_users(self, info, query=None, **kwargs):
         return resolve_staff_users(info, query=query)
 
-    @login_required
+    @permission_required('account.manage_users')
     def resolve_user(self, info, id):
-        return resolve_user(info, id)
+        return graphene.Node.get_node_from_global_id(info, id, User)
 
 
 class AccountMutations(graphene.ObjectType):

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,5 +1,5 @@
 import graphene
-from graphql_jwt.decorators import permission_required
+from graphql_jwt.decorators import login_required, permission_required
 
 from ..core.fields import PrefetchingConnectionField
 from ..descriptions import DESCRIPTIONS
@@ -20,6 +20,8 @@ class AccountQueries(graphene.ObjectType):
     customers = PrefetchingConnectionField(
         User, description='List of the shop\'s customers.',
         query=graphene.String(description=DESCRIPTIONS['user']))
+    me = graphene.Field(
+        User, description='Logged in user data.')
     staff_users = PrefetchingConnectionField(
         User, description='List of the shop\'s staff users.',
         query=graphene.String(description=DESCRIPTIONS['user']))
@@ -33,6 +35,10 @@ class AccountQueries(graphene.ObjectType):
     @permission_required('account.manage_users')
     def resolve_customers(self, info, query=None, **kwargs):
         return resolve_customers(info, query=query)
+
+    @login_required
+    def resolve_me(self, info):
+        return info.context.user
 
     @permission_required('account.manage_staff')
     def resolve_staff_users(self, info, query=None, **kwargs):

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -48,7 +48,7 @@ class User(CountableDjangoObjectType):
         PrefetchingConnectionField(
             Address, description='List of all user\'s addresses.'),
         model_field='addresses')
-    note = graphene.String(description='')
+    note = graphene.String(description='A note about the customer')
 
     class Meta:
         exclude_fields = ['password', 'is_superuser', 'OrderEvent_set']

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -2,6 +2,7 @@ import graphene
 import graphene_django_optimizer as gql_optimizer
 from django.contrib.auth import get_user_model
 from graphene import relay
+from graphql_jwt.decorators import permission_required
 
 from ...account import models
 from ...core.permissions import get_permissions
@@ -47,6 +48,7 @@ class User(CountableDjangoObjectType):
         PrefetchingConnectionField(
             Address, description='List of all user\'s addresses.'),
         model_field='addresses')
+    note = graphene.String(description='')
 
     class Meta:
         exclude_fields = ['password', 'is_superuser', 'OrderEvent_set']
@@ -64,6 +66,10 @@ class User(CountableDjangoObjectType):
 
     def resolve_addresses(self, info, **kwargs):
         return self.addresses.all()
+
+    @permission_required('account.manage_users')
+    def resolve_note(self, info):
+        return self.note
 
 
 class AddressValidationInput(graphene.InputObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1617,6 +1617,7 @@ type Query {
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
   addressValidator(input: AddressValidationInput!): AddressValidationData
   customers(query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
+  me: User
   staffUsers(query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
   user(id: ID!): User
   node(id: ID!): Node

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -256,7 +256,7 @@ def test_who_can_see_user(
 
 
 ME_QUERY = """
-    query Me{
+    query Me {
         me {
             id
             email
@@ -280,7 +280,7 @@ def test_me_query_anonymous_client(api_client):
 def test_me_query_customer_can_not_see_note(
         staff_user, staff_api_client, permission_manage_users):
     query = """
-    query Me{
+    query Me {
         me {
             id
             email

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -152,32 +152,12 @@ USER_QUERY = """
 """
 
 
-def test_customer_can_see_his_own_data(user_api_client):
-    user = user_api_client.user
-    id = graphene.Node.to_global_id('User', user.id)
-    variables = {'id': id}
-    response = user_api_client.post_graphql(USER_QUERY, variables)
-    content = get_graphql_content(response)
-    data = content['data']['user']
-    assert data['email'] == user.email
-
-
 def test_customer_can_not_see_other_users_data(user_api_client,
                                                staff_user):
     id = graphene.Node.to_global_id('User', staff_user.id)
     variables = {'id': id}
     response = user_api_client.post_graphql(USER_QUERY, variables)
-    content = get_graphql_content(response)
-    data = content['data']['user']
-    assert data is None
-
-
-def test_user_query_with_empty_id(user_api_client):
-    variables = {'id': ''}
-    response = user_api_client.post_graphql(USER_QUERY, variables)
-    content = get_graphql_content(response)
-    data = content['data']['user']
-    assert data['email'] == user_api_client.user.email
+    assert_no_permission(response)
 
 
 def test_user_query_anonymous_user(api_client):
@@ -259,10 +239,7 @@ def test_who_can_see_user(
     ID = graphene.Node.to_global_id('User', customer_user.id)
     variables = {'id': ID}
     response = staff_api_client.post_graphql(USER_QUERY, variables)
-    data = get_graphql_content(response)
-    content = get_graphql_content(response)
-    data = content['data']['user']
-    assert data is None
+    assert_no_permission(response)
 
     response = staff_api_client.post_graphql(query)
     assert_no_permission(response)


### PR DESCRIPTION
I want to merge this change because resolve #3285 

We need to refactor the `user` queries to adapt it to single-responsibility rule. We can achieve this by moving logged in user data query from `user` query to `me` query.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
