### PR TITLE
Fix handling of order without shipping address on the stripe gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,3 +43,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extract enums to separate files - #3523 by @maarcingebala
 - Add default variant create to Product mutations - #3505 by @fowczarek
 - Fix attribute filters in parent category - #3535 by @fowczarek
+- Fixed the no shipping orders payment crash on Stripe - #3550 by @NyanKiyoshi

--- a/saleor/payment/gateways/stripe/utils.py
+++ b/saleor/payment/gateways/stripe/utils.py
@@ -1,5 +1,10 @@
 from decimal import Decimal
 
+from django_countries import countries
+
+from ....account.models import Address
+from ....payment.models import Payment
+
 # List of zero-decimal currencies
 # Since there is no public API in Stripe backend or helper function
 # in Stripe's Python library, this list is straight out of Stripe's docs
@@ -50,3 +55,19 @@ def get_currency_from_stripe(currency):
     Stripe's currency is using lowercase while Saleor is using uppercase.
     """
     return currency.upper()
+
+
+def get_payment_billing_fullname(payment: Payment):
+    # Get billing name from payment
+    return '%s %s' % (
+        payment.billing_last_name, payment.billing_first_name)
+
+
+def shipping_address_to_stripe_dict(shipping_address: Address):
+    return {
+        'line1': shipping_address.street_address_1,
+        'line2': shipping_address.street_address_2,
+        'city': shipping_address.city,
+        'state': shipping_address.country_area,
+        'postal_code': shipping_address.postal_code,
+        'country': dict(countries).get(shipping_address.country, '')}


### PR DESCRIPTION
Fix #3549.
- No longer provides Stripe with the (inexisting) shipping information during Stripe payments on orders with no shipping. Only the billing address;
- Refactored the `capture` parameter of `_create_stripe_charge` to `should_capture` to fix the shadow name;
- Refactored `_create_stripe_charge`'s process to allow proper testing.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
