### PR TITLE
Support set dummy payment status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add ShopFetchTaxRates mutation - #3622 by @fowczarek
 - Add taxes section - #3622 by @dominik-zeglen
 - Expose in API list of supported payment gateways - #3639 by @fowczarek
+- Support set arbitary charge status for dummy gateway in storefront 1.0 - #3648 by @jxltom

--- a/saleor/payment/gateways/dummy/forms.py
+++ b/saleor/payment/gateways/dummy/forms.py
@@ -1,5 +1,3 @@
-import uuid
-
 from django import forms
 from django.utils.translation import pgettext_lazy
 
@@ -13,4 +11,7 @@ class DummyPaymentForm(forms.Form):
         widget=forms.RadioSelect)
 
     def get_payment_token(self):
-        return str(uuid.uuid4())
+        """Return selected charge status instead of token for testing only.
+        Gateways used for production should return an actual token instead."""
+        charge_status = self.cleaned_data['charge_status']
+        return charge_status

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -292,7 +292,7 @@ def _gateway_postprocess(transaction, payment):
     elif transaction_kind == TransactionKind.REFUND:
         changed_fields = ['captured_amount']
         payment.captured_amount -= transaction.amount
-        if not payment.captured_amount:
+        if payment.captured_amount <= 0:
             payment.charge_status = ChargeStatus.FULLY_REFUNDED
             payment.is_active = False
             changed_fields += ['charge_status', 'is_active']

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -274,6 +274,31 @@ def validate_gateway_response(responses):
                 'Gateway response needs to be json serializable')
 
 
+def _gateway_postprocess(transaction, payment):
+    transaction_kind = transaction.kind
+
+    if transaction_kind in [TransactionKind.CHARGE, TransactionKind.CAPTURE]:
+        payment.charge_status = ChargeStatus.CHARGED
+        payment.captured_amount += transaction.amount
+        payment.save(update_fields=['charge_status', 'captured_amount'])
+        order = payment.order
+        if order and order.is_fully_paid():
+            handle_fully_paid_order(order)
+
+    elif transaction_kind == TransactionKind.VOID:
+        payment.is_active = False
+        payment.save(update_fields=['is_active'])
+
+    elif transaction_kind == TransactionKind.REFUND:
+        changed_fields = ['captured_amount']
+        payment.captured_amount -= transaction.amount
+        if not payment.captured_amount:
+            payment.charge_status = ChargeStatus.FULLY_REFUNDED
+            payment.is_active = False
+            changed_fields += ['charge_status', 'is_active']
+        payment.save(update_fields=changed_fields)
+
+
 @validate_payment
 def gateway_process_payment(
         payment: Payment, payment_token: str) -> Transaction:
@@ -283,13 +308,7 @@ def gateway_process_payment(
         transaction_kind=TransactionKind.CAPTURE,
         payment=payment, payment_token=payment_token, amount=payment.total)
 
-    payment.charge_status = ChargeStatus.CHARGED
-    payment.captured_amount += transaction.amount
-    payment.save(update_fields=['charge_status', 'captured_amount'])
-    order = payment.order
-    if order and order.is_fully_paid():
-        handle_fully_paid_order(order)
-
+    _gateway_postprocess(transaction, payment)
     return transaction
 
 
@@ -315,13 +334,7 @@ def gateway_charge(
         transaction_kind=TransactionKind.CHARGE,
         payment=payment, payment_token=payment_token, amount=amount)
 
-    payment.charge_status = ChargeStatus.CHARGED
-    payment.captured_amount += transaction.amount
-    payment.save(update_fields=['charge_status', 'captured_amount'])
-    order = payment.order
-    if order and order.is_fully_paid():
-        handle_fully_paid_order(order)
-
+    _gateway_postprocess(transaction, payment)
     return transaction
 
 
@@ -358,13 +371,7 @@ def gateway_capture(payment: Payment, amount: Decimal = None) -> Transaction:
         transaction_kind=TransactionKind.CAPTURE,
         payment=payment, payment_token=payment_token, amount=amount)
 
-    payment.charge_status = ChargeStatus.CHARGED
-    payment.captured_amount += transaction.amount
-    payment.save(update_fields=['charge_status', 'captured_amount'])
-    order = payment.order
-    if order and order.is_fully_paid():
-        handle_fully_paid_order(order)
-
+    _gateway_postprocess(transaction, payment)
     return transaction
 
 
@@ -384,9 +391,7 @@ def gateway_void(payment) -> Transaction:
         transaction_kind=TransactionKind.VOID,
         payment=payment, payment_token=payment_token)
 
-    payment.is_active = False
-    payment.save(update_fields=['is_active'])
-
+    _gateway_postprocess(transaction, payment)
     return transaction
 
 
@@ -419,12 +424,5 @@ def gateway_refund(payment, amount: Decimal = None) -> Transaction:
         transaction_kind=TransactionKind.REFUND,
         payment=payment, payment_token=payment_token, amount=amount)
 
-    changed_fields = ['captured_amount']
-    payment.captured_amount -= transaction.amount
-    if not payment.captured_amount:
-        payment.charge_status = ChargeStatus.FULLY_REFUNDED
-        payment.is_active = False
-        changed_fields += ['charge_status', 'is_active']
-    payment.save(update_fields=changed_fields)
-
+    _gateway_postprocess(transaction, payment)
     return transaction

--- a/tests/gateway/test_dummy.py
+++ b/tests/gateway/test_dummy.py
@@ -223,8 +223,6 @@ def test_refund_gateway_error(payment_txn_captured, monkeypatch):
     assert payment.captured_amount == Decimal('80.00')
 
 
-@pytest.mark.xfail(
-    reason='Setting payment status through the form is currently not supported')
 @pytest.mark.parametrize(
     'kind, charge_status',
     (

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -464,7 +464,7 @@ def test_order_payment_flow(
         'is_active': True,
         'total': order.total.gross.amount,
         'currency': order.total.gross.currency,
-        'charge_status': ChargeStatus.NOT_CHARGED}
+        'charge_status': ChargeStatus.CHARGED}
     response = client.post(redirect_url, data)
 
     assert response.status_code == 302


### PR DESCRIPTION
Currently set arbitary payment charge status for dummy gateway as below image is not available after the payment is refactored. This is a very convenient feature for  testing payment flow with dummy gateway. This PR addes this feature back.

### Screenshots

![screenshot from 2019-01-24 17-33-31](https://user-images.githubusercontent.com/1401630/51668903-3867ed00-1ffe-11e9-8fa1-83d255e97d65.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
