### PR TITLE
Fix generating slug from title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add shipping zones to dashboard 2.0 - #3770 by @dominik-zeglen
 - Prefetch collections for product availability - #3813 by @michaljelonek
 - Restyle app layout - #3811 by @dominik-zeglen
+- Fix generating slug from title - #3816 by @maarcingebala
 
 
 ## 2.3.1

--- a/saleor/graphql/page/mutations.py
+++ b/saleor/graphql/page/mutations.py
@@ -38,8 +38,9 @@ class PageCreate(ModelMutation):
     @classmethod
     def clean_input(cls, info, instance, input, errors):
         cleaned_input = super().clean_input(info, instance, input, errors)
-        if 'slug' not in cleaned_input:
-            cleaned_input['slug'] = slugify(cleaned_input['name'])
+        slug = cleaned_input.get('slug', '')
+        if not slug:
+            cleaned_input['slug'] = slugify(cleaned_input['title'])
         clean_seo_fields(cleaned_input)
         return cleaned_input
 

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -21,8 +21,8 @@ def resolve_page(info, id=None, slug=None):
         # Resolve to null if page is not published and user has no permission
         # to manage pages.
         is_available_to_user = (
-            page.is_published or user.has_perm('page.manage_pages'))
-        if page and not is_available_to_user:
+            page and page.is_published or user.has_perm('page.manage_pages'))
+        if not is_available_to_user:
             page = None
     return page
 


### PR DESCRIPTION
Fixes generating slug from the title in `pageCreate` mutation. Also fixes the issue in page resolver when passed ID is wrong.


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
