### PR TITLE
Styled file field with materializecss template filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add settings to enable Django Debug Toolbar - #3983 by @koradon
 - Implement variant availability, introducing discounts in variants - #3948 by @NyanKiyoshi
 - Add bulk actions - #3955 by @dominik-zeglen
+- Update file field styles with materializecss template filter - #3998 by @zodiacfireworks
 
 
 ## 2.5.0

--- a/templates/materializecssform/field.html
+++ b/templates/materializecssform/field.html
@@ -171,19 +171,66 @@
     {% endif %}
   </div>
 {% elif field|is_file %}
-  <div class="input col {{ classes.label }}">
+  <div
+    class="input col input-field {{ classes.label }}">
+    {% if field.auto_id %}
     <p>
-      {% if field.auto_id %}
-        <label class="{{ classes.label }}" for="{{ field.auto_id }}">
-          {{ field.label }}
-          {% if not field.field.required %}
-            {% trans "(optional)" context "Dashboard form labels" %}
-          {% endif %}
-        </label>
-        <br>
-      {% endif %}
-      {{ field }}
+      <label
+        class="{{ classes.label }}"
+        for="{{ field.auto_id }}">
+        {{ field.label }}
+        {% if not field.field.required %}
+          {% trans "(optional)" context "Dashboard form labels" %}
+        {% endif %}
+      </label>
     </p>
+    {% endif %}
+
+    {% with field.field.widget as widget %}
+      {% if field.value %}
+        <p>
+          {{ widget.initial_text }}:
+          <a
+            href="{{ field.value.url }}">
+            {{ field.value }}
+          </a>
+          {% if not widget.required %}
+            <input
+              type="checkbox"
+              name="{{ field.name }}-clear"
+              id="{{ field.name }}-clear_id">
+            <label
+              for="{{ field.name }}-clear_id">
+              {{ widget.clear_checkbox_label }}
+            </label>
+          {% endif %}
+        </p>
+      {% endif %}
+    {% endwith %}
+
+    <div class="file-field">
+      <p>
+        <div class="btn">
+          <span>
+            {% trans "File" %}
+          </span>
+          <input class="file-chooser" id="{{ field.auto_id }}" name="{{ field.name }}" type="file">
+        </div>
+        <div class="file-path-wrapper">
+          <input class="file-path" type="text">
+        </div>
+      </p>
+      {% for error in field.errors %}
+        <p class="help-block materialize-red-text">
+          {{ error }}
+        </p>
+      {% endfor %}
+      {% if field.help_text %}
+        <p class="help-block">
+          {{ field.help_text|safe }}
+        </p>
+      {% endif %}
+    </div>
   </div>
 {% elif field|is_versatile_image_ppoi_click_widget %}
   <div class="input col file-field input-field {{ classes.label }}">


### PR DESCRIPTION
I want to merge this change because in some places of the dashboard we have  file fields with material style. But in other places we have an ugly browser based file field. With this little PR we will have file fields with material style using the template filter materializecss.

### Screenshots

Picture from *product image form*:
![image](https://user-images.githubusercontent.com/4976355/52392574-83f3af80-2a70-11e9-8759-1dbb421e28cd.png)

Picture from *category form*:
![image](https://user-images.githubusercontent.com/4976355/52392638-c6b58780-2a70-11e9-9512-4ee17bd197a3.png)

Picture from *category form* **after changes**:
![image](https://user-images.githubusercontent.com/4976355/52392686-f9f81680-2a70-11e9-9777-cd738f6bdd81.png)

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
