### PR TITLE
fix #3594 discounts aren't applied if sale doesn't have an end date

### DIFF
--- a/saleor/discount/models.py
+++ b/saleor/discount/models.py
@@ -142,7 +142,8 @@ class Voucher(models.Model):
 class SaleQueryset(models.QuerySet):
     def active(self, date):
         return self.filter(
-            end_date__gte=date, start_date__lte=date)
+            Q(end_date__isnull=True) | Q(end_date__gte=date),
+            start_date__lte=date)
 
 
 class VoucherTranslation(models.Model):

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -221,7 +221,7 @@ def test_get_voucher_discount_all_products(
     (date.today(), date.today(), None, True),
     (date.today() + timedelta(weeks=10), date.today(), None, True),
     ))
-def test_sale_active2(current_date, start_date, end_date, is_active):
+def test_sale_active(current_date, start_date, end_date, is_active):
     Sale.objects.create(
         type=DiscountValueType.FIXED,
         value=5,

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -213,15 +213,19 @@ def test_get_voucher_discount_all_products(
     assert discount == Money(expected_value, 'USD')
 
 
-@pytest.mark.parametrize('current_date, is_active', (
-    (date.today(), True),
-    (date.today() + timedelta(days=1), True),
-    (date.today() + timedelta(days=2), False),
-    (date.today() - timedelta(days=2), False)))
-def test_sale_active(current_date, is_active):
+@pytest.mark.parametrize('current_date, start_date, end_date, is_active', (
+    (date.today(), date.today(), date.today() + timedelta(days=1), True),
+    (date.today() + timedelta(days=1), date.today(), date.today() + timedelta(days=1), True),
+    (date.today() + timedelta(days=2), date.today(), date.today() + timedelta(days=1), False),
+    (date.today() - timedelta(days=2), date.today(), date.today() + timedelta(days=1), False),
+    (date.today(), date.today(), None, True),
+    (date.today() + timedelta(weeks=10), date.today(), None, True),
+    ))
+def test_sale_active2(current_date, start_date, end_date, is_active):
     Sale.objects.create(
         type=DiscountValueType.FIXED,
-        value=5, start_date=date.today(),
-        end_date=date.today() + timedelta(days=1))
+        value=5,
+        start_date=start_date,
+        end_date=end_date)
     sale_is_active = Sale.objects.active(date=current_date).exists()
     assert is_active == sale_is_active


### PR DESCRIPTION
I want to merge this change because...

Addresses #3594 
the active() helper method of identify current sales was not working if no end date was set.

This change also includes a refactor of the tests to allow for selection of start/end dates

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
