### PR TITLE
Make order fields display sequence in django-based dashboard same as dashboard 2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Refactor `clean_instance`, so it does not returns errors anymore - #3597 by @akjanik
 - Fix logo placement - #3602 by @dominik-zeglen
 - Add charges taxes on shipping field to shop settings in GraphQL Api - #3603 by @fowczarek
+- Make order fields sequence same as dashboard 2.0 - #3606 by @jxltom

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -11,60 +11,6 @@
   <div class="row">
     <div class="col s12">
       <div class="card">
-        <div class="data-table-header{% if not preauthorized_payments %} data-table-header--no-data{% endif %}">
-          <span class="data-table-title" title="{% blocktrans trimmed with counter=preauthorized_payments.count context "Dashboard homepage summary header title" %}Showing last {{ counter }} results{% endblocktrans %}">
-            {% trans "Preauthorized payments" context "Dashboard homepage table title" %}
-          </span>
-        </div>
-        {% if preauthorized_payments %}
-          <div class="data-table-container">
-            <table class="bordered highlight responsive data-table">
-              <thead>
-                <tr>
-                  <th>
-                    {% trans "Order" context "Preauthorized payments table header" %}
-                  </th>
-                  <th>
-                    {% trans "Date" context "Preauthorized payments table header" %}
-                  </th>
-                  <th>
-                    {% trans "Customer" context "Preauthorized payments table header" %}
-                  </th>
-                  <th class="right-align">
-                    {% trans "Amount" context "Preauthorized payments table header" %}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for payment in preauthorized_payments %}
-                  <tr data-action-go="{% url "dashboard:order-details" order_pk=payment.order.pk %}">
-                    <td>
-                      {{ payment.order }}
-                    </td>
-                    <td>
-                      {{ payment.created }}
-                    </td>
-                    <td>
-                      {{ payment.order.user|default:_("Guest") }}
-                    </td>
-                    <td class="right-align">
-                      {% price payment.get_total %}
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-          </div>
-        {% else %}
-          <div class="card-content card-content--no-data not-found">
-            <p class="grey-text">
-              {% trans "No preauthorized payments." context "Empty Preauthorized payments table message" %}
-            </p>
-          </div>
-        {% endif %}
-      </div>
-
-      <div class="card">
         <div class="data-table-header{% if not orders_to_ship %} data-table-header--no-data{% endif %}">
           <span class="data-table-title" title="{% blocktrans trimmed with counter=orders_to_ship|length context "Dashboard homepage summary header title" %}Showing last {{ counter }} results{% endblocktrans %}">
             {% trans "Orders ready for shipment" context "Dashboard homepage table title" %}
@@ -128,6 +74,61 @@
           </div>
         {% endif %}
       </div>
+
+      <div class="card">
+        <div class="data-table-header{% if not preauthorized_payments %} data-table-header--no-data{% endif %}">
+          <span class="data-table-title" title="{% blocktrans trimmed with counter=preauthorized_payments.count context "Dashboard homepage summary header title" %}Showing last {{ counter }} results{% endblocktrans %}">
+            {% trans "Preauthorized payments" context "Dashboard homepage table title" %}
+          </span>
+        </div>
+        {% if preauthorized_payments %}
+          <div class="data-table-container">
+            <table class="bordered highlight responsive data-table">
+              <thead>
+                <tr>
+                  <th>
+                    {% trans "Order" context "Preauthorized payments table header" %}
+                  </th>
+                  <th>
+                    {% trans "Date" context "Preauthorized payments table header" %}
+                  </th>
+                  <th>
+                    {% trans "Customer" context "Preauthorized payments table header" %}
+                  </th>
+                  <th class="right-align">
+                    {% trans "Amount" context "Preauthorized payments table header" %}
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for payment in preauthorized_payments %}
+                  <tr data-action-go="{% url "dashboard:order-details" order_pk=payment.order.pk %}">
+                    <td>
+                      {{ payment.order }}
+                    </td>
+                    <td>
+                      {{ payment.created }}
+                    </td>
+                    <td>
+                      {{ payment.order.user|default:_("Guest") }}
+                    </td>
+                    <td class="right-align">
+                      {% price payment.get_total %}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        {% else %}
+          <div class="card-content card-content--no-data not-found">
+            <p class="grey-text">
+              {% trans "No preauthorized payments." context "Empty Preauthorized payments table message" %}
+            </p>
+          </div>
+        {% endif %}
+      </div>
+
       <div class="card">
         <div class="data-table-header{% if not low_stock %} data-table-header--no-data{% endif %}">
           <span class="data-table-title" title="{% blocktrans trimmed with counter=low_stock.count context "Dashboard homepage summary header title" %}Showing last {{ counter }} results{% endblocktrans %}">

--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -24,15 +24,17 @@
                   <th>
                     #
                   </th>
-                  <th></th>
-                  <th>
-                    {% trans "Customer" context "Orders table header" %}
-                  </th>
                   <th>
                     {% trans "Placed on" context "Orders table header" %}
                   </th>
                   <th>
+                    {% trans "Customer" context "Orders table header" %}
+                  </th>
+                  <th>
                     {% trans "Payment status" context "Orders table header" %}
+                  </th>
+                  <th>
+                    {% trans "Order status" context "Orders table header" %}
                   </th>
                   <th>
                     {% trans "Total" context "Orders table header" %}
@@ -46,17 +48,17 @@
                       #{{ order.id }}
                     </td>
                     <td>
-                      {% render_order_status order.status order.get_status_display %}
+                      {{ order.created }}
                     </td>
                     {% trans "Guest" context "Anonymous user account value" as guest %}
                     <td>
                       {{ order.user|default:guest }}
                     </td>
                     <td>
-                      {{ order.created }}
+                      {% render_status order.get_payment_status order.get_payment_status_display %}
                     </td>
                     <td>
-                      {% render_status order.get_last_payment_status order.get_last_payment_status_display %}
+                      {% render_order_status order.status order.get_status_display %}
                     </td>
                     <td class="right-align">
                       {% price order.total.gross %}

--- a/templates/dashboard/order/list.html
+++ b/templates/dashboard/order/list.html
@@ -41,16 +41,17 @@
                 <tr>
                   {% sorting_header 'pk' '#' %}
 
-                  <th></th>
+                  {% trans "Placed on" context "Orders table header" as label %}
+                  {% sorting_header 'created' label %}
 
                   {% trans "Customer" context "Orders table header" as label %}
                   {% sorting_header 'email' label %}
 
-                  {% trans "Placed on" context "Orders table header" as label %}
-                  {% sorting_header 'created' label %}
-
                   {% trans "Payment status" context "Orders table header" as label %}
                   {% sorting_header 'payment_status' label %}
+
+                  {% trans "Order status" context "Orders table header" as label %}
+                  {% sorting_header 'order_status' label %}
 
                   {% trans "Total" context "Orders table header" as label %}
                   {% sorting_header 'total' label %}
@@ -63,17 +64,17 @@
                       #{{ order.id }}
                     </td>
                     <td>
-                      {% render_order_status order.status order.get_status_display %}
+                      {{ order.created }}
                     </td>
                     {% trans "Guest" context "Anonymous user account value" as guest %}
                     <td>
                       {{ order.user|default:guest }}
                     </td>
                     <td>
-                      {{ order.created }}
+                      {% render_status order.get_payment_status order.get_payment_status_display %}
                     </td>
                     <td>
-                      {% render_status order.get_last_payment_status order.get_last_payment_status_display %}
+                      {% render_order_status order.status order.get_status_display %}
                     </td>
                     <td class="right-align">
                       {% price order.total.gross %}


### PR DESCRIPTION
The display sequence of order sequence as well as index page in django-based dashboard is different with that in dashboard 2.0. This PR make them having same sequence by adjusting the layout in django-based dashboard.

Blocked by https://github.com/mirumee/saleor/pull/3605 which should be merged first.

### Screenshots

For index page:
before:
![screenshot from 2019-01-16 14-12-13](https://user-images.githubusercontent.com/1401630/51229862-e50bf400-1998-11e9-9bd5-df7e99614271.png)
after:
![screenshot from 2019-01-16 14-10-29](https://user-images.githubusercontent.com/1401630/51229865-e89f7b00-1998-11e9-8406-02f087bfd0b1.png)

For order list page:
before:
![screenshot from 2019-01-16 14-12-33](https://user-images.githubusercontent.com/1401630/51229874-f0f7b600-1998-11e9-8f6b-d9df72f92373.png)
after:
![screenshot from 2019-01-16 14-10-56](https://user-images.githubusercontent.com/1401630/51229876-f2c17980-1998-11e9-9da2-c7d53cf80f6d.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
