### PR TITLE
Checkout API improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix storefront styles after bootstrap is updated to 4.3.1 - #3753 by @jxltom
 - Fix logo size in different browser and devices with different sizes - #3722 by @jxltom
 - Add missing type definition for dashboard 2.0 - #3776 by @jxltom
+- Unify behavior after creating checkout in API and Storefront 1.0; code formatting improvements - #3790 by @maarcingebala
 
 
 ## 2.3.1

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -859,7 +859,7 @@ def create_order(cart: Cart, tracking_code: str, discounts, taxes):
     if order is not None:
         return order
 
-    order_data: dict = {}
+    order_data = {}
     order_data.update(_process_voucher_data_for_order(cart))
     order_data.update(_process_shipping_data_for_order(cart, taxes))
     order_data.update(_process_user_data_for_order(cart))

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -189,7 +189,11 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         # `mutate` method is overriden to properly get or create a checkout
         # instance here:
         if user.is_authenticated:
-            checkout = get_or_create_user_cart(user)
+            checkout, created = get_or_create_user_cart(user)
+            # If user has an active checkout, return it without any
+            # modifications.
+            if not created:
+                return CheckoutCreate(checkout=checkout, errors=errors)
         else:
             checkout = models.Cart()
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1250,19 +1250,19 @@ type Payment implements Node {
   created: DateTime!
   modified: DateTime!
   chargeStatus: PaymentChargeStatusEnum!
-  billingEmail: String!
-  customerIpAddress: String
-  extraData: String!
   token: String!
   total: Money
   capturedAmount: Money
   checkout: Checkout
   order: Order
+  billingEmail: String!
   ccFirstDigits: String!
   ccLastDigits: String!
   ccBrand: String!
   ccExpMonth: Int
   ccExpYear: Int
+  customerIpAddress: String
+  extraData: String!
   transactions: [Transaction]
   actions: [OrderAction]!
   billingAddress: Address
@@ -1297,7 +1297,7 @@ input PaymentInput {
   gateway: GatewaysEnum!
   token: String!
   amount: Decimal!
-  billingAddress: AddressInput!
+  billingAddress: AddressInput
 }
 
 type PaymentRefund {

--- a/saleor/payment/__init__.py
+++ b/saleor/payment/__init__.py
@@ -34,6 +34,8 @@ class OperationType(Enum):
 
 
 class TransactionError(Enum):
+    """Represents a transaction error."""
+
     INCORRECT_NUMBER = 'incorrect_number'
     INVALID_NUMBER = 'invalid_number'
     INCORRECT_CVV = 'incorrect_cvv'
@@ -47,16 +49,18 @@ class TransactionError(Enum):
 
 
 class TransactionKind:
+    """Represents the type of a transaction.
+
+    The following transactions types are possible:
+    - AUTH - an amount reserved against the customer's funding source. Money
+    does not change hands until the authorization is captured.
+    - CHARGE - authorization and capture in a single step.
+    - VOID - a cancellation of a pending authorization or capture.
+    - CAPTURE - a transfer of the money that was reserved during the
+    authorization stage.
+    - REFUND - full or partial return of captured funds to the customer.
     """
-    - Authorization: An amount reserved against the customer's funding
-                     source. Money does not change hands until the
-                     authorization is captured.
-    - Charge: Authorization and capture in a single step.
-    - Void: A cancellation of a pending authorization or capture.
-    - Capture: A transfer of the money that was reserved during the
-               authorization stage.
-    - Refund: Full or partial return of captured funds to the customer.
-    """
+
     AUTH = 'auth'
     CHARGE = 'charge'
     CAPTURE = 'capture'
@@ -73,20 +77,18 @@ class TransactionKind:
 
 
 class ChargeStatus:
+    """Represents possible statuses of a payment.
+
+    The following statuses are possible:
+    - CHARGED - funds were taken off the customer founding source,
+    partly or completely covering the payment amount.
+    - NOT_CHARGED - no funds were take off the customer founding source yet.
+    - FULLY_REFUNDED - all charged funds were returned to the customer.
     """
-    - Charged: Funds were taken off the customer founding source, partly or
-               completely covering the payment amount.
-    - Not charged: No funds were take off the customer founding source yet.
-    - Fully refunded: All charged funds were returned to the customer.
-    """
+
     CHARGED = 'charged'
     NOT_CHARGED = 'not-charged'
     FULLY_REFUNDED = 'fully-refunded'
-    # FIXME
-    # We could probably support other statuses, like:
-    # partially refunded
-    # fully charged
-    # ...?
     CHOICES = [
         (CHARGED, pgettext_lazy('payment status', 'Charged')),
         (NOT_CHARGED, pgettext_lazy('payment status', 'Not charged')),

--- a/saleor/payment/models.py
+++ b/saleor/payment/models.py
@@ -16,29 +16,44 @@ from ..order.models import Order
 
 
 class Payment(models.Model):
-    """Represents transactable payment information
-    such as credit card details, gift card information or a customer's
-    authorization to charge their PayPal account.
+    """A model that represents a single payment.
+
+    This might be a transactable payment information such as credit card
+    details, gift card information or a customer's authorization to charge
+    their PayPal account.
 
     All payment process related pieces of information are stored
     at the gateway level, we are operating on the reusable token
     which is a unique identifier of the customer for given gateway.
 
-    Several payment methods can be used within a single order.
+    Several payment methods can be used within a single order. Each payment
+    method may consist of multiple transactions.
     """
-    # FIXME we should provide an option to store the card for later usage
-    # FIXME probably we should have pending status for 3d secure
+
     gateway = models.CharField(max_length=255)
     is_active = models.BooleanField(default=True)
-    #: Creation date and time
     created = models.DateTimeField(auto_now_add=True)
-    #: Date and time of last modification
     modified = models.DateTimeField(auto_now=True)
     charge_status = models.CharField(
-        max_length=15,
-        choices=ChargeStatus.CHOICES,
+        max_length=15, choices=ChargeStatus.CHOICES,
         default=ChargeStatus.NOT_CHARGED)
+    token = models.CharField(max_length=128, blank=True, default='')
+    total = models.DecimalField(
+        max_digits=settings.DEFAULT_MAX_DIGITS,
+        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
+        default=Decimal('0.0'))
+    captured_amount = models.DecimalField(
+        max_digits=settings.DEFAULT_MAX_DIGITS,
+        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
+        default=Decimal('0.0'))
+    currency = models.CharField(max_length=10)  # FIXME: add ISO4217 validator
 
+    checkout = models.ForeignKey(
+        Cart, null=True, related_name='payments', on_delete=models.SET_NULL)
+    order = models.ForeignKey(
+        Order, null=True, related_name='payments', on_delete=models.PROTECT)
+
+    billing_email = models.EmailField(blank=True)
     billing_first_name = models.CharField(max_length=256, blank=True)
     billing_last_name = models.CharField(max_length=256, blank=True)
     billing_company_name = models.CharField(max_length=256, blank=True)
@@ -49,39 +64,18 @@ class Payment(models.Model):
     billing_postal_code = models.CharField(max_length=256, blank=True)
     billing_country_code = models.CharField(max_length=2, blank=True)
     billing_country_area = models.CharField(max_length=256, blank=True)
-    billing_email = models.EmailField(blank=True)
-    customer_ip_address = models.GenericIPAddressField(blank=True, null=True)
-    extra_data = models.TextField(blank=True, default='')
-    token = models.CharField(max_length=128, blank=True, default='')
 
-    #: Currency code (might be gateway-specific)
-    # FIXME: add ISO4217 validator?
-    currency = models.CharField(max_length=10)
-    #: Total amount (gross)
-    total = models.DecimalField(
-        max_digits=settings.DEFAULT_MAX_DIGITS,
-        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=Decimal('0.0'))
-    captured_amount = models.DecimalField(
-        max_digits=settings.DEFAULT_MAX_DIGITS,
-        decimal_places=settings.DEFAULT_DECIMAL_PLACES,
-        default=Decimal('0.0'))
-
-    checkout = models.ForeignKey(
-        Cart, null=True, related_name='payments', on_delete=models.SET_NULL)
-    order = models.ForeignKey(
-        Order, null=True, related_name='payments', on_delete=models.PROTECT)
-
-    # Credit Card data, if applicable
     cc_first_digits = models.CharField(max_length=6, blank=True, default='')
     cc_last_digits = models.CharField(max_length=4, blank=True, default='')
     cc_brand = models.CharField(max_length=40, blank=True, default='')
     cc_exp_month = models.PositiveIntegerField(
         validators=[MinValueValidator(1), MaxValueValidator(12)],
         null=True, blank=True)
-    # exp year should be in 4 digits format
     cc_exp_year = models.PositiveIntegerField(
         validators=[MinValueValidator(1000)], null=True, blank=True)
+
+    customer_ip_address = models.GenericIPAddressField(blank=True, null=True)
+    extra_data = models.TextField(blank=True, default='')
 
     class Meta:
         ordering = ('pk', )
@@ -163,26 +157,23 @@ class Payment(models.Model):
 
 
 class Transaction(models.Model):
-    """Transaction represent attempts to transfer money between your store
+    """Represents a single payment operation.
+
+    Transaction is an attempt to transfer money between your store
     and your customers, with a chosen payment method.
     """
+
     created = models.DateTimeField(auto_now_add=True, editable=False)
     payment = models.ForeignKey(
         Payment, related_name='transactions', on_delete=models.PROTECT)
     token = models.CharField(max_length=128, blank=True, default='')
     kind = models.CharField(max_length=10, choices=TransactionKind.CHOICES)
-    # FIXME probably we should have error/pending/success status instead of
-    # a bool, eg for payments with 3d secure
     is_success = models.BooleanField(default=False)
-    #: Currency code (may be gateway-specific)
-    # FIXME: ISO4217 validator?
     currency = models.CharField(max_length=10)
-    #: Total amount (gross)
     amount = models.DecimalField(
         max_digits=settings.DEFAULT_MAX_DIGITS,
         decimal_places=settings.DEFAULT_DECIMAL_PLACES,
         default=Decimal('0.0'))
-    # Unified error code across all payment gateways
     error = models.CharField(
         choices=[(tag, tag.value) for tag in TransactionError],
         max_length=256, null=True)

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -83,7 +83,7 @@ def handle_fully_paid_order(order):
         logger.exception('Recording order in analytics failed')
 
 
-def validate_payment(view):
+def require_active_payment(view):
     """Require an active payment instance.
 
     Decorate a view to check if payment is authorized, so any actions
@@ -373,7 +373,7 @@ def _gateway_postprocess(transaction, payment):
         payment.save(update_fields=changed_fields)
 
 
-@validate_payment
+@require_active_payment
 def gateway_process_payment(
         payment: Payment, payment_token: str) -> Transaction:
     """Performs whole payment process on a gateway."""
@@ -385,7 +385,7 @@ def gateway_process_payment(
     return transaction
 
 
-@validate_payment
+@require_active_payment
 def gateway_charge(
         payment: Payment, payment_token: str,
         amount: Decimal = None) -> Transaction:
@@ -410,7 +410,7 @@ def gateway_charge(
     return transaction
 
 
-@validate_payment
+@require_active_payment
 def gateway_authorize(payment: Payment, payment_token: str) -> Transaction:
     """Authorizes the payment and creates relevant transaction.
 
@@ -424,7 +424,7 @@ def gateway_authorize(payment: Payment, payment_token: str) -> Transaction:
         payment=payment, payment_token=payment_token)
 
 
-@validate_payment
+@require_active_payment
 def gateway_capture(payment: Payment, amount: Decimal = None) -> Transaction:
     """Captures the money that was reserved during the authorization stage."""
     if amount is None:
@@ -445,7 +445,7 @@ def gateway_capture(payment: Payment, amount: Decimal = None) -> Transaction:
     return transaction
 
 
-@validate_payment
+@require_active_payment
 def gateway_void(payment) -> Transaction:
     if not payment.can_void():
         raise PaymentError('Only pre-authorized transactions can be voided.')
@@ -464,7 +464,7 @@ def gateway_void(payment) -> Transaction:
     return transaction
 
 
-@validate_payment
+@require_active_payment
 def gateway_refund(payment, amount: Decimal = None) -> Transaction:
     """Refunds the charged funds back to the customer.
     Refunds can be total or partial.

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ skip =
     migrations
     node_modules
 not_skip = __init__.py
+multi_line_output = 4
 
 [yapf]
 based_on_style = pep8

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -15,9 +15,12 @@ MUTATION_CHECKOUT_CREATE = """
     mutation createCheckout($checkoutInput: CheckoutCreateInput!) {
         checkoutCreate(input: $checkoutInput) {
             checkout {
-                token,
                 id
+                token
                 email
+                lines {
+                    quantity
+                }
             }
             errors {
                 field
@@ -81,6 +84,10 @@ def test_checkout_create_reuse_cart(cart, user_api_client, variant):
     # assert that existing cart was reused and returned by mutation
     checkout_data = content['data']['checkoutCreate']['checkout']
     assert checkout_data['token'] == str(cart.token)
+
+    # if checkout was reused it should be returned unmodified (e.g. without
+    # adding new lines that was passed)
+    assert checkout_data['lines'] == []
 
 
 def test_checkout_create_required_email(api_client, variant):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -13,8 +13,8 @@ ES_URL = None
 SEARCH_BACKEND = 'saleor.search.backends.postgresql'
 INSTALLED_APPS = [a for a in INSTALLED_APPS if a != 'django_elasticsearch_dsl']
 
-RECAPTCHA_PUBLIC_KEY = None
-RECAPTCHA_PRIVATE_KEY = None
+RECAPTCHA_PUBLIC_KEY = ''
+RECAPTCHA_PRIVATE_KEY = ''
 
 VATLAYER_ACCESS_KEY = ''
 

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -79,7 +79,7 @@ def test_get_or_create_anonymous_cart_from_token(anonymous_cart, user_cart):
 
 def test_get_or_create_user_cart(
         customer_user, anonymous_cart, user_cart, admin_user):
-    cart = utils.get_or_create_user_cart(customer_user)
+    cart = utils.get_or_create_user_cart(customer_user)[0]
     assert Cart.objects.all().count() == 2
     assert cart == user_cart
 
@@ -87,7 +87,7 @@ def test_get_or_create_user_cart(
     Cart.objects.create(user=admin_user)
     queryset = Cart.objects.all()
     carts = list(queryset)
-    cart = utils.get_or_create_user_cart(admin_user)
+    cart = utils.get_or_create_user_cart(admin_user)[0]
     assert Cart.objects.all().count() == 3
     assert cart in carts
     assert cart.user == admin_user
@@ -122,7 +122,7 @@ def test_get_or_create_cart_from_request(
     request = cart_request_factory(user=customer_user, token=token)
     user_cart = Cart(user=customer_user)
     anonymous_cart = Cart()
-    mock_get_for_user = Mock(return_value=user_cart)
+    mock_get_for_user = Mock(return_value=(user_cart, False))
     mock_get_for_anonymous = Mock(return_value=anonymous_cart)
     monkeypatch.setattr(
         'saleor.checkout.utils.get_or_create_user_cart', mock_get_for_user)

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -260,6 +260,9 @@ def test_view_checkout_summary(
     assert response.request['PATH_INFO'] == redirect_url
     mock_send_confirmation.delay.assert_called_once_with(order.pk)
 
+    # cart should be deleted after order is created
+    assert request_cart_with_item.pk is None
+
 
 @patch('saleor.checkout.views.summary.send_order_confirmation')
 def test_view_checkout_summary_authorized_user(

--- a/tests/test_payment.py
+++ b/tests/test_payment.py
@@ -19,7 +19,7 @@ from saleor.payment.utils import (
     gateway_authorize, gateway_capture, gateway_charge,
     gateway_get_client_token, gateway_process_payment, gateway_refund,
     gateway_void, handle_fully_paid_order, mark_order_as_paid,
-    validate_gateway_response, validate_payment)
+    require_active_payment, validate_gateway_response)
 
 NOT_ACTIVE_PAYMENT_ERROR = 'This payment is no longer active.'
 EXAMPLE_ERROR = 'Example dummy error'
@@ -120,8 +120,8 @@ def test_handle_fully_paid_order(mock_send_payment_confirmation, order):
     mock_send_payment_confirmation.assert_called_once_with(order.pk)
 
 
-def test_validate_payment():
-    @validate_payment
+def test_require_active_payment():
+    @require_active_payment
     def test_function(payment, *args, **kwargs):
         return True
 


### PR DESCRIPTION
This PR removes some differences between checkout implementation in API and Storefront 1.0 and fixes a few other smaller issues that I discovered while working on it:
- remove checkout instance after an order is successfully created in API; send notifications and create history events,
- fixes `checkoutCreate` mutation - it used to increase order line quantity when called multiple times for an authenticated user with the same set of items,
- raise exceptions during order creation, so that they can be easily caught and handled in different places
- removed some hypothetical FIXMEs
- reorganized/reformatted code in a few places to look better (in my opinion)

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
