### PR TITLE
Enable existing search with backend picker in products query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Disable style-loader in dev mode - #3720 by @jxltom
 - Use authenticated user's email as default email in creating checkout - #3726 by @jxltom
 - Fix access to unpublished objects via API - #3724 by @Kwaidan00
+- Enable existing search with backend picker in products query - #3736 by @michaljelonek
 
 
 ## 2.3.0

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -4,6 +4,7 @@ from django.db.models import Q, Sum
 
 from ...order import OrderStatus
 from ...product import models
+from ...search.backends import picker
 from ..utils import (
     filter_by_period, filter_by_query_param, get_database_id, get_nodes)
 from .enums import StockAvailability
@@ -12,7 +13,7 @@ from .filters import (
     filter_products_by_collections, filter_products_by_price, sort_qs)
 from .types import Category, Collection, ProductVariant
 
-PRODUCT_SEARCH_FIELDS = ('name', 'description', 'category__name')
+PRODUCT_SEARCH_FIELDS = ('name', 'description')
 CATEGORY_SEARCH_FIELDS = ('name', 'slug', 'description', 'parent__name')
 COLLECTION_SEARCH_FIELDS = ('name', 'slug')
 ATTRIBUTES_SEARCH_FIELDS = ('name', 'slug')
@@ -80,7 +81,10 @@ def resolve_products(
 
     user = info.context.user
     qs = models.Product.objects.visible_to_user(user)
-    qs = filter_by_query_param(qs, query, PRODUCT_SEARCH_FIELDS)
+
+    if query:
+        search = picker.pick_backend()
+        qs &= search(query)
 
     if attributes:
         qs = filter_products_by_attributes(qs, attributes)


### PR DESCRIPTION
I want to merge this change because it enables products with query param to use existing search picker (either ES or PG) and search products matching the query. 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
