### PR TITLE
Fix logo size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Filter order by payment status from order's last payment - #3749 @jxltom
 - Reuse cart creation logic in API - #3761 by @maarcingebala
 - Add json fields to models for content/description - #3756 by @michaljelonek
+- Fix logo size in different browser and devices with different sizes - #3722 by @jxltom
+
 
 ## 2.3.0
 ### API

--- a/saleor/static/dashboard/scss/components/_nav.scss
+++ b/saleor/static/dashboard/scss/components/_nav.scss
@@ -59,14 +59,15 @@ header {
     }
 
     .logo {
+      padding: 0;
       svg {
         max-height: $navbar-height;
-        width: 140px;
+        max-width: 80px;
+        width: auto;
         margin: 9px 0;
         padding: 4px;
         @media (max-width: $small-screen) {
           height: 30px;
-          width: 130px;
           margin: 17px 0;
         }
       }

--- a/saleor/static/scss/components/_footer.scss
+++ b/saleor/static/scss/components/_footer.scss
@@ -37,7 +37,7 @@
     margin-bottom: $global-margin;
     svg {
       height: 38px;
-      width: 100%;
+      width: 113px;
     }
   }
   hr {

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -315,7 +315,7 @@
         background-color: $white;
         padding-left: 0;
         padding-right: $global-padding;
-        padding-top: $global-padding * 5;
+        padding-top: $global-padding * 2;
         transition: 0.3s ease-in-out;
         ul {
           text-align: left;

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -177,12 +177,12 @@
     align-items: center;
     a svg {
       height: 38px;
-      width: 113px;
+      width: auto;
+      max-width: 113px;
     }
     .menu-icon-mobile {
       position: relative;
       display: inline-block;
-      top: -5px;
       span {
         position: absolute;
         top: 1.3rem;
@@ -191,6 +191,7 @@
         font-size: 0.45rem;
       }
       svg {
+        height: 30px;
         vertical-align: top;
       }
       @media (max-width: 370px) {
@@ -297,7 +298,6 @@
       }
     }
     &__menu-toggle {
-      max-height: 22px;
       padding-right: $global-padding;
       padding-left: $global-padding;
       vertical-align: super;

--- a/saleor/static/scss/layouts/_checkout.scss
+++ b/saleor/static/scss/layouts/_checkout.scss
@@ -31,9 +31,9 @@
       vertical-align: baseline;
       margin-right: $global-margin;
       padding-bottom: 2px;
+      width: 113px;
       @include media-breakpoint-down(sm) {
         max-height: 34px;
-        width: auto;
         vertical-align: text-bottom;
         margin-right: 0;
         padding-bottom: 5px;


### PR DESCRIPTION
Continue https://github.com/mirumee/saleor/pull/3696.

I found the logo size in firefox and chrome have different sizes. So using specific size such as ```113px``` is better than ```100%``` or ```auto``` width. This PR fixes the logo size in top, footer and checkout.

This PR also fixes the navigation menu in mobile has too much top padding issue.

### Screenshots

Before:
![saleor e commerce-3](https://user-images.githubusercontent.com/1401630/52770543-5d380900-306e-11e9-9d00-8732e355128f.png)
![screenshot from 2019-02-14 14-55-24](https://user-images.githubusercontent.com/1401630/52770546-61fcbd00-306e-11e9-9479-cf092786e611.png)




After:

![saleor e commerce-2](https://user-images.githubusercontent.com/1401630/52770845-2d3d3580-306f-11e9-9ce8-51bbe712074a.png)
![screenshot from 2019-02-14 14-50-15](https://user-images.githubusercontent.com/1401630/52770564-6cb75200-306e-11e9-9f16-aeb13d3ab51e.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
