### PR TITLE
Fix typo in the definition of order UNFULFILLED status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add ShopFetchTaxRates mutation - #3622 by @fowczarek
 - Add taxes section - #3622 by @dominik-zeglen
 - Expose in API list of supported payment gateways - #3639 by @fowczarek
+- Fix typo in the definition of order UNFULFILLED status - #3649 by @jxltom

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -19,7 +19,7 @@ class OrderStatus:
             'staff users',
             'Draft')),
         (UNFULFILLED, pgettext_lazy(
-            'Status for an order with any items marked as fulfilled',
+            'Status for an order with no items marked as fulfilled',
             'Unfulfilled')),
         (PARTIALLY_FULFILLED, pgettext_lazy(
             'Status for an order with some items marked as fulfilled',


### PR DESCRIPTION
I think UNFULFILLED order means no items are fullfilled instead of any items are fullfilled. :p

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
