### PR TITLE
Use always the newest GraphQL playground version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Move dialog windows to querystring rather than router paths - #3953 by @dominik-zeglen
 - Add mutation for bulk cancel orders - #3967 by @akjanik
 - Hide errors in TokenVerify mutation - #3981 by @fowczarek
+- Use newest GraphQL Playground - #3971 by @salwator
+
+
 - Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
 - Removed the dead `children` field from the `Menu` type - #3973 by @NyanKiyoshi
 - Add mutations for bulk publishing and unpublishing products - #3969 by akjanik

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -4,9 +4,9 @@
   <meta charset=utf-8/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.8/build/static/js/middleware.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
+  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
+  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/js/middleware.js"></script>
 </head>
 <body>
   <div id="root">


### PR DESCRIPTION
I want to merge this change because...

Current version of playground in saleor is hardcoded to 1.7.8. We should use newer (1.8) instead, preferably refer to newest version on CDN.

One important feature available in newer version is browsing schema through dedicated playground menu.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
