### PR TITLE
Fix TypeError on calling get_client_token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,3 +39,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix typo in the definition of order UNFULFILLED status - #3649 by @jxltom
 - Add missing margin for order notes section - #3650 by @jxltom
 - Infer default transaction kind from operation type instead of passing it manually  - #3646 by @jxltom
+- Fix TypeError on calling get_client_token - #3660 by @michaljelonek

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -145,7 +145,7 @@ def gateway_get_client_token(gateway_name: str):
     client-side tokenization of the chosen payment method.
     """
     gateway, gateway_params = get_payment_gateway(gateway_name)
-    return gateway.get_client_token(**gateway_params)
+    return gateway.get_client_token(connection_params=gateway_params)
 
 
 def clean_charge(payment: Payment, amount: Decimal):


### PR DESCRIPTION
I want to merge this change because it fixes a TypeError when `get_client_token` was improperly called by unpacking `gateway_params` instead of passing them as kwargs. Also improves tests that didn't catch it.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
