### PR TITLE
Fix phone validation for local numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Copy addresses in checkoutCreate and draftOrderCreate mutations - #3866 by @pawelzar
 - Fix default product tax rate in Dashboard 1.0 - #3880 by @pawelzar
 - Introduce avatars for staff accounts - #3878 by @pawelzar
+- Fix phone number validation in GraphQL when country prefix not given - #3905 by @patrys
 
 
 ## 2.4.0

--- a/saleor/account/widgets.py
+++ b/saleor/account/widgets.py
@@ -21,6 +21,15 @@ class PhonePrefixWidget(PhoneNumberPrefixWidget):
         # pylint: disable=bad-super-call
         super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
 
+    def value_from_datadict(self, data, files, name):
+        value = super().value_from_datadict(
+            data, files, name)
+        # FIXME: this is a hack, we should not be using a multiwidget
+        # in forms used by the API but here we are
+        if not value and name in data:
+            value = data[name]
+        return value
+
 
 class DatalistTextWidget(Select):
     template_name = "account/snippets/datalist.html"

--- a/saleor/dashboard/order/forms.py
+++ b/saleor/dashboard/order/forms.py
@@ -5,7 +5,8 @@ from django.urls import reverse, reverse_lazy
 from django.utils.translation import npgettext_lazy, pgettext_lazy
 
 from ...account.i18n import (
-    AddressForm as StorefrontAddressForm, PossiblePhoneNumberFormField)
+    AddressForm as StorefrontAddressForm, PossiblePhoneNumberFormField,
+    clean_phone_for_country)
 from ...account.models import User
 from ...checkout.forms import QuantityField
 from ...core.exceptions import InsufficientStock
@@ -588,6 +589,17 @@ class AddressForm(StorefrontAddressForm):
         label=pgettext_lazy(
             'Order form: address subform - phone number input field',
             'Phone number'))
+
+    def clean(self):
+        data = super().clean()
+        phone = data.get('phone')
+        country = data.get('country')
+        if phone:
+            try:
+                data['phone'] = clean_phone_for_country(phone, country)
+            except forms.ValidationError as error:
+                self.add_error('phone', error)
+        return data
 
 
 class FulfillmentForm(forms.ModelForm):

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -38,6 +38,6 @@ class I18nMixin:
             return None, errors
         if not instance:
             instance = Address()
-        cls.construct_instance(instance, address_data)
+        cls.construct_instance(instance, address_form.cleaned_data)
         cls.clean_instance(instance, errors)
         return instance, errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -95,7 +95,7 @@ def address(db):  # pylint: disable=W0613
         first_name='John', last_name='Doe',
         company_name='Mirumee Software',
         street_address_1='Tęczowa 7',
-        city='Wrocław',
+        city='WROCŁAW',
         postal_code='53-601',
         country='PL',
         phone='+48713988102')
@@ -107,7 +107,7 @@ def address_other_country():
         first_name='John',
         last_name='Doe',
         street_address_1='4371 Lucas Knoll Apt. 791',
-        city='Bennettmouth',
+        city='BENNETTMOUTH',
         postal_code='13377',
         country='IS',
         phone='')

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -174,7 +174,7 @@ def test_address_as_data(address):
         'company_name': 'Mirumee Software',
         'street_address_1': 'Tęczowa 7',
         'street_address_2': '',
-        'city': 'Wrocław',
+        'city': 'WROCŁAW',
         'city_area': '',
         'postal_code': '53-601',
         'country': 'PL',


### PR DESCRIPTION
Fixes #3905

Turns out that `saleor.account.i18n.AddressForm` was expecting phone to be passed as `phone_0` (prefix) and `phone_1` (local part) so the form always assumed the phone number to be empty.

However `saleor.graphql.account.i18n.I18nMixin` was creating the address instance from raw input, not the cleaned data returned by the form so while the form always returned an empty phone number, the mutation would discard cleaned data and use raw values instead.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
