### PR TITLE
Get or create emtpy checkout when accessing checkout of a user in GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add instructions for using local assets in Docker - #3723 by @michaljelonek
 - Remove unused imports - #3645 by @jxltom
 - Add discount section - #3654 by @dominik-zeglen
+- Get or create checkout when accesing checkout of a user in GraphQL API - #3725 by @jxltom
 
 
 ## 2.3.0

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -5,7 +5,7 @@ from graphene import relay
 from graphql_jwt.decorators import permission_required
 
 from ...account import models
-from ...checkout.utils import get_user_cart
+from ...checkout.utils import get_or_create_user_cart
 from ...core.permissions import get_permissions
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
@@ -70,7 +70,7 @@ class User(CountableDjangoObjectType):
         return self.addresses.all()
 
     def resolve_checkout(self, info, **kwargs):
-        return get_user_cart(self)
+        return get_or_create_user_cart(self)
 
     def resolve_permissions(self, info, **kwargs):
         if self.is_superuser:


### PR DESCRIPTION
This PR is opinionated but I still would like to propose it since it will simplify the frontend logic when creating/updating checkouts for authenticated users.

If an anonymous user who already has a cart (stored in local storage) tries to login, the frontend needs to request ```me->checkout``` to see if a user has already a checkout. If the user doesn't have a checkout, the frontend needs to call ```checkoutCreate``` instead of ```checkoutLinesUpdate``` or ```checkoutLinesAdd``` to create a checkout first. If any user have an empty checkout by default, the frontend doesn't need to call ```checkoutCreate``` if checkout doesn't exist. This PR simplifies the frontend logic.

Thoughts?

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
