### PR TITLE
Fix hard-coded site name in order PDFs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Expand payment section in order view - #3502 by @dominik-zeglen
 - Fixed migrations for default currency - #3235 by @bykof
 - Filter attributes by collection in API - #3508 by @maarcingebala
+- Fixed hard-coded site name in order PDFs - #3526 by @NyanKiyoshi

--- a/saleor/dashboard/order/utils.py
+++ b/saleor/dashboard/order/utils.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.sites.models import Site
 from django.contrib.sites.shortcuts import get_current_site
 from django.template.loader import get_template
 
@@ -31,14 +32,19 @@ def _create_pdf(rendered_template, absolute_url):
 
 
 def create_invoice_pdf(order, absolute_url):
-    ctx = {'order': order}
+    ctx = {
+        'order': order,
+        'site': Site.objects.get_current()}
     rendered_template = get_template(INVOICE_TEMPLATE).render(ctx)
     pdf_file = _create_pdf(rendered_template, absolute_url)
     return pdf_file, order
 
 
 def create_packing_slip_pdf(order, fulfillment, absolute_url):
-    ctx = {'order': order, 'fulfillment': fulfillment}
+    ctx = {
+        'order': order,
+        'fulfillment': fulfillment,
+        'site': Site.objects.get_current()}
     rendered_template = get_template(PACKING_SLIP_TEMPLATE).render(ctx)
     pdf_file = _create_pdf(rendered_template, absolute_url)
     return pdf_file, order

--- a/saleor/static/dashboard/scss/document.scss
+++ b/saleor/static/dashboard/scss/document.scss
@@ -180,13 +180,3 @@ table {
     color: rgba(0, 0, 0, 0.87);
   }
 }
-
-@page {
-  @bottom-center {
-    content: "Saleor eCommerce, Mirumee Software";
-  }
-
-  @bottom-right {
-    content: "Page " counter(page) "/" counter(pages);
-  }
-}

--- a/templates/dashboard/order/pdf/base_pdf.html
+++ b/templates/dashboard/order/pdf/base_pdf.html
@@ -1,0 +1,42 @@
+{% load i18n static %}
+{% load price from taxed_prices %}
+{% load discount_as_negative from voucher %}
+{% load render_bundle from webpack_loader %}
+
+<html lang="{{ LANGUAGE_CODE }}">
+  <head>
+    <title>{% block title %}{% endblock %}</title>
+    {% render_bundle "document" "css" %}
+    <style>
+      @page {
+        @bottom-center {
+          content: "{{ site.name }}";
+        }
+
+        @bottom-right {
+          content:
+            {% blocktrans trimmed context "Order PDF footer page counter" %}
+              "Page " counter(page) "/" counter(pages)
+            {% endblocktrans %};
+        }
+      }
+    </style>
+  </head>
+
+  <body>
+    <header>
+      <div style="float: left">
+        <img alt="logo" src="{% static "images/logo-document.svg" %}" />
+      </div>
+
+      <div style="float: right">
+        {{ order.created }}<br />
+        {% blocktrans trimmed context "Order PDF header" with order_id=order.id %}
+          Order #{{ order_id }}
+        {% endblocktrans %}
+      </div>
+    </header>
+
+    {% block content %}{% endblock %}
+  </body>
+</html>

--- a/templates/dashboard/order/pdf/invoice.html
+++ b/templates/dashboard/order/pdf/invoice.html
@@ -1,158 +1,151 @@
+{% extends "dashboard/order/pdf/base_pdf.html" %}
+
 {% load i18n static %}
 {% load price from taxed_prices %}
 {% load discount_as_negative from voucher %}
 {% load render_bundle from webpack_loader %}
 
-<html>
-<head>
-  <title>{% trans "Invoice for Order" context "Invoice title" %} #{{ order.id }}</title>
-  {% render_bundle 'document' 'css' %}
-</head>
-<body>
-<header>
-  <div style="float:left">
-    <img src="{% static 'images/logo-document.svg' %}">
-  </div>
-  <div
-      style="float:right">{{ order.created }}<br>{% trans 'Order' context 'Invoice header' %} #{{ order.id }}
-  </div>
-</header>
+{% block title %}
+  {% blocktrans trimmed context "Invoice title" with order_id=order.id %}
+    Invoice for Order #{{ order_id }}
+  {% endblocktrans %}
+{% endblock %}
 
-<h2>{% trans "Invoice" context "Order invoice" %}</h2>
-<table width="100%" border="1" cellspacing="0">
-  <thead>
-  <tr>
-    {% if order.shipping_address %}
-      <th align="left" width="50%">
-        {% trans "Shipping address" context "Invoice shipping address" %}
-      </th>
-    {% endif %}
-    {% if order.billing_address %}
-      <th align="left" {% if order.shipping_address %} width="50%"{% endif %}>
-        {% trans "Billing address" context "Invoice billing address" %}
-      </th>
-    {% endif %}
-  </tr>
-  </thead>
-  <tbody>
-  <tr>
-    {% if order.shipping_address %}
-      <td>
-        {% include 'dashboard/includes/_address.html' with address=order.shipping_address only %}
-      </td>
-    {% endif %}
-    {% if order.billing_address %}
-      <td>
-        {% include 'dashboard/includes/_address.html' with address=order.billing_address only %}
-      </td>
-    {% endif %}
-  </tr>
-  </tbody>
-</table>
-
-<h2>{% trans "Items Ordered" context "Invoice ordered items header" %}</h2>
-{% if order %}
-  <table class="data-table order-table bordered">
+{% block content %}
+  <h2>{% trans "Invoice" context "Order invoice" %}</h2>
+  <table width="100%" border="1" cellspacing="0">
     <thead>
     <tr>
-      <th>
-        <div class="wide">
-          {% trans "Item" context "Shipment order table header" %}
-        </div>
-      </th>
-      <th>
-        {% trans "SKU" context "Shipment order table header" %}
-      </th>
-      <th class="right-align">
-        {% trans "Tax rate" context "Shipment order table header" %}
-      </th>
-      <th class="right-align">
-        {% trans "Gross price" context "Shipment order table header" %}
-      </th>
-      <th class="right-align">
-        {% trans "Quantity" context "Shipment order table header" %}
-      </th>
-      <th class="right-align">
-        {% trans "Total" context "Shipment order table header" %}
-      </th>
+      {% if order.shipping_address %}
+        <th align="left" width="50%">
+          {% trans "Shipping address" context "Invoice shipping address" %}
+        </th>
+      {% endif %}
+      {% if order.billing_address %}
+        <th align="left" {% if order.shipping_address %} width="50%"{% endif %}>
+          {% trans "Billing address" context "Invoice billing address" %}
+        </th>
+      {% endif %}
     </tr>
     </thead>
     <tbody>
-      {% for line in order %}
-        <tr>
-          <td>
-            {{ line.product_name|truncatechars:30 }}<br>
-          </td>
-          <td>
-            {{ line.product_sku }}
-          </td>
-          <td class="right-align">
-            {% blocktrans with tax_rate=line.tax_rate context "Order line tax rate value" %}
-              {{ tax_rate }} %
-            {% endblocktrans %}
-          </td>
-          <td class="right-align">
-            {% price line.unit_price.gross %}
-          </td>
-          <td class="right-align">
-            {{ line.quantity }}
-          </td>
-          <td class="right-align">
-            {% price line.get_total.gross %}
-          </td>
-        </tr>
-      {% endfor %}
+    <tr>
+      {% if order.shipping_address %}
+        <td>
+          {% include "dashboard/includes/_address.html" with address=order.shipping_address only %}
+        </td>
+      {% endif %}
+      {% if order.billing_address %}
+        <td>
+          {% include "dashboard/includes/_address.html" with address=order.billing_address only %}
+        </td>
+      {% endif %}
+    </tr>
     </tbody>
   </table>
-{% endif %}
 
-<table class="bordered highlight responsive data-table">
-  <tbody>
-    <tr>
-      <td class="wide">
-        {% trans "Subtotal" context "Order subtotal net price" %}
-      </td>
-      <td class="right-align">
-        {% price order.get_subtotal.gross %}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        {% trans "Shipping" context "Order total shipping price header" %} {% if order.shipping_method_name %}({{ order.shipping_method_name }}){% endif %}
-      </td>
-      <td class="right-align">
-        {% price order.shipping_price.gross %}
-      </td>
-    </tr>
-    <tr>
-      <td>
-        {% trans "Total taxes (included)" context "Order total taxes header" %}
-      </td>
-      <td class="right-align">
-        {% price order.total.tax %}
-      </td>
-    </tr>
-    {% if order.discount_amount %}
+  <h2>{% trans "Items Ordered" context "Invoice ordered items header" %}</h2>
+  {% if order %}
+    <table class="data-table order-table bordered">
+      <thead>
       <tr>
-        <td>
-          {% trans "Discount" context "Order voucher header" %} {% if order.discount_name %}({{ order.translated_discount_name|default:order.discount_name }}){% endif %}
+        <th>
+          <div class="wide">
+            {% trans "Item" context "Shipment order table header" %}
+          </div>
+        </th>
+        <th>
+          {% trans "SKU" context "Shipment order table header" %}
+        </th>
+        <th class="right-align">
+          {% trans "Tax rate" context "Shipment order table header" %}
+        </th>
+        <th class="right-align">
+          {% trans "Gross price" context "Shipment order table header" %}
+        </th>
+        <th class="right-align">
+          {% trans "Quantity" context "Shipment order table header" %}
+        </th>
+        <th class="right-align">
+          {% trans "Total" context "Shipment order table header" %}
+        </th>
+      </tr>
+      </thead>
+      <tbody>
+        {% for line in order %}
+          <tr>
+            <td>
+              {{ line.product_name|truncatechars:30 }}<br>
+            </td>
+            <td>
+              {{ line.product_sku }}
+            </td>
+            <td class="right-align">
+              {% blocktrans with tax_rate=line.tax_rate context "Order line tax rate value" %}
+                {{ tax_rate }} %
+              {% endblocktrans %}
+            </td>
+            <td class="right-align">
+              {% price line.unit_price.gross %}
+            </td>
+            <td class="right-align">
+              {{ line.quantity }}
+            </td>
+            <td class="right-align">
+              {% price line.get_total.gross %}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+
+  <table class="bordered highlight responsive data-table">
+    <tbody>
+      <tr>
+        <td class="wide">
+          {% trans "Subtotal" context "Order subtotal net price" %}
         </td>
         <td class="right-align">
-          {% discount_as_negative order.discount_amount html=True %}
+          {% price order.get_subtotal.gross %}
         </td>
       </tr>
-    {% endif %}
-  </tbody>
-  <tfoot>
-    <tr>
-      <td>
-        {% trans "Grand total" context "Order total price header" %}
-      </td>
-      <td class="right-align">
-        {% price order.total.gross %}
-      </td>
-    </tr>
-  </tfoot>
-</table>
-</body>
-</html>
+      <tr>
+        <td>
+          {% trans "Shipping" context "Order total shipping price header" %} {% if order.shipping_method_name %}({{ order.shipping_method_name }}){% endif %}
+        </td>
+        <td class="right-align">
+          {% price order.shipping_price.gross %}
+        </td>
+      </tr>
+      <tr>
+        <td>
+          {% trans "Total taxes (included)" context "Order total taxes header" %}
+        </td>
+        <td class="right-align">
+          {% price order.total.tax %}
+        </td>
+      </tr>
+      {% if order.discount_amount %}
+        <tr>
+          <td>
+            {% trans "Discount" context "Order voucher header" %} {% if order.discount_name %}({{ order.translated_discount_name|default:order.discount_name }}){% endif %}
+          </td>
+          <td class="right-align">
+            {% discount_as_negative order.discount_amount html=True %}
+          </td>
+        </tr>
+      {% endif %}
+    </tbody>
+    <tfoot>
+      <tr>
+        <td>
+          {% trans "Grand total" context "Order total price header" %}
+        </td>
+        <td class="right-align">
+          {% price order.total.gross %}
+        </td>
+      </tr>
+    </tfoot>
+  </table>
+{% endblock %}

--- a/templates/dashboard/order/pdf/packing_slip.html
+++ b/templates/dashboard/order/pdf/packing_slip.html
@@ -1,92 +1,85 @@
+{% extends "dashboard/order/pdf/base_pdf.html" %}
+
 {% load i18n static %}
 {% load render_bundle from webpack_loader %}
 {% load shop %}
 
-<html>
-<head>
-  <title>Packing slip</title>
-  {% render_bundle 'document' 'css' %}
-</head>
-<body>
-<header>
-  <div style="float:left">
-    <img src="{% static 'images/logo-document.svg' %}">
-  </div>
-  <div
-      style="float:right">{{ order.created }}<br>{% trans "Order ID:" context "Packing slip header" %} {{ order.id }}
-  </div>
-</header>
+{% block title %}
+  {% blocktrans trimmed context "Packing slips title" with fulfillment=fulfillment %}
+    Packing Slips for Fulfillment #{{ fulfillment }}
+  {% endblocktrans %}
+{% endblock %}
 
-<h2>{% trans "Packing Slips" context "Packing slips header" %}</h2>
-<table width="100%" border="1" cellspacing="0">
-  <thead>
-    <tr>
-      {% if order.shipping_address %}
-        <th align="left" width="50%">
-          {% trans "Shipping Details" context "Packing slip shipping details" %}
-        </th>
-      {% endif %}
-      <th align="left"{% if order.shipping_address %} width="50%"{% endif %}>
-        {% trans "Billing Details" context "Packing slip shipping details" %}
-      </th>
-    </tr>
-    </thead>
-  <tbody>
-  <tr>
-    {% if order.shipping_address %}
-      <td valign="top">
-        {% with order.shipping_address as address %}
-          <h2>
-            {% trans "Shipping address" context "Packing slip shipping address" %}
-          </h2>
-          {% include 'dashboard/includes/_address.html' with address=address only %}
-        {% endwith %}
-      </td>
-    {% endif %}
-    <td valign="top">
-      {% with order.billing_address as address %}
-        <h2>
-          {% trans "Billing address" context "Packing slip billing address" %}
-        </h2>
-        {% include 'dashboard/includes/_address.html' with address=address only %}
-      {% endwith %}
-    </td>
-  </tr>
-  </tbody>
-</table>
-
-<h2>{% trans "Items Ordered" context "Order invoice" %}</h2>
-{% if order %}
-  <table class="bordered data-table">
+{% block content %}
+  <h2>{% trans "Packing Slips" context "Packing slips header" %}</h2>
+  <table width="100%" border="1" cellspacing="0">
     <thead>
       <tr>
-        <th class="wide">
-          {% trans "Item" context "Order table header" %}
-        </th>
-        <th>
-          {% trans "SKU" context "Order table header" %}
-        </th>
-        <th class="right-align">
-          {% trans "Quantity" context "Order table header" %}
+        {% if order.shipping_address %}
+          <th align="left" width="50%">
+            {% trans "Shipping Details" context "Packing slip shipping details" %}
+          </th>
+        {% endif %}
+        <th align="left"{% if order.shipping_address %} width="50%"{% endif %}>
+          {% trans "Billing Details" context "Packing slip shipping details" %}
         </th>
       </tr>
-    </thead>
+      </thead>
     <tbody>
-      {% for line in fulfillment %}
-        <tr>
-          <td>
-            {{ line.order_line.product_name }}<br>
-          </td>
-          <td>
-            {{ line.order_line.product_sku }}
-          </td>
-          <td class="right-align">
-            {{ line.quantity }}
-          </td>
-        </tr>
-      {% endfor %}
+    <tr>
+      {% if order.shipping_address %}
+        <td valign="top">
+          {% with order.shipping_address as address %}
+            <h2>
+              {% trans "Shipping address" context "Packing slip shipping address" %}
+            </h2>
+            {% include "dashboard/includes/_address.html" with address=address only %}
+          {% endwith %}
+        </td>
+      {% endif %}
+      <td valign="top">
+        {% with order.billing_address as address %}
+          <h2>
+            {% trans "Billing address" context "Packing slip billing address" %}
+          </h2>
+          {% include "dashboard/includes/_address.html" with address=address only %}
+        {% endwith %}
+      </td>
+    </tr>
     </tbody>
   </table>
-{% endif %}
-</body>
-</html>
+
+  <h2>{% trans "Items Ordered" context "Order invoice" %}</h2>
+  {% if order %}
+    <table class="bordered data-table">
+      <thead>
+        <tr>
+          <th class="wide">
+            {% trans "Item" context "Order table header" %}
+          </th>
+          <th>
+            {% trans "SKU" context "Order table header" %}
+          </th>
+          <th class="right-align">
+            {% trans "Quantity" context "Order table header" %}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for line in fulfillment %}
+          <tr>
+            <td>
+              {{ line.order_line.product_name }}<br>
+            </td>
+            <td>
+              {{ line.order_line.product_sku }}
+            </td>
+            <td class="right-align">
+              {{ line.quantity }}
+            </td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
This replace the hard-coded `Saleor eCommerce, Mirumee Software` from the order PDFs stylesheet by the site name. This goes through a base PDF HTML template file containing the footer CSS code taking the data from the site settings.

Fixes #3510.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
