### PR TITLE
Solve an auto-resize conflict between Materialize and medium-editor

### DIFF
--- a/saleor/static/dashboard/js/components/editor.js
+++ b/saleor/static/dashboard/js/components/editor.js
@@ -12,6 +12,9 @@ import formatClear from '../../images/editor/format_clear.svg';
 import doneIcon from '../../images/done.svg';
 import closeIcon from '../../images/close.svg';
 
+// Solve an auto-resize conflict between Materialize and medium-editor.
+$('.rich-text-editor').removeClass('materialize-textarea');
+
 // eslint-disable-next-line
 const editor = new MediumEditor('.rich-text-editor', {
   paste: {


### PR DESCRIPTION
I want to merge this change because it fixes an auto-resize conflict between Materialize and medium-editor.

### Screenshots

- [before](https://imgur.com/a/dldMqPk)
- [after](https://imgur.com/a/0m9zVCo)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
