### PR TITLE
Update typescript types after apollo is upgraded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
+- Update typescript types after apollo is upgraded - #3823 by @jxltom
 
 
 ## 2.4.0

--- a/saleor/static/dashboard-next/auth/types/TokenAuth.ts
+++ b/saleor/static/dashboard-next/auth/types/TokenAuth.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/auth/types/User.ts
+++ b/saleor/static/dashboard-next/auth/types/User.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/auth/types/VerifyToken.ts
+++ b/saleor/static/dashboard-next/auth/types/VerifyToken.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/categories/types/CategoryCreate.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CategoryInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/categories/types/CategoryDelete.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/categories/types/CategoryDetails.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/categories/types/CategoryDetailsFragment.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/categories/types/CategoryUpdate.ts
+++ b/saleor/static/dashboard-next/categories/types/CategoryUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CategoryInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/categories/types/RootCategories.ts
+++ b/saleor/static/dashboard-next/categories/types/RootCategories.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionAssignProduct.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionAssignProduct.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionDetails.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionDetailsFragment.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionFragment.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionList.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionProductFragment.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionProductFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/CollectionUpdate.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CollectionInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/collections/types/CollectionUpdateWithHomepage.ts
+++ b/saleor/static/dashboard-next/collections/types/CollectionUpdateWithHomepage.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CollectionInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/collections/types/CreateCollection.ts
+++ b/saleor/static/dashboard-next/collections/types/CreateCollection.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CollectionCreateInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/collections/types/RemoveCollection.ts
+++ b/saleor/static/dashboard-next/collections/types/RemoveCollection.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/collections/types/UnassignCollectionProduct.ts
+++ b/saleor/static/dashboard-next/collections/types/UnassignCollectionProduct.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/components/Shop/types/ShopInfo.ts
+++ b/saleor/static/dashboard-next/components/Shop/types/ShopInfo.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../../types/globalTypes";

--- a/saleor/static/dashboard-next/containers/SearchCategories/types/SearchCategories.ts
+++ b/saleor/static/dashboard-next/containers/SearchCategories/types/SearchCategories.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/containers/SearchCollections/types/SearchCollections.ts
+++ b/saleor/static/dashboard-next/containers/SearchCollections/types/SearchCollections.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/containers/SearchProducts/types/SearchProducts.ts
+++ b/saleor/static/dashboard-next/containers/SearchProducts/types/SearchProducts.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/CreateCustomer.ts
+++ b/saleor/static/dashboard-next/customers/types/CreateCustomer.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { UserCreateInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/customers/types/CustomerCreateData.ts
+++ b/saleor/static/dashboard-next/customers/types/CustomerCreateData.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/CustomerDetails.ts
+++ b/saleor/static/dashboard-next/customers/types/CustomerDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PaymentChargeStatusEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/customers/types/CustomerDetailsFragment.ts
+++ b/saleor/static/dashboard-next/customers/types/CustomerDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/CustomerFragment.ts
+++ b/saleor/static/dashboard-next/customers/types/CustomerFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/ListCustomers.ts
+++ b/saleor/static/dashboard-next/customers/types/ListCustomers.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/RemoveCustomer.ts
+++ b/saleor/static/dashboard-next/customers/types/RemoveCustomer.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/customers/types/UpdateCustomer.ts
+++ b/saleor/static/dashboard-next/customers/types/UpdateCustomer.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CustomerInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleCataloguesAdd.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleCataloguesAdd.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleCataloguesRemove.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleCataloguesRemove.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleCreate.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleInput, SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleDelete.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/discounts/types/SaleDetails.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleDetailsFragment.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleFragment.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleList.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/SaleUpdate.ts
+++ b/saleor/static/dashboard-next/discounts/types/SaleUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SaleInput, SaleType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherCataloguesAdd.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherCataloguesAdd.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, VoucherDiscountValueType, VoucherType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherCataloguesRemove.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherCataloguesRemove.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { CatalogueInput, VoucherDiscountValueType, VoucherType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherCreate.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherInput, VoucherDiscountValueType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherDelete.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/discounts/types/VoucherDetails.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherDiscountValueType, VoucherType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherDetailsFragment.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherDiscountValueType, VoucherType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherFragment.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherDiscountValueType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherList.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherDiscountValueType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/discounts/types/VoucherUpdate.ts
+++ b/saleor/static/dashboard-next/discounts/types/VoucherUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { VoucherInput, VoucherDiscountValueType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/home/types/Home.ts
+++ b/saleor/static/dashboard-next/home/types/Home.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/AddressFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/AddressFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/orders/types/OrderAddNote.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderAddNote.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderAddNoteInput, OrderEventsEmails, OrderEvents } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCancel.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderCapture.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCapture.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderCreateFulfillment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderCreateFulfillment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentCreateInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderDetails.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderDraftCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftCancel.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderDraftCreate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/orders/types/OrderDraftFinalize.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftFinalize.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderDraftUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderDraftUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { DraftOrderInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderEventFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderEventFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderFulfillmentCancel.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderFulfillmentCancel.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentCancelInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderFulfillmentUpdateTracking.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderFulfillmentUpdateTracking.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { FulfillmentUpdateTrackingInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderLineDelete.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderLineFragment.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/orders/types/OrderLineUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLineUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderLineInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderLinesAdd.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderLinesAdd.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderLineCreateInput, OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderList.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderStatusFilter, PaymentChargeStatusEnum, OrderStatus } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderMarkAsPaid.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderMarkAsPaid.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderRefund.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderRefund.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderShippingMethodUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderShippingMethodUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderUpdateShippingInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderUpdate.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderUpdateInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/OrderVariantSearch.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderVariantSearch.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/orders/types/OrderVoid.ts
+++ b/saleor/static/dashboard-next/orders/types/OrderVoid.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { OrderEventsEmails, OrderEvents, FulfillmentStatus, PaymentChargeStatusEnum, OrderStatus, OrderAction } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/orders/types/UserSearch.ts
+++ b/saleor/static/dashboard-next/orders/types/UserSearch.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageCreate.ts
+++ b/saleor/static/dashboard-next/pages/types/PageCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PageInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/pages/types/PageDetails.ts
+++ b/saleor/static/dashboard-next/pages/types/PageDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageDetailsFragment.ts
+++ b/saleor/static/dashboard-next/pages/types/PageDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageFragment.ts
+++ b/saleor/static/dashboard-next/pages/types/PageFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageList.ts
+++ b/saleor/static/dashboard-next/pages/types/PageList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageRemove.ts
+++ b/saleor/static/dashboard-next/pages/types/PageRemove.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/pages/types/PageUpdate.ts
+++ b/saleor/static/dashboard-next/pages/types/PageUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PageInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/AttributeCreate.ts
+++ b/saleor/static/dashboard-next/productTypes/types/AttributeCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeCreateInput, AttributeTypeEnum, TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/AttributeDelete.ts
+++ b/saleor/static/dashboard-next/productTypes/types/AttributeDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/AttributeFragment.ts
+++ b/saleor/static/dashboard-next/productTypes/types/AttributeFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/productTypes/types/AttributeUpdate.ts
+++ b/saleor/static/dashboard-next/productTypes/types/AttributeUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeUpdateInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeCreate.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ProductTypeInput, TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeCreateData.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeCreateData.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeDelete.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeDetails.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType, WeightUnitsEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeDetailsFragment.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeFragment.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeList.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeUpdate.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ProductTypeInput, TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/productTypes/types/SearchAttribute.ts
+++ b/saleor/static/dashboard-next/productTypes/types/SearchAttribute.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/CategorySearch.ts
+++ b/saleor/static/dashboard-next/products/types/CategorySearch.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/CollectionSearch.ts
+++ b/saleor/static/dashboard-next/products/types/CollectionSearch.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/Money.ts
+++ b/saleor/static/dashboard-next/products/types/Money.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/Product.ts
+++ b/saleor/static/dashboard-next/products/types/Product.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductCreate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/products/types/ProductCreateData.ts
+++ b/saleor/static/dashboard-next/products/types/ProductCreateData.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductDelete.ts
+++ b/saleor/static/dashboard-next/products/types/ProductDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageById.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageById.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageCreate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageDelete.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageFragment.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageReorder.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageReorder.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductImageUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductImageUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductList.ts
+++ b/saleor/static/dashboard-next/products/types/ProductList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { StockAvailability } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/products/types/ProductUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/ProductUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/products/types/ProductVariant.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariant.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductVariantCreateData.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantCreateData.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
+++ b/saleor/static/dashboard-next/products/types/ProductVariantDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/SimpleProductUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/SimpleProductUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueInput, ProductVariantInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/products/types/VariantCreate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantCreate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/products/types/VariantDelete.ts
+++ b/saleor/static/dashboard-next/products/types/VariantDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageAssign.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
+++ b/saleor/static/dashboard-next/products/types/VariantImageUnassign.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/products/types/VariantUpdate.ts
+++ b/saleor/static/dashboard-next/products/types/VariantUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AttributeValueInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/CreateShippingRate.ts
+++ b/saleor/static/dashboard-next/shipping/types/CreateShippingRate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingPriceInput, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/CreateShippingZone.ts
+++ b/saleor/static/dashboard-next/shipping/types/CreateShippingZone.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingZoneInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/DeleteShippingRate.ts
+++ b/saleor/static/dashboard-next/shipping/types/DeleteShippingRate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/DeleteShippingZone.ts
+++ b/saleor/static/dashboard-next/shipping/types/DeleteShippingZone.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/shipping/types/ShippingMethodFragment.ts
+++ b/saleor/static/dashboard-next/shipping/types/ShippingMethodFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/ShippingZone.ts
+++ b/saleor/static/dashboard-next/shipping/types/ShippingZone.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/ShippingZoneDetailsFragment.ts
+++ b/saleor/static/dashboard-next/shipping/types/ShippingZoneDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/ShippingZoneFragment.ts
+++ b/saleor/static/dashboard-next/shipping/types/ShippingZoneFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/shipping/types/ShippingZones.ts
+++ b/saleor/static/dashboard-next/shipping/types/ShippingZones.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/shipping/types/UpdateDefaultWeightUnit.ts
+++ b/saleor/static/dashboard-next/shipping/types/UpdateDefaultWeightUnit.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { WeightUnitsEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/UpdateShippingRate.ts
+++ b/saleor/static/dashboard-next/shipping/types/UpdateShippingRate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingPriceInput, ShippingMethodTypeEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/shipping/types/UpdateShippingZone.ts
+++ b/saleor/static/dashboard-next/shipping/types/UpdateShippingZone.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShippingZoneInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/siteSettings/types/AuthorizationKeyAdd.ts
+++ b/saleor/static/dashboard-next/siteSettings/types/AuthorizationKeyAdd.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AuthorizationKeyInput, AuthorizationKeyType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/siteSettings/types/AuthorizationKeyDelete.ts
+++ b/saleor/static/dashboard-next/siteSettings/types/AuthorizationKeyDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AuthorizationKeyType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/siteSettings/types/ShopFragment.ts
+++ b/saleor/static/dashboard-next/siteSettings/types/ShopFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AuthorizationKeyType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/siteSettings/types/ShopSettingsUpdate.ts
+++ b/saleor/static/dashboard-next/siteSettings/types/ShopSettingsUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { SiteDomainInput, ShopSettingsInput, AuthorizationKeyType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/siteSettings/types/SiteSettings.ts
+++ b/saleor/static/dashboard-next/siteSettings/types/SiteSettings.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { AuthorizationKeyType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/staff/types/StaffList.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/staff/types/StaffMemberAdd.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberAdd.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { StaffCreateInput, PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/staff/types/StaffMemberDelete.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberDelete.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/staff/types/StaffMemberDetails.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberDetails.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/staff/types/StaffMemberDetailsFragment.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberDetailsFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/staff/types/StaffMemberFragment.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/staff/types/StaffMemberUpdate.ts
+++ b/saleor/static/dashboard-next/staff/types/StaffMemberUpdate.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { StaffInput, PermissionEnum } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/taxes/types/CountryFragment.ts
+++ b/saleor/static/dashboard-next/taxes/types/CountryFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/taxes/types/CountryList.ts
+++ b/saleor/static/dashboard-next/taxes/types/CountryList.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/taxes/types/CountryWithTaxesFragment.ts
+++ b/saleor/static/dashboard-next/taxes/types/CountryWithTaxesFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { TaxRateType } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/taxes/types/FetchTaxes.ts
+++ b/saleor/static/dashboard-next/taxes/types/FetchTaxes.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/taxes/types/ShopTaxesFragment.ts
+++ b/saleor/static/dashboard-next/taxes/types/ShopTaxesFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/taxes/types/UpdateTaxSettings.ts
+++ b/saleor/static/dashboard-next/taxes/types/UpdateTaxSettings.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 import { ShopSettingsInput } from "./../../types/globalTypes";

--- a/saleor/static/dashboard-next/types/PageInfoFragment.ts
+++ b/saleor/static/dashboard-next/types/PageInfoFragment.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 // ====================================================

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -1,4 +1,5 @@
 /* tslint:disable */
+/* eslint-disable */
 // This file was automatically generated and should not be edited.
 
 //==============================================================

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -1,8 +1,8 @@
 import json
 
-from django.utils.text import slugify
 import graphene
 import pytest
+from django.utils.text import slugify
 
 from saleor.page.models import Page
 from tests.api.utils import get_graphql_content


### PR DESCRIPTION
It looks like updated apollo is upgraded in https://github.com/mirumee/saleor/pull/3811, the generated typescript types has new line ```/* eslint-disable */``` by https://github.com/apollographql/apollo-tooling/pull/1017. This PR updated the types.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
