### PR TITLE
Add migrate container to run Saleor's Django migrations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Filter attributes by collection in API - #3508 by @maarcingebala
 - Fixed hard-coded site name in order PDFs - #3526 by @NyanKiyoshi
 - Extract enums to separate files - #3523 by @maarcingebala
+- Add `migrate` docker container to automatically run migrations - #3532 by @hairychris

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,23 @@ services:
     depends_on:
       - db
       - redis
+      - migrate
     command: python manage.py runserver 0.0.0.0:8000
+
+  migrate:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+      args:
+        STATIC_URL: '/static/'
+    command: python manage.py migrate
+    restart: no
+    networks:
+      - saleor-backend-tier
+    env_file: common.env
+    depends_on:
+      - db
+      - redis
 
   db:
     image: library/postgres:latest

--- a/docs/customization/docker.rst
+++ b/docs/customization/docker.rst
@@ -30,24 +30,26 @@ Usage
 
     $ docker-compose build
 
+2. Run the containers (migrations are run automatically)
 
-2. Prepare the database
+    .. code-block:: bash
 
-   .. code-block:: bash
+     $ docker-compose up
 
-    $ docker-compose run web python3 manage.py migrate
-    $ docker-compose run web python3 manage.py collectstatic
-    $ docker-compose run web python3 manage.py populatedb --createsuperuser
+3. Collect static assets
 
-   The ``--createsuperuser`` argument creates an admin account for
-   ``admin@example.com`` with the password set to ``admin``.
+    .. code-block:: bash
 
+     $ docker-compose run migrate python3 manage.py collectstatic
 
-3. Run the containers
+4. Optionally add sample data to the database
 
-   .. code-block:: bash
+    .. code-block:: bash
+    
+     $ docker-compose run migrate python3 manage.py populatedb --createsuperuser
 
-    $ docker-compose up
+    The ``--createsuperuser`` argument creates an admin account for
+    ``admin@example.com`` with the password set to ``admin``.
 
 
 By default, the application is started in debug mode and is configured to listen on port ``8000``.


### PR DESCRIPTION
This makes it easier to get up and running quickly, it does mean that the migrations will be run on startup every time but I don't think this should cause any issues and in some ways is good.

I want to merge this change because running extra commands inside the docker containers at boot (e.g. docker-compose run web python manage.py migrate or whatever) is annoying.

Due to the restart policy of these containers, you also sometimes end up with multiple long running containers and it's a mess. It seems much cleaner to just automatically run the migrations in development by having a migrate container which the web container depends on with no restart set.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] The changes are tested.
2. [x] The code is documented (docstrings, project documentation).
3. [x] Changes are mentioned in the changelog.

This is WIP, I need to add changelog and documentation so please don't merge just yet.
