### PR TITLE
Fix bug where logo-document is not renamed to logo-light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,10 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix layout in staff members details page - #3857 by @dominik-zeglen
 - Add draft orders query - #3809 by @michaljelonek
 - Restrict global orders query - #3861 by @pawelzar
-
-- Improve accessibility - #3856 by @dominik-zeglen                                                    │
+- Improve accessibility - #3856 by @dominik-zeglen
 - Add light/dark theme - #3856 by @dominik-zeglen
+- Fix bug where logo-document is not renamed to logo-light - #3867 by @jxltom
+
 
 ## 2.4.0
 ### API

--- a/saleor/core/emails.py
+++ b/saleor/core/emails.py
@@ -6,7 +6,7 @@ from ..core.utils import build_absolute_uri
 
 def get_email_base_context():
     site = Site.objects.get_current()
-    logo_url = build_absolute_uri(static('images/logo-document.svg'))
+    logo_url = build_absolute_uri(static('images/logo-light.svg'))
     return {
         'domain': site.domain,
         'logo_url': logo_url,

--- a/templates/base.html
+++ b/templates/base.html
@@ -119,7 +119,7 @@
               <svg data-src="{% static "images/mobile-menu.svg" %}" width="28px" height="20px"/>
             </div>
             <a href="{% url 'home' %}">
-              <svg data-src="{% static "images/logo-document.svg" %}"/>
+              <svg data-src="{% static "images/logo-light.svg" %}"/>
             </a>
           </div>
           <div class="col-2 col-md-5 navbar__search static">
@@ -290,7 +290,7 @@
       <div class="row">
         <div class="col-4">
           <a href="{% url 'home' %}" class="footer__logo float-md-left">
-            <svg data-src="{% static "images/logo-document.svg" %}"/>
+            <svg data-src="{% static "images/logo-light.svg" %}"/>
           </a>
         </div>
         <div class="col-8 footer__copy-text">COPYRIGHT © 2009–2019 MIRUMEE SOFTWARE</div>

--- a/templates/checkout/details.html
+++ b/templates/checkout/details.html
@@ -15,7 +15,7 @@
   <header class="checkout__header">
     <div class="container">
       <a href="{% url 'home'%}">
-        <svg data-src="{% static "images/logo-document.svg" %}" height="48px" width="176px" />
+        <svg data-src="{% static "images/logo-light.svg" %}" height="48px" width="176px" />
       </a>
       <h1>{% trans "Checkout" context "Checkout title" %}</h1>
     </div>

--- a/templates/dashboard/order/pdf/base_pdf.html
+++ b/templates/dashboard/order/pdf/base_pdf.html
@@ -26,7 +26,7 @@
   <body>
     <header>
       <div style="float: left">
-        <img alt="logo" src="{% static "images/logo-document.svg" %}" />
+        <img alt="logo" src="{% static "images/logo-light.svg" %}" />
       </div>
 
       <div style="float: right">

--- a/templates/dashboard/styleguide/index.html
+++ b/templates/dashboard/styleguide/index.html
@@ -28,7 +28,7 @@
           <ul class="left">
             <li class="logo">
               <a href="{% url 'dashboard:index' %}">
-                <svg data-src="{% static "dashboard/images/logo-document.svg" %}" height="38px" width="176px" />
+                <svg data-src="{% static "dashboard/images/logo-light.svg" %}" height="38px" width="176px" />
               </a>
             </li>
             <li>

--- a/templates/styleguide.html
+++ b/templates/styleguide.html
@@ -11,7 +11,7 @@
 <header class="checkout__header">
   <div class="container">
     <a href="/">
-      <svg data-src="{% static "images/logo-document.svg" %}" height="38px" width="176px" />
+      <svg data-src="{% static "images/logo-light.svg" %}" height="38px" width="176px" />
     </a>
     <h1>Style guide</h1>
   </div>

--- a/tests/dashboard/test_customer.py
+++ b/tests/dashboard/test_customer.py
@@ -165,7 +165,7 @@ def test_send_set_password_customer_email(customer_user, site_settings):
     site = site_settings.site
     uid = urlsafe_base64_encode(force_bytes(customer_user.pk)).decode()
     token = default_token_generator.make_token(customer_user)
-    logo_url = build_absolute_uri(static('images/logo-document.svg'))
+    logo_url = build_absolute_uri(static('images/logo-light.svg'))
     password_set_url = build_absolute_uri(
         reverse(
             'account:reset-password-confirm',

--- a/tests/dashboard/test_staff.py
+++ b/tests/dashboard/test_staff.py
@@ -138,7 +138,7 @@ def test_send_set_password_email(staff_user, site_settings):
     site = site_settings.site
     uid = urlsafe_base64_encode(force_bytes(staff_user.pk)).decode()
     token = default_token_generator.make_token(staff_user)
-    logo_url = build_absolute_uri(static('images/logo-document.svg'))
+    logo_url = build_absolute_uri(static('images/logo-light.svg'))
     password_set_url = build_absolute_uri(
         reverse(
             'account:reset-password-confirm',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -260,8 +260,8 @@ def test_build_absolute_uri(site_settings, settings):
     assert build_absolute_uri(location=url) == url
 
     # Case when static url is resolved to relative url
-    logo_url = build_absolute_uri(static('images/logo-document.svg'))
+    logo_url = build_absolute_uri(static('images/logo-light.svg'))
     protocol = 'https' if settings.ENABLE_SSL else 'http'
     current_url = '%s://%s' % (protocol, site_settings.site.domain)
-    logo_location = urljoin(current_url, static('images/logo-document.svg'))
+    logo_location = urljoin(current_url, static('images/logo-light.svg'))
     assert logo_url == logo_location

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -11,7 +11,7 @@ from saleor.core.utils import build_absolute_uri
 
 def test_get_email_base_context(site_settings):
     site = site_settings.site
-    logo_url = build_absolute_uri(static('images/logo-document.svg'))
+    logo_url = build_absolute_uri(static('images/logo-light.svg'))
     proper_context = {
         'domain': site.domain,
         'logo_url': logo_url,


### PR DESCRIPTION
In https://github.com/mirumee/saleor/pull/3856, logo-docoment is renamed to logo-light, but static storefront and tests didn't rename it. This PR fixes this issue.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
