### PR TITLE
Fix the case where an empty billing address would be supplied in email

### DIFF
--- a/templates/templated_email/order/confirm_order.email
+++ b/templates/templated_email/order/confirm_order.email
@@ -22,7 +22,7 @@ Thank you for your order. Below is the list of ordered products. To see your pay
 {% trans "Total" context "Order confirmation e-mail table header" %}:              {% price order.total.gross html=False %}
 
 {% trans "Billing address" context "Order confirmation e-mail billing address" %}
-{{ order.billing_address }}
+{% if order.billing_address %}{{ order.billing_address }}{% else %}{% trans "No billing address" context "Order confirmation e-mail text" %}{% endif %}
 
 {% trans "Shipping address" context "Order confirmation e-mail shipping address" %}
 {% if order.shipping_address %}{{ order.shipping_address }}{% else %}{% trans "No shipping required" context "Order confirmation e-mail text" %}{% endif %}

--- a/templates/templated_email/source/confirm_order.mjml
+++ b/templates/templated_email/source/confirm_order.mjml
@@ -33,7 +33,11 @@
           <tbody>
             <tr>
               <td class="address">
-                {% format_address order.billing_address %}
+                {% if order.billing_address %}
+                  {% format_address order.billing_address %}
+                {% else %}
+                  {% trans "No billing address" context "Order confirmation e-mail text" %}
+                {% endif %}
               </td>
               <td css-class="address">
                 {% if order.shipping_address %}

--- a/tests/test_emails.py
+++ b/tests/test_emails.py
@@ -7,6 +7,7 @@ from templated_email import get_connection
 import saleor.order.emails as emails
 from saleor.core.emails import get_email_base_context
 from saleor.core.utils import build_absolute_uri
+from saleor.order.utils import add_variant_to_order
 
 
 def test_get_email_base_context(site_settings):
@@ -59,6 +60,41 @@ def test_collect_data_for_email(order):
     (emails.send_order_confirmation, emails.CONFIRM_ORDER_TEMPLATE)])
 @mock.patch('saleor.order.emails.send_templated_mail')
 def test_send_emails(mocked_templated_email, order, template, send_email, settings):
+    send_email(order.pk)
+    email_data = emails.collect_data_for_email(order.pk, template)
+
+    recipients = [order.get_user_current_email()]
+
+    expected_call_kwargs = {
+        'context': email_data['context'],
+        'from_email': settings.ORDER_FROM_EMAIL,
+        'template_name': template}
+
+    mocked_templated_email.assert_called_once_with(
+        recipient_list=recipients, **expected_call_kwargs)
+
+    # Render the email to ensure there is no error
+    email_connection = get_connection()
+    email_connection.get_email_message(to=recipients, **expected_call_kwargs)
+
+
+@pytest.mark.parametrize('send_email,template', [
+    (emails.send_payment_confirmation, emails.CONFIRM_PAYMENT_TEMPLATE),
+    (emails.send_order_confirmation, emails.CONFIRM_ORDER_TEMPLATE)])
+@mock.patch('saleor.order.emails.send_templated_mail')
+def test_send_confirmation_emails_without_addresses(
+        mocked_templated_email, order, template, send_email, settings,
+        digital_content):
+
+    assert not order.lines.count()
+
+    add_variant_to_order(order, digital_content.product_variant, quantity=1)
+    order.shipping_address = None
+    order.shipping_method = None
+    order.billing_address = None
+    order.save(update_fields=[
+        'shipping_address', 'shipping_method', 'billing_address'])
+
     send_email(order.pk)
     email_data = emails.collect_data_for_email(order.pk, template)
 


### PR DESCRIPTION
Fixes #4056. I'm unsure how, but it actually happened once that when running tests, an order's billing address was set to `None`. As `billing_address` is actually a nullable field, it would be better to make sure we check it's not none.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
