### PR TITLE
Allow specification of media root through env.

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -120,7 +120,7 @@ if ENABLE_SSL:
 DEFAULT_FROM_EMAIL = os.environ.get('DEFAULT_FROM_EMAIL', EMAIL_HOST_USER)
 ORDER_FROM_EMAIL = os.getenv('ORDER_FROM_EMAIL', DEFAULT_FROM_EMAIL)
 
-MEDIA_ROOT = os.path.join(PROJECT_ROOT, 'media')
+MEDIA_ROOT = os.environ.get('MEDIA_ROOT', os.path.join(PROJECT_ROOT, 'media'))
 MEDIA_URL = os.environ.get('MEDIA_URL', '/media/')
 
 STATIC_ROOT = os.path.join(PROJECT_ROOT, 'static')


### PR DESCRIPTION
Doing a deployment on Hetzenr, which allows for attaching storage volumes to servers.

Since I'm using those to store static assets, specifying the path to `MEDIA_ROOT` through the env can be useful. 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
