### PR TITLE
Add missing margin for order notes section in storefront 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add ShopFetchTaxRates mutation - #3622 by @fowczarek
 - Add taxes section - #3622 by @dominik-zeglen
 - Expose in API list of supported payment gateways - #3639 by @fowczarek
+- Add missing margin for order notes section - #3650 by @jxltom

--- a/saleor/static/scss/layouts/_order-details.scss
+++ b/saleor/static/scss/layouts/_order-details.scss
@@ -43,9 +43,7 @@
 }
 
 .order-notes {
-  &__header {
-    margin-top: 2 * $global-margin;
-  }
+  margin-top: 2 * $global-margin;
   > p {
     white-space: pre-wrap;
   }


### PR DESCRIPTION
It looks like the top margin of order notes is missing. This PR fixes the styles.

### Screenshots

Before:
![screenshot from 2019-01-23 15-19-02](https://user-images.githubusercontent.com/1401630/51669907-6b12e500-2000-11e9-899f-b030eb267ad0.png)

After:
![screenshot from 2019-01-23 15-18-31](https://user-images.githubusercontent.com/1401630/51669913-6d753f00-2000-11e9-809a-275fd34849df.png)



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
