### PR TITLE
Use PermissionEnum as input parameter in staff mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,3 +2,5 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
+
+Use `PermissionEnum` as input parameter type for `permissions` field - #3434 by @maarcingebala

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -13,7 +13,7 @@ from ...dashboard.staff.utils import remove_staff_member
 from ..account.i18n import I18nMixin
 from ..account.types import AddressInput, User
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
-from ..core.types.common import Error
+from ..core.types import Error, PermissionEnum
 
 
 def send_user_password_reset_email(user, site):
@@ -80,7 +80,7 @@ class UserCreateInput(CustomerInput):
 
 class StaffInput(UserInput):
     permissions = graphene.List(
-        graphene.String,
+        PermissionEnum,
         description='List of permission code names to assign to this user.')
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1820,7 +1820,7 @@ input StaffCreateInput {
   email: String
   isActive: Boolean
   note: String
-  permissions: [String]
+  permissions: [PermissionEnum]
   sendPasswordEmail: Boolean
 }
 
@@ -1833,7 +1833,7 @@ input StaffInput {
   email: String
   isActive: Boolean
   note: String
-  permissions: [String]
+  permissions: [PermissionEnum]
 }
 
 type StaffUpdate {

--- a/saleor/static/dashboard-next/products/types/ProductCreateData.ts
+++ b/saleor/static/dashboard-next/products/types/ProductCreateData.ts
@@ -39,23 +39,6 @@ export interface ProductCreateData_productTypes {
   edges: ProductCreateData_productTypes_edges[];
 }
 
-export interface ProductCreateData_collections_edges_node {
-  __typename: "Collection";
-  id: string;
-  name: string;
-}
-
-export interface ProductCreateData_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductCreateData_collections_edges_node;
-}
-
-export interface ProductCreateData_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductCreateData_collections_edges[];
-}
-
 export interface ProductCreateData {
   productTypes: ProductCreateData_productTypes | null;
-  collections: ProductCreateData_collections | null;
 }

--- a/saleor/static/dashboard-next/products/types/ProductDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductDetails.ts
@@ -162,25 +162,8 @@ export interface ProductDetails_product {
   url: string;
 }
 
-export interface ProductDetails_collections_edges_node {
-  __typename: "Collection";
-  id: string;
-  name: string;
-}
-
-export interface ProductDetails_collections_edges {
-  __typename: "CollectionCountableEdge";
-  node: ProductDetails_collections_edges_node;
-}
-
-export interface ProductDetails_collections {
-  __typename: "CollectionCountableConnection";
-  edges: ProductDetails_collections_edges[];
-}
-
 export interface ProductDetails {
   product: ProductDetails_product | null;
-  collections: ProductDetails_collections | null;
 }
 
 export interface ProductDetailsVariables {

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -12,6 +12,7 @@ from tests.api.utils import get_graphql_content
 from saleor.account.models import Address, User
 from saleor.graphql.account.mutations import (
     CustomerDelete, SetPassword, StaffDelete, StaffUpdate, UserDelete)
+from saleor.graphql.core.types import PermissionEnum
 
 from .utils import assert_no_permission, convert_dict_keys_to_camel_case
 
@@ -569,7 +570,7 @@ def test_staff_create(
         send_password_reset_mock, staff_api_client,
         permission_manage_staff, permission_manage_products, staff_user):
     query = """
-    mutation CreateStaff($email: String, $permissions: [String], $send_mail: Boolean) {
+    mutation CreateStaff($email: String, $permissions: [PermissionEnum], $send_mail: Boolean) {
         staffCreate(input: {email: $email, permissions: $permissions, sendPasswordEmail: $send_mail}) {
             errors {
                 field
@@ -588,14 +589,10 @@ def test_staff_create(
     }
     """
 
-    permission_manage_products_codename = '%s.%s' % (
-        permission_manage_products.content_type.app_label,
-        permission_manage_products.codename)
-
     email = 'api_user@example.com'
     variables = {
         'email': email,
-        'permissions': [permission_manage_products_codename],
+        'permissions': [PermissionEnum.MANAGE_PRODUCTS.name],
         'send_mail': True}
 
     response = staff_api_client.post_graphql(
@@ -620,7 +617,7 @@ def test_staff_create(
 def test_staff_update(staff_api_client, permission_manage_staff):
     query = """
     mutation UpdateStaff(
-            $id: ID!, $permissions: [String], $is_active: Boolean) {
+            $id: ID!, $permissions: [PermissionEnum], $is_active: Boolean) {
         staffUpdate(
                 id: $id,
                 input: {permissions: $permissions, isActive: $is_active}) {


### PR DESCRIPTION
`StaffCreateInput` and `StaffInput` were using `String` as the input parameter while the `PermissionEnum` is the right one. Fixes crashing create/update views in Dashboard 2.0.

I've generated new types for TS and some unrelated types were changed, but I assume that we forgot to generate the new types with one of the previous PR so I kept that.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
