### PR TITLE
Fix GraphQL error: "Expected a value of type WeightUnitsEnum"

### DIFF
--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -13,7 +13,6 @@ In the end, it does not really matter unless you travel between
 different planets.
 """
 from decimal import Decimal
-from enum import Enum
 
 from django import forms
 from django.contrib.sites.models import Site
@@ -34,11 +33,6 @@ class WeightUnits:
         (POUND, pgettext_lazy('Pound weight unit symbol', 'lb')),
         (OUNCE, pgettext_lazy('Ounce weight unit symbol', 'oz')),
         (GRAM, pgettext_lazy('Gram weight unit symbol', 'g'))]
-
-
-WeightUnitsEnum = Enum(
-    'WeightUnitsEnum',
-    {unit: unit for unit in WeightUnits.CHOICES})
 
 
 def zero_weight():

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -1,6 +1,7 @@
 import graphene
 
-from ...core import TaxRateType as CoreTaxRateType, weight
+from ...core import TaxRateType as CoreTaxRateType
+from ...core.weight import WeightUnits
 from ...core.permissions import MODELS_PERMISSIONS
 from .utils import str_to_enum
 
@@ -21,4 +22,6 @@ PermissionEnum = graphene.Enum(
         for codename in MODELS_PERMISSIONS])
 
 
-WeightUnitsEnum = graphene.Enum.from_enum(weight.WeightUnitsEnum)
+WeightUnitsEnum = graphene.Enum(
+    'WeightUnitsEnum',
+    [(str_to_enum(unit[0]), unit[0]) for unit in WeightUnits.CHOICES])

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2547,8 +2547,8 @@ type Weight {
 scalar WeightScalar
 
 enum WeightUnitsEnum {
-  kg
-  lb
-  oz
-  g
+  KG
+  LB
+  OZ
+  G
 }

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -66923,12 +66923,12 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                       role="button"
                       tabindex="0"
                     >
-                      kg
+                      KG
                     </div>
                     <input
                       name="unit"
                       type="hidden"
-                      value="kg"
+                      value="KG"
                     />
                     <svg
                       aria-hidden="true"
@@ -67233,12 +67233,12 @@ exports[`Storyshots Views / Shipping / Shipping zones list loading 1`] = `
                       class="MuiSelect-select-id MuiSelect-selectMenu-id MuiSelect-disabled-id MuiInputBase-input-id MuiInput-input-id MuiInputBase-disabled-id MuiInput-disabled-id"
                       role="button"
                     >
-                      kg
+                      KG
                     </div>
                     <input
                       name="unit"
                       type="hidden"
-                      value="kg"
+                      value="KG"
                     />
                     <svg
                       aria-hidden="true"
@@ -67501,12 +67501,12 @@ exports[`Storyshots Views / Shipping / Shipping zones list no data 1`] = `
                       role="button"
                       tabindex="0"
                     >
-                      kg
+                      KG
                     </div>
                     <input
                       name="unit"
                       type="hidden"
-                      value="kg"
+                      value="KG"
                     />
                     <svg
                       aria-hidden="true"

--- a/saleor/static/dashboard-next/storybook/stories/shipping/ShippingZonesListPage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/shipping/ShippingZonesListPage.tsx
@@ -11,7 +11,7 @@ import Decorator from "../../Decorator";
 
 const props: ShippingZonesListPageProps = {
   ...pageListProps.default,
-  defaultWeightUnit: WeightUnitsEnum.kg,
+  defaultWeightUnit: WeightUnitsEnum.KG,
   onAdd: () => undefined,
   onRemove: () => undefined,
   onSubmit: () => undefined,

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -160,10 +160,10 @@ export enum VoucherTypeEnum {
 }
 
 export enum WeightUnitsEnum {
-  g = "g",
-  kg = "kg",
-  lb = "lb",
-  oz = "oz",
+  G = "G",
+  KG = "KG",
+  LB = "LB",
+  OZ = "OZ",
 }
 
 export interface AddressInput {


### PR DESCRIPTION
I want to merge this change because it Fixes #3828 - graphql error `Expected a value of type WeightUnitsEnum but received: kg`

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
