### PR TITLE
Use only_fields instead of exclude_fields in gql api

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -10,7 +10,7 @@ from ...core.permissions import get_permissions
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
 from ..core.fields import PrefetchingConnectionField
-from ..core.types import Image, CountryDisplay, PermissionDisplay
+from ..core.types import CountryDisplay, Image, PermissionDisplay
 from ..utils import format_permissions_for_display
 
 
@@ -39,10 +39,13 @@ class Address(CountableDjangoObjectType):
         description='Address is user\'s default billing address')
 
     class Meta:
-        exclude_fields = ['user_set', 'user_addresses']
         description = 'Represents user address data.'
         interfaces = [relay.Node]
         model = models.Address
+        only_fields = [
+            'city', 'city_area', 'company_name', 'country', 'country_area',
+            'first_name', 'id', 'last_name', 'phone', 'postal_code',
+            'street_address_1', 'street_address_2']
 
     def resolve_country(self, info):
         return CountryDisplay(
@@ -100,11 +103,14 @@ class User(CountableDjangoObjectType):
         Image, size=graphene.Int(description='Size of the avatar.'))
 
     class Meta:
-        exclude_fields = [
-            'carts', 'password', 'is_superuser', 'OrderEvent_set']
         description = 'Represents user data.'
         interfaces = [relay.Node]
         model = get_user_model()
+        only_fields = [
+            'date_joined', 'default_billing_address',
+            'default_shipping_address', 'email', 'first_name', 'id',
+            'is_active', 'is_staff', 'last_login', 'last_name', 'note',
+            'token']
 
     def resolve_addresses(self, info, **kwargs):
         return self.addresses.annotate_default(self).all()

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -20,7 +20,7 @@ class CheckoutLine(CountableDjangoObjectType):
         description='Indicates whether the item need to be delivered.')
 
     class Meta:
-        exclude_fields = ['cart', 'data']
+        only_fields = ['id', 'quantity', 'variant']
         description = 'Represents an item in the checkout.'
         interfaces = [graphene.relay.Node]
         model = models.CartLine
@@ -65,7 +65,11 @@ class Checkout(CountableDjangoObjectType):
             'shipping costs, and discounts included.'))
 
     class Meta:
-        exclude_fields = ['payments']
+        only_fields = [
+            'billing_address', 'created', 'discount_amount', 'discount_name',
+            'is_shipping_required', 'last_change', 'note', 'quantity',
+            'shipping_address', 'shipping_method', 'token',
+            'translated_discount_name', 'user', 'voucher_code']
         description = 'Checkout object'
         model = models.Cart
         interfaces = [graphene.relay.Node]

--- a/saleor/graphql/discount/types.py
+++ b/saleor/graphql/discount/types.py
@@ -44,9 +44,9 @@ class Sale(CountableDjangoObjectType):
         description = dedent("""
         Sales allow creating discounts for categories, collections or
         products and are visible to all the customers.""")
-        exclude_fields = ['translations']
         interfaces = [relay.Node]
         model = models.Sale
+        only_fields = ['end_date', 'id', 'name', 'start_date', 'type', 'value']
 
     def resolve_categories(self, info, **kwargs):
         return self.categories.all()
@@ -92,7 +92,10 @@ class Voucher(CountableDjangoObjectType):
         Vouchers allow giving discounts to particular customers on categories,
         collections or specific products. They can be used during checkout by
         providing valid voucher codes.""")
-        exclude_fields = ['translations']
+        only_fields = [
+            'apply_once_per_order', 'code', 'discount_value',
+            'discount_value_type', 'end_date', 'id', 'min_amount_spent',
+            'name', 'start_date', 'type', 'usage_limit', 'used']
         interfaces = [relay.Node]
         model = models.Voucher
 

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -31,7 +31,7 @@ class Menu(CountableDjangoObjectType):
         description = dedent("""Represents a single menu - an object that is used
         to help navigate through the store.""")
         interfaces = [relay.Node]
-        exclude_fields = ['json_content']
+        only_fields = ['id', 'name']
         model = models.Menu
 
     def resolve_items(self, info, **kwargs):
@@ -59,8 +59,9 @@ class MenuItem(CountableDjangoObjectType):
         description = dedent("""Represents a single item of the related menu.
         Can store categories, collection or pages.""")
         interfaces = [relay.Node]
-        exclude_fields = [
-            'sort_order', 'lft', 'rght', 'tree_id', 'translations']
+        only_fields = [
+            'category', 'collection', 'id', 'level', 'menu', 'name', 'page',
+            'parent']
         model = models.MenuItem
 
     def resolve_children(self, info, **kwargs):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -42,7 +42,7 @@ class OrderEvent(CountableDjangoObjectType):
         description = 'History log of the order.'
         model = models.OrderEvent
         interfaces = [relay.Node]
-        exclude_fields = ['order', 'parameters']
+        only_fields = ['id']
 
     def resolve_email(self, info):
         return self.parameters.get('email', None)
@@ -78,7 +78,7 @@ class FulfillmentLine(CountableDjangoObjectType):
         description = 'Represents line of the fulfillment.'
         interfaces = [relay.Node]
         model = models.FulfillmentLine
-        exclude_fields = ['fulfillment']
+        only_fields = ['id', 'quantity']
 
     @gql_optimizer.resolver_hints(prefetch_related='order_line')
     def resolve_order_line(self, info):
@@ -98,7 +98,9 @@ class Fulfillment(CountableDjangoObjectType):
         description = 'Represents order fulfillment.'
         interfaces = [relay.Node]
         model = models.Fulfillment
-        exclude_fields = ['order']
+        only_fields = [
+            'fulfillment_order', 'id', 'shipping_date', 'status',
+            'tracking_number']
 
     def resolve_lines(self, info):
         return self.lines.all()
@@ -129,8 +131,10 @@ class OrderLine(CountableDjangoObjectType):
         description = 'Represents order line of particular order.'
         model = models.OrderLine
         interfaces = [relay.Node]
-        exclude_fields = [
-            'order', 'unit_price_gross', 'unit_price_net']
+        only_fields = [
+            'digital_content_url', 'id', 'is_shipping_required',
+            'product_name', 'product_sku', 'quantity', 'quantity_fulfilled',
+            'tax_rate', 'translated_product_name']
 
     @gql_optimizer.resolver_hints(
         prefetch_related=['variant__images', 'variant__product__images'])
@@ -218,17 +222,17 @@ class Order(CountableDjangoObjectType):
     is_shipping_required = graphene.Boolean(
         description='Returns True, if order requires shipping.',
         required=True)
-    lines = graphene.List(
-        OrderLine, required=True,
-        description='List of order lines for the order')
 
     class Meta:
         description = 'Represents an order in the shop.'
         interfaces = [relay.Node]
         model = models.Order
-        exclude_fields = [
-            'checkout_token', 'shipping_price_gross', 'shipping_price_net',
-            'total_gross', 'total_net']
+        only_fields = [
+            'billing_address', 'created', 'customer_note', 'discount_amount',
+            'discount_name', 'display_gross_prices', 'id', 'language_code',
+            'shipping_address', 'shipping_method', 'shipping_method_name',
+            'shipping_price', 'status', 'token', 'tracking_client_id',
+            'translated_discount_name', 'user', 'voucher', 'weight']
 
     @staticmethod
     def resolve_shipping_price(self, info):

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -30,8 +30,10 @@ class Page(CountableDjangoObjectType):
     class Meta:
         description = dedent("""A static page that can be manually added by a shop
         operator through the dashboard.""")
-        exclude_fields = [
-            'voucher_set', 'sale_set', 'menuitem_set', 'translations']
+        only_fields = [
+            'content', 'content_json', 'created', 'id', 'is_published',
+            'publication_date', 'seo_description', 'seo_title', 'slug',
+            'title']
         interfaces = [relay.Node]
         model = models.Page
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -19,7 +19,9 @@ class Transaction(CountableDjangoObjectType):
         interfaces = [relay.Node]
         model = models.Transaction
         filter_fields = ['id']
-        exclude_fields = ['currency']
+        only_fields = [
+            'id', 'created', 'payment', 'token', 'kind', 'is_success',
+            'error', 'gateway_response']
 
     def resolve_amount(self, info):
         return self.get_amount()
@@ -70,11 +72,10 @@ class Payment(CountableDjangoObjectType):
         interfaces = [relay.Node]
         model = models.Payment
         filter_fields = ['id']
-        exclude_fields = [
-            'billing_first_name', 'billing_last_name', 'billing_company_name',
-            'billing_address_1', 'billing_address_2', 'billing_city',
-            'billing_postal_code', 'billing_country_code',
-            'billing_country_area', 'currency', 'billing_city_area']
+        only_fields = [
+            'id', 'gateway', 'is_active', 'created', 'modified', 'token',
+            'checkout', 'order', 'billing_email', 'customer_ip_address',
+            'extra_data']
 
     @gql_optimizer.resolver_hints(prefetch_related='transactions')
     def resolve_actions(self, info):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -85,7 +85,7 @@ class AttributeValue(CountableDjangoObjectType):
 
     class Meta:
         description = 'Represents a value of an attribute.'
-        exclude_fields = ['attribute', 'translations']
+        only_fields = ['id', 'sort_order']
         interfaces = [relay.Node]
         model = models.AttributeValue
 
@@ -114,7 +114,7 @@ class Attribute(CountableDjangoObjectType):
     class Meta:
         description = dedent("""Custom attribute of a product. Attributes can be
         assigned to products and variants at the product type level.""")
-        exclude_fields = ['translations']
+        only_fields = ['id', 'product_type', 'product_variant_type']
         interfaces = [relay.Node]
         model = models.Attribute
 
@@ -144,7 +144,7 @@ class DigitalContentUrl(CountableDjangoObjectType):
 
     class Meta:
         model = models.DigitalContentUrl
-        only_fields = ['token', 'content', 'created', 'download_num', 'url']
+        only_fields = ['content', 'created', 'download_num', 'token', 'url']
         interfaces = (relay.Node,)
 
     def resolve_url(self, info):
@@ -161,9 +161,9 @@ class DigitalContent(CountableDjangoObjectType):
     class Meta:
         model = models.DigitalContent
         only_fields = [
-            'urls', 'content_file', 'use_default_settings',
-            'automatic_fulfillment', 'product_variant', 'max_downloads',
-            'url_valid_days', ]
+            'automatic_fulfillment', 'content_file', 'max_downloads',
+            'product_variant', 'url_valid_days', 'urls',
+            'use_default_settings']
         interfaces = (relay.Node,)
 
     def resolve_urls(self, info, **kwargs):
@@ -224,7 +224,9 @@ class ProductVariant(CountableDjangoObjectType):
     class Meta:
         description = dedent("""Represents a version of a product such as
         different size or color.""")
-        exclude_fields = ['order_lines', 'variant_images', 'translations']
+        only_fields = [
+            'id', 'name', 'product', 'quantity', 'quantity_allocated', 'sku',
+            'track_inventory', 'weight']
         interfaces = [relay.Node]
         model = models.ProductVariant
 
@@ -362,7 +364,10 @@ class Product(CountableDjangoObjectType):
         storefront.""")
         interfaces = [relay.Node]
         model = models.Product
-        exclude_fields = ['voucher_set', 'sale_set', 'translations']
+        only_fields = [
+            'category', 'charge_taxes', 'description', 'description_json',
+            'id', 'is_published', 'name', 'product_type', 'publication_date',
+            'seo_description', 'seo_title', 'updated_at', 'weight']
 
     @gql_optimizer.resolver_hints(prefetch_related='images')
     def resolve_thumbnail_url(self, info, *, size=None):
@@ -478,6 +483,9 @@ class ProductType(CountableDjangoObjectType):
         attributes are available to products of this type.""")
         interfaces = [relay.Node]
         model = models.ProductType
+        only_fields = [
+            'has_variants', 'id', 'is_digital', 'is_shipping_required', 'name',
+            'weight']
 
     def resolve_product_attributes(self, info, **kwargs):
         return self.product_attributes.all()
@@ -515,9 +523,9 @@ class Collection(CountableDjangoObjectType):
 
     class Meta:
         description = "Represents a collection of products."
-        exclude_fields = [
-            'voucher_set', 'sale_set', 'menuitem_set', 'background_image_alt',
-            'translations']
+        only_fields = [
+            'description', 'description_json', 'id', 'is_published', 'name',
+            'publication_date', 'seo_description', 'seo_title', 'slug']
         interfaces = [relay.Node]
         model = models.Collection
 
@@ -581,9 +589,9 @@ class Category(CountableDjangoObjectType):
         description = dedent("""Represents a single category of products.
         Categories allow to organize products in a tree-hierarchies which can
         be used for navigation in the storefront.""")
-        exclude_fields = [
-            'lft', 'rght', 'tree_id', 'voucher_set', 'sale_set',
-            'menuitem_set', 'background_image_alt', 'translations']
+        only_fields = [
+            'description', 'description_json', 'id', 'level', 'name', 'parent',
+            'seo_description', 'seo_title', 'slug']
         interfaces = [relay.Node]
         model = models.Category
 
@@ -630,9 +638,7 @@ class ProductImage(CountableDjangoObjectType):
 
     class Meta:
         description = 'Represents a product image.'
-        exclude_fields = [
-            'image', 'product', 'ppoi', 'productvariant_set',
-            'variant_images']
+        only_fields = ['alt', 'id', 'sort_order']
         interfaces = [relay.Node]
         model = models.ProductImage
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -95,10 +95,10 @@ type AssignNavigation {
 
 type Attribute implements Node {
   id: ID!
-  slug: String
-  name: String
   productType: ProductType
   productVariantType: ProductType
+  name: String
+  slug: String
   values: [AttributeValue]
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
 }
@@ -170,9 +170,9 @@ type AttributeValue implements Node {
   id: ID!
   sortOrder: Int!
   name: String
-  value: String
   slug: String
   type: AttributeValueType
+  value: String
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
 }
 
@@ -269,12 +269,12 @@ type Category implements Node {
   description: String!
   descriptionJson: JSONString!
   parent: Category
-  backgroundImage(size: Int): Image
   level: Int!
-  children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String
+  children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
 }
 
@@ -338,7 +338,6 @@ type Checkout implements Node {
   created: DateTime!
   lastChange: DateTime!
   user: User
-  email: String!
   token: UUID!
   quantity: Int!
   billingAddress: Address
@@ -349,11 +348,12 @@ type Checkout implements Node {
   discountName: String
   translatedDiscountName: String
   voucherCode: String
-  lines: [CheckoutLine]
   id: ID!
   availableShippingMethods: [ShippingMethod]!
   availablePaymentGateways: [GatewaysEnum]!
+  email: String!
   isShippingRequired: Boolean!
+  lines: [CheckoutLine]
   shippingPrice: TaxedMoney
   subtotalPrice: TaxedMoney
   totalPrice: TaxedMoney
@@ -480,10 +480,10 @@ type Collection implements Node {
   id: ID!
   name: String!
   slug: String!
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  backgroundImage(size: Int): Image
   description: String!
   descriptionJson: JSONString!
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  backgroundImage(size: Int): Image
   publishedDate: Date @deprecated(reason: "publishedDate is deprecated, use publicationDate instead")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
 }
@@ -839,8 +839,8 @@ input FulfillmentCreateInput {
 
 type FulfillmentLine implements Node {
   id: ID!
-  orderLine: OrderLine
   quantity: Int!
+  orderLine: OrderLine
 }
 
 input FulfillmentLineInput {
@@ -943,8 +943,8 @@ type Margin {
 type Menu implements Node {
   id: ID!
   name: String!
-  items: [MenuItem]
   children: [MenuItem]!
+  items: [MenuItem]
 }
 
 type MenuBulkDelete {
@@ -987,12 +987,12 @@ type MenuItem implements Node {
   menu: Menu!
   name: String!
   parent: MenuItem
-  url: String
   category: Category
   collection: Collection
   page: Page
   level: Int!
   children: [MenuItem]
+  url: String
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
 }
 
@@ -1253,12 +1253,10 @@ type Order implements Node {
   trackingClientId: String!
   billingAddress: Address
   shippingAddress: Address
-  userEmail: String
   shippingMethod: ShippingMethod
   shippingPrice: TaxedMoney
   shippingMethodName: String
   token: String!
-  total: TaxedMoney
   voucher: Voucher
   discountAmount: Money
   discountName: String!
@@ -1266,22 +1264,24 @@ type Order implements Node {
   displayGrossPrices: Boolean!
   customerNote: String!
   weight: Weight
-  lines: [OrderLine]!
   fulfillments: [Fulfillment]!
-  events: [OrderEvent]
-  payments: [Payment]
+  lines: [OrderLine]!
   actions: [OrderAction]!
   availableShippingMethods: [ShippingMethod]
   number: String
   isPaid: Boolean
   paymentStatus: PaymentChargeStatusEnum
   paymentStatusDisplay: String
+  payments: [Payment]
+  total: TaxedMoney
   subtotal: TaxedMoney
   statusDisplay: String
   canFinalize: Boolean!
   totalAuthorized: Money
   totalCaptured: Money
+  events: [OrderEvent]
   totalBalance: Money!
+  userEmail: String
   isShippingRequired: Boolean!
 }
 
@@ -1383,18 +1383,18 @@ enum OrderEventsEmails {
 
 type OrderLine implements Node {
   id: ID!
-  variant: ProductVariant
   productName: String!
   translatedProductName: String!
   productSku: String!
   isShippingRequired: Boolean!
   quantity: Int!
   quantityFulfilled: Int!
-  unitPrice: TaxedMoney
   taxRate: Float!
   digitalContentUrl: DigitalContentUrl
   thumbnailUrl(size: Int): String @deprecated(reason: "thumbnailUrl is deprecated, use thumbnail instead")
   thumbnail(size: Int): Image
+  unitPrice: TaxedMoney
+  variant: ProductVariant
 }
 
 input OrderLineCreateInput {
@@ -1551,23 +1551,18 @@ type Payment implements Node {
   isActive: Boolean!
   created: DateTime!
   modified: DateTime!
-  chargeStatus: PaymentChargeStatusEnum!
   token: String!
-  total: Money
-  capturedAmount: Money
   checkout: Checkout
   order: Order
   billingEmail: String!
-  ccFirstDigits: String!
-  ccLastDigits: String!
-  ccBrand: String!
-  ccExpMonth: Int
-  ccExpYear: Int
   customerIpAddress: String
   extraData: String!
-  transactions: [Transaction]
+  chargeStatus: PaymentChargeStatusEnum!
   actions: [OrderAction]!
+  total: Money
+  capturedAmount: Money
   billingAddress: Address
+  transactions: [Transaction]
   availableCaptureAmount: Money
   availableRefundAmount: Money
   creditCard: CreditCard
@@ -1644,22 +1639,22 @@ type Product implements Node {
   description: String!
   descriptionJson: JSONString!
   category: Category!
-  price: Money
-  attributes: [SelectedAttribute!]!
   updatedAt: DateTime
   chargeTaxes: Boolean!
-  taxRate: TaxRateType
   weight: Weight
-  variants: [ProductVariant]
-  images: [ProductImage]
-  collections: [Collection]
   url: String!
   thumbnailUrl(size: Int): String @deprecated(reason: "thumbnailUrl is deprecated, use\\n         thumbnail instead")
   thumbnail(size: Int): Image
   availability: ProductAvailability
+  price: Money
+  taxRate: TaxRateType
+  attributes: [SelectedAttribute!]!
   purchaseCost: MoneyRange
   margin: Margin
   imageById(id: ID): ProductImage
+  variants: [ProductVariant]
+  images: [ProductImage]
+  collections: [Collection]
   availableOn: Date @deprecated(reason: "availableOn is deprecated, use publicationDate instead")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
 }
@@ -1817,11 +1812,11 @@ type ProductType implements Node {
   hasVariants: Boolean!
   isShippingRequired: Boolean!
   isDigital: Boolean!
-  taxRate: TaxRateType
   weight: Weight
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  productAttributes: [Attribute]
+  taxRate: TaxRateType
   variantAttributes: [Attribute]
+  productAttributes: [Attribute]
 }
 
 type ProductTypeBulkDelete {
@@ -1875,22 +1870,22 @@ type ProductVariant implements Node {
   id: ID!
   sku: String!
   name: String!
-  priceOverride: Money
   product: Product!
-  attributes: [SelectedAttribute!]!
-  images: [ProductImage]
   trackInventory: Boolean!
   quantity: Int!
   quantityAllocated: Int!
-  costPrice: Money
   weight: Weight
-  digitalContent: DigitalContent
   stockQuantity: Int!
+  priceOverride: Money
   price: Money
+  attributes: [SelectedAttribute!]!
+  costPrice: Money
   margin: Int
   quantityOrdered: Int
   revenue(period: ReportingPeriod): TaxedMoney
+  images: [ProductImage]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
+  digitalContent: DigitalContent
 }
 
 type ProductVariantBulkDelete {
@@ -2026,11 +2021,11 @@ type Sale implements Node {
   name: String!
   type: SaleType!
   value: Float!
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   startDate: Date!
   endDate: Date
+  categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
 }
 
@@ -2125,12 +2120,12 @@ input SetPasswordInput {
 type ShippingMethod implements Node {
   id: ID!
   name: String!
-  type: ShippingMethodTypeEnum
   price: Money
   minimumOrderPrice: Money
   maximumOrderPrice: Money
   minimumOrderWeight: Weight
   maximumOrderWeight: Weight
+  type: ShippingMethodTypeEnum
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
 }
 
@@ -2187,10 +2182,10 @@ type ShippingPriceUpdate {
 type ShippingZone implements Node {
   id: ID!
   name: String!
-  countries: [CountryDisplay]
   default: Boolean!
-  shippingMethods: [ShippingMethod]
   priceRange: MoneyRange
+  countries: [CountryDisplay]
+  shippingMethods: [ShippingMethod]
 }
 
 type ShippingZoneBulkDelete {
@@ -2398,9 +2393,9 @@ type Transaction implements Node {
   token: String!
   kind: TransactionKind!
   isSuccess: Boolean!
-  amount: Money
   error: TransactionError
   gatewayResponse: JSONString!
+  amount: Money
 }
 
 enum TransactionError {
@@ -2469,7 +2464,6 @@ type User implements Node {
   email: String!
   firstName: String!
   lastName: String!
-  addresses: [Address]
   isStaff: Boolean!
   token: UUID!
   isActive: Boolean!
@@ -2477,10 +2471,11 @@ type User implements Node {
   dateJoined: DateTime!
   defaultShippingAddress: Address
   defaultBillingAddress: Address
-  avatar(size: Int): Image
-  orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  addresses: [Address]
   checkout: Checkout
+  orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
   permissions: [PermissionDisplay]
+  avatar(size: Int): Image
 }
 
 input UserAddressInput {
@@ -2555,11 +2550,11 @@ type Voucher implements Node {
   applyOncePerOrder: Boolean!
   discountValueType: VoucherDiscountValueType!
   discountValue: Float!
-  countries: [CountryDisplay]
   minAmountSpent: Money
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  countries: [CountryDisplay]
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
 }
 

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -33,7 +33,9 @@ class ShippingMethod(CountableDjangoObjectType):
             They are directly exposed to the customers.""")
         model = models.ShippingMethod
         interfaces = [relay.Node]
-        exclude_fields = ['carts', 'shipping_zone', 'orders', 'translations']
+        only_fields = [
+            'id', 'maximum_order_price', 'maximum_order_weight',
+            'minimum_order_price', 'minimum_order_weight', 'name', 'price']
 
 
 class ShippingZone(CountableDjangoObjectType):
@@ -57,6 +59,7 @@ class ShippingZone(CountableDjangoObjectType):
             and are never exposed to the customers directly.""")
         model = models.ShippingZone
         interfaces = [relay.Node]
+        only_fields = ['default', 'id', 'name']
 
     def resolve_price_range(self, info):
         return self.price_range

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -8,8 +8,8 @@ from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ...site import models as site_models
 from ..core.connection import CountableDjangoObjectType
-from ..core.utils import str_to_enum
 from ..core.types import LanguageDisplay
+from ..core.utils import str_to_enum
 from .enums import LanguageCodeEnum
 
 
@@ -27,88 +27,98 @@ class BaseTranslationType(CountableDjangoObjectType):
                 if language[0] == self.language_code)
         except StopIteration:
             return None
-        return LanguageDisplay(code=LanguageCodeEnum[str_to_enum(self.language_code)], language=language)
+        return LanguageDisplay(
+            code=LanguageCodeEnum[str_to_enum(self.language_code)],
+            language=language)
 
 
 class AttributeValueTranslation(BaseTranslationType):
     class Meta:
         model = product_models.AttributeValueTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['attribute_value', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class AttributeTranslation(BaseTranslationType):
     class Meta:
         model = product_models.AttributeTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['attribute', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class ProductVariantTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductVariantTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['product_variant', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class ProductTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['product', 'language_code']
+        only_fields = [
+            'description', 'description_json', 'id', 'name', 'seo_title',
+            'seo_description']
 
 
 class CollectionTranslation(BaseTranslationType):
     class Meta:
         model = product_models.CollectionTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['collection', 'language_code']
+        only_fields = [
+            'description', 'description_json', 'id', 'name', 'seo_title',
+            'seo_description']
 
 
 class CategoryTranslation(BaseTranslationType):
     class Meta:
         model = product_models.CategoryTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['category', 'language_code']
+        only_fields = [
+            'description', 'description_json', 'id', 'name', 'seo_title',
+            'seo_description']
 
 
 class PageTranslation(BaseTranslationType):
     class Meta:
         model = page_models.PageTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['page', 'language_code']
+        only_fields = [
+            'content', 'content_json', 'id', 'seo_description', 'seo_title',
+            'title']
 
 
 class VoucherTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.VoucherTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['voucher', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class SaleTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.SaleTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['sale', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class ShopTranslation(BaseTranslationType):
     class Meta:
         model = site_models.SiteSettingsTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['site_settings', 'language_code']
+        only_fields = ['description', 'header_text', 'id']
 
 
 class MenuItemTranslation(BaseTranslationType):
     class Meta:
         model = menu_models.MenuItemTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['menu_item', 'language_code']
+        only_fields = ['id', 'name']
 
 
 class ShippingMethodTranslation(BaseTranslationType):
     class Meta:
         model = shipping_models.ShippingMethodTranslation
         interfaces = [graphene.relay.Node]
-        exclude_fields = ['shipping_method', 'language_code']
+        only_fields = ['id', 'name']


### PR DESCRIPTION
Resolves #3874.

- removed duplicated `lines` from Order type
- removed `cc*` fields from Payment type as it contains `creditCard` type and fields were a duplicate

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
