### PR TITLE
Update checkout addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutation for bulk publishing and unpublishing collections - #3970 by @akjanik
 - Rename Cart to Checkout - #3963 by @michaljelonek
 - Implement menus items reordering into the GraphQL API - #3958 by @NyanKiyoshi
-- Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
 - Support assigning other shipping/billing addresses in update checkout addresses API - #3808 by @jxltom
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,20 @@ All notable, unreleased changes to this project will be documented in this file.
 - New translations:
   - Estonian
   - Indonesian
+- Add missing type definition for dashboard 2.0 - #3776 by @jxltom
+- Add mutations to manage addresses for authenticated customers - #3772 by @Kwaidan00, @maarcingebala
+- Only include cancelled fulfillments for staff in fulfillment API - #3778 by @jxltom
+- Fix incorrect cart badge location - #3786 by @jxltom
+- Add function to recalculate order's total weight - #3755 by @Kwaidan00, @maarcingebala
+- Unify behavior after creating checkout in API and Storefront 1.0; code formatting improvements - #3790 by @maarcingebala
+- Add pages section in Dashboard 2.0; introduce Draftail WYSIWYG editor - #3751 by @dominik-zeglen
+- Support partially charged and partially refunded payment status - #3735 by @jxltom
+- Add translations to GraphQL API - #3789 by @michaljelonek
+- Fix product create when no product type provided - #3804 by @michaljelonek
+- Add ordering to shipping method - #3806 by @michaljelonek
+- Add missing types for dashboard 2.0 after adding translations to API - #3802 by @jxltom
+- Add city choices and city area type to address validator API - #3788 by @jxltom
+- Support assigning other shipping/billing addresses in update checkout addresses API - #3806 by @jxltom
 
 
 ## 2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutation for bulk publishing and unpublishing collections - #3970 by @akjanik
 - Rename Cart to Checkout - #3963 by @michaljelonek
 - Implement menus items reordering into the GraphQL API - #3958 by @NyanKiyoshi
+- Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
+- Support assigning other shipping/billing addresses in update checkout addresses API - #3808 by @jxltom
 
 
 ## 2.5.0
@@ -127,20 +129,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - New translations:
   - Estonian
   - Indonesian
-- Add missing type definition for dashboard 2.0 - #3776 by @jxltom
-- Add mutations to manage addresses for authenticated customers - #3772 by @Kwaidan00, @maarcingebala
-- Only include cancelled fulfillments for staff in fulfillment API - #3778 by @jxltom
-- Fix incorrect cart badge location - #3786 by @jxltom
-- Add function to recalculate order's total weight - #3755 by @Kwaidan00, @maarcingebala
-- Unify behavior after creating checkout in API and Storefront 1.0; code formatting improvements - #3790 by @maarcingebala
-- Add pages section in Dashboard 2.0; introduce Draftail WYSIWYG editor - #3751 by @dominik-zeglen
-- Support partially charged and partially refunded payment status - #3735 by @jxltom
-- Add translations to GraphQL API - #3789 by @michaljelonek
-- Fix product create when no product type provided - #3804 by @michaljelonek
-- Add ordering to shipping method - #3806 by @michaljelonek
-- Add missing types for dashboard 2.0 after adding translations to API - #3802 by @jxltom
-- Add city choices and city area type to address validator API - #3788 by @jxltom
-- Support assigning other shipping/billing addresses in update checkout addresses API - #3806 by @jxltom
 
 
 ## 2.3.1

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -428,7 +428,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
 
         with transaction.atomic():
             billing_address.save()
-            change_billing_address_in_cart(checkout, billing_address)
+            change_billing_address_in_checkout(checkout, billing_address)
         return CheckoutBillingAddressUpdate(checkout=checkout)
 
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -353,7 +353,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         arguments = (shipping_address, shipping_address_id)
         if not any(arguments) or all(arguments):
             raise ValidationError(
-                'One and only one of shipping address or shipping address ID '
+                'One and only one shipping address or shipping address ID '
                 'should be provided.')
 
         if shipping_address is not None:
@@ -411,7 +411,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         arguments = (billing_address, billing_address_id)
         if not any(arguments) or all(arguments):
             raise ValidationError(
-                'One and only one of billing address or billing address ID '
+                'One and only one billing address or billing address ID '
                 'should be provided.')
 
         if billing_address is not None:

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -326,9 +326,10 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
     checkout = graphene.Field(Checkout, description='An updated checkout')
 
     class Arguments:
-        checkout_id = graphene.ID(description='ID of the Checkout.')
+        checkout_id = graphene.ID(
+            required=True, description='ID of the Checkout.')
         shipping_address = AddressInput(
-            required=True,
+            required=False,
             description=(
                 'The mailing address to where the checkout will be shipped.'))
 
@@ -361,7 +362,8 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
     checkout = graphene.Field(Checkout, description='An updated checkout')
 
     class Arguments:
-        checkout_id = graphene.ID(description='ID of the Checkout.')
+        checkout_id = graphene.ID(
+            required=True, description='ID of the Checkout.')
         billing_address = AddressInput(
             required=True,
             description=('The billing address of the checkout.'))
@@ -386,7 +388,7 @@ class CheckoutEmailUpdate(BaseMutation):
     checkout = graphene.Field(Checkout, description='An updated checkout')
 
     class Arguments:
-        checkout_id = graphene.ID(description='Checkout ID')
+        checkout_id = graphene.ID(required=True, description='Checkout ID')
         email = graphene.String(required=True, description='email')
 
     class Meta:
@@ -407,7 +409,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     checkout = graphene.Field(Checkout, description='An updated checkout')
 
     class Arguments:
-        checkout_id = graphene.ID(description='Checkout ID')
+        checkout_id = graphene.ID(required=True, description='Checkout ID')
         shipping_method_id = graphene.ID(
             required=True, description='Shipping method')
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1219,18 +1219,18 @@ type Mutations {
   tokenCreate(email: String!, password: String!): CreateToken
   tokenRefresh(token: String!): Refresh
   tokenVerify(token: String!): VerifyToken
-  checkoutBillingAddressUpdate(billingAddress: AddressInput!, checkoutId: ID): CheckoutBillingAddressUpdate
+  checkoutBillingAddressUpdate(billingAddress: AddressInput, billingAddressId: ID, checkoutId: ID!): CheckoutBillingAddressUpdate
   checkoutComplete(checkoutId: ID!): CheckoutComplete
   checkoutCreate(input: CheckoutCreateInput!): CheckoutCreate
   checkoutCustomerAttach(checkoutId: ID!, customerId: ID!): CheckoutCustomerAttach
   checkoutCustomerDetach(checkoutId: ID!): CheckoutCustomerDetach
-  checkoutEmailUpdate(checkoutId: ID, email: String!): CheckoutEmailUpdate
+  checkoutEmailUpdate(checkoutId: ID!, email: String!): CheckoutEmailUpdate
   checkoutLineDelete(checkoutId: ID!, lineId: ID): CheckoutLineDelete
   checkoutLinesAdd(checkoutId: ID!, lines: [CheckoutLineInput]!): CheckoutLinesAdd
   checkoutLinesUpdate(checkoutId: ID!, lines: [CheckoutLineInput]!): CheckoutLinesUpdate
   checkoutPaymentCreate(checkoutId: ID!, input: PaymentInput!): CheckoutPaymentCreate
-  checkoutShippingAddressUpdate(checkoutId: ID, shippingAddress: AddressInput!): CheckoutShippingAddressUpdate
-  checkoutShippingMethodUpdate(checkoutId: ID, shippingMethodId: ID!): CheckoutShippingMethodUpdate
+  checkoutShippingAddressUpdate(checkoutId: ID!, shippingAddress: AddressInput, shippingAddressId: ID): CheckoutShippingAddressUpdate
+  checkoutShippingMethodUpdate(checkoutId: ID!, shippingMethodId: ID!): CheckoutShippingMethodUpdate
   checkoutUpdateVoucher(checkoutId: ID!, voucherCode: String): CheckoutUpdateVoucher
   passwordReset(email: String!): PasswordReset
   setPassword(id: ID!, input: SetPasswordInput!): SetPassword

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -729,11 +729,11 @@ def test_checkout_shipping_address_update_invalid_country_code(
 
 
 def test_checkout_shipping_address_update_by_id(
-        user_api_client, cart_with_item, address):
-    cart = cart_with_item
-    assert cart.shipping_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
-    
+        user_api_client, checkout_with_item, address):
+    checkout = checkout_with_item
+    assert checkout.shipping_address is None
+    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
+
     address_id = graphene.Node.to_global_id('Address', address.pk)
     variables = {
         'checkoutId': checkout_id, 'shippingAddressId': address_id}
@@ -745,22 +745,22 @@ def test_checkout_shipping_address_update_by_id(
     assert not data['errors']
     assert address.pk == int(graphene.Node.from_global_id(
         data['checkout']['shippingAddress']['id'])[1])
-    cart.refresh_from_db()
-    assert cart.shipping_address is not None
-    assert cart.shipping_address.first_name == address.first_name
-    assert cart.shipping_address.last_name == address.last_name
-    assert cart.shipping_address.street_address_1 == address.street_address_1
-    assert cart.shipping_address.street_address_2 == address.street_address_2
-    assert cart.shipping_address.postal_code == address.postal_code
-    assert cart.shipping_address.country == address.country
-    assert cart.shipping_address.city == address.city
+    checkout.refresh_from_db()
+    assert checkout.shipping_address is not None
+    assert checkout.shipping_address.first_name == address.first_name
+    assert checkout.shipping_address.last_name == address.last_name
+    assert checkout.shipping_address.street_address_1 == address.street_address_1
+    assert checkout.shipping_address.street_address_2 == address.street_address_2
+    assert checkout.shipping_address.postal_code == address.postal_code
+    assert checkout.shipping_address.country == address.country
+    assert checkout.shipping_address.city == address.city
 
 
 def test_checkout_shipping_address_update_invalid_argument(
-        user_api_client, cart_with_item, graphql_address_data, address):
-    cart = cart_with_item
-    assert cart.shipping_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
+        user_api_client, checkout_with_item, graphql_address_data, address):
+    checkout = checkout_with_item
+    assert checkout.shipping_address is None
+    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
 
     shipping_address = graphql_address_data
     address_id = graphene.Node.to_global_id('Address', address.pk)
@@ -777,49 +777,6 @@ def test_checkout_shipping_address_update_invalid_argument(
     assert data['errors'][0]['message'] == (
         'One and only one shipping address or shipping address ID '
         'should be provided.')
-
-
-def test_checkout_billing_address_update(
-        user_api_client, checkout_with_item, graphql_address_data):
-    checkout = checkout_with_item
-    assert checkout.shipping_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
-
-    query = """
-    mutation checkoutBillingAddressUpdate(
-            $checkoutId: ID!, $billingAddress: AddressInput!) {
-        checkoutBillingAddressUpdate(
-                checkoutId: $checkoutId, billingAddress: $billingAddress) {
-            checkout {
-                token,
-                id
-            },
-            errors {
-                field,
-                message
-            }
-        }
-    }
-    """
-    billing_address = graphql_address_data
-
-    variables = {'checkoutId': checkout_id, 'billingAddress': billing_address}
-
-    response = user_api_client.post_graphql(query, variables)
-    content = get_graphql_content(response)
-    data = content['data']['checkoutBillingAddressUpdate']
-    assert not data['errors']
-    checkout.refresh_from_db()
-    assert checkout.billing_address is not None
-    assert checkout.billing_address.first_name == billing_address['firstName']
-    assert checkout.billing_address.last_name == billing_address['lastName']
-    assert checkout.billing_address.street_address_1 == billing_address[
-        'streetAddress1']
-    assert checkout.billing_address.street_address_2 == billing_address[
-        'streetAddress2']
-    assert checkout.billing_address.postal_code == billing_address['postalCode']
-    assert checkout.billing_address.country == billing_address['country']
-    assert checkout.billing_address.city == billing_address['city'].upper()
 
 
 MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
@@ -848,10 +805,10 @@ MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE = """
 
 
 def test_checkout_billing_address_update(
-        user_api_client, cart_with_item, graphql_address_data):
-    cart = cart_with_item
-    assert cart.billing_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
+        user_api_client, checkout_with_item, graphql_address_data):
+    checkout = checkout_with_item
+    assert checkout.billing_address is None
+    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
 
     billing_address = graphql_address_data
     variables = {'checkoutId': checkout_id, 'billingAddress': billing_address}
@@ -875,10 +832,10 @@ def test_checkout_billing_address_update(
 
 
 def test_checkout_billing_address_update_by_id(
-        user_api_client, cart_with_item, address):
-    cart = cart_with_item
-    assert cart.billing_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
+        user_api_client, checkout_with_item, address):
+    checkout = checkout_with_item
+    assert checkout.billing_address is None
+    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
 
     address_id = graphene.Node.to_global_id('Address', address.pk)
     variables = {'checkoutId': checkout_id, 'billingAddressId': address_id}
@@ -890,22 +847,22 @@ def test_checkout_billing_address_update_by_id(
     assert not data['errors']
     assert address.pk == int(graphene.Node.from_global_id(
         data['checkout']['billingAddress']['id'])[1])
-    cart.refresh_from_db()
-    assert cart.billing_address is not None
-    assert cart.billing_address.first_name == address.first_name
-    assert cart.billing_address.last_name == address.last_name
-    assert cart.billing_address.street_address_1 == address.street_address_1
-    assert cart.billing_address.street_address_2 == address.street_address_2
-    assert cart.billing_address.postal_code == address.postal_code
-    assert cart.billing_address.country == address.country
-    assert cart.billing_address.city == address.city
+    checkout.refresh_from_db()
+    assert checkout.billing_address is not None
+    assert checkout.billing_address.first_name == address.first_name
+    assert checkout.billing_address.last_name == address.last_name
+    assert checkout.billing_address.street_address_1 == address.street_address_1
+    assert checkout.billing_address.street_address_2 == address.street_address_2
+    assert checkout.billing_address.postal_code == address.postal_code
+    assert checkout.billing_address.country == address.country
+    assert checkout.billing_address.city == address.city
 
 
 def test_checkout_billling_address_update_invalid_argument(
-        user_api_client, cart_with_item, graphql_address_data, address):
-    cart = cart_with_item
-    assert cart.billing_address is None
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
+        user_api_client, checkout_with_item, graphql_address_data, address):
+    checkout = checkout_with_item
+    assert checkout.billing_address is None
+    checkout_id = graphene.Node.to_global_id('Checkout', checkout.pk)
 
     billing_address = graphql_address_data
     address_id = graphene.Node.to_global_id('Address', address.pk)

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -775,7 +775,7 @@ def test_checkout_shipping_address_update_invalid_argument(
     data = content['data']['checkoutShippingAddressUpdate']
     assert len(data['errors']) == 1
     assert data['errors'][0]['message'] == (
-        'One and only one of shipping address or shipping address ID '
+        'One and only one shipping address or shipping address ID '
         'should be provided.')
 
 
@@ -920,7 +920,7 @@ def test_checkout_billling_address_update_invalid_argument(
     data = content['data']['checkoutBillingAddressUpdate']
     assert len(data['errors']) == 1
     assert data['errors'][0]['message'] == (
-        'One and only one of billing address or billing address ID '
+        'One and only one billing address or billing address ID '
         'should be provided.')
 
 

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -773,11 +773,10 @@ def test_checkout_shipping_address_update_invalid_argument(
         MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE, variables)
     content = get_graphql_content(response)
     data = content['data']['checkoutShippingAddressUpdate']
-    assert len(data['errors']) == 2
-    for error in data['errors']:
-        assert error['message'] == (
-            'One and only one of shipping address or shipping address ID '
-            'can be provided.')
+    assert len(data['errors']) == 1
+    assert data['errors'][0]['message'] == (
+        'One and only one of shipping address or shipping address ID '
+        'should be provided.')
 
 
 def test_checkout_billing_address_update(
@@ -919,11 +918,10 @@ def test_checkout_billling_address_update_invalid_argument(
         MUTATION_CHECKOUT_BILLING_ADDRESS_UPDATE, variables)
     content = get_graphql_content(response)
     data = content['data']['checkoutBillingAddressUpdate']
-    assert len(data['errors']) == 2
-    for error in data['errors']:
-        assert error['message'] == (
-            'One and only one of billing address or billing address ID '
-            'can be provided.')
+    assert len(data['errors']) == 1
+    assert data['errors'][0]['message'] == (
+        'One and only one of billing address or billing address ID '
+        'should be provided.')
 
 
 CHECKOUT_EMAIL_UPDATE_MUTATION = """


### PR DESCRIPTION
- Current ```checkoutShipping/BillingAddressUpdate``` API only supports modify checkout's addresses directly. This PR supports that other addresses can be assigned to checkout by address ID.
- This PR also make the checkout ID in several checkout mutations as required.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
