### PR TITLE
Add link to GraphQL Playground to the docs

### DIFF
--- a/docs/architecture/graphql.rst
+++ b/docs/architecture/graphql.rst
@@ -6,7 +6,7 @@ GraphQL API (Beta)
     The GraphQL API is in the early version. It is not yet fully optimized against database queries and some mutations or queries may be missing.
 
 
-Saleor provides a GraphQL API which allows to query and modify the shop's data in an efficient and flexible manner.
+Saleor provides a GraphQL API which allows to query and modify the shop's data in an efficient and flexible manner. You can `preview it here <https://demo.getsaleor.com/graphql/>`_.
 
 Learn more about GraphQL language and its concepts on the `official website <https://graphql.org>`_.
 


### PR DESCRIPTION
I had a relatively hard time finding the schema of this GraphQL-first system so I added a link to the docs. Not sure where to best put it but it's a start.