### PR TITLE
Add missing language enum in GraphQL schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - New translations:
   - Thai
 - Improve user and staff management in dashboard 1.0 - #3781 by @jxltom
+- Add missing language enum in GraphQL schema - #3854 by @jxltom
 
 
 ## 2.4.0

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -1,8 +1,8 @@
 import graphene
 
 from ...core import TaxRateType as CoreTaxRateType
-from ...core.weight import WeightUnits
 from ...core.permissions import MODELS_PERMISSIONS
+from ...core.weight import WeightUnits
 from .utils import str_to_enum
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -844,6 +844,7 @@ enum LanguageCodeEnum {
   SK
   SR
   SV
+  TH
   TR
   UK
   VI


### PR DESCRIPTION
The ```th``` language enum is missing in GraphQL schema, this PR fixes it.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
