### PR TITLE
Add thumbnail to OrderLine, deprecate thumbnailUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Disable style-loader in dev mode - #3720 by @jxltom
 - Use authenticated user's email as default email in creating checkout - #3726 by @jxltom
 - Fix access to unpublished objects via API - #3724 by @Kwaidan00
+- Add thumbnail to OrderLine, deprecate thumbnailUrl - #3737 by @michaljelonek
 
 
 ## 2.3.0

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -8,6 +8,7 @@ from ..account.types import User
 from ..core.connection import CountableDjangoObjectType
 from ..core.types.money import Money, TaxedMoney
 from ..payment.types import OrderAction, Payment, PaymentChargeStatusEnum
+from ..product.types import Image
 from ..shipping.types import ShippingMethod
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum
 from .utils import applicable_shipping_methods, can_finalize_draft_order
@@ -106,7 +107,12 @@ class Fulfillment(CountableDjangoObjectType):
 class OrderLine(CountableDjangoObjectType):
     thumbnail_url = graphene.String(
         description='The URL of a main thumbnail for the ordered product.',
-        size=graphene.Int(description='Size of the image'))
+        size=graphene.Int(description='Size of the image'),
+        deprecation_reason=(
+            'thumbnailUrl is deprecated, use thumbnail instead'))
+    thumbnail = graphene.Field(
+        Image, description='The main thumbnail for the ordered product.',
+        size=graphene.Argument(graphene.Int, description='Size of thumbnail'))
     unit_price = graphene.Field(
         TaxedMoney, description='Price of the single item in the order line.')
 
@@ -127,6 +133,18 @@ class OrderLine(CountableDjangoObjectType):
         url = get_product_image_thumbnail(
             self.variant.get_first_image(), size, method='thumbnail')
         return info.context.build_absolute_uri(url)
+
+    @gql_optimizer.resolver_hints(
+        prefetch_related=['variant__images', 'variant__product__images'])
+    def resolve_thumbnail(self, info, *, size=None):
+        if not self.variant_id:
+            return None
+        if not size:
+            size = 255
+        image = self.variant.get_first_image()
+        url = get_product_image_thumbnail(image, size, method='thumbnail')
+        alt = image.alt if image else None
+        return Image(alt=alt, url=info.context.build_absolute_uri(url))
 
     @staticmethod
     def resolve_unit_price(self, info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1109,7 +1109,8 @@ type OrderLine implements Node {
   quantityFulfilled: Int!
   unitPrice: TaxedMoney
   taxRate: Float!
-  thumbnailUrl(size: Int): String
+  thumbnailUrl(size: Int): String @deprecated(reason: "thumbnailUrl is deprecated, use thumbnail instead")
+  thumbnail(size: Int): Image
 }
 
 input OrderLineCreateInput {
@@ -1170,11 +1171,11 @@ type OrderVoid {
 }
 
 type Page implements Node {
-  id: ID!
   publicationDate: Date
   isPublished: Boolean!
   seoTitle: String
   seoDescription: String
+  id: ID!
   slug: String!
   title: String!
   content: String!
@@ -1315,11 +1316,11 @@ enum PermissionEnum {
 }
 
 type Product implements Node {
+  id: ID!
   publicationDate: Date
   isPublished: Boolean!
   seoTitle: String
   seoDescription: String
-  id: ID!
   productType: ProductType!
   name: String!
   description: String!

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -16,9 +16,8 @@ from saleor.order.models import Order, OrderEvent
 from saleor.payment import ChargeStatus, CustomPaymentChoices
 from saleor.payment.models import Payment
 from saleor.shipping.models import ShippingMethod
-from tests.api.utils import get_graphql_content
 
-from .utils import assert_no_permission
+from .utils import assert_no_permission, get_graphql_content
 
 
 def test_orderline_query(
@@ -31,6 +30,9 @@ def test_orderline_query(
                     node {
                         lines {
                             thumbnailUrl(size: 540)
+                            thumbnail(size: 540) {
+                                url
+                            }
                         }
                     }
                 }
@@ -44,10 +46,16 @@ def test_orderline_query(
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     order_data = content['data']['orders']['edges'][0]['node']
+
     thumbnails = [l['thumbnailUrl'] for l in order_data['lines']]
     assert len(thumbnails) == 2
     assert thumbnails[0] is None
     assert '/static/images/placeholder540x540.png' in thumbnails[1]
+
+    thumbnails = [l['thumbnail'] for l in order_data['lines']]
+    assert len(thumbnails) == 2
+    assert thumbnails[0] is None
+    assert '/static/images/placeholder540x540.png' in thumbnails[1]['url']
 
 
 def test_order_query(


### PR DESCRIPTION
I want to merge this change because it adds `thumbnail` and deprecates `thumbnailUrl` as on Product type.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
