### PR TITLE
Use primary button color

### DIFF
--- a/saleor/static/dashboard-next/categories/components/CategoryBackground/CategoryBackground.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryBackground/CategoryBackground.tsx
@@ -77,7 +77,7 @@ export const CategoryBackground = withStyles(styles)(
               <>
                 <Button
                   variant="text"
-                  color="secondary"
+                  color="primary"
                   onClick={this.clickImgInput}
                 >
                   {i18n.t("Upload image")}

--- a/saleor/static/dashboard-next/categories/components/CategoryCreateSubcategories/CategoryCreateSubcategories.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryCreateSubcategories/CategoryCreateSubcategories.tsx
@@ -84,7 +84,7 @@ export const CategoryCreateSubcategories = withStyles(styles, {
                 <div className={classes.inputGrid}>
                   <TextField label={i18n.t("Category Name")} />
                   <TextField label={i18n.t("Category Description")} />
-                  <IconButton className={classes.deleteIcon} color="secondary">
+                  <IconButton className={classes.deleteIcon} color="primary">
                     <DeleteIcon />
                   </IconButton>
                 </div>
@@ -92,7 +92,7 @@ export const CategoryCreateSubcategories = withStyles(styles, {
                 <Hr />
                 <Button
                   variant="text"
-                  color="secondary"
+                  color="primary"
                   className={classes.addSubCat}
                 >
                   {i18n.t("Add subcategory")}

--- a/saleor/static/dashboard-next/categories/components/CategoryList/CategoryList.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryList/CategoryList.tsx
@@ -60,7 +60,7 @@ const CategoryList = withStyles(styles, { name: "CategoryList" })(
         <CardTitle
           title={i18n.t("All Subcategories")}
           toolbar={
-            <Button color="secondary" variant="text" onClick={onAdd}>
+            <Button color="primary" variant="text" onClick={onAdd}>
               {i18n.t("Add subcategory")}
             </Button>
           }

--- a/saleor/static/dashboard-next/categories/components/CategoryListPage/CategoryListPage.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryListPage/CategoryListPage.tsx
@@ -32,7 +32,7 @@ export const CategoryListPage: React.StatelessComponent<CategoryTableProps> = ({
 }) => (
   <Container>
     <PageHeader title={i18n.t("Category")}>
-      <Button color="secondary" variant="contained" onClick={onAdd}>
+      <Button color="primary" variant="contained" onClick={onAdd}>
         {i18n.t("Add category")} <AddIcon />
       </Button>
     </PageHeader>

--- a/saleor/static/dashboard-next/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -24,7 +24,7 @@ import { renderCollection } from "../../../misc";
 const styles = (theme: Theme) =>
   createStyles({
     link: {
-      color: theme.palette.secondary.main,
+      color: theme.palette.primary.main,
       cursor: "pointer"
     },
     textLeft: {

--- a/saleor/static/dashboard-next/categories/components/CategoryProducts/CategoryProducts.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryProducts/CategoryProducts.tsx
@@ -64,7 +64,7 @@ export const ProductList = withStyles(styles, { name: "ProductList" })(
       <CardTitle
         title={i18n.t("Products")}
         toolbar={
-          <Button variant="text" color="secondary" onClick={onAddProduct}>
+          <Button variant="text" color="primary" onClick={onAddProduct}>
             {i18n.t("Add product")}
           </Button>
         }

--- a/saleor/static/dashboard-next/categories/components/CategoryProductsCard/CategoryProductsCard.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryProductsCard/CategoryProductsCard.tsx
@@ -29,7 +29,7 @@ export const CategoryProductsCard: React.StatelessComponent<
     <CardTitle
       title={i18n.t("Products in {{ categoryName }}", { categoryName })}
       toolbar={
-        <Button color="secondary" variant="text" onClick={onAdd}>
+        <Button color="primary" variant="text" onClick={onAdd}>
           {i18n.t("Add product")}
         </Button>
       }

--- a/saleor/static/dashboard-next/collections/components/CollectionImage/CollectionImage.tsx
+++ b/saleor/static/dashboard-next/collections/components/CollectionImage/CollectionImage.tsx
@@ -87,7 +87,7 @@ export const CollectionImage = withStyles(styles)(
               <>
                 <Button
                   variant="text"
-                  color="secondary"
+                  color="primary"
                   onClick={this.clickImgInput}
                 >
                   {i18n.t("Upload image")}

--- a/saleor/static/dashboard-next/collections/components/CollectionListPage/CollectionListPage.tsx
+++ b/saleor/static/dashboard-next/collections/components/CollectionListPage/CollectionListPage.tsx
@@ -21,7 +21,7 @@ const CollectionListPage: React.StatelessComponent<CollectionListPageProps> = ({
   <Container>
     <PageHeader title={i18n.t("Collections", { context: "page title" })}>
       <Button
-        color="secondary"
+        color="primary"
         disabled={disabled}
         variant="contained"
         onClick={onAdd}

--- a/saleor/static/dashboard-next/collections/components/CollectionProducts/CollectionProducts.tsx
+++ b/saleor/static/dashboard-next/collections/components/CollectionProducts/CollectionProducts.tsx
@@ -73,7 +73,7 @@ const CollectionProducts = withStyles(styles, { name: "CollectionProducts" })(
           <Button
             disabled={disabled}
             variant="text"
-            color="secondary"
+            color="primary"
             onClick={onAdd}
           >
             {i18n.t("Assign product", {
@@ -147,7 +147,7 @@ const CollectionProducts = withStyles(styles, { name: "CollectionProducts" })(
                     disabled={!product}
                     onClick={event => onProductUnassign(product.id, event)}
                   >
-                    <DeleteIcon color="secondary" />
+                    <DeleteIcon color="primary" />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/saleor/static/dashboard-next/components/AppLayout/AppLayout.tsx
+++ b/saleor/static/dashboard-next/components/AppLayout/AppLayout.tsx
@@ -176,7 +176,7 @@ const AppLayout = withStyles(styles, {
                   className={classNames(classes.appLoader, {
                     [classes.hide]: !isProgressVisible
                   })}
-                  color="secondary"
+                  color="primary"
                 />
                 <div className={classes.root}>
                   <div className={classes.sideBar}>

--- a/saleor/static/dashboard-next/components/CardMenu/CardMenu.tsx
+++ b/saleor/static/dashboard-next/components/CardMenu/CardMenu.tsx
@@ -67,7 +67,7 @@ const CardMenu = withStyles(styles, {
           aria-owns={open ? "long-menu" : null}
           aria-haspopup="true"
           className={classes.iconButton}
-          color="secondary"
+          color="primary"
           disabled={disabled}
           onClick={handleClick}
         >

--- a/saleor/static/dashboard-next/components/ConfirmButton/ConfirmButton.tsx
+++ b/saleor/static/dashboard-next/components/ConfirmButton/ConfirmButton.tsx
@@ -134,7 +134,7 @@ const ConfirmButton = withStyles(styles)(
         <Button
           variant="contained"
           onClick={transitionState === "loading" ? undefined : onClick}
-          color="secondary"
+          color="primary"
           className={classNames({
             [classes.error]:
               transitionState === "error" && displayCompletedActionState,

--- a/saleor/static/dashboard-next/components/CountryList/CountryList.tsx
+++ b/saleor/static/dashboard-next/components/CountryList/CountryList.tsx
@@ -99,7 +99,7 @@ const CountryList = withStyles(styles, {
             toolbar={
               <Button
                 variant="flat"
-                color="secondary"
+                color="primary"
                 onClick={onCountryAssign}
               >
                 {i18n.t("Assign countries")}
@@ -159,7 +159,7 @@ const CountryList = withStyles(styles, {
                           )}
                         >
                           <IconButton
-                            color="secondary"
+                            color="primary"
                             disabled={!country || disabled}
                             onClick={() => onCountryUnassign(country.code)}
                           >

--- a/saleor/static/dashboard-next/components/ErrorPage/ErrorPage.tsx
+++ b/saleor/static/dashboard-next/components/ErrorPage/ErrorPage.tsx
@@ -81,7 +81,7 @@ const ErrorPage = withStyles(styles, { name: "NotFoundPage" })(
           <div>
             <Button
               className={classes.button}
-              color="secondary"
+              color="primary"
               variant="contained"
               onClick={onBack}
             >

--- a/saleor/static/dashboard-next/components/ExternalLink/ExternalLink.tsx
+++ b/saleor/static/dashboard-next/components/ExternalLink/ExternalLink.tsx
@@ -26,7 +26,7 @@ const ExternalLink = withStyles(styles, { name: "ExternalLink" })(
     ...props
   }: ExternalLinkProps) => (
     <a href={href} className={classes.link} {...props}>
-      <Typography className={className} color="secondary" {...typographyProps}>
+      <Typography className={className} color="primary" {...typographyProps}>
         {children}
       </Typography>
     </a>

--- a/saleor/static/dashboard-next/components/ImageTile/ImageTile.tsx
+++ b/saleor/static/dashboard-next/components/ImageTile/ImageTile.tsx
@@ -64,12 +64,12 @@ const ImageTile = withStyles(styles, { name: "ImageTile" })(
       <div className={classes.imageOverlay}>
         <div className={classes.imageOverlayToolbar}>
           {onImageEdit && (
-            <IconButton color="secondary" onClick={onImageEdit}>
+            <IconButton color="primary" onClick={onImageEdit}>
               <EditIcon />
             </IconButton>
           )}
           {onImageDelete && (
-            <IconButton color="secondary" onClick={onImageDelete}>
+            <IconButton color="primary" onClick={onImageDelete}>
               <DeleteIcon />
             </IconButton>
           )}

--- a/saleor/static/dashboard-next/components/Link.tsx
+++ b/saleor/static/dashboard-next/components/Link.tsx
@@ -18,7 +18,7 @@ const styles = (theme: Theme) =>
       display: "inline"
     },
     secondary: {
-      color: theme.palette.secondary.main
+      color: theme.palette.primary.main
     },
     underline: {
       textDecoration: "underline"

--- a/saleor/static/dashboard-next/components/ListField/ListField.tsx
+++ b/saleor/static/dashboard-next/components/ListField/ListField.tsx
@@ -114,7 +114,7 @@ const ListField = withStyles(styles)(
               endAdornment: (
                 <Button
                   variant="text"
-                  color="secondary"
+                  color="primary"
                   onClick={this.handleValueAdd}
                 >
                   {i18n.t("Add", { context: "button" })}

--- a/saleor/static/dashboard-next/components/NotFoundPage/NotFoundPage.tsx
+++ b/saleor/static/dashboard-next/components/NotFoundPage/NotFoundPage.tsx
@@ -75,7 +75,7 @@ const NotFoundPage = withStyles(styles, { name: "NotFoundPage" })(
           <div>
             <Button
               className={classes.button}
-              color="secondary"
+              color="primary"
               variant="contained"
               onClick={onBack}
             >

--- a/saleor/static/dashboard-next/components/RichTextEditor/ImageEntity.tsx
+++ b/saleor/static/dashboard-next/components/RichTextEditor/ImageEntity.tsx
@@ -88,13 +88,13 @@ const ImageEntity = withStyles(styles, {
                                 disable();
                                 onEdit(entityKey);
                               }}
-                              color="secondary"
+                              color="primary"
                               variant="flat"
                             >
                               {i18n.t("Replace")}
                             </Button>
                             <IconButton onClick={() => onRemove(entityKey)}>
-                              <DeleteIcon color="secondary" />
+                              <DeleteIcon color="primary" />
                             </IconButton>
                           </div>
                         </ClickAwayListener>

--- a/saleor/static/dashboard-next/components/RichTextEditor/ImageSource.tsx
+++ b/saleor/static/dashboard-next/components/RichTextEditor/ImageSource.tsx
@@ -86,7 +86,7 @@ class ImageSource extends React.Component<ImageSourceProps> {
                 <Button onClick={onClose}>
                   {i18n.t("Cancel", { context: "button" })}
                 </Button>
-                <Button onClick={submit} color="secondary" variant="contained">
+                <Button onClick={submit} color="primary" variant="contained">
                   {i18n.t("Save", { context: "button" })}
                 </Button>
               </DialogActions>

--- a/saleor/static/dashboard-next/components/RichTextEditor/LinkEntity.tsx
+++ b/saleor/static/dashboard-next/components/RichTextEditor/LinkEntity.tsx
@@ -106,13 +106,13 @@ const LinkEntity = withStyles(styles, {
                                 disable();
                                 onEdit(entityKey);
                               }}
-                              color="secondary"
+                              color="primary"
                               variant="flat"
                             >
                               {i18n.t("Edit")}
                             </Button>
                             <IconButton onClick={() => onRemove(entityKey)}>
-                              <DeleteIcon color="secondary" />
+                              <DeleteIcon color="primary" />
                             </IconButton>
                           </div>
                         </ClickAwayListener>

--- a/saleor/static/dashboard-next/components/RichTextEditor/RichTextEditor.tsx
+++ b/saleor/static/dashboard-next/components/RichTextEditor/RichTextEditor.tsx
@@ -78,7 +78,7 @@ const styles = (theme: Theme) =>
             overflowY: "scroll"
           },
           "& a": {
-            color: theme.palette.secondary.light
+            color: theme.palette.primary.light
           },
           "&:after": {
             animationDuration: theme.transitions.duration.shortest + "ms",
@@ -125,17 +125,17 @@ const styles = (theme: Theme) =>
           "&Button": {
             "&--active": {
               "&:hover": {
-                background: theme.palette.secondary.main
+                background: theme.palette.primary.main
               },
               "&:not(:hover)": {
-                borderRightColor: theme.palette.secondary.main
+                borderRightColor: theme.palette.primary.main
               },
-              background: theme.palette.secondary.main
+              background: theme.palette.primary.main
             },
             "&:focus": {
               "&:active": {
                 "&:after": {
-                  background: fade(theme.palette.secondary.main, 0.3),
+                  background: fade(theme.palette.primary.main, 0.3),
                   borderRadius: "100%",
                   content: "''",
                   display: "block",
@@ -145,7 +145,7 @@ const styles = (theme: Theme) =>
               }
             },
             "&:hover": {
-              background: fade(theme.palette.secondary.main, 0.3)
+              background: fade(theme.palette.primary.main, 0.3)
             },
             alignItems: "center",
             background: "none",

--- a/saleor/static/dashboard-next/components/SeoForm/SeoForm.tsx
+++ b/saleor/static/dashboard-next/components/SeoForm/SeoForm.tsx
@@ -92,7 +92,7 @@ const SeoForm = withStyles(styles, { name: "SeoForm" })(
           <CardTitle
             title={i18n.t("Search Engine Preview")}
             toolbar={
-              <Button color="secondary" variant="text" onClick={toggle}>
+              <Button color="primary" variant="text" onClick={toggle}>
                 {i18n.t("Edit website SEO")}
               </Button>
             }

--- a/saleor/static/dashboard-next/components/Theme/ThemeProvider.tsx
+++ b/saleor/static/dashboard-next/components/Theme/ThemeProvider.tsx
@@ -22,7 +22,7 @@ const dark: IThemeColors = {
   },
   paperBorder: "#252728",
   primary: "#13BEBB",
-  secondary: "#13BEBB"
+  secondary: "#21125E"
 };
 const light: IThemeColors = {
   autofill: "#f4f6c5",
@@ -41,7 +41,7 @@ const light: IThemeColors = {
   },
   paperBorder: "#EAEAEA",
   primary: "#13BEBB",
-  secondary: "#13BEBB"
+  secondary: "#21125E"
 };
 
 interface IThemeContext {

--- a/saleor/static/dashboard-next/customers/components/CustomerAddress/CustomerAddress.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerAddress/CustomerAddress.tsx
@@ -101,7 +101,7 @@ const CustomerAddress = withStyles(styles, { name: "CustomerAddress" })(
       <div className={classes.actionsContainer}>
         <CardActions className={classes.actions}>
           <Button
-            color="secondary"
+            color="primary"
             disabled={disabled}
             variant="flat"
             onClick={onEdit}
@@ -109,7 +109,7 @@ const CustomerAddress = withStyles(styles, { name: "CustomerAddress" })(
             {i18n.t("Edit")}
           </Button>
           <Button
-            color="secondary"
+            color="primary"
             disabled={disabled}
             variant="flat"
             onClick={onRemove}

--- a/saleor/static/dashboard-next/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerAddressDialog/CustomerAddressDialog.tsx
@@ -95,7 +95,7 @@ const CustomerAddressDialog = withStyles(styles, {})(
                 </Button>
                 <ConfirmButton
                   transitionState={confirmButtonState}
-                  color="secondary"
+                  color="primary"
                   variant="contained"
                   onClick={submit}
                   type="submit"

--- a/saleor/static/dashboard-next/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerAddressListPage/CustomerAddressListPage.tsx
@@ -80,7 +80,7 @@ const CustomerAddressListPage = withStyles(styles, {
               })
             )}
           >
-            <Button color="secondary" variant="contained" onClick={onAdd}>
+            <Button color="primary" variant="contained" onClick={onAdd}>
               {i18n.t("Add address", {
                 context: "add customer address"
               })}
@@ -100,7 +100,7 @@ const CustomerAddressListPage = withStyles(styles, {
             </Typography>
             <Button
               className={classes.addButton}
-              color="secondary"
+              color="primary"
               variant="contained"
               onClick={onAdd}
             >

--- a/saleor/static/dashboard-next/customers/components/CustomerAddresses/CustomerAddresses.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerAddresses/CustomerAddresses.tsx
@@ -43,7 +43,7 @@ const CustomerAddresses = withStyles(styles, { name: "CustomerAddresses" })(
         title={i18n.t("Address Information")}
         toolbar={
           <Button
-            color="secondary"
+            color="primary"
             disabled={disabled}
             variant="text"
             onClick={onAddressManageClick}

--- a/saleor/static/dashboard-next/customers/components/CustomerListPage/CustomerListPage.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerListPage/CustomerListPage.tsx
@@ -22,7 +22,7 @@ const CustomerListPage: React.StatelessComponent<CustomerListPageProps> = ({
   <Container>
     <PageHeader title={i18n.t("Customers")}>
       <Button
-        color="secondary"
+        color="primary"
         variant="contained"
         disabled={disabled}
         onClick={onAdd}

--- a/saleor/static/dashboard-next/customers/components/CustomerOrders/CustomerOrders.tsx
+++ b/saleor/static/dashboard-next/customers/components/CustomerOrders/CustomerOrders.tsx
@@ -52,7 +52,7 @@ const CustomerOrders = withStyles(styles, { name: "CustomerOrders" })(
           toolbar={
             <Button
               variant="text"
-              color="secondary"
+              color="primary"
               onClick={onViewAllOrdersClick}
             >
               {i18n.t("View all orders")}

--- a/saleor/static/dashboard-next/discounts/components/DiscountCategories/DiscountCategories.tsx
+++ b/saleor/static/dashboard-next/discounts/components/DiscountCategories/DiscountCategories.tsx
@@ -69,7 +69,7 @@ const DiscountCategories = withStyles(styles, {
           saleName: maybe(() => sale.name)
         })}
         toolbar={
-          <Button variant="flat" color="secondary" onClick={onCategoryAssign}>
+          <Button variant="flat" color="primary" onClick={onCategoryAssign}>
             {i18n.t("Assign categories")}
           </Button>
         }
@@ -126,7 +126,7 @@ const DiscountCategories = withStyles(styles, {
                       onCategoryUnassign(category.id);
                     }}
                   >
-                    <DeleteIcon color="secondary" />
+                    <DeleteIcon color="primary" />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/saleor/static/dashboard-next/discounts/components/DiscountCollections/DiscountCollections.tsx
+++ b/saleor/static/dashboard-next/discounts/components/DiscountCollections/DiscountCollections.tsx
@@ -69,7 +69,7 @@ const DiscountCollections = withStyles(styles, {
           saleName: maybe(() => sale.name)
         })}
         toolbar={
-          <Button variant="flat" color="secondary" onClick={onCollectionAssign}>
+          <Button variant="flat" color="primary" onClick={onCollectionAssign}>
             {i18n.t("Assign collections")}
           </Button>
         }
@@ -126,7 +126,7 @@ const DiscountCollections = withStyles(styles, {
                       onCollectionUnassign(collection.id);
                     }}
                   >
-                    <DeleteIcon color="secondary" />
+                    <DeleteIcon color="primary" />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/saleor/static/dashboard-next/discounts/components/DiscountProducts/DiscountProducts.tsx
+++ b/saleor/static/dashboard-next/discounts/components/DiscountProducts/DiscountProducts.tsx
@@ -71,7 +71,7 @@ const DiscountProducts = withStyles(styles, {
           saleName: maybe(() => sale.name)
         })}
         toolbar={
-          <Button variant="flat" color="secondary" onClick={onProductAssign}>
+          <Button variant="flat" color="primary" onClick={onProductAssign}>
             {i18n.t("Assign products")}
           </Button>
         }
@@ -151,7 +151,7 @@ const DiscountProducts = withStyles(styles, {
                       onProductUnassign(product.id);
                     }}
                   >
-                    <DeleteIcon color="secondary" />
+                    <DeleteIcon color="primary" />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/saleor/static/dashboard-next/discounts/components/SaleListPage/SaleListPage.tsx
+++ b/saleor/static/dashboard-next/discounts/components/SaleListPage/SaleListPage.tsx
@@ -26,7 +26,7 @@ const SaleListPage: React.StatelessComponent<SaleListPageProps> = ({
 }) => (
   <Container>
     <PageHeader title={i18n.t("Sales")}>
-      <Button onClick={onAdd} variant="contained" color="secondary">
+      <Button onClick={onAdd} variant="contained" color="primary">
         {i18n.t("Add sale")}
         <AddIcon />
       </Button>

--- a/saleor/static/dashboard-next/discounts/components/VoucherListPage/VoucherListPage.tsx
+++ b/saleor/static/dashboard-next/discounts/components/VoucherListPage/VoucherListPage.tsx
@@ -26,7 +26,7 @@ const VoucherListPage: React.StatelessComponent<VoucherListPageProps> = ({
 }) => (
   <Container>
     <PageHeader title={i18n.t("Vouchers")}>
-      <Button onClick={onAdd} variant="contained" color="secondary">
+      <Button onClick={onAdd} variant="contained" color="primary">
         {i18n.t("Add voucher")}
         <AddIcon />
       </Button>

--- a/saleor/static/dashboard-next/orders/components/OrderCustomer/OrderCustomer.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderCustomer/OrderCustomer.tsx
@@ -87,7 +87,7 @@ const OrderCustomer = withStyles(styles, { name: "OrderCustomer" })(
                 toolbar={
                   !!canEditCustomer && (
                     <Button
-                      color="secondary"
+                      color="primary"
                       variant="text"
                       disabled={!onCustomerEdit}
                       onClick={toggleEditMode}
@@ -179,7 +179,7 @@ const OrderCustomer = withStyles(styles, { name: "OrderCustomer" })(
             {canEditAddresses && (
               <div className={classes.sectionHeaderToolbar}>
                 <Button
-                  color="secondary"
+                  color="primary"
                   variant="text"
                   onClick={onShippingAddressEdit}
                   disabled={!onShippingAddressEdit && user === undefined}
@@ -232,7 +232,7 @@ const OrderCustomer = withStyles(styles, { name: "OrderCustomer" })(
             {canEditAddresses && (
               <div className={classes.sectionHeaderToolbar}>
                 <Button
-                  color="secondary"
+                  color="primary"
                   variant="text"
                   onClick={onBillingAddressEdit}
                   disabled={!onBillingAddressEdit && user === undefined}

--- a/saleor/static/dashboard-next/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderDraftDetails/OrderDraftDetails.tsx
@@ -36,7 +36,7 @@ const OrderDraftDetails: React.StatelessComponent<OrderDraftDetailsProps> = ({
         context: "card title"
       })}
       toolbar={
-        <Button color="secondary" variant="text" onClick={onOrderLineAdd}>
+        <Button color="primary" variant="text" onClick={onOrderLineAdd}>
           {i18n.t("Add products", {
             context: "button"
           })}

--- a/saleor/static/dashboard-next/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderDraftDetailsProducts/OrderDraftDetailsProducts.tsx
@@ -153,7 +153,7 @@ const OrderDraftDetailsProducts = withStyles(styles, {
               </TableCell>
               <TableCell className={classes.iconCell}>
                 <IconButton onClick={() => onOrderLineRemove(line.id)}>
-                  <DeleteIcon color="secondary" />
+                  <DeleteIcon color="primary" />
                 </IconButton>
               </TableCell>
             </TableRow>

--- a/saleor/static/dashboard-next/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderDraftListPage/OrderDraftListPage.tsx
@@ -26,7 +26,7 @@ const OrderDraftListPage: React.StatelessComponent<OrderDraftListPageProps> = ({
   <Container>
     <PageHeader title={i18n.t("Draft Orders")}>
       <Button
-        color="secondary"
+        color="primary"
         variant="contained"
         disabled={disabled}
         onClick={onAdd}

--- a/saleor/static/dashboard-next/orders/components/OrderFulfillment/OrderFulfillment.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderFulfillment/OrderFulfillment.tsx
@@ -185,7 +185,7 @@ const OrderFulfillment = withStyles(styles, { name: "OrderFulfillment" })(
         </Table>
         {status === FulfillmentStatus.FULFILLED && !fulfillment.trackingNumber && (
           <CardActions>
-            <Button color="secondary" onClick={onTrackingCodeAdd}>
+            <Button color="primary" onClick={onTrackingCodeAdd}>
               {i18n.t("Add tracking")}
             </Button>
           </CardActions>

--- a/saleor/static/dashboard-next/orders/components/OrderListPage/OrderListPage.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderListPage/OrderListPage.tsx
@@ -40,7 +40,7 @@ const OrderListPage: React.StatelessComponent<OrderListPageProps> = ({
   <Container>
     <PageHeader title={i18n.t("Orders")}>
       <Button
-        color="secondary"
+        color="primary"
         variant="contained"
         disabled={disabled}
         onClick={onAdd}

--- a/saleor/static/dashboard-next/orders/components/OrderPayment/OrderPayment.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderPayment/OrderPayment.tsx
@@ -201,23 +201,23 @@ const OrderPayment = withStyles(styles, { name: "OrderPayment" })(
               <Hr />
               <CardActions>
                 {canCapture && (
-                  <Button color="secondary" variant="text" onClick={onCapture}>
+                  <Button color="primary" variant="text" onClick={onCapture}>
                     {i18n.t("Capture", { context: "button" })}
                   </Button>
                 )}
                 {canRefund && (
-                  <Button color="secondary" variant="text" onClick={onRefund}>
+                  <Button color="primary" variant="text" onClick={onRefund}>
                     {i18n.t("Refund", { context: "button" })}
                   </Button>
                 )}
                 {canVoid && (
-                  <Button color="secondary" variant="text" onClick={onVoid}>
+                  <Button color="primary" variant="text" onClick={onVoid}>
                     {i18n.t("Void", { context: "button" })}
                   </Button>
                 )}
                 {canMarkAsPaid && (
                   <Button
-                    color="secondary"
+                    color="primary"
                     variant="text"
                     onClick={onMarkAsPaid}
                   >

--- a/saleor/static/dashboard-next/orders/components/OrderUnfulfilledItems/OrderUnfulfilledItems.tsx
+++ b/saleor/static/dashboard-next/orders/components/OrderUnfulfilledItems/OrderUnfulfilledItems.tsx
@@ -115,7 +115,7 @@ const OrderUnfulfilledItems = withStyles(styles, {
     </Table>
     {canFulfill && (
       <CardActions>
-        <Button variant="text" color="secondary" onClick={onFulfill}>
+        <Button variant="text" color="primary" onClick={onFulfill}>
           {i18n.t("Fulfill", {
             context: "button"
           })}

--- a/saleor/static/dashboard-next/pages/components/PageListPage/PageListPage.tsx
+++ b/saleor/static/dashboard-next/pages/components/PageListPage/PageListPage.tsx
@@ -32,7 +32,7 @@ const PageListPage: React.StatelessComponent<PageListPageProps> = ({
         disabled={disabled}
         onClick={onAdd}
         variant="contained"
-        color="secondary"
+        color="primary"
       >
         {i18n.t("Add page")}
         <AddIcon />

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -71,7 +71,7 @@ const ProductTypeAttributes = withStyles(styles, {
         }
         toolbar={
           <Button
-            color="secondary"
+            color="primary"
             variant="text"
             onClick={() => onAttributeAdd(type)}
           >
@@ -117,7 +117,7 @@ const ProductTypeAttributes = withStyles(styles, {
                   <IconButton
                     onClick={event => onAttributeDelete(attribute.id, event)}
                   >
-                    <DeleteIcon color="secondary" />
+                    <DeleteIcon color="primary" />
                   </IconButton>
                 </TableCell>
               </TableRow>

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeListPage/ProductTypeListPage.tsx
@@ -31,7 +31,7 @@ const ProductTypeListPage: React.StatelessComponent<
     <AppHeader onBack={onBack}>{i18n.t("Configuration")}</AppHeader>
     <PageHeader title={i18n.t("Product types")}>
       <Button
-        color="secondary"
+        color="primary"
         variant="contained"
         disabled={disabled}
         onClick={onAdd}

--- a/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
@@ -179,7 +179,7 @@ const ProductImages = withStyles(styles, { name: "ProductImages" })(
               onClick={() => this.upload.click()}
               disabled={loading}
               variant="text"
-              color="secondary"
+              color="primary"
             >
               {i18n.t("Upload image")}
             </Button>

--- a/saleor/static/dashboard-next/products/components/ProductListCard/ProductListCard.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductListCard/ProductListCard.tsx
@@ -41,7 +41,7 @@ export const ProductListCard: React.StatelessComponent<
 }) => (
   <Container>
     <PageHeader title={i18n.t("Products")}>
-      <Button onClick={onAdd} color="secondary" variant="contained">
+      <Button onClick={onAdd} color="primary" variant="contained">
         {i18n.t("Add product")} <AddIcon />
       </Button>
     </PageHeader>

--- a/saleor/static/dashboard-next/products/components/ProductVariantImages/ProductVariantImages.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariantImages/ProductVariantImages.tsx
@@ -60,7 +60,7 @@ export const ProductVariantImages = withStyles(styles, {
       title={i18n.t("Images")}
       toolbar={
         <Button
-          color="secondary"
+          color="primary"
           variant="text"
           disabled={disabled}
           onClick={onImageAdd}

--- a/saleor/static/dashboard-next/products/components/ProductVariants/ProductVariants.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductVariants/ProductVariants.tsx
@@ -67,10 +67,10 @@ export const ProductVariants = withStyles(styles, { name: "ProductVariants" })(
         title={i18n.t("Variants")}
         toolbar={
           <>
-            <Button onClick={onAttributesEdit} variant="text" color="secondary">
+            <Button onClick={onAttributesEdit} variant="text" color="primary">
               {i18n.t("Edit attributes")}
             </Button>
-            <Button onClick={onVariantAdd} variant="text" color="secondary">
+            <Button onClick={onVariantAdd} variant="text" color="primary">
               {i18n.t("Add variant")}
             </Button>
           </>

--- a/saleor/static/dashboard-next/shipping/components/ShippingWeightUnitForm/ShippingWeightUnitForm.tsx
+++ b/saleor/static/dashboard-next/shipping/components/ShippingWeightUnitForm/ShippingWeightUnitForm.tsx
@@ -59,7 +59,7 @@ const ShippingWeightUnitForm: React.StatelessComponent<
           </CardContent>
           <Hr />
           <CardActions>
-            <Button color="secondary" onClick={submit}>
+            <Button color="primary" onClick={submit}>
               {i18n.t("Save", {
                 context: "button"
               })}

--- a/saleor/static/dashboard-next/shipping/components/ShippingZoneRates/ShippingZoneRates.tsx
+++ b/saleor/static/dashboard-next/shipping/components/ShippingZoneRates/ShippingZoneRates.tsx
@@ -70,7 +70,7 @@ const ShippingZoneRates = withStyles(styles, { name: "ShippingZoneRates" })(
             : i18n.t("Weight Based Rates")
         }
         toolbar={
-          <Button color="secondary" onClick={onRateAdd}>
+          <Button color="primary" onClick={onRateAdd}>
             {i18n.t("Add rate", {
               context: "button"
             })}
@@ -134,7 +134,7 @@ const ShippingZoneRates = withStyles(styles, { name: "ShippingZoneRates" })(
                 </TableCell>
                 <TableCell className={classes.alignRight}>
                   <IconButton
-                    color="secondary"
+                    color="primary"
                     disabled={disabled}
                     onClick={event => {
                       event.stopPropagation();
@@ -146,7 +146,7 @@ const ShippingZoneRates = withStyles(styles, { name: "ShippingZoneRates" })(
                 </TableCell>
                 <TableCell className={classes.alignRight}>
                   <IconButton
-                    color="secondary"
+                    color="primary"
                     disabled={disabled}
                     onClick={event => {
                       event.stopPropagation();

--- a/saleor/static/dashboard-next/shipping/components/ShippingZonesList/ShippingZonesList.tsx
+++ b/saleor/static/dashboard-next/shipping/components/ShippingZonesList/ShippingZonesList.tsx
@@ -57,7 +57,7 @@ const ShippingZonesList = withStyles(styles, { name: "ShippingZonesList" })(
         height="const"
         title={i18n.t("Shipping by zone")}
         toolbar={
-          <Button color="secondary" onClick={onAdd}>
+          <Button color="primary" onClick={onAdd}>
             {i18n.t("Add shipping zone", {
               context: "button"
             })}
@@ -108,7 +108,7 @@ const ShippingZonesList = withStyles(styles, { name: "ShippingZonesList" })(
                 </TableCell>
                 <TableCell className={classes.alignRight}>
                   <IconButton
-                    color="secondary"
+                    color="primary"
                     disabled={disabled}
                     onClick={event => {
                       event.stopPropagation();

--- a/saleor/static/dashboard-next/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
+++ b/saleor/static/dashboard-next/siteSettings/components/SiteSettingsKeyDialog/SiteSettingsKeyDialog.tsx
@@ -86,7 +86,7 @@ const SiteSettingsKeyDialog: React.StatelessComponent<
               <Button onClick={onClose}>
                 {i18n.t("Cancel", { context: "button" })}
               </Button>
-              <Button color="secondary" type="submit" variant="contained">
+              <Button color="primary" type="submit" variant="contained">
                 {i18n.t("Add authentication", {
                   context: "button"
                 })}

--- a/saleor/static/dashboard-next/siteSettings/components/SiteSettingsKeys/SiteSettingsKeys.tsx
+++ b/saleor/static/dashboard-next/siteSettings/components/SiteSettingsKeys/SiteSettingsKeys.tsx
@@ -55,7 +55,7 @@ const SiteSettingsKeys = withStyles(styles, { name: "SiteSettingsKeys" })(
           })}
           toolbar={
             <Button
-              color="secondary"
+              color="primary"
               disabled={disabled}
               variant="text"
               onClick={onAdd}
@@ -97,7 +97,7 @@ const SiteSettingsKeys = withStyles(styles, { name: "SiteSettingsKeys" })(
                   </TableCell>
                   <TableCell className={classes.iconCell}>
                     <IconButton onClick={() => onRemove(key.name)}>
-                      <DeleteIcon color="secondary" />
+                      <DeleteIcon color="primary" />
                     </IconButton>
                   </TableCell>
                 </TableRow>

--- a/saleor/static/dashboard-next/staff/components/StaffListPage/StaffListPage.tsx
+++ b/saleor/static/dashboard-next/staff/components/StaffListPage/StaffListPage.tsx
@@ -30,7 +30,7 @@ const StaffListPage: React.StatelessComponent<StaffListPageProps> = ({
     <AppHeader onBack={onBack}>{i18n.t("Configuration")}</AppHeader>
     <PageHeader title={i18n.t("Staff members", { context: "page title" })}>
       <Button
-        color="secondary"
+        color="primary"
         disabled={disabled}
         variant="contained"
         onClick={onAdd}

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -19,7 +19,7 @@ exports[`Storyshots Categories / CategoryProducts when loading data 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -212,7 +212,7 @@ exports[`Storyshots Categories / CategoryProducts with clickable rows 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -480,7 +480,7 @@ exports[`Storyshots Categories / CategoryProducts with initial data 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -748,7 +748,7 @@ exports[`Storyshots Categories / CategoryProducts without initial data 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -920,7 +920,7 @@ exports[`Storyshots Components / ErrorPage default 1`] = `
         </div>
         <div>
           <button
-            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id NotFoundPage-button-id"
+            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id NotFoundPage-button-id"
             tabindex="0"
             type="button"
           >
@@ -1308,7 +1308,7 @@ exports[`Storyshots Generics / Card menu default 1`] = `
     <button
       aria-haspopup="true"
       aria-label="More"
-      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
       tabindex="0"
       type="button"
     >
@@ -1474,7 +1474,7 @@ exports[`Storyshots Generics / External Link default 1`] = `
     href="http://www.google.com"
   >
     <p
-      class="MuiTypography-root-id MuiTypography-body1-id MuiTypography-colorSecondary-id"
+      class="MuiTypography-root-id MuiTypography-body1-id MuiTypography-colorPrimary-id"
     >
       Link to google.com
     </p>
@@ -1492,7 +1492,7 @@ exports[`Storyshots Generics / External Link new tab 1`] = `
     target="_blank"
   >
     <p
-      class="MuiTypography-root-id MuiTypography-body1-id MuiTypography-colorSecondary-id"
+      class="MuiTypography-root-id MuiTypography-body1-id MuiTypography-colorPrimary-id"
     >
       Link to google.com
     </p>
@@ -5032,7 +5032,7 @@ exports[`Storyshots Orders / OrderCustomer default 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -5170,7 +5170,7 @@ exports[`Storyshots Orders / OrderCustomer editable 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -5242,7 +5242,7 @@ exports[`Storyshots Orders / OrderCustomer editable 1`] = `
           class="OrderCustomer-sectionHeaderToolbar-id"
         >
           <button
-            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
             tabindex="0"
             type="button"
           >
@@ -5297,7 +5297,7 @@ exports[`Storyshots Orders / OrderCustomer editable 1`] = `
           class="OrderCustomer-sectionHeaderToolbar-id"
         >
           <button
-            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
             tabindex="0"
             type="button"
           >
@@ -5338,7 +5338,7 @@ exports[`Storyshots Orders / OrderCustomer loading 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -5452,7 +5452,7 @@ exports[`Storyshots Orders / OrderCustomer with different addresses 1`] = `
         class="CardTitle-toolbar-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -6326,7 +6326,7 @@ exports[`Storyshots Views / Categories / Category list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -6603,7 +6603,7 @@ exports[`Storyshots Views / Categories / Category list empty 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -6776,7 +6776,7 @@ exports[`Storyshots Views / Categories / Category list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -7333,7 +7333,7 @@ Ctrl + K"
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -7748,7 +7748,7 @@ Ctrl + K"
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -8331,7 +8331,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -8367,7 +8367,7 @@ Ctrl + K"
                 class="ImageTile-imageOverlayToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -8474,7 +8474,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -8537,7 +8537,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -9065,7 +9065,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -9122,7 +9122,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -9185,7 +9185,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -9899,7 +9899,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -9935,7 +9935,7 @@ Ctrl + K"
                 class="ImageTile-imageOverlayToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -10042,7 +10042,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -10105,7 +10105,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -10796,7 +10796,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -10832,7 +10832,7 @@ Ctrl + K"
                 class="ImageTile-imageOverlayToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -10939,7 +10939,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -11002,7 +11002,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -11699,7 +11699,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -11735,7 +11735,7 @@ Ctrl + K"
                 class="ImageTile-imageOverlayToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -11842,7 +11842,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -11905,7 +11905,7 @@ Ctrl + K"
             class="CardTitle-toolbar-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
               tabindex="0"
               type="button"
             >
@@ -12598,7 +12598,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -12634,7 +12634,7 @@ Ctrl + K"
                     class="ImageTile-imageOverlayToolbar-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -12741,7 +12741,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -12921,7 +12921,7 @@ Ctrl + K"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -12985,7 +12985,7 @@ Ctrl + K"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -13049,7 +13049,7 @@ Ctrl + K"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -13113,7 +13113,7 @@ Ctrl + K"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -13151,7 +13151,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -13681,7 +13681,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -13742,7 +13742,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -13943,7 +13943,7 @@ Ctrl + K"
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -13981,7 +13981,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -14678,7 +14678,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -14714,7 +14714,7 @@ Ctrl + K"
                     class="ImageTile-imageOverlayToolbar-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -14821,7 +14821,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -14989,7 +14989,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -15154,7 +15154,7 @@ exports[`Storyshots Views / Collections / Collection list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -15363,7 +15363,7 @@ exports[`Storyshots Views / Collections / Collection list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -15922,7 +15922,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -16016,7 +16016,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -16500,7 +16500,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -16594,7 +16594,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -17430,7 +17430,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -17483,7 +17483,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
               <button
                 aria-haspopup="true"
                 aria-label="More"
-                class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                 tabindex="0"
                 type="button"
               >
@@ -17553,7 +17553,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
             class="MuiCardActions-root-id CustomerAddress-actions-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -17564,7 +17564,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -17598,7 +17598,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
               <button
                 aria-haspopup="true"
                 aria-label="More"
-                class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                 tabindex="0"
                 type="button"
               >
@@ -17667,7 +17667,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
             class="MuiCardActions-root-id CustomerAddress-actions-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -17678,7 +17678,7 @@ exports[`Storyshots Views / Customers / Address Book default 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -17720,7 +17720,7 @@ exports[`Storyshots Views / Customers / Address Book loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -17772,7 +17772,7 @@ exports[`Storyshots Views / Customers / Address Book loading 1`] = `
               <button
                 aria-haspopup="true"
                 aria-label="More"
-                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id CardMenu-iconButton-id"
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id CardMenu-iconButton-id"
                 disabled=""
                 tabindex="-1"
                 type="button"
@@ -17822,7 +17822,7 @@ exports[`Storyshots Views / Customers / Address Book loading 1`] = `
             class="MuiCardActions-root-id CustomerAddress-actions-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id MuiCardActions-action-id"
               disabled=""
               tabindex="-1"
               type="button"
@@ -17834,7 +17834,7 @@ exports[`Storyshots Views / Customers / Address Book loading 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id MuiCardActions-action-id"
               disabled=""
               tabindex="-1"
               type="button"
@@ -17874,7 +17874,7 @@ exports[`Storyshots Views / Customers / Address Book no data 1`] = `
         This customer doesn’t have any adresses added to his address book. You can add address using the button below.
       </p>
       <button
-        class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id CustomerAddressListPage-addButton-id"
+        class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id CustomerAddressListPage-addButton-id"
         tabindex="0"
         type="button"
       >
@@ -19749,7 +19749,7 @@ exports[`Storyshots Views / Customers / Customer details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -19859,7 +19859,7 @@ exports[`Storyshots Views / Customers / Customer details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -20210,7 +20210,7 @@ exports[`Storyshots Views / Customers / Customer details different addresses 1`]
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -20320,7 +20320,7 @@ exports[`Storyshots Views / Customers / Customer details different addresses 1`]
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -20723,7 +20723,7 @@ exports[`Storyshots Views / Customers / Customer details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -20833,7 +20833,7 @@ exports[`Storyshots Views / Customers / Customer details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -21192,7 +21192,7 @@ exports[`Storyshots Views / Customers / Customer details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -21308,7 +21308,7 @@ exports[`Storyshots Views / Customers / Customer details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -21628,7 +21628,7 @@ exports[`Storyshots Views / Customers / Customer details never logged 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -21738,7 +21738,7 @@ exports[`Storyshots Views / Customers / Customer details never logged 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -22083,7 +22083,7 @@ exports[`Storyshots Views / Customers / Customer details never placed order 1`] 
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -22193,7 +22193,7 @@ exports[`Storyshots Views / Customers / Customer details never placed order 1`] 
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -22538,7 +22538,7 @@ exports[`Storyshots Views / Customers / Customer details no address at all 1`] =
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -22648,7 +22648,7 @@ exports[`Storyshots Views / Customers / Customer details no address at all 1`] =
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -22974,7 +22974,7 @@ exports[`Storyshots Views / Customers / Customer details no default billing addr
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -23084,7 +23084,7 @@ exports[`Storyshots Views / Customers / Customer details no default billing addr
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -23435,7 +23435,7 @@ exports[`Storyshots Views / Customers / Customer details no default shipping add
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -23545,7 +23545,7 @@ exports[`Storyshots Views / Customers / Customer details no default shipping add
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -23692,7 +23692,7 @@ exports[`Storyshots Views / Customers / Customer list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -24311,7 +24311,7 @@ exports[`Storyshots Views / Customers / Customer list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -24501,7 +24501,7 @@ exports[`Storyshots Views / Customers / Customer list no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -25540,7 +25540,7 @@ exports[`Storyshots Views / Discounts / Sale details collections 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -25689,7 +25689,7 @@ exports[`Storyshots Views / Discounts / Sale details collections 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -26037,7 +26037,7 @@ exports[`Storyshots Views / Discounts / Sale details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -26186,7 +26186,7 @@ exports[`Storyshots Views / Discounts / Sale details default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -26554,7 +26554,7 @@ exports[`Storyshots Views / Discounts / Sale details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -26703,7 +26703,7 @@ exports[`Storyshots Views / Discounts / Sale details form errors 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -27060,7 +27060,7 @@ exports[`Storyshots Views / Discounts / Sale details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -27219,7 +27219,7 @@ exports[`Storyshots Views / Discounts / Sale details loading 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -27583,7 +27583,7 @@ exports[`Storyshots Views / Discounts / Sale details products 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -27763,7 +27763,7 @@ exports[`Storyshots Views / Discounts / Sale details products 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -27827,7 +27827,7 @@ exports[`Storyshots Views / Discounts / Sale details products 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -27891,7 +27891,7 @@ exports[`Storyshots Views / Discounts / Sale details products 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -27955,7 +27955,7 @@ exports[`Storyshots Views / Discounts / Sale details products 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -28082,7 +28082,7 @@ exports[`Storyshots Views / Discounts / Sale list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -28401,7 +28401,7 @@ exports[`Storyshots Views / Discounts / Sale list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -28610,7 +28610,7 @@ exports[`Storyshots Views / Discounts / Sale list no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -31273,7 +31273,7 @@ exports[`Storyshots Views / Discounts / Voucher list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -31534,7 +31534,7 @@ exports[`Storyshots Views / Discounts / Voucher list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -31773,7 +31773,7 @@ exports[`Storyshots Views / Discounts / Voucher list no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -33447,7 +33447,7 @@ exports[`Storyshots Views / Not found error page default 1`] = `
         </div>
         <div>
           <button
-            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id NotFoundPage-button-id"
+            class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id NotFoundPage-button-id"
             tabindex="0"
             type="button"
           >
@@ -33488,7 +33488,7 @@ exports[`Storyshots Views / Orders / Draft order list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -34257,7 +34257,7 @@ exports[`Storyshots Views / Orders / Draft order list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -34468,7 +34468,7 @@ exports[`Storyshots Views / Orders / Draft order list when no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -35427,7 +35427,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -35579,7 +35579,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -35621,7 +35621,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -35735,7 +35735,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -35777,7 +35777,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -35891,7 +35891,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36045,7 +36045,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36056,7 +36056,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36067,7 +36067,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36078,7 +36078,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36284,7 +36284,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -36339,7 +36339,7 @@ exports[`Storyshots Views / Orders / Order details default 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -36420,7 +36420,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -36572,7 +36572,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36614,7 +36614,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -36728,7 +36728,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -36770,7 +36770,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -36884,7 +36884,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -37038,7 +37038,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -37049,7 +37049,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -37060,7 +37060,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -37071,7 +37071,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -37277,7 +37277,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -37332,7 +37332,7 @@ exports[`Storyshots Views / Orders / Order details fulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -37418,7 +37418,7 @@ exports[`Storyshots Views / Orders / Order details loading 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -37856,7 +37856,7 @@ exports[`Storyshots Views / Orders / Order details loading 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -37893,7 +37893,7 @@ exports[`Storyshots Views / Orders / Order details loading 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -37975,7 +37975,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -38127,7 +38127,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38169,7 +38169,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -38283,7 +38283,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38325,7 +38325,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -38439,7 +38439,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38593,7 +38593,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38604,7 +38604,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38615,7 +38615,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38626,7 +38626,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -38832,7 +38832,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -38887,7 +38887,7 @@ exports[`Storyshots Views / Orders / Order details no customer note 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -38968,7 +38968,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -39120,7 +39120,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39162,7 +39162,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -39276,7 +39276,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39318,7 +39318,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -39432,7 +39432,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39586,7 +39586,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39597,7 +39597,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39608,7 +39608,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39619,7 +39619,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -39825,7 +39825,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -39880,7 +39880,7 @@ exports[`Storyshots Views / Orders / Order details no payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -39961,7 +39961,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -40113,7 +40113,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40155,7 +40155,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -40269,7 +40269,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40311,7 +40311,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -40425,7 +40425,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40579,7 +40579,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40590,7 +40590,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40601,7 +40601,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40612,7 +40612,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -40818,7 +40818,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -40854,7 +40854,7 @@ exports[`Storyshots Views / Orders / Order details no shipping address 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -40954,7 +40954,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -41106,7 +41106,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41148,7 +41148,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -41262,7 +41262,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41304,7 +41304,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -41418,7 +41418,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41572,7 +41572,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41583,7 +41583,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41594,7 +41594,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41605,7 +41605,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -41811,7 +41811,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -41866,7 +41866,7 @@ exports[`Storyshots Views / Orders / Order details partially fulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -41947,7 +41947,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -42099,7 +42099,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42141,7 +42141,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -42255,7 +42255,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42297,7 +42297,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -42411,7 +42411,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42565,7 +42565,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42576,7 +42576,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42587,7 +42587,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42598,7 +42598,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -42804,7 +42804,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -42859,7 +42859,7 @@ exports[`Storyshots Views / Orders / Order details payment confirmed 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -42940,7 +42940,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -43092,7 +43092,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43134,7 +43134,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -43248,7 +43248,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43290,7 +43290,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -43404,7 +43404,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43558,7 +43558,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43569,7 +43569,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43580,7 +43580,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43591,7 +43591,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -43797,7 +43797,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -43852,7 +43852,7 @@ exports[`Storyshots Views / Orders / Order details payment error 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -43933,7 +43933,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -44085,7 +44085,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44127,7 +44127,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -44241,7 +44241,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44283,7 +44283,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -44397,7 +44397,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44551,7 +44551,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44562,7 +44562,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44573,7 +44573,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44584,7 +44584,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -44790,7 +44790,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -44845,7 +44845,7 @@ exports[`Storyshots Views / Orders / Order details pending payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -44926,7 +44926,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -45078,7 +45078,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45120,7 +45120,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -45234,7 +45234,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45276,7 +45276,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -45390,7 +45390,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45544,7 +45544,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45555,7 +45555,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45566,7 +45566,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45577,7 +45577,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -45783,7 +45783,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -45838,7 +45838,7 @@ exports[`Storyshots Views / Orders / Order details refunded payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -45919,7 +45919,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -46071,7 +46071,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46113,7 +46113,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -46227,7 +46227,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46269,7 +46269,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -46383,7 +46383,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46537,7 +46537,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46548,7 +46548,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46559,7 +46559,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46570,7 +46570,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -46776,7 +46776,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -46831,7 +46831,7 @@ exports[`Storyshots Views / Orders / Order details rejected payment 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -46912,7 +46912,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -47064,7 +47064,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47106,7 +47106,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -47220,7 +47220,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47262,7 +47262,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
                 <button
                   aria-haspopup="true"
                   aria-label="More"
-                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+                  class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
                   tabindex="0"
                   type="button"
                 >
@@ -47376,7 +47376,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47530,7 +47530,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
             class="MuiCardActions-root-id"
           >
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47541,7 +47541,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47552,7 +47552,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47563,7 +47563,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
               </span>
             </button>
             <button
-              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+              class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
               tabindex="0"
               type="button"
             >
@@ -47769,7 +47769,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -47824,7 +47824,7 @@ exports[`Storyshots Views / Orders / Order details unfulfilled 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -47905,7 +47905,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -47966,7 +47966,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -48100,7 +48100,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -48190,7 +48190,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -48363,7 +48363,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -48429,7 +48429,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -48465,7 +48465,7 @@ exports[`Storyshots Views / Orders / Order draft default 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -48517,7 +48517,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -48573,7 +48573,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -48672,7 +48672,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -48780,7 +48780,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -48846,7 +48846,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -48883,7 +48883,7 @@ exports[`Storyshots Views / Orders / Order draft loading 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -48931,7 +48931,7 @@ exports[`Storyshots Views / Orders / Order draft without lines 1`] = `
           <button
             aria-haspopup="true"
             aria-label="More"
-            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id CardMenu-iconButton-id"
+            class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id CardMenu-iconButton-id"
             tabindex="0"
             type="button"
           >
@@ -48992,7 +48992,7 @@ exports[`Storyshots Views / Orders / Order draft without lines 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -49137,7 +49137,7 @@ exports[`Storyshots Views / Orders / Order draft without lines 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -49203,7 +49203,7 @@ exports[`Storyshots Views / Orders / Order draft without lines 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -49239,7 +49239,7 @@ exports[`Storyshots Views / Orders / Order draft without lines 1`] = `
                 class="OrderCustomer-sectionHeaderToolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -49283,7 +49283,7 @@ exports[`Storyshots Views / Orders / Order list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -50502,7 +50502,7 @@ exports[`Storyshots Views / Orders / Order list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -50821,7 +50821,7 @@ exports[`Storyshots Views / Orders / Order list when no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -51090,7 +51090,7 @@ exports[`Storyshots Views / Orders / Order list with custom filters 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -52963,7 +52963,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -53698,7 +53698,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -54270,7 +54270,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -54472,7 +54472,7 @@ exports[`Storyshots Views / Pages / Page list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -54727,7 +54727,7 @@ exports[`Storyshots Views / Pages / Page list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -54923,7 +54923,7 @@ exports[`Storyshots Views / Pages / Page list no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -55597,7 +55597,7 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -55671,7 +55671,7 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -55714,7 +55714,7 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -55757,7 +55757,7 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -56050,7 +56050,7 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -56132,7 +56132,7 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                           focusable="false"
                           role="presentation"
                           viewBox="0 0 24 24"
@@ -56354,7 +56354,7 @@ exports[`Storyshots Views / Product types / Product types list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -56637,7 +56637,7 @@ exports[`Storyshots Views / Product types / Product types list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -57379,7 +57379,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -58259,7 +58259,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -60324,7 +60324,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -60610,7 +60610,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -60621,7 +60621,7 @@ Ctrl + K"
                   </span>
                 </button>
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -60747,7 +60747,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -61595,7 +61595,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -61826,7 +61826,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -62703,7 +62703,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -62901,7 +62901,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -62912,7 +62912,7 @@ Ctrl + K"
                   </span>
                 </button>
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -63038,7 +63038,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -64050,7 +64050,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -64416,7 +64416,7 @@ Ctrl + K"
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -65292,7 +65292,7 @@ exports[`Storyshots Views / Products / Product list default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -65943,7 +65943,7 @@ exports[`Storyshots Views / Products / Product list loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -66258,7 +66258,7 @@ exports[`Storyshots Views / Products / Product list no data 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -66515,7 +66515,7 @@ exports[`Storyshots Views / Products / Product list with custom filters 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -67557,7 +67557,7 @@ exports[`Storyshots Views / Products / Product variant details when loaded data 
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -67982,7 +67982,7 @@ exports[`Storyshots Views / Products / Product variant details when loading data
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                   disabled=""
                   tabindex="-1"
                   type="button"
@@ -68286,7 +68286,7 @@ exports[`Storyshots Views / Shipping / Create shipping zone default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -68456,7 +68456,7 @@ exports[`Storyshots Views / Shipping / Create shipping zone form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -68621,7 +68621,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -68708,7 +68708,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -68788,7 +68788,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -68817,7 +68817,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -68865,7 +68865,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -68894,7 +68894,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -68941,7 +68941,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -69021,7 +69021,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69050,7 +69050,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69098,7 +69098,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69127,7 +69127,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details default 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69257,7 +69257,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -69344,7 +69344,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -69424,7 +69424,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69453,7 +69453,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69501,7 +69501,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69530,7 +69530,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69577,7 +69577,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -69657,7 +69657,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69686,7 +69686,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69734,7 +69734,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69763,7 +69763,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details form errors 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                      class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                       tabindex="0"
                       type="button"
                     >
@@ -69893,7 +69893,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -69980,7 +69980,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -70072,7 +70072,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id"
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -70102,7 +70102,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id"
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -70150,7 +70150,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                 class="CardTitle-toolbar-id"
               >
                 <button
-                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                   tabindex="0"
                   type="button"
                 >
@@ -70242,7 +70242,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id"
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -70272,7 +70272,7 @@ exports[`Storyshots Views / Shipping / Shipping zone details loading 1`] = `
                     class="MuiTableCell-root-id MuiTableCell-body-id ShippingZoneRates-alignRight-id"
                   >
                     <button
-                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id"
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id"
                       disabled=""
                       tabindex="-1"
                       type="button"
@@ -70347,7 +70347,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -70487,7 +70487,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                     tabindex="0"
                     type="button"
                   >
@@ -70530,7 +70530,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                     tabindex="0"
                     type="button"
                   >
@@ -70573,7 +70573,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                     tabindex="0"
                     type="button"
                   >
@@ -70616,7 +70616,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                     tabindex="0"
                     type="button"
                   >
@@ -70659,7 +70659,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorSecondary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiIconButton-colorPrimary-id"
                     tabindex="0"
                     type="button"
                   >
@@ -70771,7 +70771,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list default 1`] = `
               class="MuiCardActions-root-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
                 tabindex="0"
                 type="button"
               >
@@ -70828,7 +70828,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list loading 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -70977,7 +70977,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list loading 1`] = `
                   class="MuiTableCell-root-id MuiTableCell-body-id ShippingZonesList-alignRight-id"
                 >
                   <button
-                    class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorSecondary-id MuiIconButton-disabled-id"
+                    class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiIconButton-root-id MuiIconButton-colorPrimary-id MuiIconButton-disabled-id"
                     disabled=""
                     tabindex="-1"
                     type="button"
@@ -71089,7 +71089,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list loading 1`] = `
               class="MuiCardActions-root-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
                 tabindex="0"
                 type="button"
               >
@@ -71146,7 +71146,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list no data 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -71365,7 +71365,7 @@ exports[`Storyshots Views / Shipping / Shipping zones list no data 1`] = `
               class="MuiCardActions-root-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
                 tabindex="0"
                 type="button"
               >
@@ -71537,7 +71537,7 @@ exports[`Storyshots Views / Site settings / Page default 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -71611,7 +71611,7 @@ exports[`Storyshots Views / Site settings / Page default 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -71795,7 +71795,7 @@ exports[`Storyshots Views / Site settings / Page form errors 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
                 tabindex="0"
                 type="button"
               >
@@ -71869,7 +71869,7 @@ exports[`Storyshots Views / Site settings / Page form errors 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -72051,7 +72051,7 @@ exports[`Storyshots Views / Site settings / Page loading 1`] = `
               class="CardTitle-toolbar-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id"
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id"
                 disabled=""
                 tabindex="-1"
                 type="button"
@@ -72134,7 +72134,7 @@ exports[`Storyshots Views / Site settings / Page loading 1`] = `
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root-id MuiSvgIcon-colorSecondary-id"
+                        class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
                         focusable="false"
                         role="presentation"
                         viewBox="0 0 24 24"
@@ -73825,7 +73825,7 @@ exports[`Storyshots Views / Staff / Staff members default 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id"
+          class="MuiButtonBase-root-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id"
           tabindex="0"
           type="button"
         >
@@ -74366,7 +74366,7 @@ exports[`Storyshots Views / Staff / Staff members when loading 1`] = `
         class="ExtendedPageHeader-action-id"
       >
         <button
-          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedSecondary-id MuiButton-raised-id MuiButton-raisedSecondary-id MuiButton-disabled-id"
+          class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-contained-id MuiButton-containedPrimary-id MuiButton-raised-id MuiButton-raisedPrimary-id MuiButton-disabled-id"
           disabled=""
           tabindex="-1"
           type="button"
@@ -75288,7 +75288,7 @@ exports[`Storyshots Views / Taxes / Country List default 1`] = `
               class="MuiCardActions-root-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiCardActions-action-id"
+                class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiCardActions-action-id"
                 tabindex="0"
                 type="button"
               >
@@ -75551,7 +75551,7 @@ exports[`Storyshots Views / Taxes / Country List loading 1`] = `
               class="MuiCardActions-root-id"
             >
               <button
-                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textSecondary-id MuiButton-flat-id MuiButton-flatSecondary-id MuiButton-disabled-id MuiCardActions-action-id"
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id MuiButton-disabled-id MuiCardActions-action-id"
                 disabled=""
                 tabindex="-1"
                 type="button"

--- a/saleor/static/dashboard-next/taxes/components/TaxConfiguration/TaxConfiguration.tsx
+++ b/saleor/static/dashboard-next/taxes/components/TaxConfiguration/TaxConfiguration.tsx
@@ -67,7 +67,7 @@ export const TaxConfiguration = withStyles(styles, {
           disabled={disabled}
           onClick={onTaxFetch}
           variant="flat"
-          color="secondary"
+          color="primary"
         >
           {i18n.t("Fetch taxes")}
         </Button>


### PR DESCRIPTION
I want to merge this change because it adds (currently unused) secondary color. 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
