### PR TITLE
Continue fix logo placement in storefront 1.0 and dashboard 2.0's login page

### DIFF
--- a/saleor/static/dashboard-next/auth/components/LoginPage/LoginPage.tsx
+++ b/saleor/static/dashboard-next/auth/components/LoginPage/LoginPage.tsx
@@ -47,7 +47,9 @@ const styles = (theme: Theme) =>
     logo: {
       "& svg": {
         display: "block",
-        margin: `0 auto ${theme.spacing.unit * 7}px`
+        height: "38px",
+        margin: `0 auto ${theme.spacing.unit * 7}px`,
+        width: "auto"
       }
     },
     panel: {

--- a/saleor/static/scss/components/_footer.scss
+++ b/saleor/static/scss/components/_footer.scss
@@ -36,7 +36,8 @@
   &__logo {
     margin-bottom: $global-margin;
     svg {
-      width: 113px;
+      height: 38px;
+      width: auto;
     }
   }
   hr {

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -176,7 +176,8 @@
     display: flex;
     align-items: center;
     svg {
-      width: 113px;
+      height: 38px;
+      width: auto;
     }
     .menu-icon-mobile {
       position: relative;

--- a/templates/base.html
+++ b/templates/base.html
@@ -119,7 +119,7 @@
               <svg data-src="{% static "images/mobile-menu.svg" %}" width="28px" height="20px"/>
             </div>
             <a href="{% url 'home' %}">
-              <svg data-src="{% static "images/logo-document.svg" %}" height="38px"/>
+              <svg data-src="{% static "images/logo-document.svg" %}"/>
             </a>
           </div>
           <div class="col-2 col-md-5 navbar__search static">
@@ -290,7 +290,7 @@
       <div class="row">
         <div class="col-4">
           <a href="{% url 'home' %}" class="footer__logo">
-            <svg data-src="{% static "images/logo-document.svg" %}" height="38px"/>
+            <svg data-src="{% static "images/logo-document.svg" %}"/>
           </a>
         </div>
         <div class="col-8 footer__copy-text">COPYRIGHT © 2009–2019 MIRUMEE SOFTWARE</div>


### PR DESCRIPTION
The logo should have ```auto``` width but fixed heights. Othewise the logo width will display incorrectly when screen size changes.

### Screenshots

Storefront 1.0:
before:
![screenshot from 2019-01-17 14-52-54](https://user-images.githubusercontent.com/1401630/51302343-05a57e00-1a6d-11e9-833f-f3b790f247a6.png)
after:
![screenshot from 2019-01-17 14-55-45](https://user-images.githubusercontent.com/1401630/51302346-076f4180-1a6d-11e9-891d-39b47422c5fa.png)

Dashboard 2.0's login page:
before:
![screenshot from 2019-01-17 14-53-22](https://user-images.githubusercontent.com/1401630/51302371-181fb780-1a6d-11e9-9a64-03087a8ea8f0.png)

after:
![screenshot from 2019-01-17 14-49-09](https://user-images.githubusercontent.com/1401630/51302375-1bb33e80-1a6d-11e9-99b5-e4967494160d.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
