### PR TITLE
Add vat tax rates to country

### DIFF
--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -8,6 +8,7 @@ from saleor.graphql.core.utils import str_to_enum
 
 from ....core import weight
 from ..connection import CountableConnection
+from .money import VAT
 
 
 class ReportingPeriod(graphene.Enum):
@@ -34,7 +35,8 @@ class Decimal(graphene.Float):
 
 class CountryDisplay(graphene.ObjectType):
     code = graphene.String(description='Country code.', required=True)
-    country = graphene.String(description='Country.', required=True)
+    country = graphene.String(description='Country name.', required=True)
+    vat = graphene.Field(VAT, description='Country tax.')
 
 
 class CountableDjangoObjectType(DjangoObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -468,6 +468,7 @@ type CollectionUpdate {
 type CountryDisplay {
   code: String!
   country: String!
+  vat: VAT
 }
 
 type CreateToken {
@@ -668,6 +669,7 @@ input FulfillmentUpdateTrackingInput {
 enum GatewaysEnum {
   DUMMY
   BRAINTREE
+  RAZORPAY
 }
 
 scalar GenericScalar
@@ -1591,6 +1593,11 @@ type Query {
   node(id: ID!): Node
 }
 
+type ReducedRate {
+  rate: Float!
+  rateType: String!
+}
+
 type Refresh {
   token: String
   payload: GenericScalar
@@ -1954,6 +1961,12 @@ input UserCreateInput {
   isActive: Boolean
   note: String
   sendPasswordEmail: Boolean
+}
+
+type VAT {
+  countryCode: String!
+  standardRate: Float
+  reducedRates: [ReducedRate]
 }
 
 type VariantImageAssign {


### PR DESCRIPTION
Resolves https://github.com/mirumee/saleor/issues/3383.

Added vat tax rate information when querying for countries. Instead of proposed solution to change country from String! to object I decided it's better to put tax information next to it. Additionally added tax rate to default country. Other places where country is used didn't seem like needed this information. 

Example query:
```
{
  shop {
    countries {
      country
      vat {
        standardRate
        reducedRates {
          rate
          rateType
        }
      }
    }
  }
}
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
