### PR TITLE
Fix product create when no product type provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add pages section in Dashboard 2.0; introduce Draftail WYSIWYG editor - #3751 by @dominik-zeglen
 - Support partially charged and partially refunded payment status - #3735 by @jxltom
 - Add translations to GraphQL API - #3789 by @michaljelonek
+- Fix product create when no product type provided - #3804 by @michaljelonek
 
 
 ## 2.3.1

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -351,7 +351,7 @@ class ProductCreate(ModelMutation):
         See the documentation for `has_variants` field for details:
         http://docs.getsaleor.com/en/latest/architecture/products.html#product-types
         """
-        if not product_type.has_variants:
+        if product_type and not product_type.has_variants:
             input_sku = cleaned_input.get('sku')
             if not input_sku:
                 cls.add_error(errors, 'sku', 'This field cannot be blank.')

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -710,6 +710,29 @@ def test_create_product_without_variants_sku_duplication(
     assert data['errors'][0]['message'] == 'Product with this SKU already exists.'
 
 
+def test_product_create_without_product_type(
+        staff_api_client, permission_manage_products):
+    query = """
+    mutation createProduct($name: String!) {
+        productCreate(input: {name: $name, productType: ""}) {
+            product {
+                id
+            }
+            errors {
+                message
+                field
+            }
+        }
+    }
+    """
+
+    response = staff_api_client.post_graphql(
+        query, {'name': 'Product'}, permissions=[permission_manage_products])
+    errors = get_graphql_content(response)['data']['productCreate']['errors']
+
+    assert errors[0]['field'] == 'productType'
+    assert errors[0]['message'] == 'This field cannot be null.'
+
 def test_update_product(
         staff_api_client, category, non_default_category, product,
         permission_manage_products):

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -711,10 +711,14 @@ def test_create_product_without_variants_sku_duplication(
 
 
 def test_product_create_without_product_type(
-        staff_api_client, permission_manage_products):
+        staff_api_client, category, permission_manage_products):
     query = """
-    mutation createProduct($name: String!) {
-        productCreate(input: {name: $name, productType: ""}) {
+    mutation createProduct($categoryId: ID!) {
+        productCreate(input: {
+                name: "Product", 
+                price: "2.5", 
+                productType: "",
+                category: $categoryId}) {
             product {
                 id
             }
@@ -726,12 +730,15 @@ def test_product_create_without_product_type(
     }
     """
 
+    category_id = graphene.Node.to_global_id('Category', category.id)
     response = staff_api_client.post_graphql(
-        query, {'name': 'Product'}, permissions=[permission_manage_products])
+        query, {'categoryId': category_id},
+        permissions=[permission_manage_products])
     errors = get_graphql_content(response)['data']['productCreate']['errors']
 
     assert errors[0]['field'] == 'productType'
     assert errors[0]['message'] == 'This field cannot be null.'
+
 
 def test_update_product(
         staff_api_client, category, non_default_category, product,


### PR DESCRIPTION
I want to merge this change because this gets rid of the exception throw when no product type was provided. 

Issue - #3797
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
