### PR TITLE
Fix range filters not being applied

### DIFF
--- a/saleor/dashboard/widgets.py
+++ b/saleor/dashboard/widgets.py
@@ -1,25 +1,25 @@
 from django import forms
 from django.conf import settings
 from django.forms import Textarea, TextInput
-from django_filters.widgets import RangeWidget
+from django_filters import widgets
 from django_prices.widgets import MoneyInput
 
 from ..account.widgets import PhonePrefixWidget as StorefrontPhonePrefixWidget
 
 
-class DateRangeWidget(RangeWidget):
+class DateRangeWidget(widgets.DateRangeWidget):
     def __init__(self, attrs=None):
-        widgets = (forms.DateInput, forms.DateInput)
+        date_widgets = (forms.DateInput, forms.DateInput)
         # pylint: disable=bad-super-call
-        super(RangeWidget, self).__init__(widgets, attrs)
+        super(widgets.RangeWidget, self).__init__(date_widgets, attrs)
 
 
-class MoneyRangeWidget(RangeWidget):
+class MoneyRangeWidget(widgets.RangeWidget):
     def __init__(self, attrs=None):
         self.currency = getattr(settings, 'DEFAULT_CURRENCY')
-        widgets = (MoneyInput(self.currency), MoneyInput(self.currency))
+        money_widgets = (MoneyInput(self.currency), MoneyInput(self.currency))
         # pylint: disable=bad-super-call
-        super(RangeWidget, self).__init__(widgets, attrs)
+        super(widgets.RangeWidget, self).__init__(money_widgets, attrs)
 
 
 class PhonePrefixWidget(StorefrontPhonePrefixWidget):

--- a/templates/materializecssform/field.html
+++ b/templates/materializecssform/field.html
@@ -258,8 +258,9 @@
       {% endif %}
     </label>
     {% for value in field.value %}
-      <input type="date" id="{{ field.auto_id }}" class="datepicker col s5" name="{{ field.name }}_{{ forloop.counter0 }}"
-        value="{% if field.value %}{{ field.value|date:'Y-m-d' }}{% endif %}" data-value="{% if field.value %}{{ field.value|date:'Y-m-d' }}{% endif %}">
+      {% comment %} cycle after/before - this is assuming range will only iterate over 2 fields, required for django-filter instead of 0-1 indexes {% endcomment %}
+      <input type="date" id="{{ field.auto_id }}" class="datepicker col s5" name="{{ field.name }}_{% cycle 'after' 'before' %}"
+        value="{% if value %}{{ value }}{% endif %}" data-value="{% if value %}{{ value }}{% endif %}">
       {% for error in field.errors %}
         <p class="help-block materialize-red-text">
           {{ error }}
@@ -287,7 +288,8 @@
       {% for value in field.value %}
         <div class="input-range--field">
           <div class="input-with-suffix">
-            <input type="number" name="{{ field.name }}_{{ forloop.counter0 }}" value="{{ value }}"
+            {% comment %} cycle min/max - this is assuming range will only iterate over 2 fields, required for django-filter instead of 0-1 indexes {% endcomment %}
+            <input type="number" name="{{ field.name }}_{% cycle 'min' 'max' %}" value="{{ value }}"
                    id="{{ field.auto_id }}_{{ forloop.counter0 }}">
             <div class="input-text-suffix">{{ field.field.widget.currency }}</div>
           </div>
@@ -327,8 +329,9 @@
           {{ field.help_text|safe }}
         </p>
       {% endif %}
+      {% comment %} cycle min/max - this is assuming range will only iterate over 2 fields, required for django-filter instead of 0-1 indexes {% endcomment %}
       <input type="number" class="col s5"
-             name="{{ field.name }}_{{ forloop.counter0 }}" value="{{ value }}"
+             name="{{ field.name }}_{% cycle 'min' 'max' %}" value="{{ value }}"
              id="{{ field.auto_id }}_{{ forloop.counter0 }}">
       {% if not forloop.last %}
         <div class="col s2 center-align separator">-</div>


### PR DESCRIPTION
Fixes https://github.com/mirumee/saleor/issues/3371.

`django-filters` requires suffixes instead of indexed fields (i.e. range_min/max instead of range_0/1). We use a different renderer (materialcss) effectively skipping Django widget render and thus never running `get_context` that django-filters relies on (it renames the fields to use the correct suffix). This fix kinda "brute-forces" the correct naming with the cycle in the template, but assuming that range will always be max (and min) two fields, which it wouldn't make sense if it was less or more (it's a range after all, right? ;') )

### Screenshots

![image](https://user-images.githubusercontent.com/7791528/49440913-47cc7600-f7c5-11e8-9f1c-05b50baf9a30.png)

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
