### PR TITLE
Add django-versatile's on demand image creation settings to the docs

### DIFF
--- a/docs/gettingstarted/configuration.rst
+++ b/docs/gettingstarted/configuration.rst
@@ -76,3 +76,9 @@ Environment variables
 
 ``DEFAULT_COUNTRY``
   Sets the default country for the store. It controls the default VAT to be shown if required, the default shipping country, etc.
+
+``CREATE_IMAGES_ON_DEMAND``
+  Whether or not to create new images on-the-fly (``True`` by default).
+  Set this to ``False`` for speedy performance, which is recommended for production.
+  Every image should come with a pre-warm to ensure they're
+  created and available at the appropriate URL.


### PR DESCRIPTION
This documents django-versatile's `CREATE_IMAGES_ON_DEMAND` settings to Saleor. Which was totally missing despite the fact we fully support pre-warming.
### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
