### PR TITLE
Prefetch collections when getting sales of a bunch of products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutation for bulk delete order lines - #3935 by @akjanik
 - Fix dashboard 1.0 missing logo and missing back arrow on collections - #3958 by @NyanKiyoshi
 - Add mutations for publishing and unpublishing multiple pages - #3954 by @akjanik
+- Prefetch collections when getting sales of a bunch of products - #3961 by @NyanKiyoshi
 
 ## 2.5.0
 

--- a/saleor/product/utils/__init__.py
+++ b/saleor/product/utils/__init__.py
@@ -41,7 +41,8 @@ def products_for_products_list(user):
 def products_for_homepage(user, homepage_collection):
     products = products_visible_to_user(user)
     products = products.prefetch_related(
-        'translations', 'images', 'variants__variant_images__image')
+        'translations', 'images', 'variants__variant_images__image',
+        'collections')
     products = products.filter(collections=homepage_collection)
     return products
 

--- a/saleor/product/views.py
+++ b/saleor/product/views.py
@@ -151,8 +151,10 @@ def category_index(request, slug, category_id):
             category_id=category_id)
     # Check for subcategories
     categories = category.get_descendants(include_self=True)
-    products = products_for_products_list(user=request.user).filter(
-        category__in=categories).order_by('name')
+    products = products_for_products_list(user=request.user)\
+        .filter(category__in=categories)\
+        .order_by('name')\
+        .prefetch_related('collections')
     product_filter = ProductCategoryFilter(
         request.GET, queryset=products, category=category)
     ctx = get_product_list_context(request, product_filter)


### PR DESCRIPTION
Fixes #3896. This improves the performances of the product listing (storefront 1.0) in the case of:
- The homepage;
- The categories;
- The collections;
- The search results.

This changes introduce a `collections` variable to allow some kind of pooling during the retrieval of a bunch of products. 

### Screenshots
The home page loading time difference and query count (changes removing 50 duplicated queries in the demo store):

<img width="185" alt="Screenshot 2019-04-11 at 16 11 03" src="https://user-images.githubusercontent.com/6186720/55964118-6ca19000-5c74-11e9-862a-6624240b4d24.png">
<img width="185" alt="Screenshot 2019-04-11 at 16 10 53" src="https://user-images.githubusercontent.com/6186720/55964117-6ca19000-5c74-11e9-88aa-69544608bd84.png">


<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
