### PR TITLE
Add indent setting useful for pycharm users

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ trim_trailing_whitespace = true
 
 [*.py]
 indent_size = 4
+continuation_indent_size = 8
 combine_as_imports = true
 max_line_length = 79
 multi_line_output = 4


### PR DESCRIPTION
I found out that `.editorconfig` overwrites pycharm setting while formatting code and results in the following:
from 
```
def test_delete_draft_orders(
        staff_api_client, order_list, permission_manage_orders):
```
to
```
def test_delete_draft_orders(
    staff_api_client, order_list, permission_manage_orders):
```
Which is not convention we use.
This little change fixes it, so Pycharm users are happy again.

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
