### PR TITLE
Resolve to None when empty ID was passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change mutation errors field from [Error] to [Error!] - #3489 by @fowczarek
 - Update favicons to the new style - #3483 by @dominik-zeglen
 - Add publication date to collections - #3369 by @k-brk
+- Resolve to `None` when empty object ID was passed as mutation argument - #3497 by @maarcingebala

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -80,6 +80,9 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def get_node_or_error(cls, info, global_id, errors, field, only_type=None):
+        if not global_id:
+            return None
+
         node = None
         try:
             node = graphene.Node.get_node_from_global_id(

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -182,6 +182,7 @@ export interface CollectionCreateInput {
   backgroundImage?: any | null;
   backgroundImageAlt?: string | null;
   seo?: SeoInput | null;
+  publishedDate?: any | null;
   products?: (string | null)[] | null;
 }
 
@@ -193,6 +194,7 @@ export interface CollectionInput {
   backgroundImage?: any | null;
   backgroundImageAlt?: string | null;
   seo?: SeoInput | null;
+  publishedDate?: any | null;
 }
 
 export interface CustomerInput {

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -1,6 +1,7 @@
 import graphene
 import pytest
 from django.core.exceptions import ImproperlyConfigured
+from unittest.mock import Mock
 
 from saleor.graphql.core.mutations import BaseMutation
 from saleor.graphql.product import types as product_types
@@ -109,3 +110,11 @@ def test_user_error_id_of_different_type(product):
     assert user_errors
     assert user_errors[0]['field'] == 'productId'
     assert user_errors[0]['message'] == 'Must receive a Product id.'
+
+
+def test_get_node_or_error_returns_null_for_empty_id():
+    errors = []
+    info = Mock()
+    response = Mutation.get_node_or_error(info, '', errors, '')
+    assert not errors
+    assert response is None


### PR DESCRIPTION
This is a small improvement to the `get_node_or_error` function - if empty ID was passed as an argument it should immediately resolve to `None`. Without this change, multiple errors will be returned if empty String was passed as an ID to a mutation:

Currently, if we pass an empty string as an ID argument in a mutation, it will result in two errors:
```
{
    "field": "category",
    "message": "Couldn't resolve to a node: "
},
{
    "field": "category",
     "message": "This field cannot be null."
}
```

This PR changes this behavior to immediately return `None` in the `get_node_or_error` function so that the actual object resolver is not fired. This will result in only one meaningful error:
```
{
    "field": "category",
     "message": "This field cannot be null."
}
```

Edit: not related, but this PR also includes one minor TS types update, as it was out-of-date.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
