### PR TITLE
Fix rendering payments without an order

### DIFF
--- a/templates/dashboard/index.html
+++ b/templates/dashboard/index.html
@@ -104,20 +104,22 @@
               </thead>
               <tbody>
                 {% for payment in preauthorized_payments %}
-                  <tr data-action-go="{% url "dashboard:order-details" order_pk=payment.order.pk %}">
-                    <td>
-                      {{ payment.order }}
-                    </td>
-                    <td>
-                      {{ payment.created }}
-                    </td>
-                    <td>
-                      {{ payment.order.user|default:_("Guest") }}
-                    </td>
-                    <td class="right-align">
-                      {% price payment.get_total %}
-                    </td>
-                  </tr>
+                  {% if payment.order %}
+                    <tr data-action-go="{% url "dashboard:order-details" order_pk=payment.order.pk %}">
+                      <td>
+                        {{ payment.order }}
+                      </td>
+                      <td>
+                        {{ payment.created }}
+                      </td>
+                      <td>
+                        {{ payment.order.user|default:_("Guest") }}
+                      </td>
+                      <td class="right-align">
+                        {% price payment.get_total %}
+                      </td>
+                    </tr>
+                  {% endif %}
                 {% endfor %}
               </tbody>
             </table>


### PR DESCRIPTION
I'm occasionally getting a bug where payments list on Dashboard 1.0 homepage cannot be rendered because payment has no relationship with an order (this is allowed state when creating payments through API). This PR adds a check in the template to prevent that.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
