### PR TITLE
Refactor error handling in mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
-...
+- Refactor error handling in mutations #3891 by @maarcingebala @akjanik
 
 
 ## 2.5.0

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -893,24 +893,19 @@ def is_fully_paid(cart: Cart, taxes, discounts):
 
 def clean_checkout(cart: Cart, taxes, discounts):
     """Check if checkout can be completed."""
-    errors = {}
-
     if cart.is_shipping_required():
         if not cart.shipping_method:
-            errors.append('Shipping method is not set')
+            raise ValidationError('Shipping method is not set')
         if not cart.shipping_address:
-            errors.append('Shipping address is not set')
+            raise ValidationError('Shipping address is not set')
         if not is_valid_shipping_method(cart, taxes, discounts):
-            errors.append(
+            raise ValidationError(
                 'Shipping method is not valid for your shipping address')
 
     if not cart.billing_address:
-        errors.append('Billing address is not set')
+        raise ValidationError('Billing address is not set')
 
     if not is_fully_paid(cart, taxes, discounts):
-        errors.append(
+        raise ValidationError(
             'Provided payment methods can not cover the checkout\'s total '
             'amount')
-
-    if errors:
-        raise ValidationError(errors)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -5,6 +5,7 @@ from uuid import UUID
 
 from django.conf import settings
 from django.contrib import messages
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Sum
 from django.utils.encoding import smart_text
@@ -890,25 +891,26 @@ def is_fully_paid(cart: Cart, taxes, discounts):
     return total_paid >= cart_total
 
 
-def ready_to_place_order(cart: Cart, taxes, discounts):
+def clean_checkout(cart: Cart, taxes, discounts):
     """Check if checkout can be completed."""
+    errors = {}
+
     if cart.is_shipping_required():
         if not cart.shipping_method:
-            return False, pgettext_lazy(
-                'order placement_error', 'Shipping method is not set')
+            errors.append('Shipping method is not set')
         if not cart.shipping_address:
-            return False, pgettext_lazy(
-                'order placement error', 'Shipping address is not set')
+            errors.append('Shipping address is not set')
         if not is_valid_shipping_method(cart, taxes, discounts):
-            return False, pgettext_lazy(
-                'order placement error',
+            errors.append(
                 'Shipping method is not valid for your shipping address')
+
     if not cart.billing_address:
-        return False, pgettext_lazy(
-            'order placement_error', 'Billing address is not set')
+        errors.append('Billing address is not set')
+
     if not is_fully_paid(cart, taxes, discounts):
-        return False, pgettext_lazy(
-            'order placement error', (
-                'Provided payment methods can not '
-                'cover the checkout\'s total amount'))
-    return True, None
+        errors.append(
+            'Provided payment methods can not cover the checkout\'s total '
+            'amount')
+
+    if errors:
+        raise ValidationError(errors)

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -1,15 +1,8 @@
 from django_countries import countries
+from django.core.exceptions import ValidationError
 
 from ...account.forms import get_address_form
 from ...account.models import Address
-
-
-def get_field_name(field_name, parent_field_name):
-    if not field_name:
-        return None
-    if not parent_field_name:
-        return field_name
-    return '%s:%s' % (parent_field_name, field_name)
 
 
 class I18nMixin:
@@ -18,26 +11,20 @@ class I18nMixin:
     """
 
     @classmethod
-    def validate_address(
-            cls, address_data, errors, parent_field_name=None,
-            instance=None):
+    def validate_address(cls, address_data, instance=None):
         country_code = address_data.get('country')
         if country_code in countries.countries.keys():
             address_form, _ = get_address_form(
                 address_data, address_data['country'])
         else:
-            error_msg = 'Invalid country code.'
-            cls.add_error(errors, 'country', error_msg)
-            return None, errors
+            raise ValidationError({'country': 'Invalid country code.'})
+
         if not address_form.is_valid():
-            for field_name, field_errors in address_form.errors.items():
-                error_field = get_field_name(field_name, parent_field_name)
-                # sometimes same error is duplicated within the field errors
-                for error_msg in set(field_errors):
-                    cls.add_error(errors, error_field, error_msg)
-            return None, errors
+            raise ValidationError(address_form.errors)
+
         if not instance:
             instance = Address()
+
         cls.construct_instance(instance, address_form.cleaned_data)
-        cls.clean_instance(instance, errors)
-        return instance, errors
+        cls.clean_instance(instance)
+        return instance

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -621,8 +621,6 @@ class CustomerSetDefaultAddress(BaseMutation):
             address_type = AddressType.BILLING
         elif type == AddressTypeEnum.SHIPPING.value:
             address_type = AddressType.SHIPPING
-        else:
-            raise ValueError('Unknown value of AddressTypeEnum: %s' % type)
 
         utils.change_user_default_address(user, address, address_type)
         return cls(user=user)

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -661,7 +661,7 @@ class UserAvatarUpdate(BaseMutation):
         user.save()
         create_user_avatar_thumbnails.delay(user_id=user.pk)
 
-        return UserAvatarUpdate(user=user, errors=errors)
+        return UserAvatarUpdate(user=user)
 
 
 class UserAvatarDelete(BaseMutation):
@@ -674,7 +674,6 @@ class UserAvatarDelete(BaseMutation):
     @staff_member_required
     def perform_mutation(cls, root, info):
         user = info.context.user
-        errors = []
         user.avatar.delete_sized_images()
         user.avatar.delete()
         return UserAvatarDelete(user=user)

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -522,7 +522,8 @@ class AddressSetDefault(BaseMutation):
         address_id = graphene.ID(
             required=True, description='ID of the address.')
         user_id = graphene.ID(
-            required=True, description='ID of the user to change the address for.')
+            required=True,
+            description='ID of the user to change the address for.')
         type = AddressTypeEnum(
             required=True, description='The type of address.')
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -23,7 +23,7 @@ class AddressInput(graphene.InputObjectType):
     city = graphene.String(description='City.')
     city_area = graphene.String(description='District.')
     postal_code = graphene.String(description='Postal code.')
-    country = graphene.String(required=True, description='Country.')
+    country = graphene.String(description='Country.')
     country_area = graphene.String(description='State or province.')
     phone = graphene.String(description='Phone number.')
 

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -1,3 +1,5 @@
+from django.core.exceptions import ValidationError
+
 
 class UserDeleteMixin:
     class Meta:
@@ -7,9 +9,10 @@ class UserDeleteMixin:
     def clean_instance(cls, info, instance, errors):
         user = info.context.user
         if instance == user:
-            cls.add_error(errors, 'id', 'You cannot delete your own account.')
+            raise ValidationError({
+                'id': 'You cannot delete your own account.'})
         elif instance.is_superuser:
-            cls.add_error(errors, 'id', 'Cannot delete this account.')
+            raise ValidationError({'id': 'Cannot delete this account.'})
 
 
 class CustomerDeleteMixin(UserDeleteMixin):
@@ -20,7 +23,7 @@ class CustomerDeleteMixin(UserDeleteMixin):
     def clean_instance(cls, info, instance, errors):
         super().clean_instance(info, instance, errors)
         if instance.is_staff:
-            cls.add_error(errors, 'id', 'Cannot delete a staff account.')
+            raise ValidationError({'id': 'Cannot delete a staff account.'})
 
 
 class StaffDeleteMixin(UserDeleteMixin):
@@ -31,4 +34,4 @@ class StaffDeleteMixin(UserDeleteMixin):
     def clean_instance(cls, info, instance, errors):
         super().clean_instance(info, instance, errors)
         if not instance.is_staff:
-            cls.add_error(errors, 'id', 'Cannot delete a non-staff user.')
+            raise ValidationError({'id': 'Cannot delete a non-staff user.'})

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -6,7 +6,7 @@ class UserDeleteMixin:
         abstract = True
 
     @classmethod
-    def clean_instance(cls, info, instance, errors):
+    def clean_instance(cls, info, instance):
         user = info.context.user
         if instance == user:
             raise ValidationError({
@@ -20,8 +20,8 @@ class CustomerDeleteMixin(UserDeleteMixin):
         abstract = True
 
     @classmethod
-    def clean_instance(cls, info, instance, errors):
-        super().clean_instance(info, instance, errors)
+    def clean_instance(cls, info, instance):
+        super().clean_instance(info, instance)
         if instance.is_staff:
             raise ValidationError({'id': 'Cannot delete a staff account.'})
 
@@ -31,7 +31,7 @@ class StaffDeleteMixin(UserDeleteMixin):
         abstract = True
 
     @classmethod
-    def clean_instance(cls, info, instance, errors):
-        super().clean_instance(info, instance, errors)
+    def clean_instance(cls, info, instance):
+        super().clean_instance(info, instance)
         if not instance.is_staff:
             raise ValidationError({'id': 'Cannot delete a non-staff user.'})

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -7,8 +7,8 @@ from django.db import transaction
 from ...checkout import models
 from ...checkout.utils import (
     add_variant_to_cart, add_voucher_to_cart, change_billing_address_in_cart,
-    change_shipping_address_in_cart, create_order, get_or_create_user_cart,
-    get_taxes_for_cart, get_voucher_for_cart, clean_checkout,
+    change_shipping_address_in_cart, clean_checkout, create_order,
+    get_or_create_user_cart, get_taxes_for_cart, get_voucher_for_cart,
     recalculate_cart_discount, remove_voucher_from_cart)
 from ...core import analytics
 from ...core.exceptions import InsufficientStock
@@ -32,7 +32,7 @@ def clean_shipping_method(
         checkout, method, discounts, taxes, country_code=None, remove=True):
     # FIXME Add tests for this function
     if not method:
-        return
+        return None
 
     if not checkout.is_shipping_required():
         raise ValidationError('This checkout does not requires shipping.')
@@ -208,8 +208,6 @@ class CheckoutLinesAdd(BaseMutation):
     def perform_mutation(cls, root, info, checkout_id, lines, replace=False):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field='checkout_id')
-
-        variants, quantities = None, None
 
         variant_ids = [line.get('variant_id') for line in lines]
         variants = cls.get_nodes_or_error(

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -62,10 +62,7 @@ def clean_shipping_method(
 
 
 def check_lines_quantity(variants, quantities):
-    """Check if stock is sufficient for each line in the list of dicts.
-    Return list of errors.
-    """
-    errors = {}
+    """Check if stock is sufficient for each line in the list of dicts."""
     for variant, quantity in zip(variants, quantities):
         try:
             variant.check_quantity(quantity)
@@ -75,10 +72,7 @@ def check_lines_quantity(variants, quantities):
                 + '%(item_name)s. Only %(remaining)d remaining in stock.' % {
                     'remaining': e.item.quantity_available,
                     'item_name': e.item.display_product()})
-            ValidationError({'quantity': message}).update_error_dict(errors)
-
-    if errors:
-        raise ValidationError(errors)
+            raise ValidationError({'quantity': message})
 
 
 class CheckoutLineInput(graphene.InputObjectType):
@@ -331,12 +325,6 @@ class CheckoutCustomerDetach(BaseMutation):
         errors = []
         checkout = cls.get_node_or_error(
             info, checkout_id, errors, 'checkout_id', only_type=Checkout)
-
-        # FIXME: is this error actually useful? IN this case mutation could just do nothing
-        if not checkout.user:
-            raise ValidationError(
-                'There\'s no customer assigned to this Checkout.')
-
         checkout.user = None
         checkout.save(update_fields=['user'])
         return CheckoutCustomerDetach(checkout=checkout)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -28,10 +28,12 @@ from ..shipping.types import ShippingMethod
 from .types import Checkout, CheckoutLine
 
 
-# FIXME Add tests for this function
 def clean_shipping_method(
         checkout, method, errors, discounts, taxes, country_code=None,
         remove=True):
+    # FIXME Add tests for this function
+    if not method:
+        return errors
     if not checkout.is_shipping_required():
         raise ValidationError('This checkout does not requires shipping.')
 
@@ -173,7 +175,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 add_variant_to_cart(instance, variant, quantity)
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, root, info, input):
         errors = []
         user = info.context.user
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -90,7 +90,7 @@ class Checkout(CountableDjangoObjectType):
         taxes = get_taxes_for_address(self.shipping_address)
         price = self.get_subtotal(
             taxes=taxes, discounts=info.context.discounts)
-        return applicable_shipping_methods(self, info, price.gross.amount)
+        return applicable_shipping_methods(self, price.gross.amount)
 
     def resolve_available_payment_gateways(self, info):
         return settings.CHECKOUT_PAYMENT_GATEWAYS.keys()

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -4,7 +4,7 @@ from textwrap import dedent
 import graphene
 from django.contrib.auth import get_user_model
 from django.core.exceptions import (
-    ImproperlyConfigured, NON_FIELD_ERRORS, ValidationError)
+    NON_FIELD_ERRORS, ImproperlyConfigured, ValidationError)
 from django.db.models.fields.files import FileField
 from graphene.types.mutation import MutationOptions
 from graphene_django.registry import get_global_registry
@@ -85,7 +85,6 @@ class BaseMutation(graphene.Mutation):
         if not node_id:
             return None
 
-        node = None
         try:
             node = graphene.Node.get_node_from_global_id(
                 info, node_id, only_type)
@@ -99,7 +98,6 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def get_nodes_or_error(cls, ids, field, only_type=None):
-        instances = None
         try:
             instances = get_nodes(ids, only_type)
         except GraphQLError as e:
@@ -432,8 +430,7 @@ class BaseBulkMutation(BaseMutation):
         if errors:
             errors = validation_error_to_error_type(errors)
             return cls(errors=errors, count=count)
-        else:
-            return cls(count=count)
+        return cls(count=count)
 
 
 class ModelBulkDeleteMutation(BaseBulkMutation):

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -429,8 +429,7 @@ class BaseBulkMutation(BaseMutation):
         count, errors = cls.perform_mutation(root, info, **data)
         if errors:
             errors = validation_error_to_error_type(errors)
-            return cls(errors=errors, count=count)
-        return cls(count=count)
+        return cls(errors=errors, count=count)
 
 
 class ModelBulkDeleteMutation(BaseBulkMutation):

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -103,8 +103,6 @@ class BaseMutation(graphene.Mutation):
         try:
             instances = get_nodes(ids, only_type)
         except GraphQLError as e:
-            # FIXME: czy zawsze tutaj powinien lecieć ValidationError? moze
-            # tylko jak nie znaleziono danego IDka?
             raise ValidationError({field: str(e)})
         return instances
 
@@ -325,11 +323,11 @@ class ModelMutation(BaseMutation):
         errors = []  # Initialize the errors list.
         instance = cls.get_instance(info, errors, **data)
 
-        input_data = data.get('input')  # FIXME: pass data to clean_input
+        input_data = data.get('input')
 
         cleaned_input = cls.clean_input(info, instance, input_data, errors)
-        instance = cls.construct_instance(instance, cleaned_input)  # FIXME: maybe rename to `populate_instance`
-        cls.clean_instance(instance, errors)  # FIXME: maybe rename to `pre_save_instance` ?
+        instance = cls.construct_instance(instance, cleaned_input)
+        cls.clean_instance(instance, errors)
         cls.save(info, instance, cleaned_input)
         cls._save_m2m(info, instance, cleaned_input)
         return cls.success_response(instance)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -45,7 +45,8 @@ def validation_error_to_error_type(validation_error: ValidationError) -> list:
         # convert field errors
         for field, field_errors in validation_error.message_dict.items():
             for err in field_errors:
-                field = None if field == NON_FIELD_ERRORS else snake_to_camel_case(field)
+                field = None if field == NON_FIELD_ERRORS else snake_to_camel_case(
+                    field)
                 err_list.append(Error(field=field, message=err))
     else:
         # convert non-field errors
@@ -234,14 +235,14 @@ class ModelMutation(BaseMutation):
 
         def is_list_of_ids(field):
             return (
-                isinstance(field.type, graphene.List)
-                and field.type.of_type == graphene.ID)
+                    isinstance(field.type, graphene.List)
+                    and field.type.of_type == graphene.ID)
 
         def is_id_field(field):
             return (
-                field.type == graphene.ID
-                or isinstance(field.type, graphene.NonNull)
-                and field.type.of_type == graphene.ID)
+                    field.type == graphene.ID
+                    or isinstance(field.type, graphene.NonNull)
+                    and field.type.of_type == graphene.ID)
 
         def is_upload_field(field):
             if hasattr(field.type, 'of_type'):

--- a/saleor/graphql/core/utils.py
+++ b/saleor/graphql/core/utils.py
@@ -25,4 +25,4 @@ def str_to_enum(name):
 def validate_image_file(file, field_name):
     """Validate if the file is an image."""
     if not file.content_type.startswith('image/'):
-        raise ValidationError({field_name: 'Invalid file type.'})
+        raise ValidationError({field_name: 'Invalid file type'})

--- a/saleor/graphql/core/utils.py
+++ b/saleor/graphql/core/utils.py
@@ -1,3 +1,6 @@
+from django.core.exceptions import ValidationError
+
+
 def clean_seo_fields(data):
     """Extract and assign seo fields to given dictionary."""
     seo_fields = data.pop('seo', None)
@@ -19,7 +22,7 @@ def str_to_enum(name):
     return name.replace(' ', '_').replace('-', '_').upper()
 
 
-def validate_image_file(mutation_cls, file, field_name, errors):
+def validate_image_file(file, field_name):
     """Validate if the file is an image."""
     if not file.content_type.startswith('image/'):
-        mutation_cls.add_error(errors, field_name, 'Invalid file type')
+        raise ValidationError({field_name: 'Invalid file type.'})

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -1,5 +1,4 @@
 import graphene
-from graphql_jwt.decorators import permission_required
 
 from ...discount import models
 from ...discount.utils import generate_voucher_code
@@ -166,8 +165,11 @@ class VoucherAddCatalogues(VoucherBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    @permission_required('discount.manage_discounts')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('discount.manage_discounts')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         voucher = cls.get_node_or_error(
             info, id, errors, 'voucherId', only_type=Voucher)
@@ -182,8 +184,11 @@ class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
             'Removes products, categories, collections from a voucher.')
 
     @classmethod
-    @permission_required('discount.manage_discounts')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('discount.manage_discounts')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         voucher = cls.get_node_or_error(
             info, id, errors, 'voucherId', only_type=Voucher)
@@ -275,8 +280,11 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    @permission_required('discount.manage_discounts')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('discount.manage_discounts')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         sale = cls.get_node_or_error(
             info, id, errors, 'saleId', only_type=Sale)
@@ -290,8 +298,11 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
         description = 'Removes products, categories, collections from a sale.'
 
     @classmethod
-    @permission_required('discount.manage_discounts')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('discount.manage_discounts')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         sale = cls.get_node_or_error(
             info, id, errors, 'saleId', only_type=Sale)

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -29,39 +29,38 @@ class BaseDiscountCatalogueMutation(BaseMutation):
         abstract = True
 
     @classmethod
-    def add_catalogues_to_node(cls, node, input, errors):
+    def add_catalogues_to_node(cls, node, input):
         products = input.get('products', [])
         if products:
             products = cls.get_nodes_or_error(
-                products, errors, 'products', only_type=Product)
+                products, 'products', Product)
             node.products.add(*products)
         categories = input.get('categories', [])
         if categories:
             categories = cls.get_nodes_or_error(
-                categories, errors, 'categories', only_type=Category)
+                categories, 'categories', Category)
             node.categories.add(*categories)
         collections = input.get('collections', [])
         if collections:
             collections = cls.get_nodes_or_error(
-                collections, errors, 'collections', only_type=Collection)
+                collections, 'collections', Collection)
             node.collections.add(*collections)
 
     @classmethod
-    def remove_catalogues_from_node(cls, node, input, errors):
+    def remove_catalogues_from_node(cls, node, input):
         products = input.get('products', [])
         if products:
-            products = cls.get_nodes_or_error(
-                products, errors, 'products', only_type=Product)
+            products = cls.get_nodes_or_error(products, 'products', Product)
             node.products.remove(*products)
         categories = input.get('categories', [])
         if categories:
             categories = cls.get_nodes_or_error(
-                categories, errors, 'categories', only_type=Category)
+                categories, 'categories', Category)
             node.categories.remove(*categories)
         collections = input.get('collections', [])
         if collections:
             collections = cls.get_nodes_or_error(
-                collections, errors, 'collections', only_type=Collection)
+                collections, 'collections', Collection)
             node.collections.remove(*collections)
 
 
@@ -110,11 +109,11 @@ class VoucherCreate(ModelMutation):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
+    def clean_input(cls, info, instance, input):
         code = input.get('code', None)
         if code == '':
             input['code'] = generate_voucher_code()
-        cleaned_input = super().clean_input(info, instance, input, errors)
+        cleaned_input = super().clean_input(info, instance, input)
         return cleaned_input
 
 
@@ -170,12 +169,10 @@ class VoucherAddCatalogues(VoucherBaseCatalogueMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
         voucher = cls.get_node_or_error(
-            info, id, errors, 'voucherId', only_type=Voucher)
-
-        cls.add_catalogues_to_node(voucher, input, errors)
-        return VoucherAddCatalogues(voucher=voucher, errors=errors)
+            info, id, only_type=Voucher, field='voucher_id')
+        cls.add_catalogues_to_node(voucher, input)
+        return VoucherAddCatalogues(voucher=voucher)
 
 
 class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
@@ -189,12 +186,10 @@ class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
         voucher = cls.get_node_or_error(
-            info, id, errors, 'voucherId', only_type=Voucher)
-
-        cls.remove_catalogues_from_node(voucher, input, errors)
-        return VoucherRemoveCatalogues(voucher=voucher, errors=errors)
+            info, id, only_type=Voucher, field='voucher_id')
+        cls.remove_catalogues_from_node(voucher, input)
+        return VoucherRemoveCatalogues(voucher=voucher)
 
 
 class SaleInput(graphene.InputObjectType):
@@ -285,12 +280,9 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
-        sale = cls.get_node_or_error(
-            info, id, errors, 'saleId', only_type=Sale)
-
-        cls.add_catalogues_to_node(sale, input, errors)
-        return SaleAddCatalogues(sale=sale, errors=errors)
+        sale = cls.get_node_or_error(info, id, only_type=Sale, field='sale_id')
+        cls.add_catalogues_to_node(sale, input)
+        return SaleAddCatalogues(sale=sale)
 
 
 class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
@@ -303,9 +295,7 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
         sale = cls.get_node_or_error(
-            info, id, errors, 'saleId', only_type=Sale)
-
-        cls.remove_catalogues_from_node(sale, input, errors)
-        return SaleRemoveCatalogues(sale=sale, errors=errors)
+            info, id, only_type=Sale, field='sale_id')
+        cls.remove_catalogues_from_node(sale, input)
+        return SaleRemoveCatalogues(sale=sale)

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -1,7 +1,7 @@
 from textwrap import dedent
 
 import graphene
-from graphql_jwt.decorators import permission_required
+from django.core.exceptions import ValidationError
 
 from ...menu import models
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
@@ -60,14 +60,15 @@ class MenuCreate(ModelMutation):
     def clean_input(cls, info, instance, input, errors):
         cleaned_input = super().clean_input(info, instance, input, errors)
         items = []
+        errors = {}
         for item in cleaned_input.get('items', []):
             category = item.get('category')
             collection = item.get('collection')
             page = item.get('page')
             url = item.get('url')
             if len([i for i in [category, collection, page, url] if i]) > 1:
-                cls.add_error(
-                    errors, 'items', 'More than one item provided.')
+                ValidationError({
+                    'items': 'More than one item provided.'}).update_error_dict(errors)
             else:
                 if category:
                     category = cls.get_node_or_error(
@@ -83,8 +84,13 @@ class MenuCreate(ModelMutation):
                         info, page, errors, 'items', only_type=Page)
                     item['page'] = page
                 elif not url:
-                    cls.add_error(errors, 'items', 'No menu item provided.')
+                    ValidationError({
+                        'items': 'No menu item provided.'}).update_error_dict(errors)
                 items.append(item)
+
+        if errors:
+            raise ValidationError(errors)
+
         cleaned_input['items'] = items
         return cleaned_input
 
@@ -151,9 +157,7 @@ class MenuItemCreate(ModelMutation):
             cleaned_input.get('url'), cleaned_input.get('category')]
         items = [item for item in items if item is not None]
         if len(items) > 1:
-            cls.add_error(
-                errors=errors,
-                field='items', message='More than one item provided.')
+            raise ValidationError({'items': 'More than one item provided.'})
         return cleaned_input
 
 
@@ -203,8 +207,7 @@ class AssignNavigation(BaseMutation):
     menu = graphene.Field(Menu, description='Assigned navigation menu.')
 
     class Arguments:
-        menu = graphene.ID(
-            description='ID of the menu.')
+        menu = graphene.ID(description='ID of the menu.')  # FIXME: required=True?
         navigation_type = NavigationType(
             description='Type of the navigation bar to assign the menu to.',
             required=True)
@@ -212,22 +215,26 @@ class AssignNavigation(BaseMutation):
     class Meta:
         description = 'Assigns storefront\'s navigation menus.'
 
+    def user_is_allowed(cls, instance, input):
+        return instance.has_perms([
+            'menu.manage_menus', 'site.manage_settings'])
+
     @classmethod
-    @permission_required(['menu.manage_menus', 'site.manage_settings'])
-    def mutate(cls, root, info, navigation_type, menu=None):
+    def perform_mutation(cls, root, info, navigation_type, menu=None):
         errors = []
         site_settings = info.context.site.settings
         if menu is not None:
             menu = cls.get_node_or_error(
                 info, menu, errors=errors, field='menu')
-        if not errors:
-            if navigation_type == NavigationType.MAIN:
-                site_settings.top_menu = menu
-                site_settings.save(update_fields=['top_menu'])
-            elif navigation_type == NavigationType.SECONDARY:
-                site_settings.bottom_menu = menu
-                site_settings.save(update_fields=['bottom_menu'])
-            else:
-                raise AssertionError(
-                    'Unknown navigation type: %s' % navigation_type)
+
+        if navigation_type == NavigationType.MAIN:
+            site_settings.top_menu = menu
+            site_settings.save(update_fields=['top_menu'])
+        elif navigation_type == NavigationType.SECONDARY:
+            site_settings.bottom_menu = menu
+            site_settings.save(update_fields=['bottom_menu'])
+        else:
+            raise AssertionError(
+                'Unknown navigation type: %s' % navigation_type)
+
         return AssignNavigation(menu=menu, errors=errors)

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -215,6 +215,7 @@ class AssignNavigation(BaseMutation):
     class Meta:
         description = 'Assigns storefront\'s navigation menus.'
 
+    @classmethod
     def user_is_allowed(cls, instance, input):
         return instance.has_perms([
             'menu.manage_menus', 'site.manage_settings'])

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -67,8 +67,7 @@ class MenuCreate(ModelMutation):
             page = item.get('page')
             url = item.get('url')
             if len([i for i in [category, collection, page, url] if i]) > 1:
-                ValidationError({
-                    'items': 'More than one item provided.'}).update_error_dict(errors)
+                raise ValidationError({'items': 'More than one item provided.'})
             else:
                 if category:
                     category = cls.get_node_or_error(
@@ -84,8 +83,7 @@ class MenuCreate(ModelMutation):
                         info, page, errors, 'items', only_type=Page)
                     item['page'] = page
                 elif not url:
-                    ValidationError({
-                        'items': 'No menu item provided.'}).update_error_dict(errors)
+                    raise ValidationError({'items': 'No menu item provided.'})
                 items.append(item)
 
         if errors:
@@ -207,7 +205,7 @@ class AssignNavigation(BaseMutation):
     menu = graphene.Field(Menu, description='Assigned navigation menu.')
 
     class Arguments:
-        menu = graphene.ID(description='ID of the menu.')  # FIXME: required=True?
+        menu = graphene.ID(description='ID of the menu.')
         navigation_type = NavigationType(
             description='Type of the navigation bar to assign the menu to.',
             required=True)

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -67,22 +67,22 @@ class MenuCreate(ModelMutation):
             url = item.get('url')
             if len([i for i in [category, collection, page, url] if i]) > 1:
                 raise ValidationError({'items': 'More than one item provided.'})
-            else:
-                if category:
-                    category = cls.get_node_or_error(
-                        info, category, field='items', only_type=Category)
-                    item['category'] = category
-                elif collection:
-                    collection = cls.get_node_or_error(
-                        info, collection, field='items', only_type=Collection)
-                    item['collection'] = collection
-                elif page:
-                    page = cls.get_node_or_error(
-                        info, page, field='items', only_type=Page)
-                    item['page'] = page
-                elif not url:
-                    raise ValidationError({'items': 'No menu item provided.'})
-                items.append(item)
+
+            if category:
+                category = cls.get_node_or_error(
+                    info, category, field='items', only_type=Category)
+                item['category'] = category
+            elif collection:
+                collection = cls.get_node_or_error(
+                    info, collection, field='items', only_type=Collection)
+                item['collection'] = collection
+            elif page:
+                page = cls.get_node_or_error(
+                    info, page, field='items', only_type=Page)
+                item['page'] = page
+            elif not url:
+                raise ValidationError({'items': 'No menu item provided.'})
+            items.append(item)
 
         cleaned_input['items'] = items
         return cleaned_input
@@ -225,8 +225,5 @@ class AssignNavigation(BaseMutation):
         elif navigation_type == NavigationType.SECONDARY:
             site_settings.bottom_menu = menu
             site_settings.save(update_fields=['bottom_menu'])
-        else:
-            raise AssertionError(
-                'Unknown navigation type: %s' % navigation_type)
 
         return AssignNavigation(menu=menu)

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -1,4 +1,5 @@
 import graphene
+from django.core.exceptions import ValidationError
 
 from ....order import OrderStatus, models
 from ...core.mutations import ModelBulkDeleteMutation
@@ -18,7 +19,7 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
     @classmethod
     def clean_instance(cls, info, instance, errors):
         if instance.status != OrderStatus.DRAFT:
-            cls.add_error(errors, 'id', 'Cannot delete non-draft orders.')
+            raise ValidationError({'id': 'Cannot delete non-draft orders.'})
 
     @classmethod
     def user_is_allowed(cls, user, input):

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -17,7 +17,7 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
         model = models.Order
 
     @classmethod
-    def clean_instance(cls, info, instance, errors):
+    def clean_instance(cls, info, instance):
         if instance.status != OrderStatus.DRAFT:
             raise ValidationError({'id': 'Cannot delete non-draft orders.'})
 

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -68,7 +68,6 @@ class FulfillmentCreate(BaseMutation):
 
     @classmethod
     def clean_lines(cls, order_lines, quantities, errors):
-        errors = {}
         for order_line, quantity in zip(order_lines, quantities):
             if quantity > order_line.quantity_unfulfilled:
                 msg = npgettext_lazy(
@@ -78,12 +77,7 @@ class FulfillmentCreate(BaseMutation):
                     number='quantity') % {
                         'quantity': order_line.quantity_unfulfilled,
                         'order_line': order_line}
-                ValidationError({
-                    'order_line_id': msg}).update_error_dict(errors)
-                ValidationError(msg).update_error_dict(errors)
-        if errors:
-            raise ValidationError(errors)
-        return errors
+                raise ValidationError({'order_line_id': msg})
 
     @classmethod
     def clean_input(cls, input, errors):
@@ -207,7 +201,7 @@ class FulfillmentCancel(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutatation(cls, root, info, id, input):
+    def perform_mutation(cls, root, info, id, input):
         restock = input.get('restock')
         fulfillment = cls.get_node_or_error(info, id, [], 'id', Fulfillment)
 

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -1,8 +1,8 @@
 from textwrap import dedent
 
 import graphene
+from django.core.exceptions import ValidationError
 from django.utils.translation import npgettext_lazy, pgettext_lazy
-from graphql_jwt.decorators import permission_required
 
 from ....order import OrderEvents, OrderEventsEmails, models
 from ....order.emails import send_fulfillment_confirmation
@@ -68,19 +68,21 @@ class FulfillmentCreate(BaseMutation):
 
     @classmethod
     def clean_lines(cls, order_lines, quantities, errors):
-        if errors:
-            return errors
-
+        errors = {}
         for order_line, quantity in zip(order_lines, quantities):
             if quantity > order_line.quantity_unfulfilled:
                 msg = npgettext_lazy(
                     'Fulfill order line mutation error',
-                    'Only %(quantity)d item remaining to fulfill.',
-                    'Only %(quantity)d items remaining to fulfill.',
+                    'Only %(quantity)d item remaining to fulfill: %(order_line)s.',
+                    'Only %(quantity)d items remaining to fulfill: %(order_line)s.',
                     number='quantity') % {
                         'quantity': order_line.quantity_unfulfilled,
                         'order_line': order_line}
-                cls.add_error(errors, order_line, msg)
+                ValidationError({
+                    'order_line_id': msg}).update_error_dict(errors)
+                ValidationError(msg).update_error_dict(errors)
+        if errors:
+            raise ValidationError(errors)
         return errors
 
     @classmethod
@@ -94,11 +96,9 @@ class FulfillmentCreate(BaseMutation):
         cls.clean_lines(order_lines, quantities, errors)
 
         if sum(quantities) <= 0:
-            cls.add_error(
-                errors, 'lines', 'Total quantity must be larger than 0.')
+            raise ValidationError({
+                'lines': 'Total quantity must be larger than 0.'})
 
-        if errors:
-            return cls(errors=errors)
         input['order_lines'] = order_lines
         input['quantities'] = quantities
         return input
@@ -130,19 +130,17 @@ class FulfillmentCreate(BaseMutation):
         return fulfillment
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, order, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, order, input):
         errors = []
-        order = cls.get_node_or_error(
-            info, order, errors, 'order', Order)
-        if errors:
-            return cls(errors=errors)
+        order = cls.get_node_or_error(info, order, errors, 'order', Order)
         fulfillment = models.Fulfillment(
             tracking_number=input.pop('tracking_number', None) or '',
             order=order)
         cleaned_input = cls.clean_input(input, errors)
-        if errors:
-            return cls(errors=errors)
         fulfillment = cls.save(
             info.context.user, fulfillment, order, cleaned_input)
         return FulfillmentCreate(
@@ -166,13 +164,14 @@ class FulfillmentUpdateTracking(BaseMutation):
         description = 'Updates a fulfillment for an order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         fulfillment = cls.get_node_or_error(
             info, id, errors, 'id', Fulfillment)
-        if errors:
-            return cls(errors=errors)
         tracking_number = input.get('tracking_number') or ''
         fulfillment.tracking_number = tracking_number
         fulfillment.save()
@@ -204,24 +203,24 @@ class FulfillmentCancel(BaseMutation):
         and optionally restocks items.""")
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, input):
-        errors = []
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutatation(cls, root, info, id, input):
         restock = input.get('restock')
-        fulfillment = cls.get_node_or_error(
-            info, id, errors, 'id', Fulfillment)
-        if fulfillment:
-            order = fulfillment.order
-            if not fulfillment.can_edit():
-                err_msg = pgettext_lazy(
-                    'Cancel fulfillment mutation error',
-                    'This fulfillment can\'t be canceled')
-                cls.add_error(errors, 'fulfillment', err_msg)
+        fulfillment = cls.get_node_or_error(info, id, [], 'id', Fulfillment)
 
-        if errors:
-            return cls(errors=errors)
+        if not fulfillment.can_edit():
+            err_msg = pgettext_lazy(
+                'Cancel fulfillment mutation error',
+                'This fulfillment can\'t be canceled')
+            raise ValidationError({'fulfillment': err_msg})
 
+        order = fulfillment.order
         cancel_fulfillment(fulfillment, restock)
+
+        # FIXME: move event creation to `cancel_fulfillment`
         if restock:
             order.events.create(
                 parameters={'quantity': fulfillment.get_total_quantity()},

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -22,7 +22,7 @@ def clean_order_update_shipping(order, method):
     if not order.shipping_address:
         raise ValidationError({
             'order': 'Cannot choose a shipping method for an order without '
-                'the shipping address.'})
+                     'the shipping address.'})
 
     valid_methods = (
         ShippingMethodModel.objects.applicable_shipping_methods(
@@ -33,7 +33,7 @@ def clean_order_update_shipping(order, method):
     if method.pk not in valid_methods:
         raise ValidationError({
             'shipping_method':
-            'Shipping method cannot be used with this order.'})
+                'Shipping method cannot be used with this order.'})
 
 
 def clean_order_cancel(order):
@@ -125,7 +125,7 @@ class OrderUpdateShipping(BaseMutation):
             if not order.is_draft() and order.is_shipping_required():
                 raise ValidationError({
                     'shipping_method':
-                    'Shipping method is required for this order.'})
+                        'Shipping method is required for this order.'})
 
             order.shipping_method = None
             order.shipping_price = ZERO_TAXED_MONEY

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -119,8 +119,7 @@ class OrderUpdateShipping(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
 
         if not input['shipping_method']:
             if not order.is_draft() and order.is_shipping_required():
@@ -138,8 +137,8 @@ class OrderUpdateShipping(BaseMutation):
             return OrderUpdateShipping(order=order)
 
         method = cls.get_node_or_error(
-            info, input['shipping_method'], errors,
-            'shipping_method', ShippingMethod)
+            info, input['shipping_method'], field='shipping_method',
+            only_type=ShippingMethod)
 
         clean_order_update_shipping(order, method)
 
@@ -178,8 +177,7 @@ class OrderAddNote(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         event = order.events.create(
             type=OrderEvents.NOTE_ADDED.value,
             user=info.context.user,
@@ -207,8 +205,7 @@ class OrderCancel(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, restock):
-        errors = []
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         clean_order_cancel(order)
         cancel_order(order=order, restock=restock)
         if restock:
@@ -238,8 +235,7 @@ class OrderMarkAsPaid(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id):
-        errors = []
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         try:
             clean_mark_order_as_paid(order)
         except PaymentError as e:
@@ -266,12 +262,11 @@ class OrderCapture(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, amount):
-        errors = []
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})
 
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         payment = order.get_last_payment()
         clean_order_capture(payment, amount)
 
@@ -303,8 +298,7 @@ class OrderVoid(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id):
-        errors = []
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         payment = order.get_last_payment()
         clean_void_payment(payment)
         try:
@@ -335,12 +329,11 @@ class OrderRefund(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, amount):
-        errors = []
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})
 
-        order = cls.get_node_or_error(info, id, errors, 'id', Order)
+        order = cls.get_node_or_error(info, id, only_type=Order)
         payment = order.get_last_payment()
         clean_refund_payment(payment, amount)
 

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -1,5 +1,5 @@
 import graphene
-from graphql_jwt.decorators import permission_required
+from django.core.exceptions import ValidationError
 
 from ....account.models import User
 from ....core.utils.taxes import ZERO_TAXED_MONEY
@@ -13,23 +13,17 @@ from ....shipping.models import ShippingMethod as ShippingMethodModel
 from ...account.types import AddressInput
 from ...core.mutations import BaseMutation
 from ...core.scalars import Decimal
-from ...core.types.common import Error
 from ...order.mutations.draft_orders import DraftOrderUpdate
 from ...order.types import Order, OrderEvent
 from ...shipping.types import ShippingMethod
 
 
-def clean_order_update_shipping(order, method, errors):
-    if not method:
-        return errors
+def clean_order_update_shipping(order, method):
     if not order.shipping_address:
-        errors.append(
-            Error(
-                field='order',
-                message=(
-                    'Cannot choose a shipping method for an '
-                    'order without the shipping address.')))
-        return errors
+        raise ValidationError({
+            'order': 'Cannot choose a shipping method for an order without '
+                'the shipping address.'})
+
     valid_methods = (
         ShippingMethodModel.objects.applicable_shipping_methods(
             price=order.get_subtotal().gross.amount,
@@ -37,56 +31,36 @@ def clean_order_update_shipping(order, method, errors):
             country_code=order.shipping_address.country.code))
     valid_methods = valid_methods.values_list('id', flat=True)
     if method.pk not in valid_methods:
-        errors.append(
-            Error(
-                field='shippingMethod',
-                message='Shipping method cannot be used with this order.'))
-    return errors
+        raise ValidationError({
+            'shipping_method':
+            'Shipping method cannot be used with this order.'})
 
 
-def clean_order_cancel(order, errors):
+def clean_order_cancel(order):
     if order and not order.can_cancel():
-        errors.append(
-            Error(
-                field='order',
-                message='This order can\'t be canceled.'))
-    return errors
+        raise ValidationError({'order': 'This order can\'t be canceled.'})
 
 
-def clean_order_capture(payment, amount, errors):
+def clean_order_capture(payment, amount):
     if not payment:
-        errors.append(
-            Error(
-                field='payment',
-                message='There\'s no payment associated with the order.'))
-        return errors
+        raise ValidationError({
+            'payment': 'There\'s no payment associated with the order.'})
     if not payment.is_active:
-        errors.append(
-            Error(
-                field='payment',
-                message='Only pre-authorized payments can be captured'))
-    return errors
+        raise ValidationError({
+            'payment': 'Only pre-authorized payments can be captured'})
 
 
-def clean_void_payment(payment, errors):
+def clean_void_payment(payment):
     """Check for payment errors."""
     if not payment.is_active:
-        errors.append(
-            Error(field='payment',
-                  message='Only pre-authorized payments can be voided'))
-    try:
-        gateway_void(payment)
-    except (PaymentError, ValueError) as e:
-        errors.append(Error(field='payment', message=str(e)))
-    return errors
+        raise ValidationError({
+            'payment': 'Only pre-authorized payments can be voided'})
 
 
-def clean_refund_payment(payment, amount, errors):
+def clean_refund_payment(payment, amount):
     if payment.gateway == CustomPaymentChoices.MANUAL:
-        errors.append(
-            Error(field='payment',
-                  message='Manual payments can not be refunded.'))
-    return errors
+        raise ValidationError({
+            'payment': 'Manual payments can not be refunded.'})
 
 
 class OrderUpdateInput(graphene.InputObjectType):
@@ -140,17 +114,20 @@ class OrderUpdateShipping(BaseMutation):
         description = 'Updates a shipping method of the order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
 
         if not input['shipping_method']:
             if not order.is_draft() and order.is_shipping_required():
-                cls.add_error(
-                    errors, 'shippingMethod',
-                    'Shipping method is required for this order.')
-                return OrderUpdateShipping(errors=errors)
+                raise ValidationError({
+                    'shipping_method':
+                    'Shipping method is required for this order.'})
+
             order.shipping_method = None
             order.shipping_price = ZERO_TAXED_MONEY
             order.shipping_method_name = None
@@ -163,9 +140,8 @@ class OrderUpdateShipping(BaseMutation):
         method = cls.get_node_or_error(
             info, input['shipping_method'], errors,
             'shipping_method', ShippingMethod)
-        clean_order_update_shipping(order, method, errors)
-        if errors:
-            return OrderUpdateShipping(errors=errors)
+
+        clean_order_update_shipping(order, method)
 
         order.shipping_method = method
         order.shipping_price = method.get_total(info.context.taxes)
@@ -197,13 +173,13 @@ class OrderAddNote(BaseMutation):
         description = 'Adds note to the order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
-        if errors:
-            return OrderAddNote(errors=errors)
-
         event = order.events.create(
             type=OrderEvents.NOTE_ADDED.value,
             user=info.context.user,
@@ -226,14 +202,14 @@ class OrderCancel(BaseMutation):
         description = 'Cancel an order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, restock):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, restock):
         errors = []
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
-        clean_order_cancel(order, errors)
-        if errors:
-            return OrderCancel(errors=errors)
-
+        clean_order_cancel(order)
         cancel_order(order=order, restock=restock)
         if restock:
             order.events.create(
@@ -257,17 +233,17 @@ class OrderMarkAsPaid(BaseMutation):
         description = 'Mark order as manually paid.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id):
         errors = []
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
-        if order is not None:
-            try:
-                clean_mark_order_as_paid(order)
-            except PaymentError as e:
-                errors.append(Error(field='payment', message=str(e)))
-        if errors:
-            return OrderMarkAsPaid(errors=errors)
+        try:
+            clean_mark_order_as_paid(order)
+        except PaymentError as e:
+            raise ValidationError({'payment': str(e)})
         mark_order_as_paid(order, info.context.user)
         return OrderMarkAsPaid(order=order)
 
@@ -285,25 +261,24 @@ class OrderCapture(BaseMutation):
         description = 'Capture an order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, amount):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, amount):
         errors = []
         if amount <= 0:
-            cls.add_error(
-                errors, 'amount', 'Amount should be a positive number.')
-            return OrderCapture(errors=errors)
+            raise ValidationError({
+                'amount': 'Amount should be a positive number.'})
 
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
         payment = order.get_last_payment()
-        clean_order_capture(payment, amount, errors)
+        clean_order_capture(payment, amount)
 
         try:
             gateway_capture(payment, amount)
         except PaymentError as e:
-            errors.append(Error(field='payment', message=str(e)))
-
-        if errors:
-            return OrderCapture(errors=errors)
+            raise ValidationError({'payment': str(e)})
 
         order.events.create(
             parameters={'amount': amount},
@@ -323,16 +298,19 @@ class OrderVoid(BaseMutation):
         description = 'Void an order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id):
         errors = []
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
-        if order:
-            payment = order.get_last_payment()
-            clean_void_payment(payment, errors)
-
-        if errors:
-            return OrderVoid(errors=errors)
+        payment = order.get_last_payment()
+        clean_void_payment(payment)
+        try:
+            gateway_void(payment)
+        except (PaymentError, ValueError) as e:
+            raise ValidationError({'payment': str(e)})
         order.events.create(
             type=OrderEvents.PAYMENT_VOIDED.value,
             user=info.context.user)
@@ -352,25 +330,24 @@ class OrderRefund(BaseMutation):
         description = 'Refund an order.'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, id, amount):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, amount):
         errors = []
         if amount <= 0:
-            cls.add_error(
-                errors, 'amount', 'Amount should be a positive number.')
-            return OrderRefund(errors=errors)
+            raise ValidationError({
+                'amount': 'Amount should be a positive number.'})
 
         order = cls.get_node_or_error(info, id, errors, 'id', Order)
-        if order:
-            payment = order.get_last_payment()
-            clean_refund_payment(payment, amount, errors)
-            try:
-                gateway_refund(payment, amount)
-            except PaymentError as e:
-                errors.append(Error(field='payment', message=str(e)))
+        payment = order.get_last_payment()
+        clean_refund_payment(payment, amount)
 
-        if errors:
-            return OrderRefund(errors=errors)
+        try:
+            gateway_refund(payment, amount)
+        except PaymentError as e:
+            raise ValidationError({'payment': str(e)})
 
         order.events.create(
             type=OrderEvents.PAYMENT_REFUNDED.value,

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -54,10 +54,6 @@ def resolve_order(info, id):
     return None
 
 
-def resolve_shipping_methods(obj, info, price):
-    return applicable_shipping_methods(obj, info, price)
-
-
 def resolve_homepage_events(info):
     # Filter only selected events to be displayed on homepage.
     types = [

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 
+from django.core.exceptions import ValidationError
 import graphene
 import graphene_django_optimizer as gql_optimizer
 from graphene import relay
@@ -14,7 +15,7 @@ from ..payment.types import OrderAction, Payment, PaymentChargeStatusEnum
 from ..product.types import Image, ProductVariant
 from ..shipping.types import ShippingMethod
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum
-from .utils import applicable_shipping_methods, can_finalize_draft_order
+from .utils import applicable_shipping_methods, validate_draft_order
 
 
 class OrderEvent(CountableDjangoObjectType):
@@ -318,8 +319,11 @@ class Order(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_can_finalize(self, info):
-        errors = can_finalize_draft_order(self, [])
-        return not errors
+        try:
+            validate_draft_order(self)
+        except ValidationError:
+            return False
+        return True
 
     @staticmethod
     def resolve_user_email(self, info):
@@ -332,7 +336,7 @@ class Order(CountableDjangoObjectType):
     @staticmethod
     def resolve_available_shipping_methods(self, info):
         return applicable_shipping_methods(
-            self, info, self.get_subtotal().gross.amount)
+            self, self.get_subtotal().gross.amount)
 
     def resolve_is_shipping_required(self, info):
         return self.is_shipping_required()

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -1,54 +1,47 @@
+from django.core.exceptions import ValidationError
+
 from ...shipping import models as shipping_models
-from ..core.types.common import Error
 
 
-def _check_can_finalize_products_quantity(order, errors):
+def validate_total_quantity(order):
     if order.get_total_quantity() == 0:
-        errors.append(
-            Error(
-                field='lines',
-                message='Could not create order without any products.'))
+        raise ValidationError({
+            'lines': 'Could not create order without any products.'})
 
 
-def _check_can_finalize_shipping(order, errors):
-    if order.is_shipping_required():
-        method = order.shipping_method
-        shipping_address = order.shipping_address
-        shipping_not_valid = (
-            method and shipping_address and
-            shipping_address.country.code not in method.shipping_zone.countries)  # noqa
-        if shipping_not_valid:
-            errors.append(
-                Error(
-                    field='shipping',
-                    message='Shipping method is not valid for chosen shipping '
-                    'address'))
+def validate_shipping_method(order):
+    method = order.shipping_method
+    shipping_address = order.shipping_address
+    shipping_not_valid = (
+        method and shipping_address and
+        shipping_address.country.code not in method.shipping_zone.countries)  # noqa
+    if shipping_not_valid:
+        raise ValidationError({
+            'shipping':
+            'Shipping method is not valid for chosen shipping address'})
 
 
-def _check_can_finalize_products_exists(order, errors):
-    line_variants = [line.variant for line in order]
-    if None in line_variants:
-        errors.append(
-            Error(
-                field='lines',
-                message='Could not create orders with non-existing products.'))
+def validate_order_lines(order):
+    for line in order:
+        if line.variant is None:
+            raise ValidationError({
+                'lines': 'Could not create orders with non-existing products.'})
 
 
-def can_finalize_draft_order(order, errors):
-    """Return a list of errors associated with the order.
-
-    Checks, if given order has a proper customer data, shipping
+def validate_draft_order(order):
+    """Checks, if given order has a proper customer data, shipping
     address and method set up and return list of errors if not.
     Checks if product variants for order lines still exists in
     database, too.
     """
-    _check_can_finalize_products_quantity(order, errors)
-    _check_can_finalize_shipping(order, errors)
-    _check_can_finalize_products_exists(order, errors)
-    return errors
+    if order.is_shipping_required():
+        validate_shipping_method(order)
+    validate_total_quantity(order)
+    validate_order_lines(order)
 
 
-def applicable_shipping_methods(obj, info, price):
+# FIXME: is this function needed? QS method might be enough
+def applicable_shipping_methods(obj, price):
     if not obj.is_shipping_required():
         return []
     if not obj.shipping_address:

--- a/saleor/graphql/page/mutations.py
+++ b/saleor/graphql/page/mutations.py
@@ -36,8 +36,8 @@ class PageCreate(ModelMutation):
         return user.has_perm('page.manage_pages')
 
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
+    def clean_input(cls, info, instance, input):
+        cleaned_input = super().clean_input(info, instance, input)
         slug = cleaned_input.get('slug', '')
         if not slug:
             cleaned_input['slug'] = slugify(cleaned_input['title'])

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -55,9 +55,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
 
     @classmethod
     def perform_mutation(cls, root, info, checkout_id, input):
-        errors = []
         checkout = cls.get_node_or_error(
-            info, checkout_id, errors, 'checkout_id', only_type=Checkout)
+            info, checkout_id, field='checkout_id', only_type=Checkout)
 
         billing_address = checkout.billing_address
         if 'billing_address' in input:
@@ -109,10 +108,8 @@ class PaymentCapture(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, payment_id, amount=None):
-        errors = []
         payment = cls.get_node_or_error(
-            info, payment_id, errors, 'payment_id', only_type=Payment)
-
+            info, payment_id, field='payment_id', only_type=Payment)
         try:
             gateway_capture(payment, amount)
         except PaymentError as e:
@@ -131,10 +128,8 @@ class PaymentRefund(PaymentCapture):
 
     @classmethod
     def perform_mutation(cls, root, info, payment_id, amount=None):
-        errors = []
         payment = cls.get_node_or_error(
-            info, payment_id, errors, 'payment_id', only_type=Payment)
-
+            info, payment_id, field='payment_id', only_type=Payment)
         try:
             gateway_refund(payment, amount=amount)
         except PaymentError as e:
@@ -157,10 +152,8 @@ class PaymentVoid(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, payment_id, amount=None):
-        errors = []
         payment = cls.get_node_or_error(
-            info, payment_id, errors, 'payment_id', only_type=Payment)
-
+            info, payment_id, field='payment_id', only_type=Payment)
         try:
             gateway_void(payment)
         except PaymentError as e:

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -2,6 +2,7 @@ from textwrap import dedent
 
 import graphene
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from graphql_jwt.decorators import permission_required
 
 from ...core.utils import get_client_ip
@@ -53,33 +54,28 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         description = 'Create a new payment for given checkout.'
 
     @classmethod
-    def mutate(cls, root, info, checkout_id, input):
+    def perform_mutation(cls, root, info, checkout_id, input):
         errors = []
         checkout = cls.get_node_or_error(
             info, checkout_id, errors, 'checkout_id', only_type=Checkout)
-        if checkout is None:
-            return CheckoutPaymentCreate(errors=errors)
 
         billing_address = checkout.billing_address
         if 'billing_address' in input:
-            billing_address, errors = cls.validate_address(
-                input['billing_address'], errors, 'billing_address')
+            billing_address = cls.validate_address(input['billing_address'])
         if billing_address is None:
-            cls.add_error(
-                errors, 'billingAddress',
-                'No billing address associated with this checkout.')
-            return CheckoutPaymentCreate(errors=errors)
+            raise ValidationError({
+                'billing_address':
+                'No billing address associated with this checkout.'})
 
         checkout_total = checkout.get_total(
             discounts=info.context.discounts,
             taxes=get_taxes_for_address(checkout.billing_address))
         amount = input.get('amount', checkout_total)
         if amount < checkout_total.gross.amount:
-            cls.add_error(
-                errors, 'amount',
-                'Partial payments are not allowed, '
-                'amount should be equal checkout\'s total.')
-            return CheckoutPaymentCreate(errors=errors)
+            raise ValidationError({
+                'amount':
+                'Partial payments are not allowed, amount should be '
+                'equal checkout\'s total.'})
 
         extra_data = {
             'customer_user_agent': info.context.META.get('HTTP_USER_AGENT')}
@@ -94,7 +90,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             extra_data=extra_data,
             customer_ip_address=get_client_ip(info.context),
             checkout=checkout)
-        return CheckoutPaymentCreate(payment=payment, errors=errors)
+        return CheckoutPaymentCreate(payment=payment)
 
 
 class PaymentCapture(BaseMutation):
@@ -108,43 +104,42 @@ class PaymentCapture(BaseMutation):
         description = 'Captures the authorized payment amount'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, payment_id, amount=None):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, payment_id, amount=None):
         errors = []
         payment = cls.get_node_or_error(
             info, payment_id, errors, 'payment_id', only_type=Payment)
-
-        if not payment:
-            return PaymentCapture(errors=errors)
 
         try:
             gateway_capture(payment, amount)
-        except PaymentError as exc:
-            msg = str(exc)
-            cls.add_error(field=None, message=msg, errors=errors)
-        return PaymentCapture(payment=payment, errors=errors)
+        except PaymentError as e:
+            raise ValidationError(str(e))
+        return PaymentCapture(payment=payment)
 
 
 class PaymentRefund(PaymentCapture):
+
+    class Meta:
+        description = 'Refunds the captured payment amount'
+
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, payment_id, amount=None):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, payment_id, amount=None):
         errors = []
         payment = cls.get_node_or_error(
             info, payment_id, errors, 'payment_id', only_type=Payment)
 
-        if not payment:
-            return PaymentRefund(errors=errors)
-
         try:
             gateway_refund(payment, amount=amount)
-        except PaymentError as exc:
-            msg = str(exc)
-            cls.add_error(field=None, message=msg, errors=errors)
-        return PaymentRefund(payment=payment, errors=errors)
-
-    class Meta:
-        description = 'Refunds the captured payment amount'
+        except PaymentError as e:
+            raise ValidationError(str(e))
+        return PaymentRefund(payment=payment)
 
 
 class PaymentVoid(BaseMutation):
@@ -157,18 +152,17 @@ class PaymentVoid(BaseMutation):
         description = 'Voids the authorized payment'
 
     @classmethod
-    @permission_required('order.manage_orders')
-    def mutate(cls, root, info, payment_id, amount=None):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def perform_mutation(cls, root, info, payment_id, amount=None):
         errors = []
         payment = cls.get_node_or_error(
             info, payment_id, errors, 'payment_id', only_type=Payment)
 
-        if not payment:
-            return PaymentVoid(errors=errors)
-
         try:
             gateway_void(payment)
-        except PaymentError as exc:
-            msg = str(exc)
-            cls.add_error(field=None, message=msg, errors=errors)
-        return PaymentVoid(payment=payment, errors=errors)
+        except PaymentError as e:
+            raise ValidationError(str(e))
+        return PaymentVoid(payment=payment)

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -56,7 +56,7 @@ class AttributeMixin:
                 'Provided values are not unique.'})
 
     @classmethod
-    def clean_values(cls, cleaned_input, attribute, errors):
+    def clean_values(cls, cleaned_input, attribute):
         """Clean attribute values.
 
         Transforms AttributeValueCreateInput into AttributeValue instances.
@@ -81,7 +81,7 @@ class AttributeMixin:
 
     @classmethod
     def clean_attribute(
-            cls, instance, cleaned_input, errors, product_type=None):
+            cls, instance, cleaned_input, product_type=None):
         if 'name' in cleaned_input:
             slug = slugify(cleaned_input['name'])
         elif instance.pk:
@@ -141,17 +141,15 @@ class AttributeCreate(AttributeMixin, ModelMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, type, input):
-        errors = []
-        product_type = cls.get_node_or_error(
-            info, id, errors, 'id', ProductType)
+        product_type = cls.get_node_or_error(info, id, only_type=ProductType)
         instance = models.Attribute()
 
-        cleaned_input = cls.clean_input(info, instance, input, errors)
+        cleaned_input = cls.clean_input(info, instance, input)
         cls.clean_attribute(
-            instance, cleaned_input, errors, product_type=product_type)
-        cls.clean_values(cleaned_input, instance, errors)
+            instance, cleaned_input, product_type=product_type)
+        cls.clean_values(cleaned_input, instance)
         instance = cls.construct_instance(instance, cleaned_input)
-        cls.clean_instance(instance, errors)
+        cls.clean_instance(instance)
 
         instance.save()
         if type == AttributeTypeEnum.VARIANT.name:
@@ -180,7 +178,7 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
         model = models.Attribute
 
     @classmethod
-    def clean_remove_values(cls, cleaned_input, instance, errors):
+    def clean_remove_values(cls, cleaned_input, instance):
         """Check if AttributeValues to be removed are assigned to given
         Attribute.
         """
@@ -203,17 +201,16 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id, input):
-        errors = []
-        instance = cls.get_node_or_error(info, id, errors, 'id', Attribute)
+        instance = cls.get_node_or_error(info, id, only_type=Attribute)
 
-        cleaned_input = cls.clean_input(info, instance, input, errors)
+        cleaned_input = cls.clean_input(info, instance, input)
         product_type = instance.product_type
         cls.clean_attribute(
-            instance, cleaned_input, errors, product_type=product_type)
-        cls.clean_values(cleaned_input, instance, errors)
-        cls.clean_remove_values(cleaned_input, instance, errors)
+            instance, cleaned_input, product_type=product_type)
+        cls.clean_values(cleaned_input, instance)
+        cls.clean_remove_values(cleaned_input, instance)
         instance = cls.construct_instance(instance, cleaned_input)
-        cls.clean_instance(instance, errors)
+        cls.clean_instance(instance)
 
         instance.save()
         cls._save_m2m(info, instance, cleaned_input)
@@ -261,8 +258,8 @@ class AttributeValueCreate(ModelMutation):
         model = models.AttributeValue
 
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
+    def clean_input(cls, info, instance, input):
+        cleaned_input = super().clean_input(info, instance, input)
         cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input
 
@@ -272,14 +269,13 @@ class AttributeValueCreate(ModelMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, attribute_id, input):
-        errors = []
         attribute = cls.get_node_or_error(
-            info, attribute_id, errors, 'id', Attribute)
+            info, attribute_id, only_type=Attribute)
 
         instance = models.AttributeValue(attribute=attribute)
-        cleaned_input = cls.clean_input(info, instance, input, errors)
+        cleaned_input = cls.clean_input(info, instance, input)
         instance = cls.construct_instance(instance, cleaned_input)
-        cls.clean_instance(instance, errors)
+        cls.clean_instance(instance)
 
         instance.save()
         cls._save_m2m(info, instance, cleaned_input)
@@ -307,8 +303,8 @@ class AttributeValueUpdate(ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
+    def clean_input(cls, info, instance, input):
+        cleaned_input = super().clean_input(info, instance, input)
         if 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -188,7 +188,6 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
         for value in remove_values:
             if value.attribute != instance:
                 msg = 'Value %s does not belong to this attribute.' % value
-                # FIXME: HANDLE THIS
                 raise ValidationError({'remove_values': msg})
         return remove_values
 

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -2,7 +2,6 @@ import graphene
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.template.defaultfilters import slugify
-from graphql_jwt.decorators import permission_required
 
 from ....product import models
 from ...core.mutations import ModelDeleteMutation, ModelMutation
@@ -46,14 +45,14 @@ class AttributeMixin:
                 msg = (
                     'Value %s already exists within this attribute.' %
                     value_data['name'])
-                cls.add_error(errors, cls.ATTRIBUTE_VALUES_FIELD, msg)
+                raise ValidationError({cls.ATTRIBUTE_VALUES_FIELD: msg})
 
         new_slugs = [
             slugify(value_data['name']) for value_data in values_input]
         if len(set(new_slugs)) != len(new_slugs):
-            cls.add_error(
-                errors, cls.ATTRIBUTE_VALUES_FIELD,
-                'Provided values are not unique.')
+            raise ValidationError({
+                cls.ATTRIBUTE_VALUES_FIELD:
+                'Provided values are not unique.'})
 
     @classmethod
     def clean_values(cls, cleaned_input, attribute, errors):
@@ -74,9 +73,9 @@ class AttributeMixin:
                 for field in validation_errors.message_dict:
                     if field == 'attribute':
                         continue
-                    for message in validation_errors.message_dict[field]:
-                        cls.add_error(
-                            errors, cls.ATTRIBUTE_VALUES_FIELD, message)
+                    for msg in validation_errors.message_dict[field]:
+                        # FIXME :HANDLE this
+                        raise ValidationError({cls.ATTRIBUTE_VALUES_FIELD: msg})
         cls.check_unique_values(values_input, attribute, errors)
         return errors
 
@@ -88,8 +87,7 @@ class AttributeMixin:
         elif instance.pk:
             slug = instance.slug
         else:
-            cls.add_error(errors, 'name', 'This field cannot be blank.')
-            return cleaned_input
+            raise ValidationError({'name': 'This field cannot be blank.'})
         cleaned_input['slug'] = slug
 
         if not product_type:
@@ -100,9 +98,8 @@ class AttributeMixin:
             | Q(product_variant_type=product_type))
         query = query.exclude(pk=getattr(instance, 'pk', None))
         if query.exists():
-            cls.add_error(
-                errors, 'name',
-                'Attribute already exists within this product type.')
+            raise ValidationError({
+                'name': 'Attribute already exists within this product type.'})
         return cleaned_input
 
     @classmethod
@@ -139,24 +136,22 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         model = models.Attribute
 
     @classmethod
-    @permission_required('product.manage_products')
-    def mutate(cls, root, info, id, type, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('product.manage_products')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, type, input):
         errors = []
         product_type = cls.get_node_or_error(
             info, id, errors, 'id', ProductType)
-        if not product_type:
-            return AttributeCreate(errors=errors)
         instance = models.Attribute()
 
         cleaned_input = cls.clean_input(info, instance, input, errors)
         cls.clean_attribute(
             instance, cleaned_input, errors, product_type=product_type)
         cls.clean_values(cleaned_input, instance, errors)
-
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(instance, errors)
-        if errors:
-            return AttributeCreate(errors=errors)
 
         instance.save()
         if type == AttributeTypeEnum.VARIANT.name:
@@ -164,8 +159,7 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         else:
             product_type.product_attributes.add(instance)
         cls._save_m2m(info, instance, cleaned_input)
-        return AttributeCreate(
-            attribute=instance, product_type=product_type, errors=errors)
+        return AttributeCreate(attribute=instance, product_type=product_type)
 
 
 class AttributeUpdate(AttributeMixin, ModelMutation):
@@ -194,7 +188,8 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
         for value in remove_values:
             if value.attribute != instance:
                 msg = 'Value %s does not belong to this attribute.' % value
-                cls.add_error(errors, 'remove_values', msg)
+                # FIXME: HANDLE THIS
+                raise ValidationError({'remove_values': msg})
         return remove_values
 
     @classmethod
@@ -204,8 +199,11 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
             attribute_value.delete()
 
     @classmethod
-    @permission_required('product.manage_products')
-    def mutate(cls, root, info, id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('product.manage_products')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id, input):
         errors = []
         instance = cls.get_node_or_error(info, id, errors, 'id', Attribute)
 
@@ -215,16 +213,13 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
             instance, cleaned_input, errors, product_type=product_type)
         cls.clean_values(cleaned_input, instance, errors)
         cls.clean_remove_values(cleaned_input, instance, errors)
-
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(instance, errors)
-        if errors:
-            return AttributeUpdate(errors=errors)
 
         instance.save()
         cls._save_m2m(info, instance, cleaned_input)
         return AttributeUpdate(
-            attribute=instance, product_type=product_type, errors=errors)
+            attribute=instance, product_type=product_type)
 
 
 class AttributeDelete(ModelDeleteMutation):
@@ -273,8 +268,11 @@ class AttributeValueCreate(ModelMutation):
         return cleaned_input
 
     @classmethod
-    @permission_required('product.manage_products')
-    def mutate(cls, root, info, attribute_id, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('product.manage_products')
+
+    @classmethod
+    def perform_mutation(cls, root, info, attribute_id, input):
         errors = []
         attribute = cls.get_node_or_error(
             info, attribute_id, errors, 'id', Attribute)
@@ -283,13 +281,11 @@ class AttributeValueCreate(ModelMutation):
         cleaned_input = cls.clean_input(info, instance, input, errors)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(instance, errors)
-        if errors:
-            return cls(errors=errors)
 
         instance.save()
         cls._save_m2m(info, instance, cleaned_input)
         return AttributeValueCreate(
-            attribute=attribute, attributeValue=instance, errors=errors)
+            attribute=attribute, attributeValue=instance)
 
 
 class AttributeValueUpdate(ModelMutation):

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -35,8 +35,9 @@ class AttributeUpdateInput(graphene.InputObjectType):
 
 
 class AttributeMixin:
+
     @classmethod
-    def check_unique_values(cls, values_input, attribute, errors):
+    def check_unique_values(cls, values_input, attribute):
         # Check values uniqueness in case of creating new attribute.
         existing_values = attribute.values.values_list('slug', flat=True)
         for value_data in values_input:
@@ -74,10 +75,9 @@ class AttributeMixin:
                     if field == 'attribute':
                         continue
                     for msg in validation_errors.message_dict[field]:
-                        # FIXME :HANDLE this
-                        raise ValidationError({cls.ATTRIBUTE_VALUES_FIELD: msg})
-        cls.check_unique_values(values_input, attribute, errors)
-        return errors
+                        raise ValidationError({
+                            cls.ATTRIBUTE_VALUES_FIELD: msg})
+        cls.check_unique_values(values_input, attribute)
 
     @classmethod
     def clean_attribute(

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -749,7 +749,7 @@ class ProductImageReorder(BaseMutation):
             if image and image.product != product:
                 raise ValidationError({
                     'order':
-                    'Image %(image_id)s does not belong to this product.'},
+                        'Image %(image_id)s does not belong to this product.'},
                     params={'image_id': image_id})
             images.append(image)
 

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -1,7 +1,7 @@
 from textwrap import dedent
 
 import graphene
-from graphql_jwt.decorators import permission_required
+from django.core.exceptions import ValidationError
 
 from ...dashboard.shipping.forms import default_shipping_zone_exists
 from ...shipping import models
@@ -49,8 +49,8 @@ class ShippingZoneMixin:
         default = cleaned_input.get('default')
         if default:
             if default_shipping_zone_exists(instance.pk):
-                cls.add_error(
-                    errors, 'default', 'Default shipping zone already exists.')
+                raise ValidationError({
+                    'default': 'Default shipping zone already exists.'})
             elif cleaned_input.get('countries'):
                 cleaned_input['countries'] = []
         else:
@@ -121,19 +121,19 @@ class ShippingPriceMixin:
                 max_price = cleaned_input.get('maximum_order_price')
                 if (min_price is not None and max_price is not None
                         and max_price <= min_price):
-                    cls.add_error(
-                        errors, 'maximum_order_price',
+                    raise ValidationError({
+                        'maximum_order_price':
                         'Maximum order price should be larger than the '
-                        'minimum order price.')
+                        'minimum order price.'})
             else:
                 min_weight = cleaned_input.get('minimum_order_weight')
                 max_weight = cleaned_input.get('maximum_order_weight')
                 if (min_weight is not None and max_weight is not None
                         and max_weight <= min_weight):
-                    cls.add_error(
-                        errors, 'maximum_order_weight',
+                    raise ValidationError({
+                        'maximum_order_weight':
                         'Maximum order weight should be larger than the '
-                        'minimum order weight.')
+                        'minimum order weight.'})
         return cleaned_input
 
 
@@ -204,20 +204,18 @@ class ShippingPriceDelete(BaseMutation):
         description = 'Deletes a shipping price.'
 
     @classmethod
-    @permission_required('shipping.manage_shipping')
-    def mutate(cls, root, info, id):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('shipping.manage_shipping')
+
+    @classmethod
+    def perform_mutation(cls, root, info, id):
         errors = []
         shipping_method = cls.get_node_or_error(
             info, id, errors, 'id', only_type=ShippingMethod)
-        if not shipping_method:
-            return ShippingPriceDelete(errors=errors)
 
         shipping_method_id = shipping_method.id
         shipping_zone = shipping_method.shipping_zone
-
         shipping_method.delete()
         shipping_method.id = shipping_method_id
         return ShippingPriceDelete(
-            shipping_method=shipping_method,
-            shipping_zone=shipping_zone,
-            errors=errors)
+            shipping_method=shipping_method, shipping_zone=shipping_zone)

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -44,8 +44,8 @@ class ShippingZoneInput(graphene.InputObjectType):
 
 class ShippingZoneMixin:
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
+    def clean_input(cls, info, instance, input):
+        cleaned_input = super().clean_input(info, instance, input)
         default = cleaned_input.get('default')
         if default:
             if default_shipping_zone_exists(instance.pk):
@@ -112,8 +112,8 @@ class ShippingZoneDelete(ModelDeleteMutation):
 
 class ShippingPriceMixin:
     @classmethod
-    def clean_input(cls, info, instance, input, errors):
-        cleaned_input = super().clean_input(info, instance, input, errors)
+    def clean_input(cls, info, instance, input):
+        cleaned_input = super().clean_input(info, instance, input)
         type = cleaned_input.get('type')
         if type:
             if type == ShippingMethodTypeEnum.PRICE.value:
@@ -209,10 +209,8 @@ class ShippingPriceDelete(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, id):
-        errors = []
         shipping_method = cls.get_node_or_error(
-            info, id, errors, 'id', only_type=ShippingMethod)
-
+            info, id, only_type=ShippingMethod)
         shipping_method_id = shipping_method.id
         shipping_zone = shipping_method.shipping_zone
         shipping_method.delete()

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -102,12 +102,11 @@ class ShopFetchTaxRates(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info):
-        if settings.VATLAYER_ACCESS_KEY:
-            call_command('get_vat_rates')
-        else:
+        if not settings.VATLAYER_ACCESS_KEY:
             raise ValidationError(
                 'Could not fetch tax rates. Make sure you have supplied a '
                 'valid API Access Key.')
+        call_command('get_vat_rates')
         return ShopFetchTaxRates(shop=Shop())
 
 

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -1,7 +1,7 @@
 import graphene
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.core.management import call_command
-from graphql_jwt.decorators import permission_required
 
 from ...site import models as site_models
 from ..core.enums import WeightUnitsEnum
@@ -48,8 +48,11 @@ class ShopSettingsUpdate(BaseMutation):
         description = 'Updates shop settings'
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info, input):
         errors = []
         instance = info.context.site.settings
         for field_name, desired_value in input.items():
@@ -58,10 +61,8 @@ class ShopSettingsUpdate(BaseMutation):
                 setattr(instance, field_name, desired_value)
         cls.clean_instance(instance, errors)
 
-        if errors:
-            return ShopSettingsUpdate(errors=errors)
         instance.save()
-        return ShopSettingsUpdate(shop=Shop(), errors=errors)
+        return ShopSettingsUpdate(shop=Shop())
 
 
 class ShopDomainUpdate(BaseMutation):
@@ -74,8 +75,11 @@ class ShopDomainUpdate(BaseMutation):
         description = 'Updates site domain of the shop'
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info, input):
         errors = []
         site = info.context.site
         domain = input.get('domain')
@@ -85,10 +89,8 @@ class ShopDomainUpdate(BaseMutation):
         if name is not None:
             site.name = name
         cls.clean_instance(site, errors)
-        if errors:
-            return ShopDomainUpdate(errors=errors)
         site.save()
-        return ShopDomainUpdate(shop=Shop(), errors=errors)
+        return ShopDomainUpdate(shop=Shop())
 
 
 class ShopFetchTaxRates(BaseMutation):
@@ -98,16 +100,19 @@ class ShopFetchTaxRates(BaseMutation):
         description = 'Fetch tax rates'
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info):
         errors = []
         if settings.VATLAYER_ACCESS_KEY:
             call_command('get_vat_rates')
         else:
-            cls.add_error(
-                errors, None, 'Could not fetch tax rates. '
-                'Make sure you have supplied a valid API Access Key.')
-        return ShopFetchTaxRates(shop=Shop(), errors=errors)
+            raise ValidationError(
+                'Could not fetch tax rates. Make sure you have supplied a '
+                'valid API Access Key.')
+        return ShopFetchTaxRates(shop=Shop())
 
 
 class HomepageCollectionUpdate(BaseMutation):
@@ -121,22 +126,19 @@ class HomepageCollectionUpdate(BaseMutation):
         description = 'Updates homepage collection of the shop'
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info, collection=None):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info, collection=None):
         errors = []
-        new_collection = None
-        if collection:
-            new_collection = cls.get_node_or_error(
-                info, collection, errors, 'collection', Collection)
-        if errors:
-            return HomepageCollectionUpdate(errors=errors)
+        new_collection = cls.get_node_or_error(
+            info, collection, errors, 'collection', Collection)
         site_settings = info.context.site.settings
         site_settings.homepage_collection = new_collection
         cls.clean_instance(site_settings, errors)
-        if errors:
-            return HomepageCollectionUpdate(errors=errors)
         site_settings.save(update_fields=['homepage_collection'])
-        return HomepageCollectionUpdate(shop=Shop(), errors=errors)
+        return HomepageCollectionUpdate(shop=Shop())
 
 
 class AuthorizationKeyInput(graphene.InputObjectType):
@@ -162,21 +164,20 @@ class AuthorizationKeyAdd(BaseMutation):
             description='Fields required to create an authorization key.')
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info, key_type, input):
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info, key_type, input):
         errors = []
         if site_models.AuthorizationKey.objects.filter(name=key_type).exists():
-            cls.add_error(
-                errors, 'key_type', 'Authorization key already exists.')
-            return AuthorizationKeyAdd(errors=errors)
+            raise ValidationError({
+                'key_type': 'Authorization key already exists.'})
 
         site_settings = info.context.site.settings
         instance = site_models.AuthorizationKey(
             name=key_type, site_settings=site_settings, **input)
         cls.clean_instance(instance, errors)
-        if errors:
-            return AuthorizationKeyAdd(errors=errors)
-
         instance.save()
         return AuthorizationKeyAdd(authorization_key=instance, shop=Shop())
 
@@ -194,17 +195,18 @@ class AuthorizationKeyDelete(BaseMutation):
         description = 'Deletes an authorization key.'
 
     @classmethod
-    @permission_required('site.manage_settings')
-    def mutate(cls, root, info, key_type):
-        errors = []
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('site.manage_settings')
+
+    @classmethod
+    def perform_mutation(cls, root, info, key_type):
         try:
             site_settings = info.context.site.settings
             instance = site_models.AuthorizationKey.objects.get(
                 name=key_type, site_settings=site_settings)
         except site_models.AuthorizationKey.DoesNotExist:
-            cls.add_error(
-                errors, 'key_type', 'Couldn\'t resolve authorization key')
-            return AuthorizationKeyDelete(errors=errors)
+            raise ValidationError({
+                'key_type': 'Couldn\'t resolve authorization key'})
 
         instance.delete()
         return AuthorizationKeyDelete(authorization_key=instance, shop=Shop())

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -53,14 +53,12 @@ class ShopSettingsUpdate(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, input):
-        errors = []
         instance = info.context.site.settings
         for field_name, desired_value in input.items():
             current_value = getattr(instance, field_name)
             if current_value != desired_value:
                 setattr(instance, field_name, desired_value)
-        cls.clean_instance(instance, errors)
-
+        cls.clean_instance(instance)
         instance.save()
         return ShopSettingsUpdate(shop=Shop())
 
@@ -80,7 +78,6 @@ class ShopDomainUpdate(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, input):
-        errors = []
         site = info.context.site
         domain = input.get('domain')
         name = input.get('name')
@@ -88,7 +85,7 @@ class ShopDomainUpdate(BaseMutation):
             site.domain = domain
         if name is not None:
             site.name = name
-        cls.clean_instance(site, errors)
+        cls.clean_instance(site)
         site.save()
         return ShopDomainUpdate(shop=Shop())
 
@@ -105,7 +102,6 @@ class ShopFetchTaxRates(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info):
-        errors = []
         if settings.VATLAYER_ACCESS_KEY:
             call_command('get_vat_rates')
         else:
@@ -131,12 +127,11 @@ class HomepageCollectionUpdate(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, collection=None):
-        errors = []
         new_collection = cls.get_node_or_error(
-            info, collection, errors, 'collection', Collection)
+            info, collection, field='collection', only_type=Collection)
         site_settings = info.context.site.settings
         site_settings.homepage_collection = new_collection
-        cls.clean_instance(site_settings, errors)
+        cls.clean_instance(site_settings)
         site_settings.save(update_fields=['homepage_collection'])
         return HomepageCollectionUpdate(shop=Shop())
 
@@ -169,7 +164,6 @@ class AuthorizationKeyAdd(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, key_type, input):
-        errors = []
         if site_models.AuthorizationKey.objects.filter(name=key_type).exists():
             raise ValidationError({
                 'key_type': 'Authorization key already exists.'})
@@ -177,7 +171,7 @@ class AuthorizationKeyAdd(BaseMutation):
         site_settings = info.context.site.settings
         instance = site_models.AuthorizationKey(
             name=key_type, site_settings=site_settings, **input)
-        cls.clean_instance(instance, errors)
+        cls.clean_instance(instance)
         instance.save()
         return AuthorizationKeyAdd(authorization_key=instance, shop=Shop())
 

--- a/saleor/payment/gateways/braintree/forms.py
+++ b/saleor/payment/gateways/braintree/forms.py
@@ -18,10 +18,6 @@ class BraintreePaymentForm(forms.Form):
         self.payment_information = payment_information
         self.fields['amount'].initial = payment_information['amount']
 
-        # FIXME IMPROVEMENT:
-        # if environment is Sandbox, we could provide couple of predefined
-        # nounces for easier testing
-
     def clean(self):
         cleaned_data = super().clean()
         # Amount is sent client-side

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -744,13 +744,13 @@ def test_customer_delete(
 def test_customer_delete_errors(customer_user, admin_user, staff_user):
     info = Mock(context=Mock(user=admin_user))
     with pytest.raises(ValidationError) as e:
-        CustomerDelete.clean_instance(info, staff_user, [])
+        CustomerDelete.clean_instance(info, staff_user)
 
     msg = 'Cannot delete a staff account.'
     assert e.value.error_dict['id'][0].message == msg
 
     # shuold not raise any errors
-    CustomerDelete.clean_instance(info, customer_user, [])
+    CustomerDelete.clean_instance(info, customer_user)
 
 
 @patch('saleor.dashboard.emails.send_set_password_staff_email.delay')
@@ -878,14 +878,14 @@ def test_staff_delete(staff_api_client, permission_manage_staff):
 def test_user_delete_errors(staff_user, admin_user):
     info = Mock(context=Mock(user=staff_user))
     with pytest.raises(ValidationError) as e:
-        UserDelete.clean_instance(info, staff_user, [])
+        UserDelete.clean_instance(info, staff_user)
 
     msg = 'You cannot delete your own account.'
     assert e.value.error_dict['id'][0].message == msg
 
     info = Mock(context=Mock(user=staff_user))
     with pytest.raises(ValidationError) as e:
-        UserDelete.clean_instance(info, admin_user, [])
+        UserDelete.clean_instance(info, admin_user)
 
     msg = 'Cannot delete this account.'
     assert e.value.error_dict['id'][0].message == msg
@@ -894,13 +894,13 @@ def test_user_delete_errors(staff_user, admin_user):
 def test_staff_delete_errors(staff_user, customer_user, admin_user):
     info = Mock(context=Mock(user=staff_user))
     with pytest.raises(ValidationError) as e:
-        StaffDelete.clean_instance(info, customer_user, [])
+        StaffDelete.clean_instance(info, customer_user)
     msg = 'Cannot delete a non-staff user.'
     assert e.value.error_dict['id'][0].message == msg
 
     # shuold not raise any errors
     info = Mock(context=Mock(user=admin_user))
-    StaffDelete.clean_instance(info, staff_user, [])
+    StaffDelete.clean_instance(info, staff_user)
 
 
 def test_staff_update_errors(staff_user, customer_user, admin_user):

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -467,7 +467,8 @@ def test_create_attribute_value_not_unique_name(
     content = get_graphql_content(response)
     data = content['data']['attributeValueCreate']
     assert data['errors']
-    assert data['errors'][0]['field'] == 'All'
+    assert data['errors'][0]['message']
+    assert not data['errors'][0]['field']
 
 
 UPDATE_ATTRIBUTE_VALUE_QUERY = """
@@ -523,7 +524,8 @@ def test_update_attribute_value_name_not_unique(
     content = get_graphql_content(response)
     data = content['data']['attributeValueUpdate']
     assert data['errors']
-    assert data['errors'][0]['field'] == 'All'
+    assert data['errors'][0]['message']
+    assert not data['errors'][0]['field']
 
 
 def test_update_same_attribute_value(

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -18,12 +18,10 @@ class Mutation(BaseMutation):
         description = 'Base mutation'
 
     @classmethod
-    def mutate(cls, root, info, product_id):
+    def perform_mutation(cls, root, info, product_id):
         errors = []
         product = cls.get_node_or_error(
             info, product_id, errors, 'product_id', product_types.Product)
-        if errors:
-            return Mutation(errors=errors)
         return Mutation(name=product.name)
 
 

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -19,9 +19,9 @@ class Mutation(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, product_id):
-        errors = []
         product = cls.get_node_or_error(
-            info, product_id, errors, 'product_id', product_types.Product)
+            info, product_id, field='product_id',
+            only_type=product_types.Product)
         return Mutation(name=product.name)
 
 
@@ -115,8 +115,6 @@ def test_user_error_id_of_different_type(product, schema_context):
 
 
 def test_get_node_or_error_returns_null_for_empty_id():
-    errors = []
     info = Mock()
-    response = Mutation.get_node_or_error(info, '', errors, '')
-    assert not errors
+    response = Mutation.get_node_or_error(info, '', field='')
     assert response is None

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -6,7 +6,7 @@ import pytest
 
 from saleor.checkout.models import Cart
 from saleor.checkout.utils import (
-    add_voucher_to_cart, is_fully_paid, ready_to_place_order)
+    add_voucher_to_cart, is_fully_paid, clean_checkout)
 from saleor.graphql.core.utils import str_to_enum
 from saleor.order.models import Order
 from tests.api.utils import get_graphql_content
@@ -1155,7 +1155,7 @@ def test_ready_to_place_order(
     payment.currency = total.gross.currency
     payment.checkout = checkout
     payment.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert ready
     assert not error
 
@@ -1164,7 +1164,7 @@ def test_ready_to_place_order_no_shipping_method(cart_with_item, address):
     checkout = cart_with_item
     checkout.shipping_address = address
     checkout.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert not ready
     assert error == 'Shipping method is not set'
 
@@ -1174,7 +1174,7 @@ def test_ready_to_place_order_no_shipping_address(
     checkout = cart_with_item
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert not ready
     assert error == 'Shipping address is not set'
 
@@ -1186,7 +1186,7 @@ def test_ready_to_place_order_invalid_shipping_method(
     shipping_method = shipping_zone_without_countries.shipping_methods.first()
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert not ready
     assert error == 'Shipping method is not valid for your shipping address'
 
@@ -1197,7 +1197,7 @@ def test_ready_to_place_order_no_billing_address(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert not ready
     assert error == 'Billing address is not set'
 
@@ -1209,7 +1209,7 @@ def test_ready_to_place_order_no_payment(
     checkout.shipping_method = shipping_method
     checkout.billing_address = address
     checkout.save()
-    ready, error = ready_to_place_order(checkout, None, None)
+    ready, error = clean_checkout(checkout, None, None)
     assert not ready
     assert error == (
         'Provided payment methods can not '

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -1,6 +1,7 @@
 import uuid
 from unittest.mock import ANY, patch
 
+from django.core.exceptions import ValidationError
 import graphene
 import pytest
 
@@ -1155,18 +1156,20 @@ def test_ready_to_place_order(
     payment.currency = total.gross.currency
     payment.checkout = checkout
     payment.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert ready
-    assert not error
+    # Shouldn't raise any errors
+    clean_checkout(checkout, None, None)
 
 
 def test_ready_to_place_order_no_shipping_method(cart_with_item, address):
     checkout = cart_with_item
     checkout.shipping_address = address
     checkout.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert not ready
-    assert error == 'Shipping method is not set'
+
+    with pytest.raises(ValidationError) as e:
+        clean_checkout(checkout, None, None)
+
+    msg = 'Shipping method is not set'
+    assert e.value.error_list[0].message == msg
 
 
 def test_ready_to_place_order_no_shipping_address(
@@ -1174,9 +1177,11 @@ def test_ready_to_place_order_no_shipping_address(
     checkout = cart_with_item
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert not ready
-    assert error == 'Shipping address is not set'
+
+    with pytest.raises(ValidationError) as e:
+        clean_checkout(checkout, None, None)
+    msg = 'Shipping address is not set'
+    assert e.value.error_list[0].message == msg
 
 
 def test_ready_to_place_order_invalid_shipping_method(
@@ -1186,9 +1191,12 @@ def test_ready_to_place_order_invalid_shipping_method(
     shipping_method = shipping_zone_without_countries.shipping_methods.first()
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert not ready
-    assert error == 'Shipping method is not valid for your shipping address'
+
+    with pytest.raises(ValidationError) as e:
+        clean_checkout(checkout, None, None)
+
+    msg = 'Shipping method is not valid for your shipping address'
+    assert e.value.error_list[0].message == msg
 
 
 def test_ready_to_place_order_no_billing_address(
@@ -1197,9 +1205,11 @@ def test_ready_to_place_order_no_billing_address(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert not ready
-    assert error == 'Billing address is not set'
+
+    with pytest.raises(ValidationError) as e:
+        clean_checkout(checkout, None, None)
+    msg = 'Billing address is not set'
+    assert e.value.error_list[0].message == msg
 
 
 def test_ready_to_place_order_no_payment(
@@ -1209,11 +1219,12 @@ def test_ready_to_place_order_no_payment(
     checkout.shipping_method = shipping_method
     checkout.billing_address = address
     checkout.save()
-    ready, error = clean_checkout(checkout, None, None)
-    assert not ready
-    assert error == (
-        'Provided payment methods can not '
-        'cover the checkout\'s total amount')
+
+    with pytest.raises(ValidationError) as e:
+        clean_checkout(checkout, None, None)
+
+    msg = 'Provided payment methods can not cover the checkout\'s total amount'
+    assert e.value.error_list[0].message == msg
 
 
 def test_is_fully_paid(cart_with_item, payment_dummy):

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -1059,7 +1059,8 @@ def test_checkout_shipping_method_update(
     checkout.refresh_from_db()
     assert checkout.shipping_method == shipping_method
     mock_clean_shipping.assert_called_once_with(
-        checkout, shipping_method, [], ANY, ANY, remove=False)
+        checkout=checkout, method=shipping_method, discounts=ANY, taxes=ANY,
+        remove=False)
 
 
 def test_query_checkout_line(cart_with_item, user_api_client):

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -612,21 +612,6 @@ def test_checkout_customer_detach(
     assert cart.user is None
 
 
-def test_checkout_customer_detach_without_customer(
-        user_api_client, cart_with_item):
-    cart = cart_with_item
-
-    checkout_id = graphene.Node.to_global_id('Checkout', cart.pk)
-    variables = {
-        'checkoutId': checkout_id, }
-    response = user_api_client.post_graphql(
-        MUTATION_CHECKOUT_CUSTOMER_DETACH, variables)
-    content = get_graphql_content(response)
-    data = content['data']['checkoutCustomerDetach']
-    assert data['errors'][0][
-        'message'] == 'There\'s no customer assigned to this Checkout.'
-
-
 MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE = """
     mutation checkoutShippingAddressUpdate(
             $checkoutId: ID!, $shippingAddress: AddressInput!) {

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -109,13 +109,13 @@ def test_create_fulfillment_with_emtpy_quantity(
 
 
 @pytest.mark.parametrize(
-    'quantity, error_message',
+    'quantity, error_message, error_field',
     (
-        (0, 'Total quantity must be larger than 0.'),
-        (100, 'Only 3 items remaining to fulfill.')))
+        (0, 'Total quantity must be larger than 0.', 'lines'),
+        (100, 'Only 3 items remaining to fulfill:', 'orderLineId')))
 def test_create_fulfillment_not_sufficient_quantity(
         staff_api_client, order_with_lines, staff_user, quantity,
-        error_message, permission_manage_orders):
+        error_message, error_field, permission_manage_orders):
     query = CREATE_FULFILLMENT_QUERY
     order_line = order_with_lines.lines.first()
     order_line_id = graphene.Node.to_global_id('OrderLine', order_line.id)
@@ -127,8 +127,8 @@ def test_create_fulfillment_not_sufficient_quantity(
     content = get_graphql_content(response)
     data = content['data']['orderFulfillmentCreate']
     assert data['errors']
-    assert data['errors'][0]['field'] in (str(order_line), 'lines')
-    assert data['errors'][0]['message'] == error_message
+    assert data['errors'][0]['field'] == error_field
+    assert error_message in data['errors'][0]['message']
 
 
 def test_create_fulfillment_with_invalid_input(

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import graphene
 import pytest
+from django.core.exceptions import ValidationError
 
 from saleor.core.utils.taxes import ZERO_TAXED_MONEY
 from saleor.graphql.core.enums import ReportingPeriod
@@ -1121,24 +1122,30 @@ def test_order_mark_as_paid(
     assert event_order_paid.user == staff_user
 
 
+ORDER_VOID = """
+    mutation voidOrder($id: ID!) {
+        orderVoid(id: $id) {
+            order {
+                paymentStatus
+                paymentStatusDisplay
+            }
+            errors {
+                field
+                message
+            }
+        }
+    }
+"""
+
+
 def test_order_void(
         staff_api_client, permission_manage_orders, payment_txn_preauth,
         staff_user):
     order = payment_txn_preauth.order
-    query = """
-            mutation voidOrder($id: ID!) {
-                orderVoid(id: $id) {
-                    order {
-                        paymentStatus
-                        paymentStatusDisplay
-                    }
-                }
-            }
-        """
     order_id = graphene.Node.to_global_id('Order', order.id)
     variables = {'id': order_id}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_orders])
+        ORDER_VOID, variables, permissions=[permission_manage_orders])
     content = get_graphql_content(response)
     data = content['data']['orderVoid']['order']
     assert data['paymentStatus'] == PaymentChargeStatusEnum.NOT_CHARGED.name
@@ -1148,6 +1155,20 @@ def test_order_void(
     event_payment_voided = order.events.last()
     assert event_payment_voided.type == OrderEvents.PAYMENT_VOIDED.value
     assert event_payment_voided.user == staff_user
+
+
+def test_order_void_payment_error(staff_api_client, permission_manage_orders, payment_txn_preauth):
+    msg = 'error has happened'
+    order = payment_txn_preauth.order
+    order_id = graphene.Node.to_global_id('Order', order.id)
+    variables = {'id': order_id}
+    with patch('saleor.graphql.order.mutations.orders.gateway_void', side_effect=ValueError(msg)):
+        response = staff_api_client.post_graphql(
+            ORDER_VOID, variables, permissions=[permission_manage_orders])
+        content = get_graphql_content(response)
+        errors = content['data']['orderVoid']['errors']
+        assert errors[0]['field'] == 'payment'
+        assert errors[0]['message'] == msg
 
 
 def test_order_refund(
@@ -1189,45 +1210,45 @@ def test_order_refund(
 def test_clean_order_void_payment():
     payment = MagicMock(spec=Payment)
     payment.is_active = False
-    errors = clean_void_payment(payment, [])
-    assert errors[0].field == 'payment'
-    assert errors[0].message == 'Only pre-authorized payments can be voided'
+    with pytest.raises(ValidationError) as e:
+        clean_void_payment(payment)
 
-    payment.is_active = True
-    error_msg = 'error has happened.'
-    with patch('saleor.graphql.order.mutations.orders.gateway_void',
-               side_effect=ValueError(error_msg)):
-        errors = clean_void_payment(payment, [])
-    assert errors[0].field == 'payment'
-    assert errors[0].message == error_msg
+    msg = 'Only pre-authorized payments can be voided'
+    assert e.value.error_dict['payment'][0].message == msg
 
 
 def test_clean_order_refund_payment():
     payment = MagicMock(spec=Payment)
     payment.gateway = CustomPaymentChoices.MANUAL
     amount = Mock(spec='string')
-    errors = clean_refund_payment(payment, amount, [])
-    assert errors[0].field == 'payment'
-    assert errors[0].message == 'Manual payments can not be refunded.'
+    with pytest.raises(ValidationError) as e:
+        clean_refund_payment(payment, amount)
+
+    msg = 'Manual payments can not be refunded.'
+    assert e.value.error_dict['payment'][0].message == msg
 
 
 def test_clean_order_capture():
     amount = Mock(spec='string')
-    errors = clean_order_capture(None, amount, [])
-    assert errors[0].field == 'payment'
-    assert errors[0].message == (
-        'There\'s no payment associated with the order.')
+    with pytest.raises(ValidationError) as e:
+        clean_order_capture(None, amount)
+
+    msg = 'There\'s no payment associated with the order.'
+    assert e.value.error_dict['payment'][0].message == msg
 
 
 def test_clean_order_cancel(order):
-    assert clean_order_cancel(order, []) == []
+    # Shouldn't raise any errors
+    clean_order_cancel(order)
 
     order.status = OrderStatus.DRAFT
     order.save()
 
-    errors = clean_order_cancel(order, [])
-    assert errors[0].field == 'order'
-    assert errors[0].message == 'This order can\'t be canceled.'
+    with pytest.raises(ValidationError) as e:
+        clean_order_cancel(order)
+
+    msg = 'This order can\'t be canceled.'
+    assert e.value.error_dict['order'][0].message == msg
 
 
 ORDER_UPDATE_SHIPPING_QUERY = """

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -7,11 +7,11 @@ from django.core.exceptions import ValidationError
 
 from saleor.core.utils.taxes import ZERO_TAXED_MONEY
 from saleor.graphql.core.enums import ReportingPeriod
-from saleor.graphql.order.enums import OrderEventsEmailsEnum, OrderStatusFilter
+from saleor.graphql.order.enums import OrderEventsEmailsEnum
 from saleor.graphql.order.mutations.orders import (
     clean_order_cancel, clean_order_capture, clean_refund_payment,
     clean_void_payment)
-from saleor.graphql.order.utils import can_finalize_draft_order
+from saleor.graphql.order.utils import validate_draft_order
 from saleor.graphql.payment.types import PaymentChargeStatusEnum
 from saleor.order import OrderEvents, OrderEventsEmails, OrderStatus
 from saleor.order.models import Order, OrderEvent
@@ -459,8 +459,8 @@ def test_can_finalize_order_no_order_lines(
 
 
 def test_can_finalize_draft_order(order_with_lines):
-    errors = can_finalize_draft_order(order_with_lines, [])
-    assert not errors
+    # should not raise any errors
+    validate_draft_order(order_with_lines)
 
 
 def test_can_finalize_draft_order_wrong_shipping(order_with_lines):
@@ -469,14 +469,17 @@ def test_can_finalize_draft_order_wrong_shipping(order_with_lines):
     shipping_zone.countries = ['DE']
     shipping_zone.save()
     assert order.shipping_address.country.code not in shipping_zone.countries
-    errors = can_finalize_draft_order(order, [])
+    with pytest.raises(ValidationError) as e:
+        validate_draft_order(order)
     msg = 'Shipping method is not valid for chosen shipping address'
-    assert errors[0].message == msg
+    assert e.value.error_dict['shipping'][0].message == msg
 
 
 def test_can_finalize_draft_order_no_order_lines(order):
-    errors = can_finalize_draft_order(order, [])
-    assert errors[0].message == 'Could not create order without any products.'
+    with pytest.raises(ValidationError) as e:
+        validate_draft_order(order)
+    msg = 'Could not create order without any products.'
+    assert e.value.error_dict['lines'][0].message == msg
 
 
 def test_can_finalize_draft_order_non_existing_variant(order_with_lines):
@@ -487,10 +490,10 @@ def test_can_finalize_draft_order_non_existing_variant(order_with_lines):
     line.refresh_from_db()
     assert line.variant is None
 
-    errors = can_finalize_draft_order(order, [])
-    assert (
-        errors[0].message ==
-        'Could not create orders with non-existing products.')
+    with pytest.raises(ValidationError) as e:
+        validate_draft_order(order)
+    msg = 'Could not create orders with non-existing products.'
+    assert e.value.error_dict['lines'][0].message == msg
 
 
 def test_draft_order_complete(
@@ -1212,7 +1215,6 @@ def test_clean_order_void_payment():
     payment.is_active = False
     with pytest.raises(ValidationError) as e:
         clean_void_payment(payment)
-
     msg = 'Only pre-authorized payments can be voided'
     assert e.value.error_dict['payment'][0].message == msg
 
@@ -1223,7 +1225,6 @@ def test_clean_order_refund_payment():
     amount = Mock(spec='string')
     with pytest.raises(ValidationError) as e:
         clean_refund_payment(payment, amount)
-
     msg = 'Manual payments can not be refunded.'
     assert e.value.error_dict['payment'][0].message == msg
 
@@ -1232,7 +1233,6 @@ def test_clean_order_capture():
     amount = Mock(spec='string')
     with pytest.raises(ValidationError) as e:
         clean_order_capture(None, amount)
-
     msg = 'There\'s no payment associated with the order.'
     assert e.value.error_dict['payment'][0].message == msg
 
@@ -1246,7 +1246,6 @@ def test_clean_order_cancel(order):
 
     with pytest.raises(ValidationError) as e:
         clean_order_cancel(order)
-
     msg = 'This order can\'t be canceled.'
     assert e.value.error_dict['order'][0].message == msg
 
@@ -1423,8 +1422,6 @@ def test_order_by_token_query(api_client, order):
     }
     """
     order_id = graphene.Node.to_global_id('Order', order.id)
-
     response = api_client.post_graphql(query, {'token': order.token})
     content = get_graphql_content(response)
-
     assert content['data']['orderByToken']['id'] == order_id

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -715,8 +715,8 @@ def test_product_create_without_product_type(
     query = """
     mutation createProduct($categoryId: ID!) {
         productCreate(input: {
-                name: "Product", 
-                price: "2.5", 
+                name: "Product",
+                price: "2.5",
                 productType: "",
                 category: $categoryId}) {
             product {
@@ -1166,7 +1166,7 @@ def test_product_type_update_mutation(
     assert data['name'] == product_type_name
     assert data['hasVariants'] == has_variants
     assert data['isShippingRequired'] == require_shipping
-    assert len(data['productAttributes']) == 0
+    assert not data['productAttributes']
     assert len(data['variantAttributes']) == (
         variant_attributes.count())
 


### PR DESCRIPTION
This PR is an attempt to simplify the mutations code by introducing the following changes:
- added `perform_mutation` function which is fired by `mutate` - this allows to catch validation errors that occur at any time during `perform_mutation` execution:
- removed `if errors` checks 
- removed accumulating errors in `errors` lists which were passed between various functions during a mutation execution

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
