### PR TITLE
Remove volume on celery compose

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,30 @@
+version: '2'
+
+services:
+  web:
+    volumes:
+      - .:/app:Z
+    ports:
+      - 8000:8000
+
+  db:
+    volumes:
+      - saleor-db:/var/lib/postgresql
+    ports:
+      - 5432:5432
+
+  redis:
+    volumes:
+      - saleor-redis:/data
+    ports:
+      - 6379:6379
+
+  celery:
+    volumes:
+      - .:/app:Z
+
+volumes:
+  saleor-db:
+    driver: local
+  saleor-redis:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,8 +51,6 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    volumes:
-      - .:/app:Z
     env_file: common.env
     depends_on:
       - redis

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,6 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    ports:
-      - 8000:8000
     env_file: common.env
     depends_on:
       - db
@@ -23,10 +21,6 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    volumes:
-      - saleor-db:/var/lib/postgresql
-    ports:
-      - 5432:5432
     environment:
       - POSTGRES_USER=saleor
       - POSTGRES_PASSWORD=saleor
@@ -36,10 +30,6 @@ services:
     restart: unless-stopped
     networks:
       - saleor-backend-tier
-    volumes:
-      - saleor-redis:/data
-    ports:
-      - 6379:6379
 
   celery:
     build:
@@ -54,12 +44,6 @@ services:
     env_file: common.env
     depends_on:
       - redis
-
-volumes:
-  saleor-db:
-    driver: local
-  saleor-redis:
-    driver: local
 
 networks:
   saleor-backend-tier:

--- a/docs/customization/docker.rst
+++ b/docs/customization/docker.rst
@@ -18,8 +18,8 @@ You will need to install Docker and `docker-compose <https://docs.docker.com/com
 
 .. note::
 
-   Our configuration exposes PostgreSQL, Redis and Elasticsearch ports. If you have problems running this docker file because of port conflicts, you can remove ``ports`` section from ``docker-compose.yml``.
-
+   Our configuration uses a ``docker-compose.override.yml`` that exposes PostgreSQL and Redis ports and mounts the host machine code into the containers. 
+   If you don't want to expose the ports or if you want to specify your own volumes (eg. in production) you can tell Docker Compose to not include the additional configurations (ports) in the ``docker-compose.override.yml`` file by specifying ``docker-compose.yml`` with the ``-f`` option, as in ``docker-compose -f docker-compose.yml up -d`` and/or by specifying an alternative override file with ``docker-compose -f docker-compose.yml -f docker-compose.alternative-override.yml up -d``
 
 Usage
 -----


### PR DESCRIPTION
In docker compose, `web` does not have a volume mounted (because the /app is in the container through Dockerfile)

However, `celery` has  a volume mounted, which caused me problems (I don't have the full codebase in the place I run docker compose, eg `docker-compose -f path/to/docker-compose.yml`) and seems to cause some other problems: https://github.com/mirumee/saleor/issues/3465 -- I imagine that windows has trouble with mounting that volume.

I don't know of any use-case for mounting that volume other than for development environments. But if that would be the case, `web` in the docker-compose file would also have it mounted.

So here's a proposal to drop that.
Alternative is to add that same volume in `web` and assume that the docker compose is a development environment.
 
--- 

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [ ] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
