### PR TITLE
Add mutation to connect voucher with checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Enable existing search with backend picker in products query - #3736 by @michaljelonek
 - Fix bug where payment is not filtered from active ones when creating payment - #3731 by @jxltom
 - Sort order's payment and history descendingly - #3747 by @jxltom
-
+- Add mutation to connect voucher with checkout - #3739 by @Kwaidan00
 
 ## 2.3.0
 ### API

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -740,7 +740,7 @@ def recalculate_cart_discount(cart, discounts, taxes):
 
 def add_voucher_to_cart(voucher, cart):
     """Add voucher data to cart.
-    
+
     Raise NotApplicable if voucher of given type cannot be applied."""
     discount_amount = get_voucher_discount_for_cart(voucher, cart)
     cart.voucher_code = voucher.code

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -738,6 +738,23 @@ def recalculate_cart_discount(cart, discounts, taxes):
         remove_voucher_from_cart(cart)
 
 
+def add_voucher_to_cart(voucher, cart):
+    """Add voucher data to cart.
+    
+    Raise NotApplicable if voucher of given type cannot be applied."""
+    discount_amount = get_voucher_discount_for_cart(voucher, cart)
+    cart.voucher_code = voucher.code
+    cart.discount_name = voucher.name
+    cart.translated_discount_name = (
+        voucher.translated.name
+        if voucher.translated.name != voucher.name else '')
+    cart.discount_amount = discount_amount
+    cart.save(
+        update_fields=[
+            'voucher_code', 'discount_name', 'translated_discount_name',
+            'discount_amount'])
+
+
 def remove_voucher_from_cart(cart):
     """Remove voucher data from cart."""
     cart.voucher_code = None

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -8,7 +8,8 @@ from .mutations import (
     CheckoutBillingAddressUpdate, CheckoutComplete, CheckoutCreate,
     CheckoutCustomerAttach, CheckoutCustomerDetach, CheckoutEmailUpdate,
     CheckoutLineDelete, CheckoutLinesAdd, CheckoutLinesUpdate,
-    CheckoutShippingAddressUpdate, CheckoutShippingMethodUpdate)
+    CheckoutShippingAddressUpdate, CheckoutShippingMethodUpdate,
+    CheckoutUpdateVoucher)
 from .resolvers import (
     resolve_checkout, resolve_checkout_lines, resolve_checkouts)
 from .types import Checkout, CheckoutLine
@@ -55,3 +56,4 @@ class CheckoutMutations(graphene.ObjectType):
     checkout_payment_create = CheckoutPaymentCreate.Field()
     checkout_shipping_address_update = CheckoutShippingAddressUpdate.Field()
     checkout_shipping_method_update = CheckoutShippingMethodUpdate.Field()
+    checkout_update_voucher = CheckoutUpdateVoucher.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -403,6 +403,11 @@ type CheckoutShippingMethodUpdate {
   checkout: Checkout
 }
 
+type CheckoutUpdateVoucher {
+  errors: [Error!]
+  checkout: Checkout
+}
+
 type ChoiceValue {
   raw: String
   verbose: String
@@ -932,6 +937,7 @@ type Mutations {
   checkoutPaymentCreate(checkoutId: ID!, input: PaymentInput!): CheckoutPaymentCreate
   checkoutShippingAddressUpdate(checkoutId: ID, shippingAddress: AddressInput): CheckoutShippingAddressUpdate
   checkoutShippingMethodUpdate(checkoutId: ID, shippingMethodId: ID!): CheckoutShippingMethodUpdate
+  checkoutUpdateVoucher(checkoutId: ID!, voucherCode: String): CheckoutUpdateVoucher
   passwordReset(email: String!): PasswordReset
   setPassword(id: ID!, input: SetPasswordInput!): SetPassword
   customerCreate(input: UserCreateInput!): CustomerCreate

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -1293,5 +1293,7 @@ def test_checkout_shipping_address_update_with_not_applicable_voucher(
     assert not data['errors']
 
     cart_with_item.refresh_from_db()
+    cart_with_item.shipping_address.refresh_from_db()
+    
     assert cart_with_item.shipping_address.country == new_address['country']
     assert cart_with_item.voucher_code is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -453,6 +453,14 @@ def voucher(db):  # pylint: disable=W0613
     return Voucher.objects.create(code='mirumee', discount_value=20)
 
 
+@pytest.fixture
+def voucher_with_high_min_amount_spent():
+    return Voucher.objects.create(
+        code='mirumee',
+        discount_value=10,
+        min_amount_spent=Money(1000000, 'USD'))
+
+
 @pytest.fixture()
 def order_with_lines(
         order, product_type, category, shipping_zone, vatlayer):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ from saleor.checkout.models import Cart
 from saleor.checkout.utils import add_variant_to_cart
 from saleor.dashboard.menu.utils import update_menu
 from saleor.dashboard.order.utils import fulfill_order_line
+from saleor.discount import VoucherType
 from saleor.discount.models import Sale, Voucher, VoucherTranslation
 from saleor.menu.models import Menu, MenuItem
 from saleor.order import OrderEvents, OrderStatus
@@ -97,6 +98,19 @@ def address(db):  # pylint: disable=W0613
         postal_code='53-601',
         country='PL',
         phone='+48713988102')
+
+
+@pytest.fixture
+def address_other_country():
+    return Address.objects.create(
+        first_name='John',
+        last_name='Doe',
+        street_address_1='4371 Lucas Knoll Apt. 791',
+        city='Bennettmouth',
+        postal_code='13377',
+        country='IS',
+        phone='')
+
 
 @pytest.fixture
 def graphql_address_data():
@@ -459,6 +473,15 @@ def voucher_with_high_min_amount_spent():
         code='mirumee',
         discount_value=10,
         min_amount_spent=Money(1000000, 'USD'))
+
+
+@pytest.fixture
+def voucher_shipping_type():
+    return Voucher.objects.create(
+        code='mirumee',
+        discount_value=10,
+        type=VoucherType.SHIPPING,
+        countries='IS')
 
 
 @pytest.fixture()

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -11,7 +11,7 @@ from saleor.account.models import Address
 from saleor.checkout import views
 from saleor.checkout.forms import CartVoucherForm, CountryForm
 from saleor.checkout.utils import (
-    add_variant_to_cart, change_billing_address_in_cart,
+    add_variant_to_cart, add_voucher_to_cart, change_billing_address_in_cart,
     change_shipping_address_in_cart, clear_shipping_method, create_order,
     get_cart_data_for_checkout,
     get_prices_of_products_in_discounted_categories, get_taxes_for_cart,
@@ -975,3 +975,19 @@ def test_get_prices_of_products_in_discounted_categories(cart_with_item):
         lines, [discounted_category])
     # None of the lines are belongs to the discounted category
     assert not discounted_lines
+
+
+def test_add_voucher_to_cart(cart_with_item, voucher):
+    assert cart_with_item.voucher_code is None
+    add_voucher_to_cart(voucher, cart_with_item)
+
+    assert cart_with_item.voucher_code == voucher.code
+
+
+def test_add_voucher_to_cart_fail(
+        cart_with_item, voucher_with_high_min_amount_spent):
+    with pytest.raises(NotApplicable) as e:
+        add_voucher_to_cart(
+            voucher_with_high_min_amount_spent, cart_with_item)
+
+    assert cart_with_item.voucher_code is None


### PR DESCRIPTION
I want to merge this change because it adds API mutation to use voucher with checkout.

As it was described in #3222, it adds mutation `checkoutUpdateVoucher(checkoutId: ID!, voucherCode: String)`. In addition, voucher discount is recalculated every time when checkout is modified (e.g. by removing lines or changing shipping address).

<!-- Please mention all relevant issue numbers. -->
It closes #3222 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.