### PR TITLE
Fix wrong description key for voucher field

### DIFF
--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -21,7 +21,7 @@ class DiscountQueries(graphene.ObjectType):
         Voucher, id=graphene.Argument(graphene.ID, required=True),
         description='Lookup a voucher by ID.')
     vouchers = PrefetchingConnectionField(
-        Voucher, query=graphene.String(description=DESCRIPTIONS['product']),
+        Voucher, query=graphene.String(description=DESCRIPTIONS['voucher']),
         description="List of the shop\'s vouchers.")
 
     @permission_required('discount.manage_discounts')


### PR DESCRIPTION
I want to merge this change because I think description of `Voucher` Field should relate to `voucher` key in description dict, not `product`.

### Screenshots

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
