### PR TITLE
Removed the dead `children` field from the `Menu` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutations for publishing and unpublishing multiple pages - #3954 by @akjanik
 - Prefetch collections when getting sales of a bunch of products - #3961 by @NyanKiyoshi
 - Move dialog windows to querystring rather than router paths - #3953 by @dominik-zeglen
-
-
 - Cleanup and maintenance of the GraphQL API code - #3942 by @NyanKiyoshi
+- Removed the dead `children` field from the `Menu` type - #3973 by @NyanKiyoshi
 
 ## 2.5.0
 

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -20,9 +20,6 @@ def prefetch_menus(info, *_args, **_kwargs):
 
 
 class Menu(CountableDjangoObjectType):
-    children = graphene.List(
-        lambda: MenuItem, required=True,
-        description='List of menu item children items')
     items = gql_optimizer.field(
         graphene.List(lambda: MenuItem),
         prefetch_related=prefetch_menus)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -950,7 +950,6 @@ type Margin {
 type Menu implements Node {
   id: ID!
   name: String!
-  children: [MenuItem]!
   items: [MenuItem]
 }
 


### PR DESCRIPTION
This removes a leftover from #2983 where the `children` field was dropped from the `Menu` type.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [ ] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
