### PR TITLE
Sort order's payment and history descendingly in dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add orderByToken query - #3740 by @michaljelonek
 - Enable existing search with backend picker in products query - #3736 by @michaljelonek
 - Fix bug where payment is not filtered from active ones when creating payment - #3731 by @jxltom
+- Sort order's payment and history descendingly - #3747 by @jxltom
 
 
 ## 2.3.0

--- a/saleor/dashboard/order/views.py
+++ b/saleor/dashboard/order/views.py
@@ -119,12 +119,12 @@ def order_details(request, order_pk):
         'payments__transactions', 'events__user', 'lines__variant__product',
         'fulfillments__lines__order_line')
     order = get_object_or_404(qs, pk=order_pk)
-    all_payments = order.payments.all()
+    all_payments = order.payments.order_by('-pk').all()
     payment = order.get_last_payment()
     ctx = {
         'order': order, 'all_payments': all_payments, 'payment': payment,
         'notes': order.events.filter(type=OrderEvents.NOTE_ADDED.value),
-        'events': order.events.all(),
+        'events': order.events.order_by('-date').all(),
         'order_fulfillments': order.fulfillments.all()}
     return TemplateResponse(request, 'dashboard/order/detail.html', ctx)
 


### PR DESCRIPTION
Usually the last payment and last order event of a order is most important. This PR sorts the payment and order event descendingly in dashboard. I feels it is more intuitive.

### Screenshots

![screenshot from 2019-02-19 15-22-57](https://user-images.githubusercontent.com/1401630/52997375-60126f80-345b-11e9-9023-413ea91f9672.png)
![screenshot from 2019-02-19 15-23-08](https://user-images.githubusercontent.com/1401630/52997379-61dc3300-345b-11e9-9581-e7d6290387ac.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
