### PR TITLE
Fix storefront styles after bootstrap is updated to 4.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Filter order by payment status from order's last payment - #3749 @jxltom
 - Reuse cart creation logic in API - #3761 by @maarcingebala
 - Add json fields to models for content/description - #3756 by @michaljelonek
+- Fix storefront styles after bootstrap is updated to 4.3.1 - #3753 by @jxltom
+
 
 ## 2.3.0
 ### API

--- a/saleor/static/scss/components/_forms.scss
+++ b/saleor/static/scss/components/_forms.scss
@@ -95,6 +95,7 @@ input {
     }
   }
   .form-control {
+    height: 53px;
     width: 100%;
     border-radius: $button-border-radius;
     padding: $global-padding;

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -241,7 +241,7 @@
         display: block;
         border: solid 1px transparent;
         border-radius: 4px 4px 0 0;
-        padding: $global-padding * 2.5;
+        padding: $global-padding * 2.5 $global-padding * 1.5;
         position: absolute;
         right: 0;
         top: 0;
@@ -278,8 +278,8 @@
         }
         .badge {
           position: absolute;
-          right: 20px;
-          top: 20px;
+          right: 10px;
+          top: 30px;
           background-color: $light-turquoise;
           border-radius: 100px;
           color: $white;

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -209,7 +209,7 @@
         vertical-align: middle;
       }
       .btn {
-        padding: $global-padding;
+        padding: $global-padding / 2;
       }
     }
     .mobile-search-icon {

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -209,7 +209,7 @@
         vertical-align: middle;
       }
       .btn {
-        padding: $global-padding / 2;
+        padding: $global-padding;
       }
     }
     .mobile-search-icon {
@@ -241,7 +241,7 @@
         display: block;
         border: solid 1px transparent;
         border-radius: 4px 4px 0 0;
-        padding: $global-padding * 2;
+        padding: $global-padding * 2.5;
         position: absolute;
         right: 0;
         top: 0;

--- a/saleor/static/scss/layouts/_checkout.scss
+++ b/saleor/static/scss/layouts/_checkout.scss
@@ -91,8 +91,8 @@
           border-radius: 12px;
         }
         .btn {
-          height: 3.6rem;
-          padding: $global-padding;
+          height: calc(2.25rem + 2px);
+          padding: $global-padding / 2;
         }
         .btn-voucher-remove {
           position: relative;


### PR DESCRIPTION
After bootstrap is updated to 4.3.1 in https://github.com/mirumee/saleor/pull/3734 (actually the incompatibility is introduced in 4.2.1), some styles in storefront are broken. This PR fixes them.

### Screenshots

Before:
![screenshot from 2019-02-20 10-21-04](https://user-images.githubusercontent.com/1401630/53061889-02813000-34fa-11e9-8432-9678497af119.png)
![screenshot from 2019-02-20 10-27-45](https://user-images.githubusercontent.com/1401630/53061978-3a887300-34fa-11e9-8fac-a1edc8484bff.png)

After:
![screenshot from 2019-02-20 10-28-59](https://user-images.githubusercontent.com/1401630/53062009-5a1f9b80-34fa-11e9-9fff-0b80a079ee4d.png)
![screenshot from 2019-02-20 10-28-47](https://user-images.githubusercontent.com/1401630/53062011-5be95f00-34fa-11e9-978e-30fc53d0a3d6.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
