### PR TITLE
Create emtpy checkout when accessing checkout if user has no available checkouts in me API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add orderByToken query - #3740 by @michaljelonek
 - Enable existing search with backend picker in products query - #3736 by @michaljelonek
 - Fix bug where payment is not filtered from active ones when creating payment - #3731 by @jxltom
+- Create checkout when accesing checkout if user has no available checkouts in me API - #3745 by @jxltom
 
 
 ## 2.3.0

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -38,6 +38,7 @@ class AccountQueries(graphene.ObjectType):
 
     @login_required
     def resolve_me(self, info):
+        info.context.create_user_checkout = True
         return info.context.user
 
     @permission_required('account.manage_staff')

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -38,7 +38,7 @@ class AccountQueries(graphene.ObjectType):
 
     @login_required
     def resolve_me(self, info):
-        info.context.create_user_checkout = True
+        info.context.kwargs = dict(create_user_checkout=True)
         return info.context.user
 
     @permission_required('account.manage_staff')

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -5,7 +5,7 @@ from graphene import relay
 from graphql_jwt.decorators import permission_required
 
 from ...account import models
-from ...checkout.utils import get_user_cart
+from ...checkout.utils import get_or_create_user_cart
 from ...core.permissions import get_permissions
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
@@ -70,7 +70,7 @@ class User(CountableDjangoObjectType):
         return self.addresses.all()
 
     def resolve_checkout(self, info, **kwargs):
-        return get_user_cart(self)
+        return get_or_create_user_cart(self)
 
     def resolve_permissions(self, info, **kwargs):
         if self.is_superuser:

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -70,7 +70,8 @@ class User(CountableDjangoObjectType):
         return self.addresses.all()
 
     def resolve_checkout(self, info, **kwargs):
-        if getattr(info.context, 'create_user_checkout', False):
+        context_kwargs = getattr(info.context, 'kwargs', {})
+        if context_kwargs.get('create_user_checkout', False):
             return get_or_create_user_cart(self)
         return get_user_cart(self)
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -5,7 +5,7 @@ from graphene import relay
 from graphql_jwt.decorators import permission_required
 
 from ...account import models
-from ...checkout.utils import get_or_create_user_cart
+from ...checkout.utils import get_or_create_user_cart, get_user_cart
 from ...core.permissions import get_permissions
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
@@ -70,7 +70,9 @@ class User(CountableDjangoObjectType):
         return self.addresses.all()
 
     def resolve_checkout(self, info, **kwargs):
-        return get_or_create_user_cart(self)
+        if getattr(info.context, 'create_user_checkout', False):
+            return get_or_create_user_cart(self)
+        return get_user_cart(self)
 
     def resolve_permissions(self, info, **kwargs):
         if self.is_superuser:

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -183,6 +183,9 @@ def test_query_customers(
             edges {
                 node {
                     isStaff
+                    checkout {
+                        id
+                    }
                 }
             }
         }
@@ -195,6 +198,7 @@ def test_query_customers(
     users = content['data']['customers']['edges']
     assert users
     assert all([not user['node']['isStaff'] for user in users])
+    assert all([user['node']['checkout'] is None for user in users])
 
     # check permissions
     response = user_api_client.post_graphql(query, variables)


### PR DESCRIPTION
Continue https://github.com/mirumee/saleor/pull/3725

@maarcingebala Thanks for the comments. It is not good to create empty checkouts for each user especially in dashboard 2.0 indeed. I did some update on the PR which will only create emtpy checkout for ```me->checkout``` API if this user doesn't have any available checkouts. The remaining API such as ```customers->checkout``` or ```user->checkout``` which is used in dashboard is still kept same which won't create empty checkouts.

Free feel to close it if it's still not suitable for Saleor. :d

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
