### PR TITLE
Fix calls to ngettext_lazy

### DIFF
--- a/saleor/dashboard/order/forms.py
+++ b/saleor/dashboard/order/forms.py
@@ -401,7 +401,7 @@ class ChangeQuantityForm(forms.ModelForm):
                     'Change quantity form error',
                     'Only %(remaining)d remaining in stock.',
                     'Only %(remaining)d remaining in stock.',
-                    'remaining') % {
+                    number='remaining') % {
                         'remaining': (
                             self.initial_quantity + variant.quantity_available)})  # noqa
         return quantity
@@ -433,7 +433,7 @@ class CancelOrderForm(forms.Form):
             'Cancel order form action',
             'Restock %(quantity)d item',
             'Restock %(quantity)d items',
-            'quantity') % {'quantity': self.order.get_total_quantity()}
+            number='quantity') % {'quantity': self.order.get_total_quantity()}
 
     def clean(self):
         data = super().clean()
@@ -463,7 +463,7 @@ class CancelFulfillmentForm(forms.Form):
             'Cancel fulfillment form action',
             'Restock %(quantity)d item',
             'Restock %(quantity)d items',
-            'quantity') % {'quantity': self.fulfillment.get_total_quantity()}
+            number='quantity') % {'quantity': self.fulfillment.get_total_quantity()}
 
     def clean(self):
         data = super().clean()
@@ -638,7 +638,7 @@ class FulfillmentLineForm(forms.ModelForm):
                 'Fulfill order line form error',
                 '%(quantity)d item remaining to fulfill.',
                 '%(quantity)d items remaining to fulfill.',
-                'quantity') % {
+                number='quantity') % {
                     'quantity': order_line.quantity_unfulfilled,
                     'order_line': order_line})
         return quantity

--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -609,7 +609,7 @@ def fulfill_order_lines(request, order_pk):
                 'Dashboard message related to an order',
                 'Fulfilled %(quantity_fulfilled)d item',
                 'Fulfilled %(quantity_fulfilled)d items',
-                'quantity_fulfilled') % {
+                number='quantity_fulfilled') % {
                     'quantity_fulfilled': quantity_fulfilled}
             order.events.create(
                 parameters={'quantity': quantity_fulfilled},

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -192,7 +192,7 @@ def product_bulk_update(request):
             'Dashboard message',
             '%(count)d product has been updated',
             '%(count)d products have been updated',
-            number=count) % {'count': count}
+            number='count') % {'count': count}
         messages.success(request, msg)
     return redirect('dashboard:product-list')
 

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -78,7 +78,7 @@ class FulfillmentCreate(BaseMutation):
                     'Fulfill order line mutation error',
                     'Only %(quantity)d item remaining to fulfill.',
                     'Only %(quantity)d items remaining to fulfill.',
-                    'quantity') % {
+                    number='quantity') % {
                         'quantity': order_line.quantity_unfulfilled,
                         'order_line': order_line}
                 cls.add_error(errors, order_line, msg)

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -146,7 +146,7 @@ def display_order_event(order_event):
             'Dashboard message related to an order',
             'We restocked %(quantity)d item',
             'We restocked %(quantity)d items',
-            'quantity') % {'quantity': params['quantity']}
+            number='quantity') % {'quantity': params['quantity']}
     if event_type == OrderEvents.NOTE_ADDED.value:
         return pgettext_lazy(
             'Dashboard message related to an order',
@@ -164,7 +164,7 @@ def display_order_event(order_event):
             'Dashboard message related to an order',
             'Fulfilled %(quantity_fulfilled)d item',
             'Fulfilled %(quantity_fulfilled)d items',
-            'quantity_fulfilled') % {
+            number='quantity_fulfilled') % {
                 'quantity_fulfilled': params['quantity']}
     if event_type == OrderEvents.PLACED.value:
         return pgettext_lazy(
@@ -198,7 +198,8 @@ def display_order_event(order_event):
         return npgettext_lazy(
             'Dashboard message related to an order',
             '%(quantity)d line item oversold on this order.',
-            '%(quantity)d line items oversold on this order.') % {
+            '%(quantity)d line items oversold on this order.',
+            number='quantity') % {
                 'quantity': len(params['oversold_items'])}
 
     if event_type == OrderEvents.OTHER.value:


### PR DESCRIPTION
This makes all calls to `ngettext_lazy` explicitly name the `number` argument and fixes the missing `number` when formatting the message for oversold items. Not sure why but tests seemed to pass on CI yet they failed for me locally.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
