### PR TITLE
Fix seo_title and seo_description values in db.json 

### DIFF
--- a/saleor/static/db.json
+++ b/saleor/static/db.json
@@ -190,8 +190,8 @@
   "model": "product.product",
   "pk": 63,
   "fields": {
-    "seo_title": null,
-    "seo_description": null,
+    "seo_title": "",
+    "seo_description": "",
     "product_type": 7,
     "name": "Red Dwarf Red Paint",
     "description": "We are all connected to the universe, because every cell in our bodies was cooked in the hearts of dying stars. Red Dwarf Paint: the color of Carl Sagan\u2019s dreams.",
@@ -4743,8 +4743,8 @@
   "model": "product.collection",
   "pk": 1,
   "fields": {
-    "seo_title": null,
-    "seo_description": null,
+    "seo_title": "",
+    "seo_description": "",
     "name": "Summer collection",
     "slug": "summer-collection",
     "background_image": "collection-backgrounds/summer_3Zz9sHf.jpg",
@@ -4761,8 +4761,8 @@
   "model": "product.collection",
   "pk": 2,
   "fields": {
-    "seo_title": null,
-    "seo_description": null,
+    "seo_title": "",
+    "seo_description": "",
     "name": "Winter sale",
     "slug": "winter-sale",
     "background_image": "collection-backgrounds/sale_THIKyXw.jpg",


### PR DESCRIPTION
Closes #3681 
Sets `seo_title` and `seo_description` values to empty strings instead of null

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] ~Privileged views and APIs are guarded by proper permission checks.~
1. [ ] ~All visible strings are translated with proper context.~
1. [ ] ~All data-formatting is locale-aware (dates, numbers, and so on).~
1. [ ] ~Database queries are optimized and the number of queries is constant.~
1. [ ] ~Database migration files are up to date.~
1. [ ] ~The changes are tested.~
1. [ ] ~The code is documented (docstrings, project documentation).~
1. [ ] ~GraphQL schema and type definitions are up to date.~
1. [ ] ~Changes are mentioned in the changelog.~
