### PR TITLE
Derive state from props in forms

### DIFF
--- a/saleor/static/dashboard-next/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryUpdatePage/CategoryUpdatePage.tsx
@@ -94,12 +94,7 @@ export const CategoryUpdatePage = decorate<CategoryUpdatePageProps>(
           seoTitle: ""
         };
     return (
-      <Form
-        onSubmit={onSubmit}
-        initial={initialData}
-        errors={userErrors}
-        key={JSON.stringify(category)}
-      >
+      <Form onSubmit={onSubmit} initial={initialData} errors={userErrors}>
         {({ data, change, errors, submit, hasChanged }) => (
           <Container width="md">
             <PageHeader

--- a/saleor/static/dashboard-next/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
+++ b/saleor/static/dashboard-next/collections/components/CollectionDetailsPage/CollectionDetailsPage.tsx
@@ -67,7 +67,6 @@ const CollectionDetailsPage = decorate<CollectionDetailsPageProps>(
         seoTitle: maybe(() => collection.seoTitle)
       }}
       onSubmit={onSubmit}
-      key={JSON.stringify(collection) + isFeatured}
     >
       {({ change, data, errors: formErrors, hasChanged, submit }) => (
         <Container width="md">

--- a/saleor/static/dashboard-next/components/Form/Form.tsx
+++ b/saleor/static/dashboard-next/components/Form/Form.tsx
@@ -2,40 +2,82 @@ import * as React from "react";
 import { UserError } from "../../types";
 
 export interface FormProps<T extends {}> {
-  children:
-    | ((
-        props: {
-          data: T;
-          hasChanged: boolean;
-          errors: { [key: string]: string };
-          change(event: React.ChangeEvent<any>);
-          submit(event?: React.FormEvent<any>);
-        }
-      ) => React.ReactElement<any>)
-    | React.ReactNode;
+  children: ((
+    props: {
+      data: T;
+      hasChanged: boolean;
+      errors: { [key: string]: string };
+      change(event: React.ChangeEvent<any>);
+      submit(event?: React.FormEvent<any>);
+    }
+  ) => React.ReactElement<any>);
   errors?: UserError[];
   initial?: T;
   useForm?: boolean;
   onSubmit?(data: T);
 }
+interface FormState<T extends {}> {
+  initial: T;
+  fields: T;
+}
 
-class Form<T extends {} = {}> extends React.Component<FormProps<T>, T> {
-  state: T = this.props.initial;
+class Form<T extends {} = {}> extends React.Component<
+  FormProps<T>,
+  FormState<T>
+> {
+  static getDerivedStateFromProps<T extends {} = {}>(
+    nextProps: FormProps<T>,
+    prevState: FormState<T>
+  ): FormState<T> {
+    const changedFields = Object.keys(nextProps.initial).filter(
+      nextFieldName =>
+        nextProps.initial[nextFieldName] !== prevState.initial[nextFieldName]
+    );
+    if (changedFields.length > 0) {
+      const swapFields = changedFields.reduce((prev, curr) => {
+        prev[curr] = nextProps.initial[curr];
+        return prev;
+      }, {});
+
+      return {
+        fields: {
+          ...(prevState.fields as any),
+          ...swapFields
+        },
+        initial: {
+          ...(prevState.initial as any),
+          ...swapFields
+        }
+      };
+    }
+    return null;
+  }
+
+  state: FormState<T> = {
+    fields: this.props.initial,
+    initial: this.props.initial
+  };
 
   handleChange = (event: React.ChangeEvent<any>) => {
     const { target } = event;
-    if (!(target.name in this.state)) {
+    if (!(target.name in this.state.fields)) {
       console.error(`Unknown form field: ${target.name}`);
       return;
     }
-    this.setState(({ [target.name]: target.value } as any) as Pick<T, keyof T>);
+
+    this.setState({
+      fields: {
+        ...(this.state.fields as any),
+        [target.name]: target.value
+      }
+    });
   };
 
   handleKeyDown = (event: React.KeyboardEvent<any>) => {
     switch (event.keyCode) {
       // Enter
       case 13:
-        this.props.onSubmit(this.state);
+        this.props.onSubmit(this.state.fields);
         break;
     }
   };
@@ -47,33 +89,30 @@ class Form<T extends {} = {}> extends React.Component<FormProps<T>, T> {
       event.preventDefault();
     }
     if (onSubmit !== undefined) {
-      onSubmit(this.state);
+      onSubmit(this.state.fields);
     }
   };
 
   render() {
     const { children, errors, useForm = true } = this.props;
 
-    let contents = children;
-
-    if (typeof children === "function") {
-      contents = children({
-        change: this.handleChange,
-        data: this.state,
-        errors: errors
-          ? errors.reduce(
-              (prev, curr) => ({
-                ...prev,
-                [curr.field.split(":")[0]]: curr.message
-              }),
-              {}
-            )
-          : {},
-        hasChanged:
-          JSON.stringify(this.props.initial) !== JSON.stringify(this.state),
-        submit: this.handleSubmit
-      });
-    }
+    const contents = children({
+      change: this.handleChange,
+      data: this.state.fields,
+      errors: errors
+        ? errors.reduce(
+            (prev, curr) => ({
+              ...prev,
+              [curr.field.split(":")[0]]: curr.message
+            }),
+            {}
+          )
+        : {},
+      hasChanged:
+        JSON.stringify(this.state.initial) !==
+        JSON.stringify(this.state.fields),
+      submit: this.handleSubmit
+    });
 
     return useForm ? (
       <form onSubmit={this.handleSubmit}>{contents}</form>

--- a/saleor/static/dashboard-next/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerDetailsPage/CustomerDetailsPage.tsx
@@ -62,7 +62,6 @@ const CustomerDetailsPage = decorate<CustomerDetailsPageProps>(
         isActive: maybe(() => customer.isActive),
         note: maybe(() => customer.note)
       }}
-      key={JSON.stringify(customer)}
       onSubmit={onSubmit}
     >
       {({ change, data, errors: formErrors, hasChanged, submit }) => (

--- a/saleor/static/dashboard-next/orders/components/OrderHistory/OrderHistory.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderHistory/OrderHistory.tsx
@@ -127,11 +127,7 @@ const OrderHistory = decorate<OrderHistoryProps>(
       />
       {history ? (
         <Timeline>
-          <Form
-            initial={{ message: "" }}
-            onSubmit={onNoteAdd}
-            key={JSON.stringify(history)}
-          >
+          <Form initial={{ message: "" }} onSubmit={onNoteAdd}>
             {({ change, data, submit }) => (
               <TimelineAddNote
                 message={data.message}

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -114,12 +114,7 @@ const ProductTypeDetailsPage = decorate<ProductTypeDetailsPageProps>(
       <Toggle>
         {(openedDeleteDialog, { toggle: toggleDeleteDialog }) => (
           <>
-            <Form
-              errors={errors}
-              initial={formInitialData}
-              onSubmit={onSubmit}
-              key={JSON.stringify(productType)}
-            >
+            <Form errors={errors} initial={formInitialData} onSubmit={onSubmit}>
               {({ change, data, hasChanged, submit }) => (
                 <Container width="md">
                   <PageHeader title={pageTitle} onBack={onBack} />

--- a/saleor/static/dashboard-next/products/components/ProductUpdatePage/ProductUpdatePage.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductUpdatePage/ProductUpdatePage.tsx
@@ -185,12 +185,7 @@ export const ProductUpdate = decorate<ProductUpdateProps>(
       product && product.productType && product.productType.hasVariants;
 
     return (
-      <Form
-        onSubmit={onSubmit}
-        errors={userErrors}
-        initial={initialData}
-        key={product ? JSON.stringify(product) : "loading"}
-      >
+      <Form onSubmit={onSubmit} errors={userErrors} initial={initialData}>
         {({ change, data, errors, hasChanged, submit }) => (
           <>
             <Container width="md">

--- a/saleor/static/dashboard-next/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
+++ b/saleor/static/dashboard-next/siteSettings/components/SiteSettingsPage/SiteSettingsPage.tsx
@@ -60,12 +60,7 @@ const SiteSettingsPage = decorate<SiteSettingsPageProps>(
       name: maybe(() => shop.name, "")
     };
     return (
-      <Form
-        errors={errors}
-        initial={initialForm}
-        onSubmit={onSubmit}
-        key={JSON.stringify(shop)}
-      >
+      <Form errors={errors} initial={initialForm} onSubmit={onSubmit}>
         {({ change, data, errors: formErrors, hasChanged, submit }) => (
           <Container width="md">
             <PageHeader

--- a/saleor/static/dashboard-next/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
+++ b/saleor/static/dashboard-next/staff/components/StaffDetailsPage/StaffDetailsPage.tsx
@@ -69,11 +69,7 @@ const StaffDetailsPage = decorate<StaffDetailsPageProps>(
       )
     };
     return (
-      <Form
-        initial={initialForm}
-        onSubmit={onSubmit}
-        key={JSON.stringify({ staffMember, permissions })}
-      >
+      <Form initial={initialForm} onSubmit={onSubmit}>
         {({ data, change, hasChanged, submit }) => (
           <Container width="md">
             <PageHeader


### PR DESCRIPTION
I want to merge this change because it eases developers' life by not requiring them to set `key` in each form and fixes bugs where form was resetted after some action.
Resolves #2546 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
