### PR TITLE
Display payment status in account order list page and account order detail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,3 +31,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing migrations for tax rate choices - #3629 by @jxltom
 - Add ShopFetchTaxRates mutation - #3622 by @fowczarek
 - Add taxes section - #3622 by @dominik-zeglen
+- Display payment status in account order list page and account order detail page - #3637 by @jxltom

--- a/templates/account/details.html
+++ b/templates/account/details.html
@@ -24,7 +24,7 @@
   <div class="account">
     <div class="account__nav container">
       <h2>{% trans "My account" %}</h2>
-      <ul class="nav nav-tabs col-lg-10 m-auto" role="tablist">
+      <ul class="nav nav-tabs col-lg-11 m-auto" role="tablist">
         <li class="nav-item">
           <a class="nav-link active" data-toggle="tab" href="#orders" role="tab">
             <h3>{% trans "Recent Orders" context "User profile tab" %}</h3>
@@ -49,45 +49,49 @@
         </li>
       </ul>
     </div>
-    <div class="tab-content col-lg-10 m-auto">
+    <div class="tab-content col-lg-11 m-auto">
       <div class="tab-pane active fade show" id="orders" role="tabpanel">
         <div id="accordion" role="tablist" aria-multiselectable="true">
           {% if orders|length %}
             <div class="table__header">
               <div class="row">
-                <div class="col-md-2 col-3">
+                <div class="col-md-2 col-4">
                   <small>{% trans "Order" context "Recent orders column title" %}</small>
                 </div>
                 <div class="col-md-3 d-none d-md-block">
                   <small>{% trans "Date" context "Recent orders column title" %}</small>
                 </div>
-                <div class="col-md-2 col-4 text-right">
+                <div class="col-md-2 col-6">
                   <small>{% trans "Summary" context "Recent orders column title" %}</small>
                 </div>
-                <div class="col-md-4 d-none d-md-block">
+                <div class="col-md-2 d-none d-md-block">
+                  <small>{% trans "Payment status" context "Recent orders column title" %}</small>
+                </div>
+                <div class="col-md-2 d-none d-md-block">
                   <small>{% trans "Status" context "Recent orders column title" %}</small>
                 </div>
-                <div class="col-md-1 col-5"></div>
+                <div class="col-md-1 col-2"></div>
               </div>
             </div>
             {% for order in orders %}
               <div class="table__row">
                 <div class="row">
-                  <div class="col-md-2 col-3">
+                  <div class="col-md-2 col-4">
                     {{ order }}
                   </div>
                   <div class="col-md-3 d-none d-md-block">
                     {{ order.created }}
                   </div>
-                  <div class="col-md-2 col-4">
-                    <span class="float-right">
-                      {% price order.total.gross %}
-                    </span>
+                  <div class="col-md-2 col-6">
+                    {% price order.total.gross %}
                   </div>
-                  <div class="col-md-4 d-none d-md-block">
+                  <div class="col-md-2 d-none d-md-block">
+                    {% render_status order.get_payment_status order.get_payment_status_display %}
+                  </div>
+                  <div class="col-md-2 d-none d-md-block">
                     {% render_order_status order.status order.get_status_display %}
                   </div>
-                  <div class="col-md-1 col-5">
+                  <div class="col-md-1 col-2">
                     <a href="{{ order.get_absolute_url }}" class="float-right link--styled">
                       {% trans "Details" context "Recent orders link text" %}
                     </a>

--- a/templates/account/details.html
+++ b/templates/account/details.html
@@ -68,7 +68,7 @@
                   <small>{% trans "Payment status" context "Recent orders column title" %}</small>
                 </div>
                 <div class="col-md-2 d-none d-md-block">
-                  <small>{% trans "Status" context "Recent orders column title" %}</small>
+                  <small>{% trans "Order status" context "Recent orders column title" %}</small>
                 </div>
                 <div class="col-md-1 col-2"></div>
               </div>

--- a/templates/order/details.html
+++ b/templates/order/details.html
@@ -46,8 +46,8 @@
   <div class="row order-details">
     <div class="col-lg-10 m-auto">
       <h2 class="order-details__header">
-        {% blocktrans trimmed with order_status=order.get_status_display context "Order detail text" %}
-          Order {{ order }}: {{ order_status }}
+        {% blocktrans trimmed with payment_status=order.get_payment_status_display order_status=order.get_status_display context "Order detail text" %}
+          Order {{ order }}: {{ payment_status }} & {{ order_status }}
         {% endblocktrans %}
       </h2>
       {% if not order.is_partly_paid %}


### PR DESCRIPTION
The payment status is also very important for customers such as fully refunded. Only displaying order status probably is not enough. It will be nice to display the payment status of an order in storefront 1.0's account page.

### Screenshots

![screenshot from 2019-01-23 14-55-08](https://user-images.githubusercontent.com/1401630/51590022-996ec280-1f23-11e9-8045-a1b523a1f76a.png)
![screenshot from 2019-01-23 14-55-23](https://user-images.githubusercontent.com/1401630/51590028-9bd11c80-1f23-11e9-9bf3-1594770266ba.png)
![screenshot from 2019-01-23 15-16-19](https://user-images.githubusercontent.com/1401630/51590031-9d024980-1f23-11e9-8612-a816bd9815aa.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
