### PR TITLE
Support sorting product by update date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Improve several payment validations - #3418 by @jxltom
 - Fix decimal value argument in GraphQL = #3457 by @fowczarek
 - Bump `urllib3` and `elasticsearch` to latest versions - #3460 by @maarcingebala
+- Support sorting products by update date - #3470 by @jxltom

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -46,12 +46,18 @@ class StockAvailability(graphene.Enum):
 class ProductOrderField(graphene.Enum):
     NAME = 'name'
     PRICE = 'price'
+    DATE = 'updated_at'
 
     @property
     def description(self):
         if self == ProductOrderField.NAME:
             return 'Sort products by name.'
-        return 'Sort products by price.'
+
+        if self == ProductOrderField.PRICE:
+            return 'Sort products by price.'
+
+        if self == ProductOrderField.DATE:
+            return 'Sort products by update date.'
 
 
 class OrderDirection(graphene.Enum):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1445,6 +1445,7 @@ input ProductOrder {
 enum ProductOrderField {
   NAME
   PRICE
+  DATE
 }
 
 type ProductType implements Node {

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -356,9 +356,9 @@ def test_sort_products(user_api_client, product):
     date_1 = content['data']['products']['edges'][1]['node']['updatedAt']
     assert parse_datetime(date_0) < parse_datetime(date_1)
 
-    desc_price_query = query % {
-        'sort_by_product_order': '{field: PRICE, direction:DESC}'}
-    response = user_api_client.post_graphql(desc_price_query)
+    desc_date_query = query % {
+        'sort_by_product_order': '{field: DATE, direction:DESC}'}
+    response = user_api_client.post_graphql(desc_date_query)
     content = get_graphql_content(response)
     date_0 = content['data']['products']['edges'][0]['node']['updatedAt']
     date_1 = content['data']['products']['edges'][1]['node']['updatedAt']

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1,12 +1,12 @@
+from datetime import datetime
 from unittest.mock import Mock, patch
 
 import graphene
 import pytest
+from django.utils.dateparse import parse_datetime
 from django.utils.text import slugify
 from graphql_relay import to_global_id
 from prices import Money
-from tests.api.utils import get_graphql_content
-from tests.utils import create_image, create_pdf_file_with_image_ext
 
 from saleor.graphql.core.types import ReportingPeriod
 from saleor.graphql.product.types import (
@@ -15,6 +15,8 @@ from saleor.product.models import (
     Attribute, AttributeValue, Category, Product, ProductImage, ProductType,
     ProductVariant)
 from saleor.product.tasks import update_variants_names
+from tests.api.utils import get_graphql_content
+from tests.utils import create_image, create_pdf_file_with_image_ext
 
 from .utils import assert_no_permission, get_multipart_request_body
 
@@ -304,13 +306,15 @@ def test_filter_products_by_collections(
 
 
 def test_sort_products(user_api_client, product):
-    # set price of the first product
+    # set price and update date of the first product
     product.price = Money('10.00', 'USD')
+    product.updated_at = datetime.utcnow()
     product.save()
 
-    # create the second product with higher price
+    # Create the second product with higher price and date
     product.pk = None
     product.price = Money('20.00', 'USD')
+    product.updated_at = datetime.utcnow()
     product.save()
 
     query = """
@@ -321,6 +325,7 @@ def test_sort_products(user_api_client, product):
                     price {
                         amount
                     }
+                    updatedAt
                 }
             }
         }
@@ -342,6 +347,22 @@ def test_sort_products(user_api_client, product):
     price_0 = content['data']['products']['edges'][0]['node']['price']['amount']
     price_1 = content['data']['products']['edges'][1]['node']['price']['amount']
     assert price_0 > price_1
+
+    asc_date_query = query % {
+        'sort_by_product_order': '{field: DATE, direction:ASC}'}
+    response = user_api_client.post_graphql(asc_date_query)
+    content = get_graphql_content(response)
+    date_0 = content['data']['products']['edges'][0]['node']['updatedAt'] ## parse_datetime
+    date_1 = content['data']['products']['edges'][1]['node']['updatedAt']
+    assert parse_datetime(date_0) < parse_datetime(date_1)
+
+    desc_price_query = query % {
+        'sort_by_product_order': '{field: PRICE, direction:DESC}'}
+    response = user_api_client.post_graphql(desc_price_query)
+    content = get_graphql_content(response)
+    date_0 = content['data']['products']['edges'][0]['node']['updatedAt']
+    date_1 = content['data']['products']['edges'][1]['node']['updatedAt']
+    assert parse_datetime(date_0) > parse_datetime(date_1)
 
 
 def test_create_product(


### PR DESCRIPTION
Current the products can only be sorted by name and price, it will be nice to sort them by update date.

This PR adds this support which will sort products by ```update_at``` field of product model.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
