### PR TITLE
Improve discounts api, fix decimal empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix problem with l10n in Braintree payment gateway template - #3691 by @Kwaidan00
+- Improve discounts api, fix decimal empty string - #3707 by @michaljelonek
 
 
 ## 2.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Fix problem with l10n in Braintree payment gateway template - #3691 by @Kwaidan00
-- Improve discounts api, fix decimal empty string - #3707 by @michaljelonek
+- Improve vouchers country limiting  - #3707 by @michaljelonek
 
 
 ## 2.3.0

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -16,7 +16,6 @@ from ..account.forms import get_address_form
 from ..account.models import Address
 from ..account.utils import store_user_address
 from ..core.exceptions import InsufficientStock
-from ..core.i18n import ANY_COUNTRY
 from ..core.utils import to_local_currency
 from ..core.utils.taxes import ZERO_MONEY, get_taxes_for_country
 from ..discount import VoucherType
@@ -652,14 +651,15 @@ def _get_shipping_voucher_discount_for_cart(voucher, cart):
             'Voucher not applicable',
             'Please select a shipping method first.')
         raise NotApplicable(msg)
-    not_valid_for_country = all([
-        voucher.countries, ANY_COUNTRY not in voucher.countries,
-        cart.shipping_address.country.code not in voucher.countries])
-    if not_valid_for_country:
+
+    # check if voucher is limited to specified countries
+    shipping_country = cart.shipping_address.country
+    if voucher.countries and shipping_country.code not in voucher.countries:
         msg = pgettext(
             'Voucher not applicable',
             'This offer is not valid in your country.')
         raise NotApplicable(msg)
+
     return get_shipping_voucher_discount(
         voucher, cart.get_subtotal(), shipping_method.get_total())
 

--- a/saleor/dashboard/discount/forms.py
+++ b/saleor/dashboard/discount/forms.py
@@ -4,10 +4,10 @@ from django import forms
 from django.conf import settings
 from django.urls import reverse_lazy
 from django.utils.translation import pgettext_lazy
+from django_countries import countries
 from django_prices.forms import MoneyField
 from mptt.forms import TreeNodeMultipleChoiceField
 
-from ...core.i18n import COUNTRY_CODE_CHOICES
 from ...core.utils.taxes import ZERO_MONEY
 from ...discount import DiscountValueType
 from ...discount.models import Sale, Voucher
@@ -130,7 +130,7 @@ class VoucherForm(forms.ModelForm):
 class ShippingVoucherForm(forms.ModelForm):
     min_amount_spent = MinAmountSpent
     countries = forms.MultipleChoiceField(
-        choices=COUNTRY_CODE_CHOICES,
+        choices=countries,
         required=False,
         label=pgettext_lazy(
             'Text above the dropdown of countries',

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -216,9 +216,9 @@ class SaleInput(graphene.InputObjectType):
     collections = graphene.List(
         graphene.ID, description='Collections related to the discount.',
         name='collections')
-    start_date = graphene.types.datetime.Date(
+    start_date = graphene.Date(
         description='Start date of the sale in ISO 8601 format.')
-    end_date = graphene.types.datetime.Date(
+    end_date = graphene.Date(
         description='End date of the sale in ISO 8601 format.')
 
 


### PR DESCRIPTION
Improvements to discounts api.

Adds `Voucher.all_countries` that indicates whether it applies to all countries (`Voucher.countries` is then ignored).

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
