### PR TITLE
Fix schema after bulk mutations are added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Support is_default_shipping/billing_address for address API - #3787 by @jxltom
 - Add bulk delete mutations - #3838 by @michaljelonek
 - Fix product creating - #3837 by @dominik-zeglen
+- Fix schema after bulk mutations are added - #3843 by @jxltom
 
 
 ## 2.4.0

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1144,7 +1144,7 @@ type Mutations {
   loggedUserUpdate(input: UserAddressInput!): LoggedUserUpdate
   staffCreate(input: StaffCreateInput!): StaffCreate
   staffDelete(id: ID!): StaffDelete
-  staffBulkDelete: StaffBulkDelete
+  staffBulkDelete(ids: [ID]!): StaffBulkDelete
   staffUpdate(id: ID!, input: StaffInput!): StaffUpdate
   addressCreate(input: AddressCreateInput!): AddressCreate
   addressDelete(id: ID!): AddressDelete
@@ -2053,7 +2053,7 @@ enum ShippingMethodTypeEnum {
 
 type ShippingPriceBulkDelete {
   errors: [Error!]
-  shippingMethod: ShippingMethod
+  count: Int!
 }
 
 type ShippingPriceCreate {
@@ -2101,7 +2101,7 @@ type ShippingZone implements Node {
 
 type ShippingZoneBulkDelete {
   errors: [Error!]
-  shippingZone: ShippingZone
+  count: Int!
 }
 
 type ShippingZoneCountableConnection {


### PR DESCRIPTION
It looks the schema in https://github.com/mirumee/saleor/pull/3838 is incorrect, the bulk mutation should return ```count```. This PR fixes this issue.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
