### PR TITLE
Use py instead of python for windows

### DIFF
--- a/docs/gettingstarted/installation-windows.rst
+++ b/docs/gettingstarted/installation-windows.rst
@@ -17,6 +17,9 @@ Download the latest **3.7** Windows installer from the `Python download page <ht
 
 Make sure that "**Add Python 3.7 to PATH**" is checked.
 
+.. code-block:: powershell
+py --version
+
 
 Node.js
 ~~~~~~~
@@ -73,7 +76,7 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    python -m pip install -r requirements.txt
+    py -m pip install -r requirements.txt
 
 
 #. Set ``SECRET_KEY`` environment variable.
@@ -110,7 +113,7 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    python manage.py migrate
+    py manage.py migrate
 
    .. warning::
 
@@ -142,4 +145,4 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    python manage.py runserver
+    py manage.py runserver

--- a/docs/gettingstarted/installation-windows.rst
+++ b/docs/gettingstarted/installation-windows.rst
@@ -13,12 +13,13 @@ Before you are ready to run Saleor you will need additional software installed o
 Python
 ~~~~~~
 
-Download the latest **3.7** Windows installer from the `Python download page <https://www.python.org/downloads/>`_ and follow the instructions.
+#.  You can install the `Official Python 3.7 App <https://www.microsoft.com/en-us/p/python-37/9nj46sx7x90p>`__ from the microsoft store
 
-Make sure that "**Add Python 3.7 to PATH**" is checked.
+#. Download the latest **3.7** Windows installer from the `Python download page <https://www.python.org/downloads/>`_ and follow the instructions.
 
 .. code-block:: powershell
-py --version
+  
+  (Get-Command py).Version
 
 
 Node.js

--- a/docs/gettingstarted/installation-windows.rst
+++ b/docs/gettingstarted/installation-windows.rst
@@ -77,7 +77,9 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    py -m pip install -r requirements.txt
+    py -m virtualenv . 
+    .\scripts\activate
+    pip install -r requirements.txt
 
 
 #. Set ``SECRET_KEY`` environment variable.
@@ -114,7 +116,7 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    py manage.py migrate
+    python manage.py migrate
 
    .. warning::
 
@@ -146,4 +148,4 @@ All commands need to be performed in either PowerShell or a Command Shell.
 
    .. code-block:: powershell
 
-    py manage.py runserver
+    python manage.py runserver


### PR DESCRIPTION
I want to merge this change because...

```py``` is the python launcher for Windows. Read [PEP 397](https://www.python.org/dev/peps/pep-0397/) for more information.

```powershell
py install setup.py   # verbose option: py -3.x install setup.py
```

is more reproducible than using the PATH:

```powershell
$env::python install setup.py  # uses the python interpreter that has the highest priority 
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
