### PR TITLE
Fix incorrect cart badge location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutations to manage addresses for authenticated customers - #3772 by @Kwaidan00, @maarcingebala
 - Limit access of quantity and allocated quantity to staff in GraphQL API #3780 by @jxltom
 - Only include cancelled fulfillments for staff in fulfillment API - #3778 by @jxltom
-
+- Fix incorrect cart badge location - #3786 by @jxltom
 
 ## 2.3.1
 - Fix access to private variant fields in API - #3773 by maarcingebala

--- a/saleor/static/scss/components/_header.scss
+++ b/saleor/static/scss/components/_header.scss
@@ -293,6 +293,7 @@
           }
           @include media-breakpoint-down(sm) {
             right: 0;
+            top: 20px;
           }
         }
       }


### PR DESCRIPTION
Sorry it looks like I missed something in https://github.com/mirumee/saleor/pull/3753/. The cart badge location is incorrect in small devices such as iphone. This PR fixes this issue.

### Screenshots

Before:
![screenshot from 2019-02-28 11-18-20](https://user-images.githubusercontent.com/1401630/53539377-59b38000-3b4c-11e9-85a7-4f66e9ed1b68.png)

After:
![screenshot from 2019-02-28 11-17-16](https://user-images.githubusercontent.com/1401630/53539379-5ae4ad00-3b4c-11e9-9562-199776d6ccd3.png)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
