### PR TITLE
Support get correct payment status for order without any payments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add charges taxes on shipping field to shop settings in GraphQL Api - #3603 by @fowczarek
 - Make order fields sequence same as dashboard 2.0 - #3606 by @jxltom
 - Fix bug where orders can not be filtered by payment status - #3608 by @jxltom
+- Support get correct payment status for order without any payments - #3605 by @jxltom

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -269,12 +269,12 @@ class Order(CountableDjangoObjectType):
     @staticmethod
     @gql_optimizer.resolver_hints(prefetch_related='payments')
     def resolve_payment_status(self, info):
-        return self.get_last_payment_status()
+        return self.get_payment_status()
 
     @staticmethod
     @gql_optimizer.resolver_hints(prefetch_related='payments')
     def resolve_payment_status_display(self, info):
-        return self.get_last_payment_status_display()
+        return self.get_payment_status_display()
 
     @staticmethod
     def resolve_payments(self, info):

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -188,6 +188,18 @@ class Order(models.Model):
             return last_payment.get_charge_status_display()
         return None
 
+    def get_payment_status(self):
+        status = self.get_last_payment_status()
+        if status is None:
+            return ChargeStatus.NOT_CHARGED
+        return status
+
+    def get_payment_status_display(self):
+        status = self.get_last_payment_status_display()
+        if status is None:
+            return dict(ChargeStatus.CHOICES).get(ChargeStatus.NOT_CHARGED)
+        return status
+
     def is_pre_authorized(self):
         return self.payments.filter(
             is_active=True,

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -176,29 +176,17 @@ class Order(models.Model):
     def get_last_payment(self):
         return max(self.payments.all(), default=None, key=attrgetter('pk'))
 
-    def get_last_payment_status(self):
-        last_payment = self.get_last_payment()
-        if last_payment:
-            return last_payment.charge_status
-        return None
-
-    def get_last_payment_status_display(self):
+    def get_payment_status(self):
         last_payment = self.get_last_payment()
         if last_payment:
             return last_payment.get_charge_status_display()
-        return None
-
-    def get_payment_status(self):
-        status = self.get_last_payment_status()
-        if status is None:
-            return ChargeStatus.NOT_CHARGED
-        return status
+        return ChargeStatus.NOT_CHARGED
 
     def get_payment_status_display(self):
-        status = self.get_last_payment_status_display()
-        if status is None:
-            return dict(ChargeStatus.CHOICES).get(ChargeStatus.NOT_CHARGED)
-        return status
+        last_payment = self.get_last_payment()
+        if last_payment:
+            return last_payment.get_charge_status_display()
+        return dict(ChargeStatus.CHOICES).get(ChargeStatus.NOT_CHARGED)
 
     def is_pre_authorized(self):
         return self.payments.filter(


### PR DESCRIPTION
Current storefront 1.0 supports order without payments. But the payment status of order is got from last payment. This means payment status of order without any payments will display as ```None```, this is unfriendly and confusing to users. This PR return default payment status ```NOT_CHARGED``` for order without any payments.

### Screenshots

Before:
![screenshot from 2019-01-16 11-53-29](https://user-images.githubusercontent.com/1401630/51225411-6bb6d600-1985-11e9-85f6-da0d49af4aa6.png)

After:
![screenshot from 2019-01-16 11-52-59](https://user-images.githubusercontent.com/1401630/51225418-75d8d480-1985-11e9-90c4-25c0fa2ad234.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
