### PR TITLE
Fix django-recaptcha tests after upgraded to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update typescript types after apollo is upgraded - #3823 by @jxltom
 - Add languageCode enum to API - #3819 by @michaljelonek
 - Bump backend dependencies - #3827 by @maarcingebala
+- Fix django-recaptcha tests after upgraded to 1.5.0 - 3835 by @jxltom
 
 
 ## 2.4.0

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 import i18naddress
 import pytest
 from captcha import constants as recaptcha_constants
+from captcha.client import RecaptchaResponse
 from django.core.exceptions import ValidationError
 from django.forms import Form
 from django.http import QueryDict
@@ -292,12 +293,14 @@ def test_disabled_recaptcha():
     assert form.is_valid()
 
 
-@patch.dict(os.environ, {'RECAPTCHA_TESTING': 'True'})
-def test_requires_recaptcha(settings):
+@patch('captcha.fields.client.submit')
+def test_requires_recaptcha(captcha_submit_mock, settings):
     """
     This test creates a new form
     that should contain a (required) recaptcha field.
     """
+    captcha_submit_mock.return_value = RecaptchaResponse(is_valid=True)
+
     settings.RECAPTCHA_PUBLIC_KEY = recaptcha_constants.TEST_PUBLIC_KEY
     settings.RECAPTCHA_PRIVATE_KEY = recaptcha_constants.TEST_PRIVATE_KEY
 


### PR DESCRIPTION
I don't know why the tests passed in travis but it failed locally. Probably it is because the requirements in Travis are cached.

In https://github.com/mirumee/saleor/pull/3827 we upgraded django-recaptcha 1.5.0, but it drops support for ```RECAPTCHA_TESTING``` env var as mentioned in https://github.com/praekelt/django-recaptcha/blob/develop/CHANGELOG.rst#150-2019-01-09. This makes the tests failing and this PR fixes the tests as suggested in https://github.com/praekelt/django-recaptcha/blob/a4a3c1fa3f378b52f66625966642447ff7f3a20d/captcha/tests/tests.py#L20-L29.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
