### PR TITLE
[Refactor] Do not return errors from clean_instance method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix bug where products in homepage should be visible to request.user instead of anonymous user - #3598 by @jxltom
 - Simplify mutation's error checking - #3589 by @dominik-zeglen
 - Add checkout assignment to the logged in customer - #3587 by @fowczarek
+- Refactor `clean_instance`, so it does not returns errors anymore - #3597 by @akjanik

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -190,7 +190,6 @@ class UserDelete(ModelDeleteMutation):
         elif instance.is_superuser:
             cls.add_error(
                 errors, 'id', 'Only superuser can delete his own account.')
-        return errors
 
 
 class CustomerDelete(UserDelete):
@@ -211,7 +210,6 @@ class CustomerDelete(UserDelete):
         super().clean_instance(info, instance, errors)
         if instance.is_staff:
             cls.add_error(errors, 'id', 'Cannot delete a staff account.')
-        return errors
 
 
 class StaffCreate(ModelMutation):
@@ -315,7 +313,6 @@ class StaffDelete(UserDelete):
         if not instance.is_staff:
             cls.add_error(
                 errors, 'id', 'Cannot delete a non-staff user.')
-        return errors
 
     @classmethod
     def mutate(cls, root, info, **data):

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -123,7 +123,6 @@ class BaseMutation(graphene.Mutation):
                 for message in message_dict[field]:
                     field = snake_to_camel_case(field)
                     cls.add_error(errors, field, message)
-        return errors
 
     @classmethod
     def construct_instance(cls, instance, cleaned_data):


### PR DESCRIPTION
I think, we do not need to return `errors` from `clean_instance`, because this method internally updates passed list via `add_error` method.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
