### PR TITLE
Clean up graphql API code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix dashboard 1.0 missing logo and missing back arrow on collections - #3958 by @NyanKiyoshi
 - Add mutations for publishing and unpublishing multiple pages - #3954 by @akjanik
 
+- Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
+
 ## 2.5.0
 
 ### API

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -22,7 +22,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('account.manage_users')
 
 
@@ -32,5 +32,5 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('account.manage_staff')

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -22,7 +22,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('account.manage_users')
 
 
@@ -32,5 +32,5 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('account.manage_staff')

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -22,7 +22,7 @@ class CustomerBulkDelete(CustomerDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('account.manage_users')
 
 
@@ -32,5 +32,5 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('account.manage_staff')

--- a/saleor/graphql/account/fields.py
+++ b/saleor/graphql/account/fields.py
@@ -5,5 +5,5 @@ from ...account.models import PossiblePhoneNumberField
 
 
 @convert_django_field.register(PossiblePhoneNumberField)
-def convert_json_field_to_string(field, registry=None):
+def convert_json_field_to_string(*_args):
     return graphene.String()

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -124,7 +124,7 @@ class CustomerCreate(ModelMutation, I18nMixin):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_users')
 
     @classmethod
@@ -189,7 +189,7 @@ class LoggedUserUpdate(CustomerCreate):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.is_authenticated
 
     @classmethod
@@ -214,7 +214,7 @@ class CustomerDelete(CustomerDeleteMixin, UserDelete):
             required=True, description='ID of a customer to delete.')
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_users')
 
 
@@ -230,7 +230,7 @@ class StaffCreate(ModelMutation):
         model = models.User
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_staff')
 
     @classmethod
@@ -297,12 +297,12 @@ class StaffDelete(StaffDeleteMixin, UserDelete):
             required=True, description='ID of a staff user to delete.')
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_staff')
 
     @classmethod
     def perform_mutation(cls, root, info, **data):
-        if not cls.user_is_allowed(info.context.user, data):
+        if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 
         user_id = data.get('id')
@@ -428,7 +428,7 @@ class AddressCreate(ModelMutation):
         return response
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_users')
 
 
@@ -485,7 +485,7 @@ class AddressDelete(ModelDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, root, info, **data):
-        if not cls.user_is_allowed(info.context.user, data):
+        if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 
         node_id = data.get('id')
@@ -576,7 +576,7 @@ class CustomerAddressCreate(ModelMutation):
         exclude = ['user_addresses']
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.is_authenticated
 
     @classmethod

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -507,7 +507,7 @@ class AddressDelete(ModelDeleteMutation):
 
         # Refresh the user instance to clear the default addresses. If the
         # deleted address was used as default, it would stay cached in the
-        # user instance and the invalid ID returned in the response migt cause
+        # user instance and the invalid ID returned in the response might cause
         # an error.
         user.refresh_from_db()
 
@@ -520,12 +520,14 @@ class AddressSetDefault(BaseMutation):
 
     class Arguments:
         address_id = graphene.ID(
-            required=True, description='ID of the address.')
+            required=True,
+            description='ID of the address.')
         user_id = graphene.ID(
             required=True,
             description='ID of the user to change the address for.')
         type = AddressTypeEnum(
-            required=True, description='The type of address.')
+            required=True,
+            description='The type of address.')
 
     class Meta:
         description = 'Sets a default address for the given user.'
@@ -594,7 +596,7 @@ class CustomerAddressCreate(ModelMutation):
         instance.user_addresses.add(user)
 
 
-# The same as SetDefaultAddress, but for the currenty authenticated user.
+# The same as SetDefaultAddress, but for the currently authenticated user.
 class CustomerSetDefaultAddress(BaseMutation):
     user = graphene.Field(User, description='An updated user instance.')
 
@@ -621,6 +623,7 @@ class CustomerSetDefaultAddress(BaseMutation):
                 'id': 'The address doesn\'t belong to that user.'})
 
         raw_address_type = data.get('type')
+        address_type = None
         if raw_address_type == AddressTypeEnum.BILLING.value:
             address_type = AddressType.BILLING
         elif raw_address_type == AddressTypeEnum.SHIPPING.value:

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -128,10 +128,10 @@ class CustomerCreate(ModelMutation, I18nMixin):
         return user.has_perm('account.manage_users')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        shipping_address_data = raw_input.pop(SHIPPING_ADDRESS_FIELD, None)
-        billing_address_data = raw_input.pop(BILLING_ADDRESS_FIELD, None)
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        shipping_address_data = data.pop(SHIPPING_ADDRESS_FIELD, None)
+        billing_address_data = data.pop(BILLING_ADDRESS_FIELD, None)
+        cleaned_input = super().clean_input(info, instance, data)
 
         if shipping_address_data:
             shipping_address = cls.validate_address(
@@ -234,8 +234,8 @@ class StaffCreate(ModelMutation):
         return user.has_perm('account.manage_staff')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
 
         # set is_staff to True to create a staff user
         cleaned_input['is_staff'] = True
@@ -279,8 +279,8 @@ class StaffUpdate(StaffCreate):
                     'is_active': 'Cannot deactivate superuser\'s account.'})
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         is_active = cleaned_input.get('is_active')
         if is_active is not None:
             cls.clean_is_active(is_active, instance, info.context.user)
@@ -338,8 +338,8 @@ class SetPassword(ModelMutation):
         model = models.User
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         token = cleaned_input.pop('token')
         if not default_token_generator.check_token(instance, token):
             raise ValidationError({'token': SetPassword.INVALID_TOKEN})
@@ -448,12 +448,12 @@ class AddressUpdate(ModelMutation):
         exclude = ['user_addresses']
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
+    def clean_input(cls, info, instance, data):
         # Method user_is_allowed cannot be used for permission check, because
         # it doesn't have the address instance.
         if not can_edit_address(info.context.user, instance):
             raise PermissionDenied()
-        return super().clean_input(info, instance, raw_input)
+        return super().clean_input(info, instance, data)
 
     @classmethod
     def perform_mutation(cls, root, info, **data):

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -359,7 +359,7 @@ class PasswordReset(BaseMutation):
         description = 'Sends password reset email'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_users')
 
     @classmethod
@@ -533,7 +533,7 @@ class AddressSetDefault(BaseMutation):
         description = 'Sets a default address for the given user.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('account.manage_users')
 
     @classmethod
@@ -610,12 +610,12 @@ class CustomerSetDefaultAddress(BaseMutation):
         description = 'Sets a default address for the authenticated user.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.is_authenticated
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        address = cls.get_node_or_error(info, id, Address)
+        address = cls.get_node_or_error(info, data.get('id'), Address)
 
         user = info.context.user
         if address not in user.addresses.all():

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -301,7 +301,7 @@ class StaffDelete(StaffDeleteMixin, UserDelete):
         return user.has_perm('account.manage_staff')
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 
@@ -484,7 +484,7 @@ class AddressDelete(ModelDeleteMutation):
         return super().clean_instance(info, instance)
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -547,14 +547,10 @@ class AddressSetDefault(BaseMutation):
             raise ValidationError({
                 'address_id': 'The address doesn\'t belong to that user.'})
 
-        raw_address_type = data.get('type')
-        if raw_address_type == AddressTypeEnum.BILLING.value:
+        if data.get('type') == AddressTypeEnum.BILLING.value:
             address_type = AddressType.BILLING
-        elif raw_address_type == AddressTypeEnum.SHIPPING.value:
-            address_type = AddressType.SHIPPING
         else:
-            raise ValueError(
-                'Unknown value of AddressTypeEnum: %s' % raw_address_type)
+            address_type = AddressType.SHIPPING
 
         utils.change_user_default_address(user, address, address_type)
         return cls(user=user)
@@ -622,11 +618,9 @@ class CustomerSetDefaultAddress(BaseMutation):
             raise ValidationError({
                 'id': 'The address doesn\'t belong to that user.'})
 
-        raw_address_type = data.get('type')
-        address_type = None
-        if raw_address_type == AddressTypeEnum.BILLING.value:
+        if data.get('type') == AddressTypeEnum.BILLING.value:
             address_type = AddressType.BILLING
-        elif raw_address_type == AddressTypeEnum.SHIPPING.value:
+        else:
             address_type = AddressType.SHIPPING
 
         utils.change_user_default_address(user, address, address_type)

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -33,8 +33,8 @@ def resolve_staff_users(info, query):
     return gql_optimizer.query(qs, info)
 
 
-def resolve_address_validator(info, input):
-    country_code = input['country_code']
+def resolve_address_validator(info, data):
+    country_code = data['country_code']
     if not country_code:
         client_ip = get_client_ip(info.context)
         country = get_country_by_ip(client_ip)
@@ -44,8 +44,8 @@ def resolve_address_validator(info, input):
             return None
     params = {
         'country_code': country_code,
-        'country_area': input['country_area'],
-        'city_area': input['city_area']}
+        'country_area': data['country_area'],
+        'city_area': data['city_area']}
     rules = get_validation_rules(params)
     return AddressValidationData(
         country_code=rules.country_code,

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -35,7 +35,7 @@ class AccountQueries(graphene.ObjectType):
         return resolve_address_validator(info, input)
 
     @permission_required('account.manage_users')
-    def resolve_customers(self, info, query=None, **kwargs):
+    def resolve_customers(self, info, query=None, **_kwargs):
         return resolve_customers(info, query=query)
 
     @login_required
@@ -43,7 +43,7 @@ class AccountQueries(graphene.ObjectType):
         return info.context.user
 
     @permission_required('account.manage_staff')
-    def resolve_staff_users(self, info, query=None, **kwargs):
+    def resolve_staff_users(self, info, query=None, **_kwargs):
         return resolve_staff_users(info, query=query)
 
     @permission_required('account.manage_users')

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -47,11 +47,11 @@ class Address(CountableDjangoObjectType):
             'first_name', 'id', 'last_name', 'phone', 'postal_code',
             'street_address_1', 'street_address_2']
 
-    def resolve_country(self, info):
+    def resolve_country(self, _info):
         return CountryDisplay(
             code=self.country.code, country=self.country.name)
 
-    def resolve_is_default_shipping_address(self, info):
+    def resolve_is_default_shipping_address(self, _info):
         """
         This field is added through annotation when using the
         `resolve_addresses` resolver. It's invalid for
@@ -67,7 +67,7 @@ class Address(CountableDjangoObjectType):
             return True
         return False
 
-    def resolve_is_default_billing_address(self, info):
+    def resolve_is_default_billing_address(self, _info):
         """
         This field is added through annotation when using the
         `resolve_addresses` resolver. It's invalid for
@@ -112,13 +112,13 @@ class User(CountableDjangoObjectType):
             'is_active', 'is_staff', 'last_login', 'last_name', 'note',
             'token']
 
-    def resolve_addresses(self, info, **kwargs):
+    def resolve_addresses(self, _info, **_kwargs):
         return self.addresses.annotate_default(self).all()
 
-    def resolve_checkout(self, info, **kwargs):
+    def resolve_checkout(self, _info, **_kwargs):
         return get_user_cart(self)
 
-    def resolve_permissions(self, info, **kwargs):
+    def resolve_permissions(self, _info, **_kwargs):
         if self.is_superuser:
             permissions = get_permissions()
         else:
@@ -127,16 +127,16 @@ class User(CountableDjangoObjectType):
         return format_permissions_for_display(permissions)
 
     @permission_required('account.manage_users')
-    def resolve_note(self, info):
+    def resolve_note(self, _info):
         return self.note
 
-    def resolve_orders(self, info, **kwargs):
+    def resolve_orders(self, info, **_kwargs):
         viewer = info.context.user
         if viewer.has_perm('order.manage_orders'):
             return self.orders.all()
         return self.orders.confirmed()
 
-    def resolve_avatar(self, info, size=None, **kwargs):
+    def resolve_avatar(self, info, size=None, **_kwargs):
         if self.avatar:
             return Image.get_adjusted(
                 image=self.avatar,

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -106,10 +106,10 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         return_field_name = 'checkout'
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         user = info.context.user
-        lines = raw_input.pop('lines', None)
+        lines = data.pop('lines', None)
         if lines:
             variant_ids = [line.get('variant_id') for line in lines]
             variants = cls.get_nodes_or_error(
@@ -127,23 +127,23 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             default_billing_address = user.default_billing_address
             default_shipping_address = user.default_shipping_address
 
-        if 'shipping_address' in raw_input:
+        if 'shipping_address' in data:
             shipping_address = cls.validate_address(
-                raw_input['shipping_address'])
+                data['shipping_address'])
             cleaned_input['shipping_address'] = shipping_address
         else:
             cleaned_input['shipping_address'] = default_shipping_address
 
-        if 'billing_address' in raw_input:
+        if 'billing_address' in data:
             billing_address = cls.validate_address(
-                raw_input['billing_address'])
+                data['billing_address'])
             cleaned_input['billing_address'] = billing_address
         else:
             cleaned_input['billing_address'] = default_billing_address
 
         # Use authenticated user's email as default email
         if user.is_authenticated:
-            email = raw_input.pop('email', None)
+            email = data.pop('email', None)
             cleaned_input['email'] = email or user.email
 
         return cleaned_input

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -168,7 +168,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 add_variant_to_cart(instance, variant, quantity)
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         user = info.context.user
 
         # `perform_mutation` is overridden to properly get or create a checkout
@@ -207,7 +207,7 @@ class CheckoutLinesAdd(BaseMutation):
         description = 'Adds a checkout line to the existing checkout.'
 
     @classmethod
-    def perform_mutation(cls, root, info, checkout_id, lines, replace=False):
+    def perform_mutation(cls, _root, info, checkout_id, lines, replace=False):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field='checkout_id')
 
@@ -335,7 +335,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         description = 'Update shipping address in the existing Checkout.'
 
     @classmethod
-    def perform_mutation(cls, root, info, checkout_id, shipping_address):
+    def perform_mutation(cls, _root, info, checkout_id, shipping_address):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field='checkout_id')
         shipping_address = cls.validate_address(
@@ -369,7 +369,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         description = 'Update billing address in the existing Checkout.'
 
     @classmethod
-    def perform_mutation(cls, root, info, checkout_id, billing_address):
+    def perform_mutation(cls, _root, info, checkout_id, billing_address):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field='checkout_id')
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -90,7 +90,7 @@ class CheckoutCreateInput(graphene.InputObjectType):
         description='The customer\'s email address.')
     shipping_address = AddressInput(
         description=(
-            'The mailling address to where the checkout will be shipped.'))
+            'The mailing address to where the checkout will be shipped.'))
     billing_address = AddressInput(
         description='Billing address of the customer.')
 
@@ -171,7 +171,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     def perform_mutation(cls, root, info, **data):
         user = info.context.user
 
-        # `perform_mutation` is overriden to properly get or create a checkout
+        # `perform_mutation` is overridden to properly get or create a checkout
         # instance here and abort mutation if needed.
         if user.is_authenticated:
             checkout, created = get_or_create_user_cart(user)
@@ -330,7 +330,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         shipping_address = AddressInput(
             required=True,
             description=(
-                'The mailling address to where the checkout will be shipped.'))
+                'The mailing address to where the checkout will be shipped.'))
 
     class Meta:
         description = 'Update shipping address in the existing Checkout.'

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -182,8 +182,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         else:
             checkout = models.Cart()
 
-        cleaned_input = cls.clean_input(
-            data.get('input'), checkout, input)
+        cleaned_input = cls.clean_input(info, checkout, data.get('input'))
         checkout = cls.construct_instance(checkout, cleaned_input)
         cls.clean_instance(checkout)
         cls.save(info, checkout, cleaned_input)

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -1,16 +1,16 @@
 from ...checkout import models
 
 
-def resolve_checkout_lines(info, query):
+def resolve_checkout_lines():
     queryset = models.CartLine.objects.all()
     return queryset
 
 
-def resolve_checkouts(info, query):
+def resolve_checkouts():
     queryset = models.Cart.objects.all()
     return queryset
 
 
-def resolve_checkout(info, token):
+def resolve_checkout(token):
     checkout = models.Cart.objects.filter(token=token).first()
     return checkout

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -28,19 +28,19 @@ class CheckoutQueries(graphene.ObjectType):
     checkout_lines = PrefetchingConnectionField(
         CheckoutLine, description='List of checkout lines')
 
-    def resolve_checkout(self, info, token):
-        return resolve_checkout(info, token)
+    def resolve_checkout(self, *_args, token):
+        return resolve_checkout(token)
 
     @permission_required('order.manage_orders')
-    def resolve_checkouts(self, info, query=None, **kwargs):
-        resolve_checkouts(info, query)
+    def resolve_checkouts(self, *_args, **_kwargs):
+        resolve_checkouts()
 
     def resolve_checkout_line(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, CheckoutLine)
 
     @permission_required('order.manage_orders')
-    def resolve_checkout_lines(self, info, query=None, **kwargs):
-        return resolve_checkout_lines(info, query)
+    def resolve_checkout_lines(self, *_args, **_kwargs):
+        return resolve_checkout_lines()
 
 
 class CheckoutMutations(graphene.ObjectType):

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -30,7 +30,7 @@ class CheckoutLine(CountableDjangoObjectType):
         taxes = get_taxes_for_address(self.cart.shipping_address)
         return self.get_total(discounts=info.context.discounts, taxes=taxes)
 
-    def resolve_requires_shipping(self, info):
+    def resolve_requires_shipping(self, *_args):
         return self.is_shipping_required()
 
 
@@ -79,15 +79,15 @@ class Checkout(CountableDjangoObjectType):
         taxes = get_taxes_for_address(self.shipping_address)
         return self.get_total(discounts=info.context.discounts, taxes=taxes)
 
-    def resolve_subtotal_price(self, info):
+    def resolve_subtotal_price(self, *_args):
         taxes = get_taxes_for_address(self.shipping_address)
         return self.get_subtotal(taxes=taxes)
 
-    def resolve_shipping_price(self, info):
+    def resolve_shipping_price(self, *_args):
         taxes = get_taxes_for_address(self.shipping_address)
         return self.get_shipping_price(taxes=taxes)
 
-    def resolve_lines(self, info):
+    def resolve_lines(self, *_args):
         return self.lines.prefetch_related('variant')
 
     def resolve_available_shipping_methods(self, info):
@@ -96,8 +96,8 @@ class Checkout(CountableDjangoObjectType):
             taxes=taxes, discounts=info.context.discounts)
         return applicable_shipping_methods(self, price.gross.amount)
 
-    def resolve_available_payment_gateways(self, info):
+    def resolve_available_payment_gateways(self, _info):
         return settings.CHECKOUT_PAYMENT_GATEWAYS.keys()
 
-    def resolve_is_shipping_required(self, info):
+    def resolve_is_shipping_required(self, _info):
         return self.is_shipping_required()

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -40,7 +40,7 @@ class CountableConnection(NonNullConnection):
         description='A total count of items in the collection')
 
     @staticmethod
-    def resolve_total_count(root, info, *args, **kwargs):
+    def resolve_total_count(root, *_args, **_kwargs):
         return root.length
 
 

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -12,17 +12,17 @@ from .types.money import Money, TaxedMoney
 
 
 @convert_django_field.register(TaxedMoneyField)
-def convert_field_taxed_money(field, registry=None):
+def convert_field_taxed_money(*_args):
     return graphene.Field(TaxedMoney)
 
 
 @convert_django_field.register(MoneyField)
-def convert_field_money(field, registry=None):
+def convert_field_money(*_args):
     return graphene.Field(Money)
 
 
 @convert_django_field.register(MeasurementField)
-def convert_field_measurements(field, registry=None):
+def convert_field_measurements(*_args):
     return graphene.Field(Weight)
 
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -221,7 +221,7 @@ class ModelMutation(BaseMutation):
             arguments=arguments, fields=fields)
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
+    def clean_input(cls, info, instance, data):
         """Clean input data received from mutation arguments.
 
         Fields containing IDs or lists of IDs are automatically resolved into
@@ -253,8 +253,8 @@ class ModelMutation(BaseMutation):
         cleaned_input = {}
 
         for field_name, field_item in input_cls._meta.fields.items():
-            if field_name in raw_input:
-                value = raw_input[field_name]
+            if field_name in data:
+                value = data[field_name]
 
                 # handle list of IDs field
                 if value is not None and is_list_of_ids(field_item):
@@ -327,8 +327,8 @@ class ModelMutation(BaseMutation):
         created based on the model associated with this mutation.
         """
         instance = cls.get_instance(info, **data)
-        raw_input = data.get('input')
-        cleaned_input = cls.clean_input(info, instance, raw_input)
+        data = data.get('input')
+        cleaned_input = cls.clean_input(info, instance, data)
         instance = cls.construct_instance(instance, cleaned_input)
         cls.clean_instance(instance)
         cls.save(info, instance, cleaned_input)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -287,7 +287,7 @@ class ModelMutation(BaseMutation):
                 f.save_form_data(instance, cleaned_data[f.name])
 
     @classmethod
-    def user_is_allowed(cls, *args):
+    def user_is_allowed(cls, user):
         """Determine whether user has rights to perform this mutation.
 
         Default implementation assumes that user is allowed to perform any
@@ -351,7 +351,7 @@ class ModelDeleteMutation(ModelMutation):
     @classmethod
     def perform_mutation(cls, root, info, **data):
         """Perform a mutation that deletes a model instance."""
-        if not cls.user_is_allowed(info.context.user, data):
+        if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 
         node_id = data.get('id')

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -349,7 +349,7 @@ class ModelDeleteMutation(ModelMutation):
         """
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         """Perform a mutation that deletes a model instance."""
         if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
@@ -412,7 +412,7 @@ class BaseBulkMutation(BaseMutation):
         raise NotImplementedError
 
     @classmethod
-    def perform_mutation(cls, root, info, ids):
+    def perform_mutation(cls, _root, info, ids):
         """Perform a mutation that deletes a list of model instances."""
         clean_instance_ids, errors = [], {}
         instance_model = cls._meta.model

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -249,26 +249,26 @@ class ModelMutation(BaseMutation):
                 return field.type.of_type == Upload
             return field.type == Upload
 
-        InputCls = getattr(cls.Arguments, 'input')
+        input_cls = getattr(cls.Arguments, 'input')
         cleaned_input = {}
 
-        for field_name, field in InputCls._meta.fields.items():
+        for field_name, field_item in input_cls._meta.fields.items():
             if field_name in raw_input:
                 value = raw_input[field_name]
 
                 # handle list of IDs field
-                if value is not None and is_list_of_ids(field):
+                if value is not None and is_list_of_ids(field_item):
                     instances = cls.get_nodes_or_error(
                         value, field_name) if value else []
                     cleaned_input[field_name] = instances
 
                 # handle ID field
-                elif value is not None and is_id_field(field):
+                elif value is not None and is_id_field(field_item):
                     instance = cls.get_node_or_error(info, value, field_name)
                     cleaned_input[field_name] = instance
 
                 # handle uploaded files
-                elif value is not None and is_upload_field(field):
+                elif value is not None and is_upload_field(field_item):
                     value = info.context.FILES.get(value)
                     cleaned_input[field_name] = value
 
@@ -322,7 +322,7 @@ class ModelMutation(BaseMutation):
         """Perform model mutation.
 
         Depending on the input data, `mutate` either creates a new instance or
-        updates an existing one. If `id` arugment is present, it is assumed
+        updates an existing one. If `id` argument is present, it is assumed
         that this is an "update" mutation. Otherwise, a new instance is
         created based on the model associated with this mutation.
         """

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -503,7 +503,7 @@ class VerifyToken(Verify):
 
     user = graphene.Field(User)
 
-    def resolve_user(self, info, **kwargs):
+    def resolve_user(self, _info, **_kwargs):
         username_field = get_user_model().USERNAME_FIELD
         kwargs = {username_field: self.payload.get(username_field)}
         return models.User.objects.get(**kwargs)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -157,7 +157,7 @@ class BaseMutation(graphene.Mutation):
         return instance
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         """Determine whether user has rights to perform this mutation.
 
         Default implementation assumes that user is allowed to perform any
@@ -169,7 +169,7 @@ class BaseMutation(graphene.Mutation):
 
     @classmethod
     def mutate(cls, root, info, **data):
-        if not cls.user_is_allowed(info.context.user, data):
+        if not cls.user_is_allowed(info.context.user):
             raise PermissionDenied()
 
         try:

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -16,7 +16,7 @@ class Money(graphene.ObjectType):
     class Meta:
         description = 'Represents amount of money in specific currency.'
 
-    def resolve_localized(self, info):
+    def resolve_localized(self, _info):
         return prices_i18n.amount(self)
 
 
@@ -67,10 +67,10 @@ class VAT(graphene.ObjectType):
     class Meta:
         description = 'Represents a VAT rate for a country.'
 
-    def resolve_standard_rate(self, info):
+    def resolve_standard_rate(self, _info):
         return self.data.get('standard_rate')
 
-    def resolve_reduced_rates(self, info):
+    def resolve_reduced_rates(self, _info):
         reduced_rates = self.data.get('reduced_rates', {}) or {}
         return [
             ReducedRate(rate=rate, rate_type=rate_type)

--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -16,7 +16,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -32,5 +32,5 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('discount.manage_discounts')

--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -16,7 +16,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -32,5 +32,5 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')

--- a/saleor/graphql/discount/bulk_mutations.py
+++ b/saleor/graphql/discount/bulk_mutations.py
@@ -16,7 +16,7 @@ class SaleBulkDelete(ModelBulkDeleteMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -32,5 +32,5 @@ class VoucherBulkDelete(ModelBulkDeleteMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('discount.manage_discounts')

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -105,15 +105,15 @@ class VoucherCreate(ModelMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        code = input.get('code', None)
+    def clean_input(cls, info, instance, raw_input):
+        code = raw_input.get('code', None)
         if code == '':
-            input['code'] = generate_voucher_code()
-        cleaned_input = super().clean_input(info, instance, input)
+            raw_input['code'] = generate_voucher_code()
+        cleaned_input = super().clean_input(info, instance, raw_input)
         return cleaned_input
 
 
@@ -139,7 +139,7 @@ class VoucherDelete(ModelDeleteMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -164,14 +164,14 @@ class VoucherAddCatalogues(VoucherBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
+    def perform_mutation(cls, _root, info, **data):
         voucher = cls.get_node_or_error(
-            info, id, only_type=Voucher, field='voucher_id')
-        cls.add_catalogues_to_node(voucher, input)
+            info, data.get('id'), only_type=Voucher, field='voucher_id')
+        cls.add_catalogues_to_node(voucher, data.get('input'))
         return VoucherAddCatalogues(voucher=voucher)
 
 
@@ -181,14 +181,14 @@ class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
             'Removes products, categories, collections from a voucher.')
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
+    def perform_mutation(cls, _root, info, **data):
         voucher = cls.get_node_or_error(
-            info, id, only_type=Voucher, field='voucher_id')
-        cls.remove_catalogues_from_node(voucher, input)
+            info, data.get('id'), only_type=Voucher, field='voucher_id')
+        cls.remove_catalogues_from_node(voucher, data.get('input'))
         return VoucherRemoveCatalogues(voucher=voucher)
 
 
@@ -224,7 +224,7 @@ class SaleCreate(ModelMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -239,7 +239,7 @@ class SaleUpdate(ModelMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -252,7 +252,7 @@ class SaleDelete(ModelDeleteMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -275,13 +275,14 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        sale = cls.get_node_or_error(info, id, only_type=Sale, field='sale_id')
-        cls.add_catalogues_to_node(sale, input)
+    def perform_mutation(cls, _root, info, **data):
+        sale = cls.get_node_or_error(
+            info, data.get('id'), only_type=Sale, field='sale_id')
+        cls.add_catalogues_to_node(sale, data.get('input'))
         return SaleAddCatalogues(sale=sale)
 
 
@@ -290,12 +291,12 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
         description = 'Removes products, categories, collections from a sale.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
+    def perform_mutation(cls, _root, info, **data):
         sale = cls.get_node_or_error(
-            info, id, only_type=Sale, field='sale_id')
-        cls.remove_catalogues_from_node(sale, input)
+            info, data.get('id'), only_type=Sale, field='sale_id')
+        cls.remove_catalogues_from_node(sale, data.get('input'))
         return SaleRemoveCatalogues(sale=sale)

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -146,7 +146,7 @@ class VoucherDelete(ModelDeleteMutation):
 class VoucherBaseCatalogueMutation(BaseDiscountCatalogueMutation):
     voucher = graphene.Field(
         Voucher,
-        description=('Voucher of which catalogue IDs will be modified.'))
+        description='Voucher of which catalogue IDs will be modified.')
 
     class Arguments:
         id = graphene.ID(required=True, description='ID of a voucher.')
@@ -258,13 +258,13 @@ class SaleDelete(ModelDeleteMutation):
 
 class SaleBaseCatalogueMutation(BaseDiscountCatalogueMutation):
     sale = graphene.Field(
-        Sale, description=('Sale of which catalogue IDs will be modified.'))
+        Sale, description='Sale of which catalogue IDs will be modified.')
 
     class Arguments:
         id = graphene.ID(required=True, description='ID of a sale.')
         input = CatalogueInput(
             required=True,
-            description=('Fields required to modify catalogue IDs of sale.'))
+            description='Fields required to modify catalogue IDs of sale.')
 
     class Meta:
         abstract = True

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -109,11 +109,11 @@ class VoucherCreate(ModelMutation):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        code = raw_input.get('code', None)
+    def clean_input(cls, info, instance, data):
+        code = data.get('code', None)
         if code == '':
-            raw_input['code'] = generate_voucher_code()
-        cleaned_input = super().clean_input(info, instance, raw_input)
+            data['code'] = generate_voucher_code()
+        cleaned_input = super().clean_input(info, instance, data)
         return cleaned_input
 
 

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -164,7 +164,7 @@ class VoucherAddCatalogues(VoucherBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
@@ -181,7 +181,7 @@ class VoucherRemoveCatalogues(VoucherBaseCatalogueMutation):
             'Removes products, categories, collections from a voucher.')
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
@@ -275,7 +275,7 @@ class SaleAddCatalogues(SaleBaseCatalogueMutation):
         description = 'Adds products, categories, collections to a voucher.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
@@ -291,7 +291,7 @@ class SaleRemoveCatalogues(SaleBaseCatalogueMutation):
         description = 'Removes products, categories, collections from a sale.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod

--- a/saleor/graphql/discount/mutations.py
+++ b/saleor/graphql/discount/mutations.py
@@ -105,7 +105,7 @@ class VoucherCreate(ModelMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
     @classmethod
@@ -139,7 +139,7 @@ class VoucherDelete(ModelDeleteMutation):
         model = models.Voucher
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -224,7 +224,7 @@ class SaleCreate(ModelMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -239,7 +239,7 @@ class SaleUpdate(ModelMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
 
@@ -252,7 +252,7 @@ class SaleDelete(ModelDeleteMutation):
         model = models.Sale
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('discount.manage_discounts')
 
 

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -33,7 +33,7 @@ class DiscountQueries(graphene.ObjectType):
         return graphene.Node.get_node_from_global_id(info, id, Sale)
 
     @permission_required('discount.manage_discounts')
-    def resolve_sales(self, info, query=None, **kwargs):
+    def resolve_sales(self, info, query=None, **_kwargs):
         return resolve_sales(info, query)
 
     @permission_required('discount.manage_discounts')
@@ -41,7 +41,7 @@ class DiscountQueries(graphene.ObjectType):
         return graphene.Node.get_node_from_global_id(info, id, Voucher)
 
     @permission_required('discount.manage_discounts')
-    def resolve_vouchers(self, info, query=None, **kwargs):
+    def resolve_vouchers(self, info, query=None, **_kwargs):
         return resolve_vouchers(info, query)
 
 

--- a/saleor/graphql/discount/types.py
+++ b/saleor/graphql/discount/types.py
@@ -48,13 +48,13 @@ class Sale(CountableDjangoObjectType):
         model = models.Sale
         only_fields = ['end_date', 'id', 'name', 'start_date', 'type', 'value']
 
-    def resolve_categories(self, info, **kwargs):
+    def resolve_categories(self, *_args, **_kwargs):
         return self.categories.all()
 
-    def resolve_collections(self, info, **kwargs):
+    def resolve_collections(self, info, **_kwargs):
         return self.collections.visible_to_user(info.context.user)
 
-    def resolve_products(self, info, **kwargs):
+    def resolve_products(self, info, **_kwargs):
         return self.products.visible_to_user(info.context.user)
 
 
@@ -99,16 +99,16 @@ class Voucher(CountableDjangoObjectType):
         interfaces = [relay.Node]
         model = models.Voucher
 
-    def resolve_categories(self, info, **kwargs):
+    def resolve_categories(self, *_args, **_kwargs):
         return self.categories.all()
 
-    def resolve_collections(self, info, **kwargs):
+    def resolve_collections(self, info, **_kwargs):
         return self.collections.visible_to_user(info.context.user)
 
-    def resolve_products(self, info, **kwargs):
+    def resolve_products(self, info, **_kwargs):
         return self.products.visible_to_user(info.context.user)
 
-    def resolve_countries(self, info, **kwargs):
+    def resolve_countries(self, *_args, **_kwargs):
         return [
             CountryDisplay(code=country.code, country=country.name)
             for country in self.countries]

--- a/saleor/graphql/menu/bulk_mutations.py
+++ b/saleor/graphql/menu/bulk_mutations.py
@@ -16,7 +16,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('menu.manage_menus')
 
 
@@ -32,5 +32,5 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('menu.manage_menus')

--- a/saleor/graphql/menu/bulk_mutations.py
+++ b/saleor/graphql/menu/bulk_mutations.py
@@ -16,7 +16,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('menu.manage_menus')
 
 
@@ -32,5 +32,5 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('menu.manage_menus')

--- a/saleor/graphql/menu/bulk_mutations.py
+++ b/saleor/graphql/menu/bulk_mutations.py
@@ -16,7 +16,7 @@ class MenuBulkDelete(ModelBulkDeleteMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
 
@@ -32,5 +32,5 @@ class MenuItemBulkDelete(ModelBulkDeleteMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -57,8 +57,8 @@ class MenuCreate(ModelMutation):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         items = []
         for item in cleaned_input.get('items', []):
             category = item.get('category')
@@ -143,8 +143,8 @@ class MenuItemCreate(ModelMutation):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         items = [
             cleaned_input.get('page'), cleaned_input.get('collection'),
             cleaned_input.get('url'), cleaned_input.get('category')]

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -53,12 +53,12 @@ class MenuCreate(ModelMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         items = []
         for item in cleaned_input.get('items', []):
             category = item.get('category')
@@ -108,7 +108,7 @@ class MenuUpdate(ModelMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
 
@@ -122,7 +122,7 @@ class MenuDelete(ModelDeleteMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
 
@@ -139,12 +139,12 @@ class MenuItemCreate(ModelMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         items = [
             cleaned_input.get('page'), cleaned_input.get('collection'),
             cleaned_input.get('url'), cleaned_input.get('category')]
@@ -169,7 +169,7 @@ class MenuItemUpdate(MenuItemCreate):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
@@ -192,7 +192,7 @@ class MenuItemDelete(ModelDeleteMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('menu.manage_menus')
 
 
@@ -209,12 +209,12 @@ class AssignNavigation(BaseMutation):
         description = 'Assigns storefront\'s navigation menus.'
 
     @classmethod
-    def user_is_allowed(cls, instance, input):
+    def user_is_allowed(cls, instance, _data):
         return instance.has_perms([
             'menu.manage_menus', 'site.manage_settings'])
 
     @classmethod
-    def perform_mutation(cls, root, info, navigation_type, menu=None):
+    def perform_mutation(cls, _root, info, navigation_type, menu=None):
         site_settings = info.context.site.settings
         if menu is not None:
             menu = cls.get_node_or_error(info, menu, field='menu')

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -53,7 +53,7 @@ class MenuCreate(ModelMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
@@ -108,7 +108,7 @@ class MenuUpdate(ModelMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
 
@@ -122,7 +122,7 @@ class MenuDelete(ModelDeleteMutation):
         model = models.Menu
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
 
@@ -139,7 +139,7 @@ class MenuItemCreate(ModelMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
@@ -169,7 +169,7 @@ class MenuItemUpdate(MenuItemCreate):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
     @classmethod
@@ -192,7 +192,7 @@ class MenuItemDelete(ModelDeleteMutation):
         model = models.MenuItem
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('menu.manage_menus')
 
 

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -209,7 +209,7 @@ class AssignNavigation(BaseMutation):
         description = 'Assigns storefront\'s navigation menus.'
 
     @classmethod
-    def user_is_allowed(cls, instance, _data):
+    def user_is_allowed(cls, instance):
         return instance.has_perms([
             'menu.manage_menus', 'site.manage_settings'])
 

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -9,13 +9,13 @@ MENU_SEARCH_FIELDS = ('name',)
 MENU_ITEM_SEARCH_FIELDS = ('name',)
 
 
-def resolve_menu(info, id=None, name=None):
-    assert id or name, 'No ID or name provided.'
+def resolve_menu(info, menu_id=None, name=None):
+    assert menu_id or name, 'No ID or name provided.'
     if name is not None:
         qs = models.Menu.objects.filter(name=name)
         qs = gql_optimizer.query(qs, info)
         return qs[0] if qs else None
-    return graphene.Node.get_node_from_global_id(info, id, Menu)
+    return graphene.Node.get_node_from_global_id(info, menu_id, Menu)
 
 
 def resolve_menus(info, query):

--- a/saleor/graphql/menu/schema.py
+++ b/saleor/graphql/menu/schema.py
@@ -26,16 +26,17 @@ class MenuQueries(graphene.ObjectType):
         MenuItem, query=graphene.String(description=DESCRIPTIONS['menu_item']),
         description='List of the shop\'s menu items.')
 
-    def resolve_menu(self, info, id=None, name=None):
-        return resolve_menu(info, id, name)
+    def resolve_menu(self, info, **data):
+        return resolve_menu(info, data.get('id'), data.get('name'))
 
-    def resolve_menus(self, info, query=None, **kwargs):
+    def resolve_menus(self, info, query=None, **_kwargs):
         return resolve_menus(info, query)
 
-    def resolve_menu_item(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, MenuItem)
+    def resolve_menu_item(self, info, **data):
+        return graphene.Node.get_node_from_global_id(
+            info, data.get('id'), MenuItem)
 
-    def resolve_menu_items(self, info, query=None, **kwargs):
+    def resolve_menu_items(self, info, query=None, **_kwargs):
         return resolve_menu_items(info, query)
 
 

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -28,8 +28,9 @@ class Menu(CountableDjangoObjectType):
         prefetch_related=prefetch_menus)
 
     class Meta:
-        description = dedent("""Represents a single menu - an object that is used
-        to help navigate through the store.""")
+        description = dedent(
+            """Represents a single menu - an object that is used
+               to help navigate through the store.""")
         interfaces = [relay.Node]
         only_fields = ['id', 'name']
         model = models.Menu

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -12,7 +12,7 @@ from ..translations.resolvers import resolve_translation
 from ..translations.types import MenuItemTranslation
 
 
-def prefetch_menus(info, *args, **kwargs):
+def prefetch_menus(info, *_args, **_kwargs):
     qs = models.MenuItem.objects.filter(level=0)
     return Prefetch(
         'items', queryset=gql_optimizer.query(qs, info),
@@ -34,7 +34,7 @@ class Menu(CountableDjangoObjectType):
         only_fields = ['id', 'name']
         model = models.Menu
 
-    def resolve_items(self, info, **kwargs):
+    def resolve_items(self, _info, **_kwargs):
         if hasattr(self, 'prefetched_items'):
             return self.prefetched_items
         return self.items.filter(level=0)
@@ -64,5 +64,5 @@ class MenuItem(CountableDjangoObjectType):
             'parent']
         model = models.MenuItem
 
-    def resolve_children(self, info, **kwargs):
+    def resolve_children(self, _info, **_kwargs):
         return self.children.all()

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -14,7 +14,7 @@ def jwt_middleware(get_response):
     """
     # Disable warnings for django-graphene-jwt
     graphene_settings.MIDDLEWARE.append(JSONWebTokenMiddleware)
-    jwt_middleware = JSONWebTokenMiddleware(get_response=get_response)
+    jwt_middleware_inst = JSONWebTokenMiddleware(get_response=get_response)
     graphene_settings.MIDDLEWARE.remove(JSONWebTokenMiddleware)
 
     def middleware(request):
@@ -24,7 +24,7 @@ def jwt_middleware(get_response):
             request.user = AnonymousUser()
 
             # authenticate using JWT middleware
-            jwt_middleware.process_request(request)
+            jwt_middleware_inst.process_request(request)
         return get_response(request)
 
     return middleware

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -22,7 +22,7 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
             raise ValidationError({'id': 'Cannot delete non-draft orders.'})
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
 

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -22,7 +22,7 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
             raise ValidationError({'id': 'Cannot delete non-draft orders.'})
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('order.manage_orders')
 
 

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -38,11 +38,11 @@ class DraftOrderLinesBulkDelete(ModelBulkDeleteMutation):
         model = models.OrderLine
 
     @classmethod
-    def clean_instance(cls, info, instance):
+    def clean_instance(cls, _info, instance):
         if instance.order.status != OrderStatus.DRAFT:
             raise ValidationError(
                 {'id': 'Cannot delete line for non-draft orders.'})
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('order.manage_orders')

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -22,7 +22,7 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
             raise ValidationError({'id': 'Cannot delete non-draft orders.'})
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('order.manage_orders')
 
 

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -65,8 +65,8 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def clean_input(cls, info, instance, raw_input):
-        shipping_address = input.pop('shipping_address', None)
-        billing_address = input.pop('billing_address', None)
+        shipping_address = raw_input.pop('shipping_address', None)
+        billing_address = raw_input.pop('billing_address', None)
         cleaned_input = super().clean_input(info, instance, raw_input)
 
         lines = raw_input.pop('lines', None)
@@ -176,7 +176,7 @@ class DraftOrderComplete(BaseMutation):
                 order.user = None
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -232,7 +232,7 @@ class DraftOrderLinesCreate(BaseMutation):
         description = 'Create order lines for a draft order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -274,7 +274,7 @@ class DraftOrderLineDelete(BaseMutation):
         description = 'Deletes an order line from a draft order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -102,7 +102,7 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
         return cleaned_input
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -150,7 +150,7 @@ class DraftOrderDelete(ModelDeleteMutation):
         model = models.Order
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
 
@@ -306,7 +306,7 @@ class DraftOrderLineUpdate(ModelMutation):
         model = models.OrderLine
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -64,12 +64,12 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
         model = models.Order
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        shipping_address = raw_input.pop('shipping_address', None)
-        billing_address = raw_input.pop('billing_address', None)
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        shipping_address = data.pop('shipping_address', None)
+        billing_address = data.pop('billing_address', None)
+        cleaned_input = super().clean_input(info, instance, data)
 
-        lines = raw_input.pop('lines', None)
+        lines = data.pop('lines', None)
         if lines:
             variant_ids = [line.get('variant_id') for line in lines]
             variants = cls.get_nodes_or_error(
@@ -310,12 +310,12 @@ class DraftOrderLineUpdate(ModelMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         if instance.order.status != OrderStatus.DRAFT:
             raise ValidationError({'id': 'Only draft orders can be edited.'})
 
-        quantity = raw_input['quantity']
+        quantity = data['quantity']
         if quantity <= 0:
             raise ValidationError({
                 'quantity':

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -180,7 +180,7 @@ class DraftOrderComplete(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
+    def perform_mutation(cls, _root, info, id):
         order = cls.get_node_or_error(info, id, only_type=Order)
         validate_draft_order(order)
         cls.update_user_fields(order)
@@ -278,7 +278,7 @@ class DraftOrderLineDelete(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
+    def perform_mutation(cls, _root, info, id):
         line = cls.get_node_or_error(info, id, only_type=OrderLine)
         order = line.order
         if order.status != OrderStatus.DRAFT:

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -128,7 +128,7 @@ class FulfillmentCreate(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, order, **data):
+    def perform_mutation(cls, _root, info, order, **data):
         order = cls.get_node_or_error(
             info, order, field='order', only_type=Order)
         data = data.get('input')

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -26,7 +26,7 @@ class FulfillmentLineInput(graphene.InputObjectType):
     order_line_id = graphene.ID(
         description='The ID of the order line.', name='orderLineId')
     quantity = graphene.Int(
-        description='The number of line item(s) to be fulfiled.')
+        description='The number of line item(s) to be fulfilled.')
 
 
 class FulfillmentCreateInput(graphene.InputObjectType):
@@ -172,7 +172,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         order = fulfillment.order
         order.events.create(
             parameters={
-                'tracking_numner': tracking_number,
+                'tracking_number': tracking_number,
                 'fulfillment': fulfillment.composed_id},
             type=OrderEvents.TRACKING_UPDATED.value,
             user=info.context.user)
@@ -197,7 +197,7 @@ class FulfillmentCancel(BaseMutation):
         and optionally restocks items.""")
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -221,7 +221,7 @@ class FulfillmentCancel(BaseMutation):
                 parameters={'quantity': fulfillment.get_total_quantity()},
                 type=OrderEvents.FULFILLMENT_RESTOCKED_ITEMS.value,
                 user=info.context.user)
-        else:
+        elif order:
             order.events.create(
                 parameters={'composed_id': fulfillment.composed_id},
                 type=OrderEvents.FULFILLMENT_CANCELED.value,

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -124,7 +124,7 @@ class FulfillmentCreate(BaseMutation):
         return fulfillment
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -159,7 +159,7 @@ class FulfillmentUpdateTracking(BaseMutation):
         description = 'Updates a fulfillment for an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -197,7 +197,7 @@ class FulfillmentCancel(BaseMutation):
         and optionally restocks items.""")
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -80,8 +80,8 @@ class FulfillmentCreate(BaseMutation):
                 raise ValidationError({'order_line_id': msg})
 
     @classmethod
-    def clean_input(cls, input):
-        lines = input['lines']
+    def clean_input(cls, raw_input):
+        lines = raw_input['lines']
         quantities = [line['quantity'] for line in lines]
         lines_ids = [line['order_line_id'] for line in lines]
         order_lines = cls.get_nodes_or_error(
@@ -93,9 +93,9 @@ class FulfillmentCreate(BaseMutation):
             raise ValidationError({
                 'lines': 'Total quantity must be larger than 0.'})
 
-        input['order_lines'] = order_lines
-        input['quantities'] = quantities
-        return input
+        raw_input['order_lines'] = order_lines
+        raw_input['quantities'] = quantities
+        return raw_input
 
     @classmethod
     def save(cls, user, fulfillment, order, cleaned_input):
@@ -124,17 +124,18 @@ class FulfillmentCreate(BaseMutation):
         return fulfillment
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, order, input):
+    def perform_mutation(cls, root, info, order, **data):
         order = cls.get_node_or_error(
             info, order, field='order', only_type=Order)
+        raw_input = data.get('input')
         fulfillment = models.Fulfillment(
-            tracking_number=input.pop('tracking_number', None) or '',
+            tracking_number=raw_input.pop('tracking_number', None) or '',
             order=order)
-        cleaned_input = cls.clean_input(input)
+        cleaned_input = cls.clean_input(raw_input)
         fulfillment = cls.save(
             info.context.user, fulfillment, order, cleaned_input)
         return FulfillmentCreate(
@@ -158,13 +159,14 @@ class FulfillmentUpdateTracking(BaseMutation):
         description = 'Updates a fulfillment for an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        fulfillment = cls.get_node_or_error(info, id, only_type=Fulfillment)
-        tracking_number = input.get('tracking_number') or ''
+    def perform_mutation(cls, _root, info, **data):
+        fulfillment = cls.get_node_or_error(
+            info, data.get('id'), only_type=Fulfillment)
+        tracking_number = data.get('input').get('tracking_number') or ''
         fulfillment.tracking_number = tracking_number
         fulfillment.save()
         order = fulfillment.order
@@ -199,9 +201,10 @@ class FulfillmentCancel(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        restock = input.get('restock')
-        fulfillment = cls.get_node_or_error(info, id, only_type=Fulfillment)
+    def perform_mutation(cls, _root, info, **data):
+        restock = data.get('input').get('restock')
+        fulfillment = cls.get_node_or_error(
+            info, data.get('id'), only_type=Fulfillment)
 
         if not fulfillment.can_edit():
             err_msg = pgettext_lazy(

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -80,8 +80,8 @@ class FulfillmentCreate(BaseMutation):
                 raise ValidationError({'order_line_id': msg})
 
     @classmethod
-    def clean_input(cls, raw_input):
-        lines = raw_input['lines']
+    def clean_input(cls, data):
+        lines = data['lines']
         quantities = [line['quantity'] for line in lines]
         lines_ids = [line['order_line_id'] for line in lines]
         order_lines = cls.get_nodes_or_error(
@@ -93,9 +93,9 @@ class FulfillmentCreate(BaseMutation):
             raise ValidationError({
                 'lines': 'Total quantity must be larger than 0.'})
 
-        raw_input['order_lines'] = order_lines
-        raw_input['quantities'] = quantities
-        return raw_input
+        data['order_lines'] = order_lines
+        data['quantities'] = quantities
+        return data
 
     @classmethod
     def save(cls, user, fulfillment, order, cleaned_input):
@@ -131,11 +131,11 @@ class FulfillmentCreate(BaseMutation):
     def perform_mutation(cls, root, info, order, **data):
         order = cls.get_node_or_error(
             info, order, field='order', only_type=Order)
-        raw_input = data.get('input')
+        data = data.get('input')
         fulfillment = models.Fulfillment(
-            tracking_number=raw_input.pop('tracking_number', None) or '',
+            tracking_number=data.pop('tracking_number', None) or '',
             order=order)
-        cleaned_input = cls.clean_input(raw_input)
+        cleaned_input = cls.clean_input(data)
         fulfillment = cls.save(
             info.context.user, fulfillment, order, cleaned_input)
         return FulfillmentCreate(

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -114,7 +114,7 @@ class OrderUpdateShipping(BaseMutation):
         description = 'Updates a shipping method of the order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -174,7 +174,7 @@ class OrderAddNote(BaseMutation):
         description = 'Adds note to the order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -203,7 +203,7 @@ class OrderCancel(BaseMutation):
         description = 'Cancel an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -234,7 +234,7 @@ class OrderMarkAsPaid(BaseMutation):
         description = 'Mark order as manually paid.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -262,7 +262,7 @@ class OrderCapture(BaseMutation):
         description = 'Capture an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -299,7 +299,7 @@ class OrderVoid(BaseMutation):
         description = 'Void an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -331,7 +331,7 @@ class OrderRefund(BaseMutation):
         description = 'Refund an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -114,14 +114,16 @@ class OrderUpdateShipping(BaseMutation):
         description = 'Updates a shipping method of the order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        order = cls.get_node_or_error(info, id, only_type=Order)
+    def perform_mutation(cls, _root, info, **data):
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
+        raw_input = data.get('input')
 
-        if not input['shipping_method']:
+        if not raw_input['shipping_method']:
             if not order.is_draft() and order.is_shipping_required():
                 raise ValidationError({
                     'shipping_method':
@@ -137,7 +139,7 @@ class OrderUpdateShipping(BaseMutation):
             return OrderUpdateShipping(order=order)
 
         method = cls.get_node_or_error(
-            info, input['shipping_method'], field='shipping_method',
+            info, raw_input['shipping_method'], field='shipping_method',
             only_type=ShippingMethod)
 
         clean_order_update_shipping(order, method)
@@ -172,17 +174,18 @@ class OrderAddNote(BaseMutation):
         description = 'Adds note to the order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        order = cls.get_node_or_error(info, id, only_type=Order)
+    def perform_mutation(cls, _root, info, **data):
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         event = order.events.create(
             type=OrderEvents.NOTE_ADDED.value,
             user=info.context.user,
             parameters={
-                'message': input['message']})
+                'message': data.get('input')['message']})
         return OrderAddNote(order=order, event=event)
 
 
@@ -200,12 +203,13 @@ class OrderCancel(BaseMutation):
         description = 'Cancel an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, restock):
-        order = cls.get_node_or_error(info, id, only_type=Order)
+    def perform_mutation(cls, _root, info, restock, **data):
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         clean_order_cancel(order)
         cancel_order(order=order, restock=restock)
         if restock:
@@ -230,12 +234,13 @@ class OrderMarkAsPaid(BaseMutation):
         description = 'Mark order as manually paid.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
-        order = cls.get_node_or_error(info, id, only_type=Order)
+    def perform_mutation(cls, _root, info, **data):
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         try:
             clean_mark_order_as_paid(order)
         except PaymentError as e:
@@ -257,16 +262,17 @@ class OrderCapture(BaseMutation):
         description = 'Capture an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, amount):
+    def perform_mutation(cls, root, info, amount, **data):
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})
 
-        order = cls.get_node_or_error(info, id, only_type=Order)
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         payment = order.get_last_payment()
         clean_order_capture(payment, amount)
 
@@ -293,12 +299,13 @@ class OrderVoid(BaseMutation):
         description = 'Void an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
-        order = cls.get_node_or_error(info, id, only_type=Order)
+    def perform_mutation(cls, root, info, **data):
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         payment = order.get_last_payment()
         clean_void_payment(payment)
         try:
@@ -324,16 +331,17 @@ class OrderRefund(BaseMutation):
         description = 'Refund an order.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, amount):
+    def perform_mutation(cls, root, info, amount, **data):
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})
 
-        order = cls.get_node_or_error(info, id, only_type=Order)
+        order = cls.get_node_or_error(
+            info, data.get('id'), only_type=Order)
         payment = order.get_last_payment()
         clean_refund_payment(payment, amount)
 

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -121,9 +121,9 @@ class OrderUpdateShipping(BaseMutation):
     def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(
             info, data.get('id'), only_type=Order)
-        raw_input = data.get('input')
+        data = data.get('input')
 
-        if not raw_input['shipping_method']:
+        if not data['shipping_method']:
             if not order.is_draft() and order.is_shipping_required():
                 raise ValidationError({
                     'shipping_method':
@@ -139,7 +139,7 @@ class OrderUpdateShipping(BaseMutation):
             return OrderUpdateShipping(order=order)
 
         method = cls.get_node_or_error(
-            info, raw_input['shipping_method'], field='shipping_method',
+            info, data['shipping_method'], field='shipping_method',
             only_type=ShippingMethod)
 
         clean_order_update_shipping(order, method)

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -266,7 +266,7 @@ class OrderCapture(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, amount, **data):
+    def perform_mutation(cls, _root, info, amount, **data):
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})
@@ -303,7 +303,7 @@ class OrderVoid(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         order = cls.get_node_or_error(
             info, data.get('id'), only_type=Order)
         payment = order.get_last_payment()
@@ -335,7 +335,7 @@ class OrderRefund(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, amount, **data):
+    def perform_mutation(cls, _root, info, amount, **data):
         if amount <= 0:
             raise ValidationError({
                 'amount': 'Amount should be a positive number.'})

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -41,7 +41,7 @@ def clean_order_cancel(order):
         raise ValidationError({'order': 'This order can\'t be canceled.'})
 
 
-def clean_order_capture(payment, amount):
+def clean_order_capture(payment):
     if not payment:
         raise ValidationError({
             'payment': 'There\'s no payment associated with the order.'})
@@ -274,7 +274,7 @@ class OrderCapture(BaseMutation):
         order = cls.get_node_or_error(
             info, data.get('id'), only_type=Order)
         payment = order.get_last_payment()
-        clean_order_capture(payment, amount)
+        clean_order_capture(payment)
 
         try:
             gateway_capture(payment, amount)

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -54,7 +54,7 @@ def resolve_order(info, order_id):
     return None
 
 
-def resolve_homepage_events(info):
+def resolve_homepage_events():
     # Filter only selected events to be displayed on homepage.
     types = [
         OrderEvents.PLACED.value, OrderEvents.PLACED_FROM_DRAFT.value,
@@ -62,5 +62,5 @@ def resolve_homepage_events(info):
     return models.OrderEvent.objects.filter(type__in=types)
 
 
-def resolve_order_by_token(info, token):
+def resolve_order_by_token(token):
     return models.Order.objects.filter(token=token).first()

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -39,16 +39,16 @@ def resolve_draft_orders(info, created, query):
     return filter_orders(qs, info, created, None, query)
 
 
-def resolve_orders_total(info, period):
+def resolve_orders_total(_info, period):
     qs = models.Order.objects.confirmed().exclude(status=OrderStatus.CANCELED)
     qs = filter_by_period(qs, period, 'created')
     return sum_order_totals(qs)
 
 
-def resolve_order(info, id):
+def resolve_order(info, order_id):
     """Return order only for user assigned to it or proper staff user."""
     user = info.context.user
-    order = graphene.Node.get_node_from_global_id(info, id, Order)
+    order = graphene.Node.get_node_from_global_id(info, order_id, Order)
     if user.has_perm('order.manage_orders') or order.user == user:
         return order
     return None

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -58,8 +58,8 @@ class OrderQueries(graphene.ObjectType):
         token=graphene.Argument(graphene.String, required=True))
 
     @permission_required('order.manage_orders')
-    def resolve_homepage_events(self, info, **_kwargs):
-        return resolve_homepage_events(info)
+    def resolve_homepage_events(self, *_args, **_kwargs):
+        return resolve_homepage_events()
 
     @login_required
     def resolve_order(self, info, **data):
@@ -67,19 +67,19 @@ class OrderQueries(graphene.ObjectType):
 
     @permission_required('order.manage_orders')
     def resolve_orders(
-            self, info, created=None, status=None, query=None, **kwargs):
+            self, info, created=None, status=None, query=None, **_kwargs):
         return resolve_orders(info, created, status, query)
 
     @permission_required('order.manage_orders')
-    def resolve_draft_orders(self, info, created=None, query=None, **kwargs):
+    def resolve_draft_orders(self, info, created=None, query=None, **_kwargs):
         return resolve_draft_orders(info, created, query)
 
     @permission_required('order.manage_orders')
-    def resolve_orders_total(self, info, period, **kwargs):
+    def resolve_orders_total(self, info, period, **_kwargs):
         return resolve_orders_total(info, period)
 
-    def resolve_order_by_token(self, info, token):
-        return resolve_order_by_token(info, token)
+    def resolve_order_by_token(self, _info, token):
+        return resolve_order_by_token(token)
 
 
 class OrderMutations(graphene.ObjectType):

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -58,12 +58,12 @@ class OrderQueries(graphene.ObjectType):
         token=graphene.Argument(graphene.String, required=True))
 
     @permission_required('order.manage_orders')
-    def resolve_homepage_events(self, info, **kwargs):
+    def resolve_homepage_events(self, info, **_kwargs):
         return resolve_homepage_events(info)
 
     @login_required
-    def resolve_order(self, info, id):
-        return resolve_order(info, id)
+    def resolve_order(self, info, **data):
+        return resolve_order(info, data.get('id'))
 
     @permission_required('order.manage_orders')
     def resolve_orders(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -238,7 +238,7 @@ class Order(CountableDjangoObjectType):
         return self.shipping_price
 
     @gql_optimizer.resolver_hints(prefetch_related='payments__transactions')
-    def resolve_actions(self, info):
+    def resolve_actions(self, _info):
         actions = []
         payment = self.get_last_payment()
         if self.can_capture(payment):
@@ -321,7 +321,7 @@ class Order(CountableDjangoObjectType):
             return self.user.email
         return None
 
-    def resolve_available_shipping_methods(self, info):
+    def resolve_available_shipping_methods(self, _info):
         return applicable_shipping_methods(
             self, self.get_subtotal().gross.amount)
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -16,7 +16,7 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('page.manage_pages')
 
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -32,7 +32,7 @@ class PageBulkPublish(ModelBulkPublishMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('page.manage_pages')
 
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -16,7 +16,7 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('page.manage_pages')
 
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -16,7 +16,7 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('page.manage_pages')
 
 

--- a/saleor/graphql/page/mutations.py
+++ b/saleor/graphql/page/mutations.py
@@ -32,7 +32,7 @@ class PageCreate(ModelMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('page.manage_pages')
 
     @classmethod
@@ -65,5 +65,5 @@ class PageDelete(ModelDeleteMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('page.manage_pages')

--- a/saleor/graphql/page/mutations.py
+++ b/saleor/graphql/page/mutations.py
@@ -32,12 +32,12 @@ class PageCreate(ModelMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('page.manage_pages')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         slug = cleaned_input.get('slug', '')
         if not slug:
             cleaned_input['slug'] = slugify(cleaned_input['title'])
@@ -65,5 +65,5 @@ class PageDelete(ModelDeleteMutation):
         model = models.Page
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('page.manage_pages')

--- a/saleor/graphql/page/mutations.py
+++ b/saleor/graphql/page/mutations.py
@@ -36,8 +36,8 @@ class PageCreate(ModelMutation):
         return user.has_perm('page.manage_pages')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         slug = cleaned_input.get('slug', '')
         if not slug:
             cleaned_input['slug'] = slugify(cleaned_input['title'])

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -7,8 +7,8 @@ from .types import Page
 PAGE_SEARCH_FIELDS = ('content', 'slug', 'title')
 
 
-def resolve_page(info, id=None, slug=None):
-    assert id or slug, 'No page ID or slug provided.'
+def resolve_page(info, page_id=None, slug=None):
+    assert page_id or slug, 'No page ID or slug provided.'
     user = info.context.user
 
     if slug is not None:
@@ -17,7 +17,7 @@ def resolve_page(info, id=None, slug=None):
         except models.Page.DoesNotExist:
             page = None
     else:
-        page = graphene.Node.get_node_from_global_id(info, id, Page)
+        page = graphene.Node.get_node_from_global_id(info, page_id, Page)
         # Resolve to null if page is not published and user has no permission
         # to manage pages.
         is_available_to_user = (

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -21,7 +21,7 @@ class PageQueries(graphene.ObjectType):
     def resolve_page(self, info, id=None, slug=None):
         return resolve_page(info, id, slug)
 
-    def resolve_pages(self, info, query=None, **kwargs):
+    def resolve_pages(self, info, query=None, **_kwargs):
         return resolve_pages(info, query=query)
 
 

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -28,8 +28,9 @@ class Page(CountableDjangoObjectType):
         resolver=resolve_translation)
 
     class Meta:
-        description = dedent("""A static page that can be manually added by a shop
-        operator through the dashboard.""")
+        description = dedent(
+            """A static page that can be manually added by a shop
+               operator through the dashboard.""")
         only_fields = [
             'content', 'content_json', 'created', 'id', 'is_published',
             'publication_date', 'seo_description', 'seo_title', 'slug',

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -37,8 +37,8 @@ class Page(CountableDjangoObjectType):
         interfaces = [relay.Node]
         model = models.Page
 
-    def resolve_available_on(self, info):
+    def resolve_available_on(self, _info):
         return self.publication_date
 
-    def resolve_is_visible(self, info):
+    def resolve_is_visible(self, _info):
         return self.is_published

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -104,7 +104,7 @@ class PaymentCapture(BaseMutation):
         description = 'Captures the authorized payment amount'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -124,7 +124,7 @@ class PaymentRefund(PaymentCapture):
         description = 'Refunds the captured payment amount'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod
@@ -148,7 +148,7 @@ class PaymentVoid(BaseMutation):
         description = 'Voids the authorized payment'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -58,10 +58,10 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         checkout = cls.get_node_or_error(
             info, checkout_id, field='checkout_id', only_type=Checkout)
 
-        raw_input = data.get('input')
+        data = data.get('input')
         billing_address = checkout.billing_address
-        if 'billing_address' in raw_input:
-            billing_address = cls.validate_address(raw_input['billing_address'])
+        if 'billing_address' in data:
+            billing_address = cls.validate_address(data['billing_address'])
         if billing_address is None:
             raise ValidationError({
                 'billing_address':
@@ -70,7 +70,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         checkout_total = checkout.get_total(
             discounts=info.context.discounts,
             taxes=get_taxes_for_address(checkout.billing_address))
-        amount = raw_input.get('amount', checkout_total)
+        amount = data.get('amount', checkout_total)
         if amount < checkout_total.gross.amount:
             raise ValidationError({
                 'amount':
@@ -81,8 +81,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             'customer_user_agent': info.context.META.get('HTTP_USER_AGENT')}
 
         payment = create_payment(
-            gateway=raw_input['gateway'],
-            payment_token=raw_input['token'],
+            gateway=data['gateway'],
+            payment_token=data['token'],
             total=amount,
             currency=settings.DEFAULT_CURRENCY,
             email=checkout.email,

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -54,13 +54,14 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         description = 'Create a new payment for given checkout.'
 
     @classmethod
-    def perform_mutation(cls, root, info, checkout_id, input):
+    def perform_mutation(cls, _root, info, checkout_id, **data):
         checkout = cls.get_node_or_error(
             info, checkout_id, field='checkout_id', only_type=Checkout)
 
+        raw_input = data.get('input')
         billing_address = checkout.billing_address
-        if 'billing_address' in input:
-            billing_address = cls.validate_address(input['billing_address'])
+        if 'billing_address' in raw_input:
+            billing_address = cls.validate_address(raw_input['billing_address'])
         if billing_address is None:
             raise ValidationError({
                 'billing_address':
@@ -69,7 +70,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         checkout_total = checkout.get_total(
             discounts=info.context.discounts,
             taxes=get_taxes_for_address(checkout.billing_address))
-        amount = input.get('amount', checkout_total)
+        amount = raw_input.get('amount', checkout_total)
         if amount < checkout_total.gross.amount:
             raise ValidationError({
                 'amount':
@@ -80,8 +81,8 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             'customer_user_agent': info.context.META.get('HTTP_USER_AGENT')}
 
         payment = create_payment(
-            gateway=input['gateway'],
-            payment_token=input['token'],
+            gateway=raw_input['gateway'],
+            payment_token=raw_input['token'],
             total=amount,
             currency=settings.DEFAULT_CURRENCY,
             email=checkout.email,
@@ -147,11 +148,11 @@ class PaymentVoid(BaseMutation):
         description = 'Voids the authorized payment'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, payment_id, amount=None):
+    def perform_mutation(cls, _root, info, payment_id):
         payment = cls.get_node_or_error(
             info, payment_id, field='payment_id', only_type=Payment)
         try:

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -108,7 +108,7 @@ class PaymentCapture(BaseMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, payment_id, amount=None):
+    def perform_mutation(cls, _root, info, payment_id, amount=None):
         payment = cls.get_node_or_error(
             info, payment_id, field='payment_id', only_type=Payment)
         try:
@@ -128,7 +128,7 @@ class PaymentRefund(PaymentCapture):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def perform_mutation(cls, root, info, payment_id, amount=None):
+    def perform_mutation(cls, _root, info, payment_id, amount=None):
         payment = cls.get_node_or_error(
             info, payment_id, field='payment_id', only_type=Payment)
         try:

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -15,14 +15,15 @@ class PaymentQueries(graphene.ObjectType):
     payment_client_token = graphene.Field(
         graphene.String, args={'gateway': PaymentGatewayEnum()})
 
-    def resolve_payment(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, Payment)
+    def resolve_payment(self, info, **data):
+        return graphene.Node.get_node_from_global_id(
+            info, data.get('id'), Payment)
 
     @permission_required('order.manage_orders')
-    def resolve_payments(self, info, query=None, **kwargs):
+    def resolve_payments(self, info, query=None, **_kwargs):
         return resolve_payments(info, query)
 
-    def resolve_payment_client_token(self, info, gateway=None):
+    def resolve_payment_client_token(self, _info, gateway=None):
         return resolve_payment_client_token(gateway)
 
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -23,7 +23,7 @@ class Transaction(CountableDjangoObjectType):
             'id', 'created', 'payment', 'token', 'kind', 'is_success',
             'error', 'gateway_response']
 
-    def resolve_amount(self, info):
+    def resolve_amount(self, _info):
         return self.get_amount()
 
 
@@ -78,7 +78,7 @@ class Payment(CountableDjangoObjectType):
             'extra_data']
 
     @gql_optimizer.resolver_hints(prefetch_related='transactions')
-    def resolve_actions(self, info):
+    def resolve_actions(self, _info):
         actions = []
         if self.can_capture():
             actions.append(OrderAction.CAPTURE)
@@ -88,13 +88,13 @@ class Payment(CountableDjangoObjectType):
             actions.append(OrderAction.VOID)
         return actions
 
-    def resolve_total(self, info):
+    def resolve_total(self, _info):
         return self.get_total()
 
-    def resolve_captured_amount(self, info):
+    def resolve_captured_amount(self, _info):
         return self.get_captured_amount()
 
-    def resolve_billing_address(self, info):
+    def resolve_billing_address(self, _info):
         return Address(
             first_name=self.billing_first_name,
             last_name=self.billing_last_name,
@@ -108,23 +108,23 @@ class Payment(CountableDjangoObjectType):
             country_area=self.billing_country_area)
 
     @gql_optimizer.resolver_hints(prefetch_related='transactions')
-    def resolve_transactions(self, info):
+    def resolve_transactions(self, _info):
         return self.transactions.all()
 
-    def resolve_available_refund_amount(self, info):
+    def resolve_available_refund_amount(self, _info):
         # FIXME TESTME
         if not self.can_refund():
             return None
         return self.get_captured_amount()
 
     @gql_optimizer.resolver_hints(prefetch_related='transactions')
-    def resolve_available_capture_amount(self, info):
+    def resolve_available_capture_amount(self, _info):
         # FIXME TESTME
         if not self.can_capture():
             return None
         return self.get_charge_amount()
 
-    def resolve_credit_card(self, info):
+    def resolve_credit_card(self, _info):
         data = {
             'first_digits': self.cc_first_digits,
             'last_digits': self.cc_last_digits,

--- a/saleor/graphql/product/bulk_mutations/attributes.py
+++ b/saleor/graphql/product/bulk_mutations/attributes.py
@@ -16,7 +16,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -32,5 +32,5 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/bulk_mutations/attributes.py
+++ b/saleor/graphql/product/bulk_mutations/attributes.py
@@ -16,7 +16,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -32,5 +32,5 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/bulk_mutations/attributes.py
+++ b/saleor/graphql/product/bulk_mutations/attributes.py
@@ -16,7 +16,7 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -32,5 +32,5 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -16,7 +16,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
         model = models.Category
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -32,7 +32,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -48,7 +48,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         model = models.Product
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -64,7 +64,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductVariant
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -80,7 +80,7 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')
 
 
@@ -96,5 +96,5 @@ class ProductImageBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductImage
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -16,7 +16,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
         model = models.Category
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -32,7 +32,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -48,7 +48,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         model = models.Product
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -64,7 +64,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductVariant
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -80,7 +80,7 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')
 
 
@@ -96,5 +96,5 @@ class ProductImageBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductImage
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -16,7 +16,7 @@ class CategoryBulkDelete(ModelBulkDeleteMutation):
         model = models.Category
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -32,7 +32,7 @@ class CollectionBulkDelete(ModelBulkDeleteMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -48,7 +48,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         model = models.Product
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -64,7 +64,7 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductVariant
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -80,7 +80,7 @@ class ProductTypeBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -96,5 +96,5 @@ class ProductImageBulkDelete(ModelBulkDeleteMutation):
         model = models.ProductImage
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -2,7 +2,6 @@ import graphene
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.template.defaultfilters import slugify
-from graphql_jwt.decorators import permission_required
 
 from ....product import models
 from ...core.mutations import ModelDeleteMutation, ModelMutation

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -260,8 +260,8 @@ class AttributeValueCreate(ModelMutation):
         model = models.AttributeValue
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input
 
@@ -305,8 +305,8 @@ class AttributeValueUpdate(ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         if 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -233,7 +233,7 @@ class AttributeDelete(ModelDeleteMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -301,7 +301,7 @@ class AttributeValueUpdate(ModelMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -329,7 +329,7 @@ class AttributeValueDelete(ModelDeleteMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -141,7 +141,7 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         product_type = cls.get_node_or_error(
             info, data.get('id'), only_type=ProductType)
         instance = models.Attribute()
@@ -202,7 +202,7 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
+    def perform_mutation(cls, _root, info, id, input):
         instance = cls.get_node_or_error(info, id, only_type=Attribute)
 
         cleaned_input = cls.clean_input(info, instance, input)
@@ -270,7 +270,7 @@ class AttributeValueCreate(ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, attribute_id, input):
+    def perform_mutation(cls, _root, info, attribute_id, input):
         attribute = cls.get_node_or_error(
             info, attribute_id, only_type=Attribute)
 

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -140,11 +140,13 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, type, input):
-        product_type = cls.get_node_or_error(info, id, only_type=ProductType)
+    @permission_required('product.manage_products')
+    def mutate(cls, _root, info, **data):
+        product_type = cls.get_node_or_error(
+            info, data.get('id'), only_type=ProductType)
         instance = models.Attribute()
 
-        cleaned_input = cls.clean_input(info, instance, input)
+        cleaned_input = cls.clean_input(info, instance, data.get('input'))
         cls.clean_attribute(
             instance, cleaned_input, product_type=product_type)
         cls.clean_values(cleaned_input, instance)
@@ -152,7 +154,7 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         cls.clean_instance(instance)
 
         instance.save()
-        if type == AttributeTypeEnum.VARIANT.name:
+        if data.get('type') == AttributeTypeEnum.VARIANT.name:
             product_type.variant_attributes.add(instance)
         else:
             product_type.product_attributes.add(instance)
@@ -231,7 +233,7 @@ class AttributeDelete(ModelDeleteMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -258,8 +260,8 @@ class AttributeValueCreate(ModelMutation):
         model = models.AttributeValue
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input
 
@@ -299,12 +301,12 @@ class AttributeValueUpdate(ModelMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         if 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
         return cleaned_input
@@ -327,7 +329,7 @@ class AttributeValueDelete(ModelDeleteMutation):
         model = models.AttributeValue
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -2,6 +2,7 @@ import graphene
 from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.template.defaultfilters import slugify
+from graphql_jwt.decorators import permission_required
 
 from ....product import models
 from ...core.mutations import ModelDeleteMutation, ModelMutation
@@ -136,12 +137,11 @@ class AttributeCreate(AttributeMixin, ModelMutation):
         model = models.Attribute
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    @permission_required('product.manage_products')
-    def mutate(cls, _root, info, **data):
+    def perform_mutation(cls, root, info, **data):
         product_type = cls.get_node_or_error(
             info, data.get('id'), only_type=ProductType)
         instance = models.Attribute()
@@ -198,7 +198,7 @@ class AttributeUpdate(AttributeMixin, ModelMutation):
             attribute_value.delete()
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -266,7 +266,7 @@ class AttributeValueCreate(ModelMutation):
         return cleaned_input
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -56,26 +56,26 @@ class DigitalContentCreate(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def clean_input(cls, info, raw_input, instance):
+    def clean_input(cls, info, data, instance):
         if hasattr(instance, 'digital_content'):
             instance.digital_content.delete()
 
-        use_default_settings = raw_input.get('use_default_settings')
+        use_default_settings = data.get('use_default_settings')
         if use_default_settings:
-            return raw_input
+            return data
 
         required_fields = [
             'max_downloads', 'url_valid_days', 'automatic_fulfillment']
 
-        if not all(field in raw_input for field in required_fields):
+        if not all(field in data for field in required_fields):
             msg = ('Use default settings is disabled. Provide all '
                    'missing configuration fields: ')
-            missing_fields = set(required_fields).difference(set(raw_input))
+            missing_fields = set(required_fields).difference(set(data))
             if missing_fields:
                 msg += '{}, ' * len(missing_fields)
                 raise ValidationError(msg.format(*missing_fields))
 
-        return raw_input
+        return data
 
     @classmethod
     @permission_required('product.manage_products')
@@ -146,23 +146,23 @@ class DigitalContentUpdate(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def clean_input(cls, info, raw_input):
-        use_default_settings = raw_input.get('use_default_settings')
+    def clean_input(cls, info, data):
+        use_default_settings = data.get('use_default_settings')
         if use_default_settings:
             return {'use_default_settings': use_default_settings}
 
         required_fields = [
             'max_downloads', 'url_valid_days', 'automatic_fulfillment']
 
-        if not all(field in raw_input for field in required_fields):
+        if not all(field in data for field in required_fields):
             msg = ('Use default settings is disabled. Provide all '
                    'missing configuration fields: ')
-            missing_fields = set(required_fields).difference(set(raw_input))
+            missing_fields = set(required_fields).difference(set(data))
             if missing_fields:
                 msg += '{}, ' * len(missing_fields)
                 raise ValidationError(msg.format(*missing_fields))
 
-        return raw_input
+        return data
 
     @classmethod
     @permission_required('product.manage_products')

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -166,7 +166,7 @@ class DigitalContentUpdate(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def perform_mutation(cls, root, info, variant_id, **data):
+    def perform_mutation(cls, _root, info, variant_id, **data):
         variant = cls.get_node_or_error(
             info, variant_id, 'id', only_type=ProductVariant)
 

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -56,45 +56,45 @@ class DigitalContentCreate(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def clean_input(cls, info, input, instance):
+    def clean_input(cls, info, raw_input, instance):
         if hasattr(instance, 'digital_content'):
             instance.digital_content.delete()
 
-        use_default_settings = input.get('use_default_settings')
+        use_default_settings = raw_input.get('use_default_settings')
         if use_default_settings:
-            return input
+            return raw_input
 
         required_fields = [
             'max_downloads', 'url_valid_days', 'automatic_fulfillment']
 
-        if not all(field in input for field in required_fields):
+        if not all(field in raw_input for field in required_fields):
             msg = ('Use default settings is disabled. Provide all '
                    'missing configuration fields: ')
-            missing_fields = set(required_fields).difference(set(input))
+            missing_fields = set(required_fields).difference(set(raw_input))
             if missing_fields:
                 msg += '{}, ' * len(missing_fields)
                 raise ValidationError(msg.format(*missing_fields))
 
-        return input
+        return raw_input
 
     @classmethod
     @permission_required('product.manage_products')
-    def perform_mutation(cls, root, info, variant_id, input):
+    def perform_mutation(cls, _root, info, variant_id, **data):
         variant = cls.get_node_or_error(
             info, variant_id, 'id', only_type=ProductVariant)
 
-        input = cls.clean_input(info, input, variant)
+        clean_input = cls.clean_input(info, data.get('input'), variant)
 
-        content_data = info.context.FILES.get(input['content_file'])
+        content_data = info.context.FILES.get(clean_input['content_file'])
         digital_content = models.DigitalContent(
             content_file=content_data
         )
-        digital_content.use_default_settings = input.get(
+        digital_content.use_default_settings = clean_input.get(
             'use_default_settings', False)
 
-        digital_content.max_downloads = input.get('max_downloads')
-        digital_content.url_valid_days = input.get('url_valid_days')
-        digital_content.automatic_fulfillment = input.get(
+        digital_content.max_downloads = clean_input.get('max_downloads')
+        digital_content.url_valid_days = clean_input.get('url_valid_days')
+        digital_content.automatic_fulfillment = clean_input.get(
             'automatic_fulfillment', False)
 
         variant.digital_content = digital_content
@@ -118,7 +118,7 @@ class DigitalContentDelete(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def mutate(cls, root, info, variant_id):
+    def mutate(cls, _root, info, variant_id):
         variant = cls.get_node_or_error(
             info, variant_id, 'id', only_type=ProductVariant)
 
@@ -146,27 +146,27 @@ class DigitalContentUpdate(BaseMutation):
 
     @classmethod
     @permission_required('product.manage_products')
-    def clean_input(cls, info, input):
-        use_default_settings = input.get('use_default_settings')
+    def clean_input(cls, info, raw_input):
+        use_default_settings = raw_input.get('use_default_settings')
         if use_default_settings:
             return {'use_default_settings': use_default_settings}
 
         required_fields = [
             'max_downloads', 'url_valid_days', 'automatic_fulfillment']
 
-        if not all(field in input for field in required_fields):
+        if not all(field in raw_input for field in required_fields):
             msg = ('Use default settings is disabled. Provide all '
                    'missing configuration fields: ')
-            missing_fields = set(required_fields).difference(set(input))
+            missing_fields = set(required_fields).difference(set(raw_input))
             if missing_fields:
                 msg += '{}, ' * len(missing_fields)
                 raise ValidationError(msg.format(*missing_fields))
 
-        return input
+        return raw_input
 
     @classmethod
     @permission_required('product.manage_products')
-    def perform_mutation(cls, root, info, variant_id, input):
+    def perform_mutation(cls, root, info, variant_id, **data):
         variant = cls.get_node_or_error(
             info, variant_id, 'id', only_type=ProductVariant)
 
@@ -174,16 +174,16 @@ class DigitalContentUpdate(BaseMutation):
             msg = 'Variant %s doesn\'t have any digital content' % variant.id
             raise ValidationError({'variantId': msg})
 
-        input = cls.clean_input(info, input)
+        clean_input = cls.clean_input(info, data.get('input'))
 
         digital_content = variant.digital_content
 
-        digital_content.use_default_settings = input.get(
+        digital_content.use_default_settings = clean_input.get(
             'use_default_settings', False)
 
-        digital_content.max_downloads = input.get('max_downloads')
-        digital_content.url_valid_days = input.get('url_valid_days')
-        digital_content.automatic_fulfillment = input.get(
+        digital_content.max_downloads = clean_input.get('max_downloads')
+        digital_content.url_valid_days = clean_input.get('url_valid_days')
+        digital_content.automatic_fulfillment = clean_input.get(
             'automatic_fulfillment', False)
 
         variant.digital_content = digital_content

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -64,7 +64,7 @@ class CategoryCreate(ModelMutation):
         return cleaned_input
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -108,7 +108,7 @@ class CategoryDelete(ModelDeleteMutation):
         model = models.Category
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -147,7 +147,7 @@ class CollectionCreate(ModelMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -197,7 +197,7 @@ class CollectionDelete(ModelDeleteMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -383,7 +383,7 @@ class ProductCreate(ModelMutation):
             instance.collections.set(collections)
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -437,7 +437,7 @@ class ProductDelete(ModelDeleteMutation):
         model = models.Product
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -526,7 +526,7 @@ class ProductVariantCreate(ModelMutation):
         instance.save()
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -553,7 +553,7 @@ class ProductVariantDelete(ModelDeleteMutation):
         model = models.ProductVariant
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 
@@ -594,7 +594,7 @@ class ProductTypeCreate(ModelMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -638,7 +638,7 @@ class ProductTypeDelete(ModelDeleteMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -452,9 +452,10 @@ class ProductVariantInput(graphene.InputObjectType):
     quantity = graphene.Int(
         description='The total quantity of this variant available for sale.')
     track_inventory = graphene.Boolean(
-        description=dedent("""Determines if the inventory of this variant should
-        be tracked. If false, the quantity won't change when customers
-        buy this item."""))
+        description=dedent(
+            """Determines if the inventory of this variant should
+               be tracked. If false, the quantity won't change when customers
+               buy this item."""))
     weight = WeightScalar(
         description='Weight of the Product Variant.', required=False)
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -48,17 +48,17 @@ class CategoryCreate(ModelMutation):
         model = models.Category
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         if 'slug' not in cleaned_input and 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
-        parent_id = raw_input['parent_id']
+        parent_id = data['parent_id']
         if parent_id:
             parent = cls.get_node_or_error(
                 info, parent_id, field='parent', only_type=Category)
             cleaned_input['parent'] = parent
-        if raw_input.get('background_image'):
-            image_data = info.context.FILES.get(raw_input['background_image'])
+        if data.get('background_image'):
+            image_data = info.context.FILES.get(data['background_image'])
             validate_image_file(image_data, 'background_image')
         clean_seo_fields(cleaned_input)
         return cleaned_input
@@ -151,12 +151,12 @@ class CollectionCreate(ModelMutation):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         if 'slug' not in cleaned_input and 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
-        if raw_input.get('background_image'):
-            image_data = info.context.FILES.get(raw_input['background_image'])
+        if data.get('background_image'):
+            image_data = info.context.FILES.get(data['background_image'])
             validate_image_file(image_data, 'background_image')
         clean_seo_fields(cleaned_input)
         return cleaned_input
@@ -321,8 +321,8 @@ class ProductCreate(ModelMutation):
         model = models.Product
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to
@@ -493,15 +493,15 @@ class ProductVariantCreate(ModelMutation):
                     fieldname: 'This field cannot be blank.'})
 
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
 
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to
         # the value's PK.
 
-        if 'attributes' in raw_input:
+        if 'attributes' in data:
             attributes_input = cleaned_input.pop('attributes')
             product = instance.product if instance.pk else cleaned_input.get(
                 'product')
@@ -672,14 +672,14 @@ class ProductImageCreate(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        raw_input = data.get('input')
+        data = data.get('input')
         product = cls.get_node_or_error(
-            info, raw_input['product'], field='product', only_type=Product)
-        image_data = info.context.FILES.get(raw_input['image'])
+            info, data['product'], field='product', only_type=Product)
+        image_data = info.context.FILES.get(data['image'])
         validate_image_file(image_data, 'image')
 
         image = product.images.create(
-            image=image_data, alt=raw_input.get('alt', ''))
+            image=image_data, alt=data.get('alt', ''))
         create_product_thumbnails.delay(image.pk)
         return ProductImageCreate(product=product, image=image)
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -218,7 +218,7 @@ class CollectionAddProducts(BaseMutation):
         description = 'Adds products to a collection.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -245,7 +245,7 @@ class CollectionRemoveProducts(BaseMutation):
         description = 'Remove products from a collection.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -667,7 +667,7 @@ class ProductImageCreate(BaseMutation):
         https://github.com/jaydenseric/graphql-multipart-request-spec''')
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -703,7 +703,7 @@ class ProductImageUpdate(BaseMutation):
         description = 'Updates a product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -734,7 +734,7 @@ class ProductImageReorder(BaseMutation):
         description = 'Changes ordering of the product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -776,7 +776,7 @@ class ProductImageDelete(BaseMutation):
         description = 'Deletes a product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -806,7 +806,7 @@ class VariantImageAssign(BaseMutation):
         description = 'Assign an image to a product variant'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -843,7 +843,7 @@ class VariantImageUnassign(BaseMutation):
         description = 'Unassign an image from a product variant'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('product.manage_products')
 
     @classmethod

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -48,23 +48,23 @@ class CategoryCreate(ModelMutation):
         model = models.Category
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         if 'slug' not in cleaned_input and 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
-        parent_id = input['parent_id']
+        parent_id = raw_input['parent_id']
         if parent_id:
             parent = cls.get_node_or_error(
                 info, parent_id, field='parent', only_type=Category)
             cleaned_input['parent'] = parent
-        if input.get('background_image'):
-            image_data = info.context.FILES.get(input['background_image'])
+        if raw_input.get('background_image'):
+            image_data = info.context.FILES.get(raw_input['background_image'])
             validate_image_file(image_data, 'background_image')
         clean_seo_fields(cleaned_input)
         return cleaned_input
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -108,7 +108,7 @@ class CategoryDelete(ModelDeleteMutation):
         model = models.Category
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -147,16 +147,16 @@ class CollectionCreate(ModelMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         if 'slug' not in cleaned_input and 'name' in cleaned_input:
             cleaned_input['slug'] = slugify(cleaned_input['name'])
-        if input.get('background_image'):
-            image_data = info.context.FILES.get(input['background_image'])
+        if raw_input.get('background_image'):
+            image_data = info.context.FILES.get(raw_input['background_image'])
             validate_image_file(image_data, 'background_image')
         clean_seo_fields(cleaned_input)
         return cleaned_input
@@ -197,7 +197,7 @@ class CollectionDelete(ModelDeleteMutation):
         model = models.Collection
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -218,11 +218,11 @@ class CollectionAddProducts(BaseMutation):
         description = 'Adds products to a collection.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, collection_id, products):
+    def perform_mutation(cls, _root, info, collection_id, products):
         collection = cls.get_node_or_error(
             info, collection_id, field='collection_id', only_type=Collection)
         products = cls.get_nodes_or_error(products, 'products', Product)
@@ -245,11 +245,11 @@ class CollectionRemoveProducts(BaseMutation):
         description = 'Remove products from a collection.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, collection_id, products):
+    def perform_mutation(cls, _root, info, collection_id, products):
         collection = cls.get_node_or_error(
             info, collection_id, field='collection_id', only_type=Collection)
         products = cls.get_nodes_or_error(
@@ -321,8 +321,8 @@ class ProductCreate(ModelMutation):
         model = models.Product
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to
@@ -383,7 +383,7 @@ class ProductCreate(ModelMutation):
             instance.collections.set(collections)
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -437,7 +437,7 @@ class ProductDelete(ModelDeleteMutation):
         model = models.Product
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -492,15 +492,15 @@ class ProductVariantCreate(ModelMutation):
                     fieldname: 'This field cannot be blank.'})
 
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
 
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to
         # the value's PK.
 
-        if 'attributes' in input:
+        if 'attributes' in raw_input:
             attributes_input = cleaned_input.pop('attributes')
             product = instance.product if instance.pk else cleaned_input.get(
                 'product')
@@ -525,7 +525,7 @@ class ProductVariantCreate(ModelMutation):
         instance.save()
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -552,7 +552,7 @@ class ProductVariantDelete(ModelDeleteMutation):
         model = models.ProductVariant
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -593,7 +593,7 @@ class ProductTypeCreate(ModelMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
@@ -637,7 +637,7 @@ class ProductTypeDelete(ModelDeleteMutation):
         model = models.ProductType
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
 
@@ -666,18 +666,19 @@ class ProductImageCreate(BaseMutation):
         https://github.com/jaydenseric/graphql-multipart-request-spec''')
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, input):
+    def perform_mutation(cls, _root, info, **data):
+        raw_input = data.get('input')
         product = cls.get_node_or_error(
-            info, input['product'], field='product', only_type=Product)
-        image_data = info.context.FILES.get(input['image'])
+            info, raw_input['product'], field='product', only_type=Product)
+        image_data = info.context.FILES.get(raw_input['image'])
         validate_image_file(image_data, 'image')
 
         image = product.images.create(
-            image=image_data, alt=input.get('alt', ''))
+            image=image_data, alt=raw_input.get('alt', ''))
         create_product_thumbnails.delay(image.pk)
         return ProductImageCreate(product=product, image=image)
 
@@ -701,14 +702,15 @@ class ProductImageUpdate(BaseMutation):
         description = 'Updates a product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, id, input):
-        image = cls.get_node_or_error(info, id, only_type=ProductImage)
+    def perform_mutation(cls, _root, info, **data):
+        image = cls.get_node_or_error(
+            info, data.get('id'), only_type=ProductImage)
         product = image.product
-        alt = input.get('alt')
+        alt = data.get('input').get('alt')
         if alt is not None:
             image.alt = alt
             image.save(update_fields=['alt'])
@@ -731,11 +733,11 @@ class ProductImageReorder(BaseMutation):
         description = 'Changes ordering of the product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, product_id, images_ids):
+    def perform_mutation(cls, _root, info, product_id, images_ids):
         product = cls.get_node_or_error(
             info, product_id, field='product_id', only_type=Product)
         if len(images_ids) != product.images.count():
@@ -773,12 +775,13 @@ class ProductImageDelete(BaseMutation):
         description = 'Deletes a product image.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
-        image = cls.get_node_or_error(info, id, only_type=ProductImage)
+    def perform_mutation(cls, _root, info, **data):
+        image = cls.get_node_or_error(
+            info, data.get('id'), only_type=ProductImage)
         image_id = image.id
         image.delete()
         image.id = image_id
@@ -802,11 +805,11 @@ class VariantImageAssign(BaseMutation):
         description = 'Assign an image to a product variant'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, image_id, variant_id):
+    def perform_mutation(cls, _root, info, image_id, variant_id):
         image = cls.get_node_or_error(
             info, image_id, field='image_id', only_type=ProductImage)
         variant = cls.get_node_or_error(
@@ -839,11 +842,11 @@ class VariantImageUnassign(BaseMutation):
         description = 'Unassign an image from a product variant'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('product.manage_products')
 
     @classmethod
-    def perform_mutation(cls, root, info, image_id, variant_id):
+    def perform_mutation(cls, _root, info, image_id, variant_id):
         image = cls.get_node_or_error(
             info, image_id, field='image_id', only_type=ProductImage)
         variant = cls.get_node_or_error(

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -74,7 +74,7 @@ def resolve_collections(info, query):
     return gql_optimizer.query(qs, info)
 
 
-def resolve_digital_contents(info, query):
+def resolve_digital_contents(info):
     qs = models.DigitalContent.objects.all()
     return gql_optimizer.query(qs, info)
 
@@ -82,7 +82,7 @@ def resolve_digital_contents(info, query):
 def resolve_products(
         info, attributes=None, categories=None, collections=None,
         price_lte=None, price_gte=None, sort_by=None, stock_availability=None,
-        query=None, **kwargs):
+        query=None, **_kwargs):
 
     user = info.context.user
     qs = models.Product.objects.visible_to_user(user)
@@ -135,7 +135,7 @@ def resolve_product_variants(info, ids=None):
     return gql_optimizer.query(qs, info)
 
 
-def resolve_report_product_sales(info, period):
+def resolve_report_product_sales(period):
     qs = models.ProductVariant.objects.prefetch_related(
         'product', 'product__images', 'order_lines__order').all()
 

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -117,10 +117,10 @@ class ProductQueries(graphene.ObjectType):
 
     def resolve_attributes(
             self, info, in_category=None, in_collection=None, query=None,
-            **kwargs):
+            **_kwargs):
         return resolve_attributes(info, in_category, in_collection, query)
 
-    def resolve_categories(self, info, level=None, query=None, **kwargs):
+    def resolve_categories(self, info, level=None, query=None, **_kwargs):
         return resolve_categories(info, level=level, query=query)
 
     def resolve_category(self, info, id):
@@ -129,7 +129,7 @@ class ProductQueries(graphene.ObjectType):
     def resolve_collection(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, Collection)
 
-    def resolve_collections(self, info, query=None, **kwargs):
+    def resolve_collections(self, info, query=None, **_kwargs):
         return resolve_collections(info, query)
 
     @permission_required('product.manage_products')
@@ -137,8 +137,8 @@ class ProductQueries(graphene.ObjectType):
         return graphene.Node.get_node_from_global_id(info, id, DigitalContent)
 
     @permission_required('product.manage_products')
-    def resolve_digital_contents(self, info, query=None, **kwargs):
-        return resolve_digital_contents(info, query)
+    def resolve_digital_contents(self, info, **_kwargs):
+        return resolve_digital_contents(info)
 
     def resolve_product(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, Product)
@@ -149,18 +149,18 @@ class ProductQueries(graphene.ObjectType):
     def resolve_product_type(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, ProductType)
 
-    def resolve_product_types(self, info, **kwargs):
+    def resolve_product_types(self, info, **_kwargs):
         return resolve_product_types(info)
 
     def resolve_product_variant(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, ProductVariant)
 
-    def resolve_product_variants(self, info, ids=None, **kwargs):
+    def resolve_product_variants(self, info, ids=None, **_kwargs):
         return resolve_product_variants(info, ids)
 
     @permission_required(['order.manage_orders', 'product.manage_products'])
-    def resolve_report_product_sales(self, info, period, **kwargs):
-        return resolve_report_product_sales(info, period)
+    def resolve_report_product_sales(self, *_args, period, **_kwargs):
+        return resolve_report_product_sales(period)
 
 
 class ProductMutations(graphene.ObjectType):

--- a/saleor/graphql/product/types.py
+++ b/saleor/graphql/product/types.py
@@ -466,12 +466,6 @@ class ProductType(CountableDjangoObjectType):
         PrefetchingConnectionField(
             Product, description='List of products of this type.'),
         prefetch_related=prefetch_products)
-    product_attributes = gql_optimizer.field(
-        PrefetchingConnectionField(Attribute),
-        model_field='product_attributes')
-    variant_attributes = gql_optimizer.field(
-        PrefetchingConnectionField(Attribute),
-        model_field='variant_attributes')
     tax_rate = TaxRateType(description='A type of tax rate.')
     variant_attributes = graphene.List(
         Attribute, description='Variant attributes of that product type.')
@@ -487,9 +481,11 @@ class ProductType(CountableDjangoObjectType):
             'has_variants', 'id', 'is_digital', 'is_shipping_required', 'name',
             'weight']
 
+    @gql_optimizer.resolver_hints(prefetch_related='product_attributes')
     def resolve_product_attributes(self, info, **kwargs):
         return self.product_attributes.all()
 
+    @gql_optimizer.resolver_hints(prefetch_related='variant_attributes')
     def resolve_variant_attributes(self, info, **kwargs):
         return self.variant_attributes.all()
 

--- a/saleor/graphql/shipping/bulk_mutations.py
+++ b/saleor/graphql/shipping/bulk_mutations.py
@@ -16,7 +16,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -32,5 +32,5 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user, ids):
         return user.has_perm('shipping.manage_shipping')

--- a/saleor/graphql/shipping/bulk_mutations.py
+++ b/saleor/graphql/shipping/bulk_mutations.py
@@ -16,7 +16,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -32,5 +32,5 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')

--- a/saleor/graphql/shipping/bulk_mutations.py
+++ b/saleor/graphql/shipping/bulk_mutations.py
@@ -16,7 +16,7 @@ class ShippingZoneBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -32,5 +32,5 @@ class ShippingPriceBulkDelete(ModelBulkDeleteMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, ids):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('shipping.manage_shipping')

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -204,7 +204,7 @@ class ShippingPriceDelete(BaseMutation):
         description = 'Deletes a shipping price.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -44,8 +44,8 @@ class ShippingZoneInput(graphene.InputObjectType):
 
 class ShippingZoneMixin:
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         default = cleaned_input.get('default')
         if default:
             if default_shipping_zone_exists(instance.pk):
@@ -112,8 +112,8 @@ class ShippingZoneDelete(ModelDeleteMutation):
 
 class ShippingPriceMixin:
     @classmethod
-    def clean_input(cls, info, instance, raw_input):
-        cleaned_input = super().clean_input(info, instance, raw_input)
+    def clean_input(cls, info, instance, data):
+        cleaned_input = super().clean_input(info, instance, data)
         cleaned_type = cleaned_input.get('type')
         if cleaned_type:
             if cleaned_type == ShippingMethodTypeEnum.PRICE.value:

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -114,9 +114,9 @@ class ShippingPriceMixin:
     @classmethod
     def clean_input(cls, info, instance, raw_input):
         cleaned_input = super().clean_input(info, instance, raw_input)
-        type = cleaned_input.get('type')
-        if type:
-            if type == ShippingMethodTypeEnum.PRICE.value:
+        cleaned_type = cleaned_input.get('type')
+        if cleaned_type:
+            if cleaned_type == ShippingMethodTypeEnum.PRICE.value:
                 min_price = cleaned_input.get('minimum_order_price')
                 max_price = cleaned_input.get('maximum_order_price')
                 if (min_price is not None and max_price is not None

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -44,8 +44,8 @@ class ShippingZoneInput(graphene.InputObjectType):
 
 class ShippingZoneMixin:
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         default = cleaned_input.get('default')
         if default:
             if default_shipping_zone_exists(instance.pk):
@@ -72,7 +72,7 @@ class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -92,7 +92,7 @@ class ShippingZoneUpdate(ShippingZoneMixin, ModelMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -106,14 +106,14 @@ class ShippingZoneDelete(ModelDeleteMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
 
 class ShippingPriceMixin:
     @classmethod
-    def clean_input(cls, info, instance, input):
-        cleaned_input = super().clean_input(info, instance, input)
+    def clean_input(cls, info, instance, raw_input):
+        cleaned_input = super().clean_input(info, instance, raw_input)
         type = cleaned_input.get('type')
         if type:
             if type == ShippingMethodTypeEnum.PRICE.value:
@@ -152,7 +152,7 @@ class ShippingPriceCreate(ShippingPriceMixin, ModelMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod
@@ -179,7 +179,7 @@ class ShippingPriceUpdate(ShippingPriceMixin, ModelMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod
@@ -204,13 +204,13 @@ class ShippingPriceDelete(BaseMutation):
         description = 'Deletes a shipping price.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod
-    def perform_mutation(cls, root, info, id):
+    def perform_mutation(cls, _root, info, **data):
         shipping_method = cls.get_node_or_error(
-            info, id, only_type=ShippingMethod)
+            info, data.get('id'), only_type=ShippingMethod)
         shipping_method_id = shipping_method.id
         shipping_zone = shipping_method.shipping_zone
         shipping_method.delete()

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -72,7 +72,7 @@ class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -92,7 +92,7 @@ class ShippingZoneUpdate(ShippingZoneMixin, ModelMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -106,7 +106,7 @@ class ShippingZoneDelete(ModelDeleteMutation):
         model = models.ShippingZone
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
 
@@ -152,7 +152,7 @@ class ShippingPriceCreate(ShippingPriceMixin, ModelMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod
@@ -179,7 +179,7 @@ class ShippingPriceUpdate(ShippingPriceMixin, ModelMutation):
         model = models.ShippingMethod
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('shipping.manage_shipping')
 
     @classmethod

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -23,7 +23,7 @@ class ShippingQueries(graphene.ObjectType):
         return graphene.Node.get_node_from_global_id(info, id, ShippingZone)
 
     @permission_required('shipping.manage_shipping')
-    def resolve_shipping_zones(self, info, **kwargs):
+    def resolve_shipping_zones(self, info, **_kwargs):
         return resolve_shipping_zones(info)
 
 

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -61,13 +61,13 @@ class ShippingZone(CountableDjangoObjectType):
         interfaces = [relay.Node]
         only_fields = ['default', 'id', 'name']
 
-    def resolve_price_range(self, info):
+    def resolve_price_range(self, *_args):
         return self.price_range
 
-    def resolve_countries(self, info):
+    def resolve_countries(self, *_args):
         return [
             CountryDisplay(code=country.code, country=country.name)
             for country in self.countries]
 
-    def resolve_shipping_methods(self, info):
+    def resolve_shipping_methods(self, *_args):
         return self.shipping_methods.all()

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -48,7 +48,7 @@ class ShopSettingsUpdate(BaseMutation):
         description = 'Updates shop settings'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod
@@ -74,7 +74,7 @@ class ShopDomainUpdate(BaseMutation):
         description = 'Updates site domain of the shop'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod
@@ -99,7 +99,7 @@ class ShopFetchTaxRates(BaseMutation):
         description = 'Fetch tax rates'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod
@@ -123,7 +123,7 @@ class HomepageCollectionUpdate(BaseMutation):
         description = 'Updates homepage collection of the shop'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod
@@ -160,7 +160,7 @@ class AuthorizationKeyAdd(BaseMutation):
             description='Fields required to create an authorization key.')
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod
@@ -190,7 +190,7 @@ class AuthorizationKeyDelete(BaseMutation):
         description = 'Deletes an authorization key.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_settings')
 
     @classmethod

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -179,7 +179,7 @@ class AuthorizationKeyAdd(BaseMutation):
 
 class AuthorizationKeyDelete(BaseMutation):
     authorization_key = graphene.Field(
-        AuthorizationKey, description='Auhtorization key that was deleted.')
+        AuthorizationKey, description='Authorization key that was deleted.')
     shop = graphene.Field(Shop, description='Updated Shop')
 
     class Arguments:

--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -54,8 +54,8 @@ class ShopSettingsUpdate(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         instance = info.context.site.settings
-        raw_input = data.get('input')
-        for field_name, desired_value in raw_input.items():
+        data = data.get('input')
+        for field_name, desired_value in data.items():
             current_value = getattr(instance, field_name)
             if current_value != desired_value:
                 setattr(instance, field_name, desired_value)
@@ -80,9 +80,9 @@ class ShopDomainUpdate(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         site = info.context.site
-        raw_input = data.get('input')
-        domain = raw_input.get('domain')
-        name = raw_input.get('name')
+        data = data.get('input')
+        domain = data.get('domain')
+        name = data.get('name')
         if domain is not None:
             site.domain = domain
         if name is not None:

--- a/saleor/graphql/shop/schema.py
+++ b/saleor/graphql/shop/schema.py
@@ -10,7 +10,7 @@ from .types import Shop
 class ShopQueries(graphene.ObjectType):
     shop = graphene.Field(Shop, description='Represents a shop resources.')
 
-    def resolve_shop(self, info):
+    def resolve_shop(self, _info):
         return Shop()
 
 

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -70,7 +70,7 @@ class Shop(graphene.ObjectType):
         AuthorizationKey,
         description=dedent(
             '''List of configured authorization keys. Authorization
-               keys are used to enable third party OAuth authorization 
+               keys are used to enable third party OAuth authorization
                (currently Facebook or Google).'''),
         required=True)
     countries = graphene.List(

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -68,9 +68,10 @@ class Shop(graphene.ObjectType):
         description='Customer\'s geolocalization data.')
     authorization_keys = graphene.List(
         AuthorizationKey,
-        description=dedent('''List of configured authorization keys. Authorization
-        keys are used to enable thrid party OAuth authorization (currently
-        Facebook or Google).'''),
+        description=dedent(
+            '''List of configured authorization keys. Authorization
+               keys are used to enable third party OAuth authorization 
+               (currently Facebook or Google).'''),
         required=True)
     countries = graphene.List(
         CountryDisplay, description='List of countries available in the shop.',
@@ -175,7 +176,8 @@ class Shop(graphene.ObjectType):
     def resolve_languages(self, _info):
         return [
             LanguageDisplay(
-                code=LanguageCodeEnum[str_to_enum(language[0])], language=language[1])
+                code=LanguageCodeEnum[str_to_enum(language[0])],
+                language=language[1])
             for language in settings.LANGUAGES]
 
     def resolve_name(self, info):
@@ -216,7 +218,7 @@ class Shop(graphene.ObjectType):
     def resolve_default_weight_unit(self, info):
         return info.context.site.settings.default_weight_unit
 
-    def resolve_default_country(self, info):
+    def resolve_default_country(self, _info):
         default_country_code = settings.DEFAULT_COUNTRY
         default_country_name = countries.countries.get(default_country_code)
         if default_country_name:

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -132,17 +132,17 @@ class Shop(graphene.ObjectType):
         and configuration.''')
 
     @permission_required('site.manage_settings')
-    def resolve_authorization_keys(self, info):
+    def resolve_authorization_keys(self, _info):
         return site_models.AuthorizationKey.objects.all()
 
-    def resolve_countries(self, info):
+    def resolve_countries(self, _info):
         taxes = {vat.country_code: vat for vat in VAT.objects.all()}
         return [
             CountryDisplay(
                 code=country[0], country=country[1], vat=taxes.get(country[0]))
             for country in countries]
 
-    def resolve_currencies(self, info):
+    def resolve_currencies(self, _info):
         return settings.AVAILABLE_CURRENCIES
 
     def resolve_domain(self, info):
@@ -161,7 +161,7 @@ class Shop(graphene.ObjectType):
                     code=country.code, country=country.name))
         return Geolocalization(country=None)
 
-    def resolve_default_currency(self, info):
+    def resolve_default_currency(self, _info):
         return settings.DEFAULT_CURRENCY
 
     def resolve_description(self, info):
@@ -172,7 +172,7 @@ class Shop(graphene.ObjectType):
         qs = product_models.Collection.objects.all()
         return get_node_optimized(qs, {'pk': collection_pk}, info)
 
-    def resolve_languages(self, info):
+    def resolve_languages(self, _info):
         return [
             LanguageDisplay(
                 code=LanguageCodeEnum[str_to_enum(language[0])], language=language[1])
@@ -191,11 +191,11 @@ class Shop(graphene.ObjectType):
         return Navigation(main=top_menu, secondary=bottom_menu)
 
     @permission_required('account.manage_users')
-    def resolve_permissions(self, info):
+    def resolve_permissions(self, _info):
         permissions = get_permissions()
         return format_permissions_for_display(permissions)
 
-    def resolve_phone_prefixes(self, info):
+    def resolve_phone_prefixes(self, _info):
         return list(COUNTRY_CODE_TO_REGION_CODE.keys())
 
     def resolve_header_text(self, info):

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -214,12 +214,12 @@ class ShopSettingsTranslate(BaseMutation):
         description = 'Creates/Updates translations for Shop Settings.'
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _data):
         return user.has_perm('site.manage_translations')
 
     @classmethod
-    def perform_mutation(cls, root, info, language_code, input):
+    def perform_mutation(cls, _root, info, language_code, **data):
         instance = info.context.site.settings
         instance.translations.update_or_create(
-            language_code=language_code, defaults=input)
+            language_code=language_code, defaults=data.get('input'))
         return ShopSettingsTranslate(shop=Shop())

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -17,7 +17,7 @@ class BaseTranslateMutation(ModelMutation):
         abstract = True
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_translations')
 
     @classmethod
@@ -214,7 +214,7 @@ class ShopSettingsTranslate(BaseMutation):
         description = 'Creates/Updates translations for Shop Settings.'
 
     @classmethod
-    def user_is_allowed(cls, user, _data):
+    def user_is_allowed(cls, user):
         return user.has_perm('site.manage_translations')
 
     @classmethod

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -21,7 +21,7 @@ class BaseTranslateMutation(ModelMutation):
         return user.has_perm('site.manage_translations')
 
     @classmethod
-    def perform_mutation(cls, root, info, **data):
+    def perform_mutation(cls, _root, info, **data):
         model_type = registry.get_type_for_model(cls._meta.model)
         instance = cls.get_node_or_error(
             info, data['id'], only_type=model_type)

--- a/saleor/graphql/translations/resolvers.py
+++ b/saleor/graphql/translations/resolvers.py
@@ -4,7 +4,7 @@ from ...product import models as product_models
 from ...shipping import models as shipping_models
 
 
-def resolve_translation(instance, info, language_code):
+def resolve_translation(instance, _info, language_code):
     """Gets translation object from instance based on language code."""
     return instance.translations.filter(language_code=language_code).first()
 

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -58,7 +58,7 @@ class TranslationQueries(graphene.ObjectType):
             TranslatableKinds,
             required=True, description='Kind of objects to retrieve.'))
 
-    def resolve_translations(self, info, kind, **kwargs):
+    def resolve_translations(self, info, kind, **_kwargs):
         if kind == TranslatableKinds.PRODUCT:
             return resolve_products(info)
         elif kind == TranslatableKinds.COLLECTION:

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -20,7 +20,7 @@ class BaseTranslationType(CountableDjangoObjectType):
     class Meta:
         abstract = True
 
-    def resolve_language(self, info):
+    def resolve_language(self, *_args):
         try:
             language = next(
                 language[1] for language in settings.LANGUAGES

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -24,24 +24,31 @@ def get_database_id(info, node_id, only_type):
     return _id
 
 
+def _check_graphene_type(requested_graphene_type, received_type):
+    if requested_graphene_type:
+        assert str(requested_graphene_type) == received_type, (
+            'Must receive an {} id.'
+        ).format(requested_graphene_type._meta.name)
+
+
 def _resolve_nodes(ids, graphene_type=None):
     pks = []
     types = []
     invalid_ids = []
 
     for graphql_id in ids:
-        if graphql_id:
-            try:
-                _type, _id = from_global_id(graphql_id)
-            except Exception:
-                invalid_ids.append(graphql_id)
-            else:
-                if graphene_type:
-                    assert str(graphene_type) == _type, (
-                        'Must receive an {} id.').format(
-                            graphene_type._meta.name)
-                pks.append(_id)
-                types.append(_type)
+        if not graphql_id:
+            continue
+
+        try:
+            _type, _id = from_global_id(graphql_id)
+        except Exception:
+            invalid_ids.append(graphql_id)
+            continue
+
+        _check_graphene_type(graphene_type, _type)
+        pks.append(_id)
+        types.append(_type)
 
     if invalid_ids:
         raise GraphQLError(

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -1,10 +1,11 @@
+from typing import List
+
 import graphene
 from django.db.models import Q
 from django.utils import timezone
 from graphene_django.registry import get_global_registry
 from graphql.error import GraphQLError
 from graphql_relay import from_global_id
-from typing import List
 
 from .core.enums import PermissionEnum, ReportingPeriod
 from .core.types import PermissionDisplay
@@ -53,7 +54,7 @@ def _resolve_graphene_type(types: List):
     assert len(set(types)) == 1, 'Received IDs of more than one type.'
     # get type by name
     type_name = types[0]
-    for model, _type in registry._registry.items():
+    for _, _type in registry._registry.items():
         if _type._meta.name == type_name:
             return _type
 

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -57,6 +57,7 @@ def _resolve_graphene_type(types: List):
     for _, _type in registry._registry.items():
         if _type._meta.name == type_name:
             return _type
+    return None
 
 
 def get_nodes(ids, graphene_type=None):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -7,7 +7,7 @@ from django.shortcuts import render_to_response
 from django.views.generic import View
 from graphene_django.settings import graphene_settings
 from graphene_django.views import instantiate_middleware
-from graphql import get_default_backend, GraphQLDocument
+from graphql import GraphQLDocument, get_default_backend
 from graphql.error import (
     GraphQLError, GraphQLSyntaxError, format_error as format_graphql_error)
 from graphql.execution import ExecutionResult

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -55,7 +55,7 @@ class GraphQLView(View):
         if request.method == 'OPTIONS':
             response = self.options(request, *args, **kwargs)
         elif request.method == 'POST':
-            response = self.handle_query(request, *args, **kwargs)
+            response = self.handle_query(request)
         else:
             return HttpResponseNotAllowed(
                 ['GET', 'OPTIONS', 'POST'])
@@ -67,7 +67,7 @@ class GraphQLView(View):
             'Origin, Content-Type, Accept, Authorization')
         return response
 
-    def handle_query(self, request: HttpRequest, *args, **kwargs):
+    def handle_query(self, request: HttpRequest):
         try:
             data = self.parse_body(request)
         except ValueError:
@@ -102,7 +102,7 @@ class GraphQLView(View):
             result = None
         return result, status_code
 
-    def get_root_value(self, request: HttpRequest):
+    def get_root_value(self):
         return self.root_value
 
     def parse_query(self, query: str) -> (GraphQLDocument, ExecutionResult):
@@ -138,7 +138,7 @@ class GraphQLView(View):
             extra_options['executor'] = self.executor
         try:
             return document.execute(
-                root=self.get_root_value(request),
+                root=self.get_root_value(),
                 variables=variables,
                 operation_name=operation_name,
                 context=request,

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -149,12 +149,12 @@ CREATE_ATTRIBUTES_QUERY = """
 def test_create_attribute_and_attribute_values(
         staff_api_client, permission_manage_products, product_type):
     query = CREATE_ATTRIBUTES_QUERY
-    id = graphene.Node.to_global_id('ProductType', product_type.id)
+    node_id = graphene.Node.to_global_id('ProductType', product_type.id)
 
     attribute_name = 'Example name'
     name = 'Value name'
     variables = {
-        'name': attribute_name, 'id': id,
+        'name': attribute_name, 'id': node_id,
         'type': AttributeTypeEnum.PRODUCT.name,
         'values': [{'name': name, 'value': '#1231'}]}
     response = staff_api_client.post_graphql(
@@ -185,9 +185,9 @@ def test_create_attribute_and_attribute_values_errors(
         staff_api_client, name_1, name_2, error_msg,
         permission_manage_products, product_type):
     query = CREATE_ATTRIBUTES_QUERY
-    id = graphene.Node.to_global_id('ProductType', product_type.id)
+    node_id = graphene.Node.to_global_id('ProductType', product_type.id)
     variables = {
-        'name': 'Example name', 'id': id,
+        'name': 'Example name', 'id': node_id,
         'type': AttributeTypeEnum.PRODUCT.name,
         'values': [
             {'name': name_1, 'value': '#1231'},
@@ -207,10 +207,10 @@ def test_create_variant_attribute(
     product_type.save()
 
     query = CREATE_ATTRIBUTES_QUERY
-    id = graphene.Node.to_global_id('ProductType', product_type.id)
+    node_id = graphene.Node.to_global_id('ProductType', product_type.id)
     attribute_name = 'Example name'
     variables = {
-        'name': attribute_name, 'id': id,
+        'name': attribute_name, 'id': node_id,
         'type': AttributeTypeEnum.VARIANT.name, 'values': []}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
@@ -269,8 +269,9 @@ def test_update_attribute_name(
     query = UPDATE_ATTRIBUTE_QUERY
     attribute = color_attribute
     name = 'Wings name'
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
-    variables = {'name': name, 'id': id, 'addValues': [], 'removeValues': []}
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
+    variables = {
+        'name': name, 'id': node_id, 'addValues': [], 'removeValues': []}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
@@ -286,12 +287,12 @@ def test_update_attribute_remove_and_add_values(
     attribute = color_attribute
     name = 'Wings name'
     attribute_value_name = 'Red Color'
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
     attribute_value_id = attribute.values.first().id
     value_id = graphene.Node.to_global_id(
         'AttributeValue', attribute_value_id)
     variables = {
-        'name': name, 'id': id,
+        'name': name, 'id': node_id,
         'addValues': [{'name': attribute_value_name, 'value': '#1231'}],
         'removeValues': [value_id]}
     response = staff_api_client.post_graphql(
@@ -312,14 +313,14 @@ def test_update_empty_attribute_and_add_values(
     attribute = color_attribute_without_values
     name = 'Wings name'
     attribute_value_name = 'Yellow Color'
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
     variables = {
-        'name': name, 'id': id,
+        'name': name, 'id': node_id,
         'addValues': [{'name': attribute_value_name, 'value': '#1231'}],
         'removeValues': []}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
-    content = get_graphql_content(response)
+    get_graphql_content(response)
     attribute.refresh_from_db()
     assert attribute.values.count() == 1
     assert attribute.values.filter(name=attribute_value_name).exists()
@@ -338,9 +339,9 @@ def test_update_attribute_and_add_attribute_values_errors(
         permission_manage_products):
     query = UPDATE_ATTRIBUTE_QUERY
     attribute = color_attribute
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
     variables = {
-        'name': 'Example name', 'id': id, 'removeValues': [],
+        'name': 'Example name', 'id': node_id, 'removeValues': [],
         'addValues': [
             {'name': name_1, 'value': '#1'}, {'name': name_2, 'value': '#2'}]}
     response = staff_api_client.post_graphql(
@@ -357,12 +358,12 @@ def test_update_attribute_and_remove_others_attribute_value(
         permission_manage_products):
     query = UPDATE_ATTRIBUTE_QUERY
     attribute = color_attribute
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
     size_attribute = size_attribute.values.first()
     attr_id = graphene.Node.to_global_id(
         'AttributeValue', size_attribute.pk)
     variables = {
-        'name': 'Example name', 'id': id, 'slug': 'example-slug',
+        'name': 'Example name', 'id': node_id, 'slug': 'example-slug',
         'addValues': [], 'removeValues': [attr_id]}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
@@ -395,8 +396,8 @@ def test_delete_attribute(
         }
     }
     """
-    id = graphene.Node.to_global_id('Attribute', attribute.id)
-    variables = {'id': id}
+    node_id = graphene.Node.to_global_id('Attribute', attribute.id)
+    variables = {'id': node_id}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
@@ -499,9 +500,9 @@ def test_update_attribute_value(
         staff_api_client, pink_attribute_value, permission_manage_products):
     query = UPDATE_ATTRIBUTE_VALUE_QUERY
     value = pink_attribute_value
-    id = graphene.Node.to_global_id('AttributeValue', value.id)
+    node_id = graphene.Node.to_global_id('AttributeValue', value.id)
     name = 'Crimson name'
-    variables = {'name': name, 'value': '#RED', 'id': id}
+    variables = {'name': name, 'value': '#RED', 'id': node_id}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
@@ -517,8 +518,9 @@ def test_update_attribute_value_name_not_unique(
     query = UPDATE_ATTRIBUTE_VALUE_QUERY
     value = pink_attribute_value.attribute.values.create(
         name='Example Name', slug='example-name', value='#RED')
-    id = graphene.Node.to_global_id('AttributeValue', value.id)
-    variables = {'name': pink_attribute_value.name, 'value': '#RED', 'id': id}
+    node_id = graphene.Node.to_global_id('AttributeValue', value.id)
+    variables = {
+        'name': pink_attribute_value.name, 'value': '#RED', 'id': node_id}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
@@ -532,9 +534,9 @@ def test_update_same_attribute_value(
         staff_api_client, pink_attribute_value, permission_manage_products):
     query = UPDATE_ATTRIBUTE_VALUE_QUERY
     value = pink_attribute_value
-    id = graphene.Node.to_global_id('AttributeValue', value.id)
+    node_id = graphene.Node.to_global_id('AttributeValue', value.id)
     attr_value = '#BLUE'
-    variables = {'name': value.name, 'value': attr_value, 'id': id}
+    variables = {'name': value.name, 'value': attr_value, 'id': node_id}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     content = get_graphql_content(response)
@@ -546,7 +548,6 @@ def test_update_same_attribute_value(
 def test_delete_attribute_value(
         staff_api_client, color_attribute, pink_attribute_value,
         permission_manage_products):
-    value = pink_attribute_value
     value = color_attribute.values.get(name='Red')
     query = """
     mutation updateChoice($id: ID!) {
@@ -558,9 +559,9 @@ def test_delete_attribute_value(
         }
     }
     """
-    id = graphene.Node.to_global_id('AttributeValue', value.id)
-    variables = {'id': id}
-    response = staff_api_client.post_graphql(
+    node_id = graphene.Node.to_global_id('AttributeValue', value.id)
+    variables = {'id': node_id}
+    staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
     with pytest.raises(value._meta.model.DoesNotExist):
         value.refresh_from_db()

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -417,7 +417,7 @@ def test_checkout_lines_invalid_variant_id(user_api_client, cart, variant):
     content = get_graphql_content(response)
     data = content['data']['checkoutLinesAdd']
     error_msg = (
-        'Could not resolve to a nodes with the global id list of \'%s\'.')
+        'Could not resolve to a node with the global id list of \'%s\'.')
     assert data['errors'][0]['message'] == error_msg % [invalid_variant_id]
     assert data['errors'][0]['field'] == 'variantId'
 

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -144,7 +144,7 @@ def test_create_fulfillment_with_invalid_input(
     assert data['errors']
     assert data['errors'][0]['field'] == 'lines'
     assert data['errors'][0]['message'] == (
-        'Could not resolve to a nodes with the global id list'
+        'Could not resolve to a node with the global id list'
         ' of \'[\'fake-orderline-id\']\'.')
 
 

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -216,14 +216,14 @@ def test_get_nodes(product_list):
 
     # Raise an error if no nodes were found
     global_ids = []
-    msg = 'Could not resolve to a nodes with the global id list of {}.'.format(
+    msg = 'Could not resolve to a node with the global id list of {}.'.format(
         global_ids)
     with pytest.raises(Exception, message=msg):
         get_nodes(global_ids, Product)
 
     # Raise an error if pass wrong ids
     global_ids = ['a', 'bb']
-    msg = 'Could not resolve to a nodes with the global id list of {}.'.format(
+    msg = 'Could not resolve to a node with the global id list of {}.'.format(
         global_ids)
     with pytest.raises(Exception, message=msg):
         get_nodes(global_ids, Product)

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -937,8 +937,8 @@ def test_order_add_note(
         mutation addNote($id: ID!, $message: String) {
             orderAddNote(order: $id, input: {message: $message}) {
                 errors {
-                field
-                message
+                    field
+                    message
                 }
                 order {
                     id

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -1230,9 +1230,8 @@ def test_clean_order_refund_payment():
 
 
 def test_clean_order_capture():
-    amount = Mock(spec='string')
     with pytest.raises(ValidationError) as e:
-        clean_order_capture(None, amount)
+        clean_order_capture(None)
     msg = 'There\'s no payment associated with the order.'
     assert e.value.error_dict['payment'][0].message == msg
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -1496,7 +1496,7 @@ def test_product_type_update_changes_variant_name(
         'variantAttributes': variant_attributes_ids}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products])
-    content = get_graphql_content(response)
+    get_graphql_content(response)
     variant_attributes = set(variant_attributes)
     variant_attributes_ids = [attr.pk for attr in variant_attributes]
     mock_update_variants_names.assert_called_once_with(


### PR DESCRIPTION
Closes #3909 

### Fixes (total of 390)
```
- views.py:112:4: R1260: 'execute_graphql_request' is too complex. The McCabe rating is 7 (too-complex)
- utils.py:23:0: R1260: 'get_nodes' is too complex. The McCabe rating is 12 (too-complex)
- utils.py:56:8: W0612: Unused variable 'model' (unused-variable)
- (many) shipping/mutations.py:47:41: W0622: Redefining built-in 'input' (redefined-builtin)
- (many) shipping/mutations.py:208:32: W0622: Redefining built-in 'id' (redefined-builtin)
- (a few) shipping/mutations.py:117:8: W0622: Redefining built-in 'type' (redefined-builtin)
- (many) shipping/mutations.py:208:20: W0613: Unused argument 'root' (unused-argument)
- (a few) order/types.py:249:4: W0211: Static method with 'self' as first argument (bad-staticmethod-argument)
- some missing optimizations in the gql types
- some typos
- some PEP8 issues
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
