### PR TITLE
Fix problem with l10n in Braintree payment gateway template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
-- ...
+- Fix problem with l10n in Braintree payment gateway template - #3691 by @Kwaidan00
 
 
 ## 2.3.0

--- a/templates/order/payment/braintree.html
+++ b/templates/order/payment/braintree.html
@@ -1,6 +1,7 @@
 {% extends "order/payment/details.html" %}
 {% load bootstrap_form from bootstrap4 %}
 {% load i18n %}
+{% load l10n %}
 
 {% block forms %}
 <form method="POST" id="payment-form" class="form-horizontal"{% if form.action %} action="{{ form.action }}"{% endif %} novalidate>
@@ -23,7 +24,7 @@
         </div>
 
       <input type="hidden" id="nonce" name="payment_method_nonce"/>
-      <input type="hidden" id="amount" name="amount" value="{{ payment.total }}"/>
+      <input type="hidden" id="amount" name="amount" value="{% localize off %}{{ payment.total }}{% endlocalize %}"/>
       <button type="submit" class="btn btn-primary">
         {% trans "Make payment" context "Payment form primary action" %}
       </button>


### PR DESCRIPTION
I want to merge this change because it solves problem with l10n in template file and Django's `forms.DecimalField`.

The problem was with localized decimal point. For example, when user with `pl` locale visit `order.start_payment` view, he gets 

    <input type="hidden" id="amount" name="amount" value="42,30">

On the other hand, `payment.gateways.braintree.forms.BraintreePaymentForm` has `forms.DecimalField` field without localization. Form cannot be properly proceed and display error (see screenshots below).

I've fixed it by disabling l10n in the proper part of the template.

<!-- Please mention all relevant issue numbers. -->

### Screenshots
<img width="1392" alt="zrzut ekranu 2019-02-07 o 11 47 33" src="https://user-images.githubusercontent.com/15018155/52409752-b2a47100-2ad6-11e9-9778-f46a01115da8.png">

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.