### PR TITLE
Remove timeout for updating image height

### DIFF
--- a/saleor/static/js/components/misc.js
+++ b/saleor/static/js/components/misc.js
@@ -39,17 +39,6 @@ export default $(document).ready((e) => {
   // Update product-image height when window is initialized
   updateProductImageHeight();
 
-  // Only update product-image height after 5ms when window size changes
-  // This is to prevent window resize event is triggered multiple times at the same time.
-  // This can also prevent that window is resized but bootstrap's responsive component
-  // is not quick enough to resize too.
-  $(window).resize(function() {
-    if (this._timeout) clearTimeout(this._timeout);
-    this._timeout = setTimeout(function() {
-      $(this).trigger('resized');
-    }, 5);
-  });
-
   // Update product-image height
   $(window).bind('resized', function() {
     updateProductImageHeight();


### PR DESCRIPTION
As reported in https://github.com/mirumee/saleor/commit/4a508cefe7a1a1835cfab1114043773dabfed7fd#commitcomment-31439623 and reproduce by @NyanKiyoshi 's steps:

> Open https://demo.getsaleor.com/en/products/white-plimsolls-88/;
> Click the right arrow;
> Resize the window.

This PR fixes this bug. This is caused by previous certain js packages (probably bootstrap, I didn't try to find out) has bug where 
bootstrap component is not responsed quickly enough when window size changes. That's why I added ```setTimeout``` for https://github.com/mirumee/saleor/commit/4a508cefe7a1a1835cfab1114043773dabfed7fd#commitcomment-31439623. But it looks like this uptream bug is fixed and with this ```setTimeout``` will cause new issue. So this PR removes it and I've tested locally everything is fine for responsive image height.

@wulaaf Appreciate if you can try this to check if solves your issue.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
