### PR TITLE
Infer transaction kind from operation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add ShopFetchTaxRates mutation - #3622 by @fowczarek
 - Add taxes section - #3622 by @dominik-zeglen
 - Expose in API list of supported payment gateways - #3639 by @fowczarek
+- Infer default transaction kind from operation type instead of passing it manually  - #3646 by @jxltom

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -176,9 +176,7 @@ def clean_authorize(payment: Payment):
         raise PaymentError('Charged transactions cannot be authorized again.')
 
 
-def call_gateway(
-        operation_type, transaction_kind,
-        payment, payment_token, **extra_params):
+def call_gateway(operation_type, payment, payment_token, **extra_params):
     """Helper that calls the passed gateway function and handles exceptions.
 
     Additionally does validation of the returned gateway response."""
@@ -195,6 +193,21 @@ def call_gateway(
     except AttributeError:
         error_msg = 'Gateway doesn\'t implement {} operation'.format(
             operation_type.name)
+        logger.exception(error_msg)
+        raise PaymentError(error_msg)
+
+    # The transaction kind is provided as a default value
+    # for creating transactions when gateway has invalid response
+    # The PROCESS_PAYMENT operation has CAPTURE as default transaction kind
+    # For other operations, the transaction kind is same wtih operation type
+    default_transaction_kind = TransactionKind.CAPTURE
+    if operation_type != OperationType.PROCESS_PAYMENT:
+        default_transaction_kind = getattr(
+            TransactionKind, OperationType(operation_type).name)
+
+    # Validate the default transaction kind
+    if default_transaction_kind not in dict(TransactionKind.CHOICES):
+        error_msg = 'The default transaction kind is invalid'
         logger.exception(error_msg)
         raise PaymentError(error_msg)
 
@@ -217,7 +230,7 @@ def call_gateway(
         for response in gateway_response:
             transactions.append(create_transaction(
                 payment=payment,
-                kind=transaction_kind,
+                kind=default_transaction_kind,
                 payment_information=payment_information,
                 error_msg=error_msg,
                 gateway_response=response))
@@ -280,7 +293,6 @@ def gateway_process_payment(
     """Performs whole payment process on a gateway."""
     transaction = call_gateway(
         operation_type=OperationType.PROCESS_PAYMENT,
-        transaction_kind=TransactionKind.CAPTURE,
         payment=payment, payment_token=payment_token, amount=payment.total)
 
     payment.charge_status = ChargeStatus.CHARGED
@@ -312,7 +324,6 @@ def gateway_charge(
 
     transaction = call_gateway(
         operation_type=OperationType.CHARGE,
-        transaction_kind=TransactionKind.CHARGE,
         payment=payment, payment_token=payment_token, amount=amount)
 
     payment.charge_status = ChargeStatus.CHARGED
@@ -336,7 +347,6 @@ def gateway_authorize(payment: Payment, payment_token: str) -> Transaction:
 
     return call_gateway(
         operation_type=OperationType.AUTH,
-        transaction_kind=TransactionKind.AUTH,
         payment=payment, payment_token=payment_token)
 
 
@@ -355,7 +365,6 @@ def gateway_capture(payment: Payment, amount: Decimal = None) -> Transaction:
 
     transaction = call_gateway(
         operation_type=OperationType.CAPTURE,
-        transaction_kind=TransactionKind.CAPTURE,
         payment=payment, payment_token=payment_token, amount=amount)
 
     payment.charge_status = ChargeStatus.CHARGED
@@ -381,7 +390,6 @@ def gateway_void(payment) -> Transaction:
 
     transaction = call_gateway(
         operation_type=OperationType.VOID,
-        transaction_kind=TransactionKind.VOID,
         payment=payment, payment_token=payment_token)
 
     payment.is_active = False
@@ -416,7 +424,6 @@ def gateway_refund(payment, amount: Decimal = None) -> Transaction:
 
     transaction = call_gateway(
         operation_type=OperationType.REFUND,
-        transaction_kind=TransactionKind.REFUND,
         payment=payment, payment_token=payment_token, amount=amount)
 
     changed_fields = ['captured_amount']

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -849,7 +849,7 @@ def test_call_gateway_invalid_response(
 
     with pytest.raises(PaymentError) as e:
         call_gateway(
-            operation_type=OperationType.AUTH, transaction_kind='auth',
+            operation_type=OperationType.AUTH,
             payment=payment_dummy, payment_token='token')
     assert str(e.value) == 'Gateway response validation failed'
 
@@ -864,7 +864,7 @@ def test_call_gateway_function_not_implemented(
 
     with pytest.raises(PaymentError) as e:
         call_gateway(
-            operation_type=OperationType.AUTH, transaction_kind='auth',
+            operation_type=OperationType.AUTH,
             payment=payment_dummy, payment_token='token')
     assert str(e.value) == 'Gateway doesn\'t implement AUTH operation'
 
@@ -878,6 +878,6 @@ def test_call_gateway_generic_error(
 
     with pytest.raises(PaymentError) as e:
         call_gateway(
-            operation_type=OperationType.AUTH, transaction_kind='auth',
+            operation_type=OperationType.AUTH,
             payment=payment_dummy, payment_token='token')
     assert str(e.value) == 'Gateway encountered an error'


### PR DESCRIPTION
The transaction kind in ```create_transaction``` is only used as a default value when gateway has invalid response or has exceptions. It can be infered from operation type. There is no need to pass it manually when calling ```call_gateway``` everytime. This small refactor makes payment gateway API clearer.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
