### PR TITLE
Add instructions for using local assets in Docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Unify field names on product, collection and page - #3706 by @michaljelonek
 - Generate voucher code if it wasn't provided in mutation - #3717 by @Kwaidan00
 - Reuse Storefront's 1.0 payment logic in API - #3715 by @maarcingebala
+- Add instructions for using local assets in Docker - #3723 by @michaljelonek
 
 
 ## 2.3.0

--- a/docs/customization/docker.rst
+++ b/docs/customization/docker.rst
@@ -21,6 +21,19 @@ You will need to install `Docker <https://docs.docker.com/install/>`_ and `docke
    Our configuration uses `docker-compose.override.yml <https://docs.docker.com/compose/extends/#understanding-multiple-compose-files>`_ that exposes Saleor, PostgreSQL and Redis ports and runs Saleor via ``python manage.py runserver`` for local development. If you do not wish to use any overrides then you can tell compose to only use `docker-compose.yml` configuration using `-f`, like so `docker-compose -f docker-compose.yml up`.
 
 
+Using local assets
+------------------
+
+By default we do not mount assets for development in the Docker, reason being is those are built in the Docker at build-time
+and aren't present in the cloned repository, so what was built on the Docker would be overshadowed by empty directories from the host.
+
+However, we do know that there might be a case that you wish to mount them and see your changes reflected in the container, thus before proceeding you need to modify `docker-compose.override.yml`.
+
+In order for Docker to use your assets from the host, you need to remove ``/app/saleor/static/assets`` volume and add ``./webpack-bundle.json:/app/webpack-bundle.json`` volume.
+
+Additionally if you wish to have the compiled templated emails mounted then you need to also remove ``/app/templates/templated_email/compiled`` volume from web and celery services.
+
+
 Usage
 -----
 


### PR DESCRIPTION
I want to merge this change because it adds instructions how to use local assets. It's not ideal, but at least it's something.

I was thinking of also providing a third `docker-compose.yml`, but I feel that would be just too much files to bother with without a proper Makefile to make it simpler.

Related #3719.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
