### PR TITLE
Fix payment can not refunded if payment can also be captured

### DIFF
--- a/templates/dashboard/order/detail.html
+++ b/templates/dashboard/order/detail.html
@@ -162,7 +162,8 @@
                 <a href="#base-modal" data-href="{% url 'dashboard:capture-payment' order_pk=order.pk payment_pk=payment.pk %}" class="btn-flat modal-trigger-custom waves-effect">
                   {% trans "Capture" context "Order summary card action" %}
                 </a>
-              {% elif order.can_refund %}
+              {% endif %}
+              {% if order.can_refund %}
                 <a href="#base-modal" data-href="{% url 'dashboard:refund-payment' order_pk=order.pk payment_pk=payment.pk %}" class="btn-flat modal-trigger-custom waves-effect">
                   {% trans "Refund" context "Order summary card action" %}
                 </a>


### PR DESCRIPTION
For example, I have pre-authorized ```$10```, and I capture only ```$6```. Then for this payment, it can also be captured again (since there are still pre-authorized ```$4``` ) and also be refunded (since there are ```$6``` which is captured)

This PR fixes this issue in dashboard.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
