### PR TITLE
Fix order weight mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutations to manage addresses for authenticated customers - #3772 by @Kwaidan00, @maarcingebala
 - Limit access of quantity and allocated quantity to staff in GraphQL API #3780 by @jxltom
 - Only include cancelled fulfillments for staff in fulfillment API - #3778 by @jxltom
+- Add function to recalculate order's total weight - #3755 by @Kwaidan00, @maarcingebala
 
 
 ## 2.3.1

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -14,6 +14,7 @@ from measurement.measures import Weight
 from ..account.models import Address
 from ..core.utils.taxes import ZERO_TAXED_MONEY, zero_money
 from ..shipping.models import ShippingMethod
+from ..core.weight import zero_weight
 
 CENTS = Decimal('0.01')
 
@@ -102,7 +103,7 @@ class Cart(models.Model):
 
     def get_total_weight(self):
         # Cannot use `sum` as it parses an empty Weight to an int
-        weights = Weight(kg=0)
+        weights = zero_weight()
         for line in self:
             weights += line.variant.get_weight() * line.quantity
         return weights

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -42,7 +42,7 @@ WeightUnitsEnum = Enum(
 
 
 def zero_weight():
-    """Function used as a model's default."""
+    """Represent the zero weight value."""
     return Weight(kg=0)
 
 

--- a/saleor/dashboard/order/forms.py
+++ b/saleor/dashboard/order/forms.py
@@ -362,12 +362,11 @@ class CancelOrderLineForm(forms.Form):
         super().__init__(*args, **kwargs)
 
     def cancel_line(self):
-        if self.line.variant:
-            if self.line.variant.track_inventory:
-                deallocate_stock(self.line.variant, self.line.quantity)
-            order = self.line.order
-            delete_order_line(self.line)
-            recalculate_order(order)
+        if self.line.variant and self.line.variant.track_inventory:
+            deallocate_stock(self.line.variant, self.line.quantity)
+        order = self.line.order
+        delete_order_line(self.line)
+        recalculate_order(order)
 
 
 class ChangeQuantityForm(forms.ModelForm):
@@ -402,13 +401,12 @@ class ChangeQuantityForm(forms.ModelForm):
     def save(self):
         quantity = self.cleaned_data['quantity']
         variant = self.instance.variant
-        if variant:
-            if variant.track_inventory:
-                # update stock allocation
-                delta = quantity - self.initial_quantity
-                allocate_stock(variant, delta)
-            change_order_line_quantity(self.instance, quantity)
-            recalculate_order(self.instance.order)
+        if variant and variant.track_inventory:
+            # update stock allocation
+            delta = quantity - self.initial_quantity
+            allocate_stock(variant, delta)
+        change_order_line_quantity(self.instance, quantity)
+        recalculate_order(self.instance.order)
         return self.instance
 
 

--- a/saleor/dashboard/order/forms.py
+++ b/saleor/dashboard/order/forms.py
@@ -16,7 +16,7 @@ from ...order import OrderStatus
 from ...order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ...order.utils import (
     add_variant_to_order, cancel_fulfillment, cancel_order,
-    change_order_line_quantity, recalculate_order)
+    change_order_line_quantity, delete_order_line, recalculate_order)
 from ...payment import ChargeStatus, CustomPaymentChoices, PaymentError
 from ...payment.utils import (
     clean_mark_order_as_paid, gateway_capture, gateway_refund, gateway_void,
@@ -362,11 +362,12 @@ class CancelOrderLineForm(forms.Form):
         super().__init__(*args, **kwargs)
 
     def cancel_line(self):
-        if self.line.variant and self.line.variant.track_inventory:
-            deallocate_stock(self.line.variant, self.line.quantity)
-        order = self.line.order
-        self.line.delete()
-        recalculate_order(order)
+        if self.line.variant:
+            if self.line.variant.track_inventory:
+                deallocate_stock(self.line.variant, self.line.quantity)
+            order = self.line.order
+            delete_order_line(self.line)
+            recalculate_order(order)
 
 
 class ChangeQuantityForm(forms.ModelForm):
@@ -401,12 +402,13 @@ class ChangeQuantityForm(forms.ModelForm):
     def save(self):
         quantity = self.cleaned_data['quantity']
         variant = self.instance.variant
-        if variant and variant.track_inventory:
-            # update stock allocation
-            delta = quantity - self.initial_quantity
-            allocate_stock(variant, delta)
-        change_order_line_quantity(self.instance, quantity)
-        recalculate_order(self.instance.order)
+        if variant:
+            if variant.track_inventory:
+                # update stock allocation
+                delta = quantity - self.initial_quantity
+                allocate_stock(variant, delta)
+            change_order_line_quantity(self.instance, quantity)
+            recalculate_order(self.instance.order)
         return self.instance
 
 

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -9,8 +9,8 @@ from ....core.exceptions import InsufficientStock
 from ....core.utils.taxes import ZERO_TAXED_MONEY
 from ....order import OrderEvents, OrderStatus, models
 from ....order.utils import (
-    add_variant_to_order, allocate_stock,
-    change_order_line_quantity, delete_order_line, recalculate_order)
+    add_variant_to_order, allocate_stock, change_order_line_quantity,
+    delete_order_line, recalculate_order)
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -287,9 +287,6 @@ class DraftOrderLineDelete(BaseMutation):
         if order.status != OrderStatus.DRAFT:
             cls.add_error(
                 errors, 'id', 'Only draft orders can be edited.')
-        if not line.variant:
-            cls.add_error(
-                errors, None, 'Order line without variant can not be deleted.')
         if not errors:
             db_id = line.id
             delete_order_line(line)
@@ -330,9 +327,6 @@ class DraftOrderLineUpdate(ModelMutation):
                 errors, 'quantity',
                 'Ensure this value is greater than or equal to 1.')
 
-        if not instance.variant:
-            cls.add_error(
-                errors, None, 'Order line without variant can not be edited')
         return cleaned_input
 
     @classmethod

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -7,6 +7,8 @@ def can_finalize_draft_order(order, errors):
 
     Checks, if given order has a proper customer data, shipping
     address and method set up and return list of errors if not.
+    Checks if product variants for order lines still exists in
+    database, too.
     """
     if order.get_total_quantity() == 0:
         errors.append(
@@ -25,6 +27,13 @@ def can_finalize_draft_order(order, errors):
                     field='shipping',
                     message='Shipping method is not valid for chosen shipping '
                             'address'))
+    line_variants = [line.variant for line in order]
+    if None in line_variants:
+        errors.append(
+            Error(
+                field='lines',
+                message='Could not create orders with non-existing products.'))
+
     return errors
 
 

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -2,19 +2,15 @@ from ...shipping import models as shipping_models
 from ..core.types.common import Error
 
 
-def can_finalize_draft_order(order, errors):
-    """Return a list of errors associated with the order.
-
-    Checks, if given order has a proper customer data, shipping
-    address and method set up and return list of errors if not.
-    Checks if product variants for order lines still exists in
-    database, too.
-    """
+def _check_can_finalize_products_quantity(order, errors):
     if order.get_total_quantity() == 0:
         errors.append(
             Error(
                 field='lines',
                 message='Could not create order without any products.'))
+
+
+def _check_can_finalize_shipping(order, errors):
     if order.is_shipping_required():
         method = order.shipping_method
         shipping_address = order.shipping_address
@@ -26,7 +22,10 @@ def can_finalize_draft_order(order, errors):
                 Error(
                     field='shipping',
                     message='Shipping method is not valid for chosen shipping '
-                            'address'))
+                    'address'))
+
+
+def _check_can_finalize_products_exists(order, errors):
     line_variants = [line.variant for line in order]
     if None in line_variants:
         errors.append(
@@ -34,6 +33,18 @@ def can_finalize_draft_order(order, errors):
                 field='lines',
                 message='Could not create orders with non-existing products.'))
 
+
+def can_finalize_draft_order(order, errors):
+    """Return a list of errors associated with the order.
+
+    Checks, if given order has a proper customer data, shipping
+    address and method set up and return list of errors if not.
+    Checks if product variants for order lines still exists in
+    database, too.
+    """
+    _check_can_finalize_products_quantity(order, errors)
+    _check_can_finalize_shipping(order, errors)
+    _check_can_finalize_products_exists(order, errors)
     return errors
 
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -312,12 +312,12 @@ class OrderLine(models.Model):
         return self.product_name
 
     def save(self, *args, **kwargs):
-        print(kwargs)
         if not self.pk:
             if ('order' in kwargs and 'variant' in kwargs
                     and 'quantity' in kwargs):
                 order = kwargs['order']
-                order.weight += kwargs['variant'].get_weight() * kwargs['quantity']
+                order.weight += (
+                    kwargs['variant'].get_weight() * kwargs['quantity'])
                 order.save()
         super().save(*args, **kwargs)
 

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -274,11 +274,7 @@ class Order(models.Model):
         return self.total_captured - self.total.gross
 
     def get_total_weight(self):
-        # Cannot use `sum` as it parses an empty Weight to an int
-        weights = Weight(kg=0)
-        for line in self:
-            weights += line.variant.get_weight() * line.quantity
-        return weights
+        return self.weight
 
 
 class OrderLine(models.Model):
@@ -314,6 +310,16 @@ class OrderLine(models.Model):
 
     def __str__(self):
         return self.product_name
+
+    def save(self, *args, **kwargs):
+        print(kwargs)
+        if not self.pk:
+            if ('order' in kwargs and 'variant' in kwargs
+                    and 'quantity' in kwargs):
+                order = kwargs['order']
+                order.weight += kwargs['variant'].get_weight() * kwargs['quantity']
+                order.save()
+        super().save(*args, **kwargs)
 
     def get_total(self):
         return self.unit_price * self.quantity

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -311,16 +311,6 @@ class OrderLine(models.Model):
     def __str__(self):
         return self.product_name
 
-    def save(self, *args, **kwargs):
-        if not self.pk:
-            if ('order' in kwargs and 'variant' in kwargs
-                    and 'quantity' in kwargs):
-                order = kwargs['order']
-                order.weight += (
-                    kwargs['variant'].get_weight() * kwargs['quantity'])
-                order.save()
-        super().save(*args, **kwargs)
-
     def get_total(self):
         return self.unit_price * self.quantity
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -212,7 +212,6 @@ def add_variant_to_order(
             variant=variant,
             unit_price=variant.get_price(discounts, taxes),
             tax_rate=get_tax_rate_by_name(variant.product.tax_rate, taxes))
-        order.save(update_fields=['weight'])
 
     if variant.track_inventory and track_inventory:
         allocate_stock(variant, quantity)

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -673,25 +673,6 @@ def test_draft_order_line_update(
     assert data['errors'][0]['field'] == 'quantity'
 
 
-def test_draft_order_update_with_non_existing_product(
-        draft_order, staff_api_client, permission_manage_orders):
-    # To keep data integrity, delete broken lines from draft order
-    query = DRAFT_ORDER_LINE_UPDATE_MUTATION
-    order = draft_order
-    line = order.lines.first()
-    variant = line.variant
-    variant.delete()
-    line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = {'lineId': line_id, 'quantity': 2}
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_orders])
-    content = get_graphql_content(response)
-    data = content['data']['draftOrderLineUpdate']
-    assert not data['errors']
-    with pytest.raises(line._meta.model.DoesNotExist):
-        line.refresh_from_db()
-
-
 def test_require_draft_order_when_updating_lines(
         order_with_lines, staff_api_client, permission_manage_orders):
     query = DRAFT_ORDER_LINE_UPDATE_MUTATION

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -424,7 +424,6 @@ def test_can_finalize_draft_order_non_existing_variant(order_with_lines):
     line.refresh_from_db()
     assert line.variant is None
 
-    order.refresh_from_db()
     errors = can_finalize_draft_order(order, [])
     assert (
         errors[0].message ==

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -675,6 +675,7 @@ def test_draft_order_line_update(
 
 def test_draft_order_update_with_non_existing_product(
         draft_order, staff_api_client, permission_manage_orders):
+    # To keep data integrity, delete broken lines from draft order
     query = DRAFT_ORDER_LINE_UPDATE_MUTATION
     order = draft_order
     line = order.lines.first()
@@ -686,7 +687,9 @@ def test_draft_order_update_with_non_existing_product(
         query, variables, permissions=[permission_manage_orders])
     content = get_graphql_content(response)
     data = content['data']['draftOrderLineUpdate']
-    assert data['errors']
+    assert not data['errors']
+    with pytest.raises(line._meta.model.DoesNotExist):
+        line.refresh_from_db()
 
 
 def test_require_draft_order_when_updating_lines(
@@ -742,22 +745,6 @@ def test_require_draft_order_when_removing_lines(
     query = DRAFT_ORDER_LINE_DELETE_MUTATION
     order = order_with_lines
     line = order.lines.first()
-    line_id = graphene.Node.to_global_id('OrderLine', line.id)
-    variables = {'id': line_id}
-    response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_orders])
-    content = get_graphql_content(response)
-    data = content['data']['draftOrderLineDelete']
-    assert data['errors']
-
-
-def test_draft_order_remove_with_non_existing_product(
-        draft_order, staff_api_client, permission_manage_orders):
-    query = DRAFT_ORDER_LINE_DELETE_MUTATION
-    order = draft_order
-    line = order.lines.first()
-    variant = line.variant
-    variant.delete()
     line_id = graphene.Node.to_global_id('OrderLine', line.id)
     variables = {'id': line_id}
     response = staff_api_client.post_graphql(

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,8 +13,8 @@ ES_URL = None
 SEARCH_BACKEND = 'saleor.search.backends.postgresql'
 INSTALLED_APPS = [a for a in INSTALLED_APPS if a != 'django_elasticsearch_dsl']
 
-RECAPTCHA_PUBLIC_KEY = None
-RECAPTCHA_PRIVATE_KEY = None
+RECAPTCHA_PUBLIC_KEY = ''
+RECAPTCHA_PRIVATE_KEY = ''
 
 VATLAYER_ACCESS_KEY = ''
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -3,24 +3,24 @@ from decimal import Decimal
 import pytest
 from django.urls import reverse
 from django_countries.fields import Country
-from measurement.measures import Weight
 from prices import Money, TaxedMoney
+from tests.utils import get_redirect_location
 
 from saleor.account.models import User
 from saleor.checkout.utils import create_order
 from saleor.core.exceptions import InsufficientStock
 from saleor.core.utils.taxes import (
     DEFAULT_TAX_RATE_NAME, get_tax_rate_by_name, get_taxes_for_country)
+from saleor.core.weight import zero_weight
 from saleor.order import FulfillmentStatus, OrderStatus, models
 from saleor.order.models import Order
 from saleor.order.utils import (
     add_variant_to_order, cancel_fulfillment, cancel_order,
     change_order_line_quantity, delete_order_line, recalculate_order,
-    restock_fulfillment_lines, restock_order_lines, update_order_prices,
-    update_order_status)
+    recalculate_order_weight, restock_fulfillment_lines, restock_order_lines,
+    update_order_prices, update_order_status)
 from saleor.payment import ChargeStatus
 from saleor.payment.models import Payment
-from tests.utils import get_redirect_location
 
 
 def test_total_setter():
@@ -520,35 +520,30 @@ def test_add_order_note_view(order, authorized_client, customer_user):
 
 
 def _calculate_order_weight_from_lines(order):
-    weight = Weight(kg=0)
+    weight = zero_weight()
     for line in order:
         weight += line.variant.get_weight() * line.quantity
     return weight
 
 
-def test_order_weight(order_with_lines):
+def test_calculate_order_weight(order_with_lines):
     order_weight = order_with_lines.weight
     calculated_weight = _calculate_order_weight_from_lines(order_with_lines)
-
     assert calculated_weight == order_weight
 
 
 def test_order_weight_add_more_variant(order_with_lines):
     variant = order_with_lines.lines.first().variant
-
     add_variant_to_order(order_with_lines, variant, 2)
     order_with_lines.refresh_from_db()
-
     assert order_with_lines.weight == _calculate_order_weight_from_lines(
         order_with_lines)
 
 
 def test_order_weight_add_new_variant(order_with_lines, product):
     variant = product.variants.first()
-
     add_variant_to_order(order_with_lines, variant, 2)
     order_with_lines.refresh_from_db()
-
     assert order_with_lines.weight == _calculate_order_weight_from_lines(
         order_with_lines)
 
@@ -558,7 +553,6 @@ def test_order_weight_change_line_quantity(order_with_lines):
     new_quantity = line.quantity + 2
     change_order_line_quantity(line, new_quantity)
     order_with_lines.refresh_from_db()
-
     assert order_with_lines.weight == _calculate_order_weight_from_lines(
         order_with_lines)
 
@@ -566,7 +560,6 @@ def test_order_weight_change_line_quantity(order_with_lines):
 def test_order_weight_delete_line(order_with_lines):
     line = order_with_lines.lines.first()
     delete_order_line(line)
-
     assert order_with_lines.weight == _calculate_order_weight_from_lines(
         order_with_lines)
 


### PR DESCRIPTION
I want to merge this change because it fixes using `weight` field in `Order`.

We would like to store order data even if product related with `orderLine` was deleted. To accomplish that, we cannot use an old implementation of `Order.get_total_weight`, as it was mention in #3710. On the other hand, `Order.weight` was totally unused.

I could:
- add `weight` field to `orderLine` mode and copy value from `ProductVariant`;
- keep updated `weight` field in `Order` model.

I propose the second solution.

~~In addition, this PR resolves problem with creating order from draft with lines related to non-existing product. In that case I assumed that user cannot create order from draft.~~

EDIT (@maarcingebala): I've removed the above part from PR, we should handle that separately.

I didn't remove `Order.get_total_weight` method to keep common protocol with `Cart`. It is used when available shipping method is calculated. 

<!-- Please mention all relevant issue numbers. -->
It fixes #3710 

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.