### PR TITLE
API should be able to finalize draft without pinning it to a customer

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -125,16 +125,6 @@ class OrderUpdate(DraftOrderUpdate):
         model = models.Order
 
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
-        if not instance.user and not cleaned_input.get('user_email'):
-            cls.add_error(
-                errors, field='user_email',
-                message='User_email field is null while order was created by '
-                        'anonymous user')
-        return cleaned_input
-
-    @classmethod
     def save(cls, info, instance, cleaned_input):
         super().save(info, instance, cleaned_input)
         if instance.user_email:

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -24,9 +24,4 @@ def can_finalize_draft_order(order, errors):
                     field='shipping',
                     message='Shipping method is not valid for chosen shipping '
                             'address'))
-    if not order.user and not order.user_email:
-        errors.append(
-            Error(
-                field=None,
-                message='Both user and user_email fields are null'))
     return errors


### PR DESCRIPTION
I want to merge this change because:
resolve #3306
resolve #3317

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
