### PR TITLE
Remove additional pytest args in tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ commands =
     django21: pip install "django>=2.1a1,<2.2" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput
-    pytest -n auto --vcr-record-mode=none --cov --cov-report=
+    pytest
     codecov
 
 [travis]


### PR DESCRIPTION
The arguments for pytests is already defined in https://github.com/mirumee/saleor/blob/f9fdf5ed2f1e79f7e784076933aaab37b002baa0/setup.cfg#L17. There is no need to re-define it in tox in https://github.com/mirumee/saleor/blob/f9fdf5ed2f1e79f7e784076933aaab37b002baa0/tox.ini#L17. It is make harder to maintain since they have same logic actually.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
