### PR TITLE
Add mutation for bulk cancel orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutations for publishing and unpublishing multiple pages - #3954 by @akjanik
 - Prefetch collections when getting sales of a bunch of products - #3961 by @NyanKiyoshi
 - Move dialog windows to querystring rather than router paths - #3953 by @dominik-zeglen
-
 - Add mutation for bulk cancel orders - #3967 by @akjanik
 
 - Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Prefetch collections when getting sales of a bunch of products - #3961 by @NyanKiyoshi
 - Move dialog windows to querystring rather than router paths - #3953 by @dominik-zeglen
 
+- Add mutation for bulk cancel orders - #3967 by @akjanik
 
 - Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Prefetch collections when getting sales of a bunch of products - #3961 by @NyanKiyoshi
 - Move dialog windows to querystring rather than router paths - #3953 by @dominik-zeglen
 - Add mutation for bulk cancel orders - #3967 by @akjanik
-
 - Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
 
 ## 2.5.0

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -412,7 +412,7 @@ class BaseBulkMutation(BaseMutation):
         raise NotImplementedError
 
     @classmethod
-    def perform_mutation(cls, _root, info, ids):
+    def perform_mutation(cls, root, info, ids, **data):
         """Perform a mutation that deletes a list of model instances."""
         clean_instance_ids, errors = [], {}
         instance_model = cls._meta.model
@@ -441,7 +441,8 @@ class BaseBulkMutation(BaseMutation):
         count = len(clean_instance_ids)
         if count:
             qs = instance_model.objects.filter(pk__in=clean_instance_ids)
-            cls.bulk_action(queryset=qs)
+            data['user'] = info.context.user
+            cls.bulk_action(queryset=qs, **data)
         return count, errors
 
     @classmethod
@@ -460,7 +461,7 @@ class ModelBulkDeleteMutation(BaseBulkMutation):
         abstract = True
 
     @classmethod
-    def bulk_action(cls, queryset):
+    def bulk_action(cls, queryset, **kwargs):
         queryset.delete()
 
 
@@ -469,7 +470,7 @@ class ModelBulkPublishMutation(BaseBulkMutation):
         abstract = True
 
     @classmethod
-    def bulk_action(cls, queryset):
+    def bulk_action(cls, queryset, **kwargs):
         queryset.update(is_published=True)
 
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -412,7 +412,7 @@ class BaseBulkMutation(BaseMutation):
         raise NotImplementedError
 
     @classmethod
-    def perform_mutation(cls, root, info, ids, **data):
+    def perform_mutation(cls, _root, info, ids, **data):
         """Perform a mutation that deletes a list of model instances."""
         clean_instance_ids, errors = [], {}
         instance_model = cls._meta.model

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -407,7 +407,7 @@ class BaseBulkMutation(BaseMutation):
         """
 
     @classmethod
-    def bulk_action(cls, queryset):
+    def bulk_action(cls, queryset, **kwargs):
         """Implement action performed on queryset."""
         raise NotImplementedError
 
@@ -441,7 +441,6 @@ class BaseBulkMutation(BaseMutation):
         count = len(clean_instance_ids)
         if count:
             qs = instance_model.objects.filter(pk__in=clean_instance_ids)
-            data['user'] = info.context.user
             cls.bulk_action(queryset=qs, **data)
         return count, errors
 
@@ -461,7 +460,7 @@ class ModelBulkDeleteMutation(BaseBulkMutation):
         abstract = True
 
     @classmethod
-    def bulk_action(cls, queryset, **kwargs):
+    def bulk_action(cls, queryset):
         queryset.delete()
 
 
@@ -470,7 +469,7 @@ class ModelBulkPublishMutation(BaseBulkMutation):
         abstract = True
 
     @classmethod
-    def bulk_action(cls, queryset, **kwargs):
+    def bulk_action(cls, queryset):
         queryset.update(is_published=True)
 
 

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -6,7 +6,7 @@ from ...core.mutations import BaseBulkMutation
 from ..mutations.orders import clean_order_cancel
 
 
-class OrdersCancel(BaseBulkMutation):
+class OrderBulkCancel(BaseBulkMutation):
     class Arguments:
         ids = graphene.List(
             graphene.ID,

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -1,0 +1,42 @@
+import graphene
+
+from ....order import OrderEvents, models
+from ....order.utils import cancel_order
+from ...core.mutations import BaseBulkMutation
+from ..mutations.orders import clean_order_cancel
+
+
+class OrdersCancel(BaseBulkMutation):
+    class Arguments:
+        ids = graphene.List(
+            graphene.ID,
+            required=True,
+            description='List of orders IDs to cancel.')
+        restock = graphene.Boolean(
+            required=True,
+            description='Determine if lines will be restocked or not.')
+
+    class Meta:
+        description = 'Cancels orders.'
+        model = models.Order
+
+    @classmethod
+    def clean_instance(cls, info, instance):
+        clean_order_cancel(instance)
+
+    @classmethod
+    def user_is_allowed(cls, user, input):
+        return user.has_perm('order.manage_orders')
+
+    @classmethod
+    def bulk_action(cls, instances, user, restock):
+        for order in instances:
+            cancel_order(order=order, restock=restock)
+            if restock:
+                order.events.create(
+                    type=OrderEvents.FULFILLMENT_RESTOCKED_ITEMS.value,
+                    user=user,
+                    parameters={'quantity': order.get_total_quantity()})
+            else:
+                order.events.create(
+                    type=OrderEvents.CANCELED.value, user=user)

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -25,7 +25,7 @@ class OrderBulkCancel(BaseBulkMutation):
         clean_order_cancel(instance)
 
     @classmethod
-    def user_is_allowed(cls, user, input):
+    def user_is_allowed(cls, user, _ids):
         return user.has_perm('order.manage_orders')
 
     @classmethod

--- a/saleor/graphql/order/bulk_mutations/orders.py
+++ b/saleor/graphql/order/bulk_mutations/orders.py
@@ -29,8 +29,13 @@ class OrdersCancel(BaseBulkMutation):
         return user.has_perm('order.manage_orders')
 
     @classmethod
-    def bulk_action(cls, instances, user, restock):
-        for order in instances:
+    def perform_mutation(cls, root, info, ids, **data):
+        data['user'] = info.context.user
+        return super().perform_mutation(root, info, ids, **data)
+
+    @classmethod
+    def bulk_action(cls, queryset, user, restock):
+        for order in queryset:
             cancel_order(order=order, restock=restock)
             if restock:
                 order.events.create(

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,9 +7,9 @@ from ..core.enums import ReportingPeriod
 from ..core.fields import PrefetchingConnectionField
 from ..core.types import TaxedMoney
 from ..descriptions import DESCRIPTIONS
-from .bulk_mutations.orders import OrdersCancel
 from .bulk_mutations.draft_orders import (
     DraftOrderBulkDelete, DraftOrderLinesBulkDelete)
+from .bulk_mutations.orders import OrdersCancel
 from .enums import OrderStatusFilter
 from .mutations.draft_orders import (
     DraftOrderComplete, DraftOrderCreate, DraftOrderDelete,

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,6 +7,7 @@ from ..core.enums import ReportingPeriod
 from ..core.fields import PrefetchingConnectionField
 from ..core.types import TaxedMoney
 from ..descriptions import DESCRIPTIONS
+from .bulk_mutations.orders import OrdersCancel
 from .bulk_mutations.draft_orders import (
     DraftOrderBulkDelete, DraftOrderLinesBulkDelete)
 from .enums import OrderStatusFilter
@@ -104,3 +105,5 @@ class OrderMutations(graphene.ObjectType):
     order_update = OrderUpdate.Field()
     order_update_shipping = OrderUpdateShipping.Field()
     order_void = OrderVoid.Field()
+
+    orders_cancel = OrdersCancel.Field()

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -9,7 +9,7 @@ from ..core.types import TaxedMoney
 from ..descriptions import DESCRIPTIONS
 from .bulk_mutations.draft_orders import (
     DraftOrderBulkDelete, DraftOrderLinesBulkDelete)
-from .bulk_mutations.orders import OrdersCancel
+from .bulk_mutations.orders import OrderBulkCancel
 from .enums import OrderStatusFilter
 from .mutations.draft_orders import (
     DraftOrderComplete, DraftOrderCreate, DraftOrderDelete,
@@ -106,4 +106,4 @@ class OrderMutations(graphene.ObjectType):
     order_update_shipping = OrderUpdateShipping.Field()
     order_void = OrderVoid.Field()
 
-    orders_cancel = OrdersCancel.Field()
+    orders_cancel = OrderBulkCancel.Field()

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -106,4 +106,4 @@ class OrderMutations(graphene.ObjectType):
     order_update_shipping = OrderUpdateShipping.Field()
     order_void = OrderVoid.Field()
 
-    orders_cancel = OrderBulkCancel.Field()
+    order_bulk_cancel = OrderBulkCancel.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1173,7 +1173,7 @@ type Mutations {
   orderUpdate(id: ID!, input: OrderUpdateInput!): OrderUpdate
   orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput): OrderUpdateShipping
   orderVoid(id: ID!): OrderVoid
-  ordersCancel(ids: [ID]!, restock: Boolean!): OrdersCancel
+  ordersCancel(ids: [ID]!, restock: Boolean!): OrderBulkCancel
   assignNavigation(menu: ID, navigationType: NavigationType!): AssignNavigation
   menuCreate(input: MenuCreateInput!): MenuCreate
   menuDelete(id: ID!): MenuDelete
@@ -1311,6 +1311,11 @@ type OrderAddNote {
 
 input OrderAddNoteInput {
   message: String
+}
+
+type OrderBulkCancel {
+  errors: [Error!]
+  count: Int!
 }
 
 type OrderCancel {
@@ -1463,11 +1468,6 @@ input OrderUpdateShippingInput {
 type OrderVoid {
   errors: [Error!]
   order: Order
-}
-
-type OrdersCancel {
-  errors: [Error!]
-  count: Int!
 }
 
 type Page implements Node {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1173,6 +1173,7 @@ type Mutations {
   orderUpdate(id: ID!, input: OrderUpdateInput!): OrderUpdate
   orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput): OrderUpdateShipping
   orderVoid(id: ID!): OrderVoid
+  ordersCancel(ids: [ID]!, restock: Boolean!): OrdersCancel
   assignNavigation(menu: ID, navigationType: NavigationType!): AssignNavigation
   menuCreate(input: MenuCreateInput!): MenuCreate
   menuDelete(id: ID!): MenuDelete
@@ -1462,6 +1463,11 @@ input OrderUpdateShippingInput {
 type OrderVoid {
   errors: [Error!]
   order: Order
+}
+
+type OrdersCancel {
+  errors: [Error!]
+  count: Int!
 }
 
 type Page implements Node {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1173,7 +1173,7 @@ type Mutations {
   orderUpdate(id: ID!, input: OrderUpdateInput!): OrderUpdate
   orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput): OrderUpdateShipping
   orderVoid(id: ID!): OrderVoid
-  ordersCancel(ids: [ID]!, restock: Boolean!): OrderBulkCancel
+  orderBulkCancel(ids: [ID]!, restock: Boolean!): OrderBulkCancel
   assignNavigation(menu: ID, navigationType: NavigationType!): AssignNavigation
   menuCreate(input: MenuCreateInput!): MenuCreate
   menuDelete(id: ID!): MenuDelete

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -1437,7 +1437,7 @@ def test_order_by_token_query(api_client, order):
 
 MUTATION_CANCEL_ORDERS = """
     mutation CancelManyOrders($ids: [ID]!, $restock: Boolean!) {
-        ordersCancel(ids: $ids, restock: $restock) {
+        orderBulkCancel(ids: $ids, restock: $restock) {
             count
             errors {
                 field
@@ -1464,7 +1464,7 @@ def test_order_bulk_cancel_with_restock(
         permissions=[permission_manage_orders])
     order_with_lines.refresh_from_db()
     content = get_graphql_content(response)
-    data = content['data']['ordersCancel']
+    data = content['data']['orderBulkCancel']
     assert data['count'] == expected_count
     event = order_with_lines.events.first()
     assert event.type == OrderEvents.FULFILLMENT_RESTOCKED_ITEMS.value

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -1436,7 +1436,7 @@ def test_order_by_token_query(api_client, order):
 
 
 MUTATION_CANCEL_ORDERS = """
-    CancelManyOrders($ids: [ID]!, !restock: Boolean) {
+    mutation CancelManyOrders($ids: [ID]!, $restock: Boolean!) {
         ordersCancel(ids: $ids, restock: $restock) {
             count
             errors {
@@ -1445,7 +1445,7 @@ MUTATION_CANCEL_ORDERS = """
             }
         }
     }
-"""
+    """
 
 
 def test_order_bulk_cancel_with_restock(


### PR DESCRIPTION
Part of #3927

@maarcingebala I named it `OrdersCancel` but if it's required, may change to more technical, but less human-friendly something like `OrderBulkCancel`.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
