### PR TITLE
Prefetch collections for product availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Support setting as default address directly when creating customer address #3782 by @jxltom
 - Include example JSON content in dumpdata file - #3810 by @maarcingebala
 - Add shipping zones to dashboard 2.0 - #3770 by @dominik-zeglen
+- Prefetch collections for product availability - #3813 by @michaljelonek
 
 
 ## 2.3.1

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -359,7 +359,7 @@ class Product(CountableDjangoObjectType):
         return self.get_absolute_url()
 
     @gql_optimizer.resolver_hints(
-        prefetch_related='variants',
+        prefetch_related=('variants', 'collections'),
         only=['publication_date', 'charge_taxes', 'price', 'tax_rate'])
     def resolve_availability(self, info):
         context = info.context


### PR DESCRIPTION
I want to merge this change because it fixes the amount of queries made for product with availability.

This query resulted in 300+ db hits:
```
query ProductList {
  products(first: 20) {
    edges {
      node {
        availability {
          available
        }
      }
    }
  }
}
```



<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
