### PR TITLE
Remove unpublish mutation in favor of one with parameter

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -464,15 +464,6 @@ class ModelBulkDeleteMutation(BaseBulkMutation):
         queryset.delete()
 
 
-class ModelBulkPublishMutation(BaseBulkMutation):
-    class Meta:
-        abstract = True
-
-    @classmethod
-    def bulk_action(cls, queryset):
-        queryset.update(is_published=True)
-
-
 class CreateToken(ObtainJSONWebToken):
     """Mutation that authenticates a user and returns token and user data.
 

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...page import models
-from ..core.mutations import ModelBulkDeleteMutation, BaseBulkMutation
+from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
 
 
 class PageBulkDelete(ModelBulkDeleteMutation):

--- a/saleor/graphql/page/bulk_mutations.py
+++ b/saleor/graphql/page/bulk_mutations.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...page import models
-from ..core.mutations import ModelBulkDeleteMutation, ModelBulkPublishMutation
+from ..core.mutations import ModelBulkDeleteMutation, BaseBulkMutation
 
 
 class PageBulkDelete(ModelBulkDeleteMutation):
@@ -20,12 +20,15 @@ class PageBulkDelete(ModelBulkDeleteMutation):
         return user.has_perm('page.manage_pages')
 
 
-class PageBulkPublish(ModelBulkPublishMutation):
+class PageBulkPublish(BaseBulkMutation):
     class Arguments:
         ids = graphene.List(
             graphene.ID,
             required=True,
-            description='List of page IDs to publish.')
+            description='List of page IDs to (un)publish.')
+        is_published = graphene.Boolean(
+            required=True,
+            description='Determine if pages will be published or not.')
 
     class Meta:
         description = 'Publish pages.'
@@ -35,18 +38,6 @@ class PageBulkPublish(ModelBulkPublishMutation):
     def user_is_allowed(cls, user, _ids):
         return user.has_perm('page.manage_pages')
 
-
-class PageBulkUnpublish(PageBulkPublish):
-    class Arguments:
-        ids = graphene.List(
-            graphene.ID,
-            required=True,
-            description='List of page IDs to unpublish.')
-
-    class Meta:
-        description = 'Unpublish pages.'
-        model = models.Page
-
     @classmethod
-    def bulk_action(cls, queryset):
-        queryset.update(is_published=False)
+    def bulk_action(cls, queryset, is_published):
+        queryset.update(is_published=is_published)

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ..core.fields import PrefetchingConnectionField
 from ..descriptions import DESCRIPTIONS
 from ..translations.mutations import PageTranslate
-from .bulk_mutations import PageBulkDelete, PageBulkPublish, PageBulkUnpublish
+from .bulk_mutations import PageBulkDelete, PageBulkPublish
 from .mutations import PageCreate, PageDelete, PageUpdate
 from .resolvers import resolve_page, resolve_pages
 from .types import Page
@@ -30,6 +30,5 @@ class PageMutations(graphene.ObjectType):
     page_delete = PageDelete.Field()
     page_bulk_delete = PageBulkDelete.Field()
     page_bulk_publish = PageBulkPublish.Field()
-    page_bulk_unpublish = PageBulkUnpublish.Field()
     page_update = PageUpdate.Field()
     page_translate = PageTranslate.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1149,8 +1149,7 @@ type Mutations {
   pageCreate(input: PageInput!): PageCreate
   pageDelete(id: ID!): PageDelete
   pageBulkDelete(ids: [ID]!): PageBulkDelete
-  pageBulkPublish(ids: [ID]!): PageBulkPublish
-  pageBulkUnpublish(ids: [ID]!): PageBulkUnpublish
+  pageBulkPublish(ids: [ID]!, isPublished: Boolean!): PageBulkPublish
   pageUpdate(id: ID!, input: PageInput!): PageUpdate
   pageTranslate(id: ID!, input: PageTranslationInput!, languageCode: LanguageCodeEnum!): PageTranslate
   draftOrderComplete(id: ID!): DraftOrderComplete
@@ -1492,11 +1491,6 @@ type PageBulkDelete {
 }
 
 type PageBulkPublish {
-  errors: [Error!]
-  count: Int!
-}
-
-type PageBulkUnpublish {
   errors: [Error!]
   count: Int!
 }

--- a/tests/api/test_page.py
+++ b/tests/api/test_page.py
@@ -212,24 +212,27 @@ def test_paginate_pages(user_api_client, page):
     assert len(pages_data['edges']) == 2
 
 
+MUTATION_PUBLISH_PAGES = """
+    mutation publishManyPages($ids: [ID]!, $is_published: Boolean!) {
+        pageBulkPublish(ids: $ids, isPublished: $is_published) {
+            count
+        }
+    }
+    """
+
+
 def test_bulk_publish(
         staff_api_client, page_list_unpublished,
         permission_manage_pages):
     page_list = page_list_unpublished
     assert not any(page.is_published for page in page_list)
 
-    query = """
-        mutation publishManyPages($ids: [ID]!) {
-            pageBulkPublish(ids: $ids) {
-                count
-            }
-        }
-    """
+
     variables = {'ids': [
         graphene.Node.to_global_id('Page', page.id)
-        for page in page_list]}
+        for page in page_list], 'is_published': True}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_pages])
+        MUTATION_PUBLISH_PAGES, variables, permissions=[permission_manage_pages])
     content = get_graphql_content(response)
     page_list = Page.objects.filter(id__in=[page.pk for page in page_list])
 
@@ -241,21 +244,13 @@ def test_bulk_unpublish(
         staff_api_client, page_list,
         permission_manage_pages):
     assert all(page.is_published for page in page_list)
-
-    query = """
-        mutation unPublishManyPages($ids: [ID]!) {
-            pageBulkUnpublish(ids: $ids) {
-                count
-            }
-        }
-    """
     variables = {'ids': [
         graphene.Node.to_global_id('Page', page.id)
-        for page in page_list]}
+        for page in page_list], 'is_published': False}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_pages])
+        MUTATION_PUBLISH_PAGES, variables, permissions=[permission_manage_pages])
     content = get_graphql_content(response)
     page_list = Page.objects.filter(id__in=[page.pk for page in page_list])
 
-    assert content['data']['pageBulkUnpublish']['count'] == len(page_list)
+    assert content['data']['pageBulkPublish']['count'] == len(page_list)
     assert not any(page.is_published for page in page_list)


### PR DESCRIPTION
I want to merge this change because we decided it is a better approach to have one mutation for publishing a given model with the parameter to set publish status.

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
