### PR TITLE
Remove the reporting of coverage supplied by default to pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ exclude_lines =
     return NotImplemented
 
 [tool:pytest]
-addopts = -n auto --vcr-record-mode=none --cov --cov-report=
+addopts = -n auto --vcr-record-mode=none
 testpaths = tests saleor
 filterwarnings =
     ignore::DeprecationWarning

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     django22: pip install "django>=2.2a1,<2.3" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput --verbosity=0
-    pytest
+    pytest --cov --cov-report=
     codecov
 
 [travis]


### PR DESCRIPTION
For some reasons, it was supplied to pytest to run in coverage mode by default, which is obviously making the tests way slower when we do not care about testing the coverage.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
