### PR TITLE
Remove comment and set up explicit __hash__ function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Restrict single payment resolving - #4009 @NyanKiyoshi
 - Add mandatory fields errors in new product form - #4024 by @benekex2
 - Add navigation drawer support - #3839 by @benekex2
+- Set up explicit __hash__ function - #3979 by @akjanik
 
 
 ## 2.5.0

--- a/saleor/account/models.py
+++ b/saleor/account/models.py
@@ -68,9 +68,7 @@ class Address(models.Model):
     def __eq__(self, other):
         return self.as_data() == other.as_data()
 
-    def __hash__(self):
-        # FIXME: in Django 2.2 this is not present if __eq__ is defined
-        return super().__hash__()
+    __hash__ = models.Model.__hash__
 
     def as_data(self):
         """Return the address as a dict suitable for passing as kwargs.

--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -140,9 +140,7 @@ class CheckoutLine(models.Model):
     def __str__(self):
         return smart_str(self.variant)
 
-    def __hash__(self):
-        # FIXME: in Django 2.2 this is not present if __eq__ is defined
-        return super().__hash__()
+    __hash__ = models.Model.__hash__
 
     def __eq__(self, other):
         if not isinstance(other, CheckoutLine):


### PR DESCRIPTION
It turns out that in Django 2.2 bug we were unknowingly relying on was fixed. Indeed, from https://docs.python.org/3/reference/datamodel.html#object.__hash__

> A class that overrides __eq__() and does not define __hash__() will have its __hash__() implicitly set to None.

> If a class that overrides __eq__() needs to retain the implementation of __hash__() from a parent class, the interpreter must be told this explicitly by setting __hash__ = <ParentClass>.__hash__.

Additional explanation of the issue:
https://code.djangoproject.com/ticket/30333

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
