### PR TITLE
Get authorized amount from succeeded auth transactions instead of payment.total

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -248,7 +248,7 @@ class Order(models.Model):
     def total_authorized(self):
         payment = self.get_last_payment()
         if payment:
-            return Money(payment.total, payment.currency)
+            return payment.get_authorized_amount()
         return zero_money()
 
     @property

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -565,3 +565,15 @@ def test_can_refund(payment_dummy: Payment):
 
     payment_dummy.charge_status = ChargeStatus.CHARGED
     assert payment_dummy.can_refund()
+
+
+def test_payment_get_authorized_amount(payment_txn_preauth):
+    authorized_amount = payment_txn_preauth.transactions.first().amount
+    assert payment_txn_preauth.get_authorized_amount().amount == \
+        authorized_amount
+    assert payment_txn_preauth.order.total_authorized.amount == \
+        authorized_amount
+
+
+    payment_txn_preauth.transactions.all().delete()
+    assert payment_txn_preauth.get_authorized_amount().amount == Decimal(0)


### PR DESCRIPTION
The ```Preauthorized amount``` used in dashboard's order detail page is using ```payment.total```. But this may be wrong such as when a payment is created but ```authorize``` method fails. In this case, a payment did in ```NOT_CHARGED``` status but it is not acutally authorized since the authorization process is failed.

So this authorized amount should be calcuated from the succeeded auth transactions.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
