### PR TITLE
Fix product list price filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,3 +50,4 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add component generator - #3670 by @dominik-zeglen
 - Fix set-password email to customer created in dashboard - #3688 by @Kwaidan00
 - Allow e-mail null in checkout create, always return list for available shipping methods - #3685 by @michaljelonek
+- Fix product list price filter - #3697 by @Kwaidan00

--- a/templates/product/_filters.html
+++ b/templates/product/_filters.html
@@ -12,8 +12,7 @@
               This is required if you want to have sorting to be kept during further filtering.
             {% endcomment %}
             <input type="hidden" name="sort_by" value="{% if request.GET.sort_by %}{{ request.GET.sort_by }}{% endif %}">
-          {% elif field.name == 'price' %}
-          {% else %}
+          {% elif field.name != 'price' %}
             <div class="filter-section" aria-expanded="true">
               <div class="filter-section__header">
                 <h3>{{ field.label }}</h3>
@@ -40,10 +39,10 @@
               </div>
               <div class="filter-section__content">
                 <div class="filter-form-field price-field">
-                  <input id="{{ field.auto_id }}_0" name="{{ field.name }}_0"
+                  <input id="{{ field.auto_id }}_0" name="{{ field.name }}_min"
                         value="{% if field.value.0 %}{{ field.value.0 }}{% endif %}" type="number" min="0"
                         class="form-control d-inline"
-                        placeholder="{% trans 'from' context 'Product price filter' %}"/><span>-</span><input id="{{ field.auto_id }}_1" name="{{ field.name }}_1"
+                        placeholder="{% trans 'from' context 'Product price filter' %}"/><span>-</span><input id="{{ field.auto_id }}_1" name="{{ field.name }}_max"
                         value="{% if field.value.1 %}{{ field.value.1 }}{% endif %}" type="number" min="0"
                         class="form-control d-inline" placeholder="{% trans 'to' context 'Product price filter' %}"/>
                 </div>


### PR DESCRIPTION
I want to merge this change because it fixes broken price range filter on the category/collection list pages. We rendered wrong names for `input` fields (`django-filters` requires names with `_min` and `_max` suffixes, we had `_0/_1`). I've just rename it.

Fixes #3689, fixes #3421 

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

Before:

<img width="1392" alt="before" src="https://user-images.githubusercontent.com/15018155/52469707-7b909700-2b8c-11e9-9449-ef504aca4e31.png">

After:

<img width="1392" alt="after" src="https://user-images.githubusercontent.com/15018155/52469715-80ede180-2b8c-11e9-9ca1-f438a6eec261.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.