### PR TITLE
Limit access of quantity and allocated quantity to staff in GraphQL API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix storefront styles after bootstrap is updated to 4.3.1 - #3753 by @jxltom
 - Fix logo size in different browser and devices with different sizes - #3722 by @jxltom
 - Add missing type definition for dashboard 2.0 - #3776 by @jxltom
-
+- Limit access of quantity and allocated quantity to staff in GraphQL API #3780 by @jxltom
 
 ## 2.3.1
 - Fix access to private variant fields in API - #3773 by maarcingebala

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -189,11 +189,19 @@ class ProductVariant(CountableDjangoObjectType):
     def resolve_price_override(self, info):
         return self.price_override
 
+    @permission_required('product.manage_products')
+    def resolve_quantity(self, info):
+        return self.quantity
+
     @permission_required(['order.manage_orders', 'product.manage_products'])
     def resolve_quantity_ordered(self, info):
         # This field is added through annotation when using the
         # `resolve_report_product_sales` resolver.
         return getattr(self, 'quantity_ordered', None)
+
+    @permission_required(['order.manage_orders', 'product.manage_products'])
+    def resolve_quantity_allocated(self, info):
+        return self.quantity_allocated
 
     @permission_required(['order.manage_orders', 'product.manage_products'])
     def resolve_revenue(self, info, period):

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1662,6 +1662,24 @@ def test_variant_revenue_permissions(
     assert content['data']['productVariant']['revenue']
 
 
+def test_variant_quantity_permissions(
+        staff_api_client, permission_manage_products, product):
+    query = """
+    query Quantity($id: ID!) {
+        productVariant(id: $id) {
+            quantity
+        }
+    }
+    """
+    variant = product.variants.first()
+    variables = {
+        'id': graphene.Node.to_global_id('ProductVariant', variant.pk)}
+    permissions = [permission_manage_products]
+    response = staff_api_client.post_graphql(query, variables, permissions)
+    content = get_graphql_content(response)
+    assert 'quantity' in content['data']['productVariant']
+
+
 def test_variant_quantity_ordered_permissions(
         staff_api_client, permission_manage_products,
         permission_manage_orders, product):
@@ -1679,6 +1697,25 @@ def test_variant_quantity_ordered_permissions(
     response = staff_api_client.post_graphql(query, variables, permissions)
     content = get_graphql_content(response)
     assert 'quantityOrdered' in content['data']['productVariant']
+
+
+def test_variant_quantity_allocated_permissions(
+        staff_api_client, permission_manage_products,
+        permission_manage_orders, product):
+    query = """
+    query QuantityAllocated($id: ID!) {
+        productVariant(id: $id) {
+            quantityAllocated
+        }
+    }
+    """
+    variant = product.variants.first()
+    variables = {
+        'id': graphene.Node.to_global_id('ProductVariant', variant.pk)}
+    permissions = [permission_manage_orders, permission_manage_products]
+    response = staff_api_client.post_graphql(query, variables, permissions)
+    content = get_graphql_content(response)
+    assert 'quantityAllocated' in content['data']['productVariant']
 
 
 def test_variant_margin_permissions(


### PR DESCRIPTION
Continue fix https://github.com/mirumee/saleor/issues/3768

The ```quantity_allocated``` is similar with ```quantity_ordered```, so it should only be acessed by staff.
With ```quantity``` and ```stock```, anyone could calculate the ordered quantity, so access of ```quantity``` should also be limited.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
