### PR TITLE
Pin redis version since 3.0 is not compatible with Celery

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -58,6 +58,7 @@ social-auth-app-django = ">=2.0.0"
 text-unidecode = "*"
 uwsgi = {version = ">=2.0.0", platform_system = "!= 'Windows'"}
 celery = {version = "*", extras = ["redis"]}
+redis = "<3.0.0"  # this can be safely removed after Celery v4.2.2 is released
 weasyprint = ">=0.42.2"
 graphene-django-optimizer = "*"
 braintree = "==3.49.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ccf332313efa4f7f6a6cafdc4fedff2a892f95d0e414027fb243537950c367fd"
+            "sha256": "37bd379ffb4e617c998bb0dc22b01c4d93175170a3ee68737ddb440f89382694"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -748,10 +748,10 @@
         },
         "pyjwt": {
             "hashes": [
-                "sha256:30b1380ff43b55441283cc2b2676b755cca45693ae3097325dea01f3d110628c",
-                "sha256:4ee413b357d53fd3fb44704577afac88e72e878716116270d722723d65b42176"
+                "sha256:00414bfef802aaecd8cc0d5258b6cb87bd8f553c2986c2c5f29b19dd5633aeb7",
+                "sha256:ddec8409c57e9d371c6006e388f91daf3b0b43bdf9fcbf99451fb7cf5ce0a86d"
             ],
-            "version": "==1.6.4"
+            "version": "==1.7.0"
         },
         "pyphen": {
             "hashes": [
@@ -800,10 +800,11 @@
         },
         "redis": {
             "hashes": [
-                "sha256:2100750629beff143b6a200a2ea8e719fcf26420adabb81402895e144c5083cf",
-                "sha256:8e0bdd2de02e829b6225b25646f9fb9daffea99a252610d040409a6738541f0a"
+                "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
+                "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
             ],
-            "version": "==3.0.1"
+            "index": "pypi",
+            "version": "==2.10.6"
         },
         "requests": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,14 +83,14 @@ purl==1.4
 pycodestyle==2.4.0
 pycparser==2.19
 pygments==2.3.0
-pyjwt==1.6.4
+pyjwt==1.7.0
 pyphen==0.9.5
 python-dateutil==2.7.5 ; python_version >= '2.7'
 python3-openid==3.1.0 ; python_version >= '3.0'
 pytz==2018.7
 raven==6.9.0
 razorpay==1.1.1
-redis==3.0.1
+redis==2.10.6
 requests-oauthlib==1.0.0
 requests==2.20.1
 rx==1.6.1


### PR DESCRIPTION
Closes https://github.com/mirumee/saleor/issues/3364. As discussed here https://github.com/celery/celery/issues/5175, redis 3.0 is not supported by celery and is fixed in https://github.com/celery/celery/pull/5176 in Celery.

This patch can be removed after Celery 4.2.2 is released

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
