### PR TITLE
Use authenticated user's email as default email in creating checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add instructions for using local assets in Docker - #3723 by @michaljelonek
 - Remove unused imports - #3645 by @jxltom
 - Add discount section - #3654 by @dominik-zeglen
+- Use authenticated user's email as default email in creating checkout - #3726 by @jxltom
 
 
 ## 2.3.0

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -151,6 +151,11 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         else:
             cleaned_input['billing_address'] = default_billing_address
 
+        # Use authenticated user's email as default email
+        if not user.is_anonymous:
+            email = input.pop('email', None)
+            cleaned_input['email'] = email or user.email
+
         return cleaned_input
 
     @classmethod

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -16,6 +16,7 @@ MUTATION_CHECKOUT_CREATE = """
             checkout {
                 token,
                 id
+                email
             }
             errors {
                 field
@@ -80,6 +81,26 @@ def test_checkout_create_required_email(api_client, variant):
     assert errors
     assert errors[0]['field'] == 'email'
     assert errors[0]['message'] == 'This field cannot be blank.'
+
+
+def test_checkout_create_default_email_for_logged_in_customer(
+        user_api_client, variant):
+    variant_id = graphene.Node.to_global_id('ProductVariant', variant.id)
+    variables = {
+        'checkoutInput': {
+            'lines': [{
+                'quantity': 1,
+                'variantId': variant_id}]}}
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_CREATE, variables)
+    customer = user_api_client.user
+    content = get_graphql_content(response)
+    new_cart = Cart.objects.first()
+    assert new_cart is not None
+    checkout_data = content['data']['checkoutCreate']['checkout']
+    assert checkout_data['email'] == str(customer.email)
+    assert new_cart.user.id == customer.id
+    assert new_cart.email == customer.email
 
 
 def test_checkout_create_logged_in_customer(user_api_client, variant):


### PR DESCRIPTION
In ```checkoutCreate```, if a user is authenticated, there is no need to provide addtional email. This PR sets authenticated user's email address as default email in creating checkout.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
