### PR TITLE
Fix bug where cart can not be got or created when user has multiple carts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add instructions for using local assets in Docker - #3723 by @michaljelonek
 - Remove unused imports - #3645 by @jxltom
 - Add discount section - #3654 by @dominik-zeglen
+- Fix bug where cart can not be got or created when user has multiple carts - #3727 by @jxltom
 
 
 ## 2.3.0

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -175,7 +175,11 @@ def get_or_create_user_cart(user, cart_queryset=Cart.objects.all()):
     defaults = {
         'shipping_address': user.default_shipping_address,
         'billing_address': user.default_billing_address}
-    return cart_queryset.get_or_create(user=user, defaults=defaults)[0]
+
+    cart = cart_queryset.filter(user=user).first()
+    if cart is None:
+        cart = Cart.objects.create(user=user, **defaults)
+    return cart
 
 
 def get_anonymous_cart_from_token(token, cart_queryset=Cart.objects.all()):


### PR DESCRIPTION
Closes https://github.com/mirumee/saleor/issues/3728

The ```checkoutCreate``` or ```checkoutCustomerAttach``` could create multiple checkouts for a same user. Then ```get_or_create_user_cart``` will raise ```saleor.apps.checkout.models.Cart.MultipleObjectsReturned: get() returned more than one Cart``` error since it can not handle this case. This PR fixes this issue.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
