### PR TITLE
Add variant field to OrderLine type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Bump django-graphql-jwt - #3814 by @michaljelonek
 - Fix generating slug from title - #3816 by @maarcingebala
 - Fix minor bugs in page details' view - #3818 by @dominik-zeglen
+- Add `variant` field to `OrderLine` type - #3820 by @maarcingebala
 
 
 ## 2.3.1

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1,3 +1,5 @@
+from textwrap import dedent
+
 import graphene
 import graphene_django_optimizer as gql_optimizer
 from graphene import relay
@@ -9,7 +11,7 @@ from ..account.types import User
 from ..core.connection import CountableDjangoObjectType
 from ..core.types.money import Money, TaxedMoney
 from ..payment.types import OrderAction, Payment, PaymentChargeStatusEnum
-from ..product.types import Image
+from ..product.types import Image, ProductVariant
 from ..shipping.types import ShippingMethod
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum
 from .utils import applicable_shipping_methods, can_finalize_draft_order
@@ -116,13 +118,19 @@ class OrderLine(CountableDjangoObjectType):
         size=graphene.Argument(graphene.Int, description='Size of thumbnail'))
     unit_price = graphene.Field(
         TaxedMoney, description='Price of the single item in the order line.')
+    variant = graphene.Field(
+        ProductVariant,
+        required=False,
+        description=dedent('''
+            A purchased product variant. Note: this field may be null if the
+            variant has been removed from stock at all.'''))
 
     class Meta:
         description = 'Represents order line of particular order.'
         model = models.OrderLine
         interfaces = [relay.Node]
         exclude_fields = [
-            'order', 'unit_price_gross', 'unit_price_net', 'variant']
+            'order', 'unit_price_gross', 'unit_price_net']
 
     @gql_optimizer.resolver_hints(
         prefetch_related=['variant__images', 'variant__product__images'])

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1214,6 +1214,7 @@ enum OrderEventsEmails {
 
 type OrderLine implements Node {
   id: ID!
+  variant: ProductVariant
   productName: String!
   translatedProductName: String!
   productSku: String!


### PR DESCRIPTION
Order details page in saleor-storefront relies on `variant` field in the `OrderLine` type, which must have been removed recently. This PR adds this field back to the schema.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
