### PR TITLE
Drop support for Django 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     - DATABASE_URL="postgres://postgres@localhost:5432/saleor"
     - SECRET_KEY="irrelevant"
   matrix:
-  - DJANGO="1.11"
   - DJANGO="2.2"
   - DJANGO="master"
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Prevent user from changing his own status and permissions - #3922 by @dominik-zeglen
 - Support for digital product - #3868 by @korycins
 - Add translation interface - #3884 by @dominik-zeglen
+- Drop support for Django 2.1 and Django 1.11 (previous LTS)
 
 
 ## 2.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37}-django{111,22,_master}
+envlist = py{35,36,37}-django{22,_master}
 skipsdist = True
 
 [testenv]
@@ -10,7 +10,6 @@ deps =
     -rrequirements.txt
     -rrequirements_dev.txt
 commands =
-    django111: pip install "django>=1.11a1,<1.12" --upgrade --pre
     django22: pip install "django>=2.2a1,<2.3" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput --verbosity=0
@@ -26,6 +25,5 @@ unignore_outcomes = True
 
 [travis:env]
 DJANGO =
-    1.11: django111
     2.2: django22
     master: django_master


### PR DESCRIPTION
Our policy is "latest stable and latest LTS" which means we no longer support
Django 1.11.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
