### PR TITLE
Refactor the account avatars path from a relative to absolute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop support for Django 2.1 and Django 1.11 (previous LTS)
 - Fix variants for juices in example data - #3926 by @michaljelonek
 - Fix logo in docs - #3928 by @michaljelonek
+- Refactor the account avatars path from a relative to absolute - #3938 by @NyanKiyoshi
 
 
 ## 2.4.0

--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -1,9 +1,14 @@
 import os
+import os.path
 import random
 
+from django.conf import settings
 from django.core.files import File
 
 from ..checkout import AddressType
+
+AVATARS_PATH = os.path.join(
+    settings.PROJECT_ROOT, 'saleor', 'static', 'images', 'avatars')
 
 
 def store_user_address(user, address, address_type):
@@ -61,7 +66,6 @@ def get_user_last_name(user):
 
 def get_random_avatar():
     """Return random avatar picked from a pool of static avatars."""
-    avatars_dir = 'saleor/static/images/avatars/'
-    avatar_name = random.choice(os.listdir(avatars_dir))
-    avatar_path = os.path.join(avatars_dir, avatar_name)
+    avatar_name = random.choice(os.listdir(AVATARS_PATH))
+    avatar_path = os.path.join(AVATARS_PATH, avatar_name)
     return File(open(avatar_path, 'rb'), name=avatar_name)


### PR DESCRIPTION
If we were to run saleor or tests in a different working directory than the saleor project, it would trigger "access denied" errors as saleor would look for avatars in the wrong location. To fix that, I refactored the relative path to an absolute one.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
