### PR TITLE
Create many menu items in one mutation.

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -152,7 +152,6 @@ class BaseMutation(graphene.Mutation):
 
         input_cls = getattr(cls.Arguments, 'input')
         cleaned_input = {}
-        import pdb; pdb.set_trace()
         for field_name, field_item in input_cls._meta.fields.items():
             if field_name in data:
                 value = data[field_name]
@@ -251,7 +250,6 @@ class BaseMutation(graphene.Mutation):
 
         try:
             response = cls.perform_mutation(root, info, **data)
-            import pdb; pdb.set_trace()
             if response.errors is None:
                 response.errors = []
             return response
@@ -309,9 +307,8 @@ class ModelMutation(BaseMutation):
 
     @classmethod
     def success_response(cls, instance):
-        return {'ehe': 'aha'}
         """Return a success response."""
-        # return cls(**{cls._meta.return_field_name: instance, 'errors': []})
+        return cls(**{cls._meta.return_field_name: instance, 'errors': []})
 
     @classmethod
     def save(cls, info, instance, cleaned_input):

--- a/saleor/graphql/menu/schema.py
+++ b/saleor/graphql/menu/schema.py
@@ -5,8 +5,8 @@ from ..descriptions import DESCRIPTIONS
 from ..translations.mutations import MenuItemTranslate
 from .bulk_mutations import MenuBulkDelete, MenuItemBulkDelete
 from .mutations import (
-    AssignNavigation, MenuCreate, MenuDelete, MenuItemCreate, MenuItemDelete,
-    MenuItemMove, MenuItemUpdate, MenuUpdate)
+    AssignNavigation, MenuCreate, MenuDelete, MenuItemBulkCreate,
+    MenuItemCreate, MenuItemDelete, MenuItemMove, MenuItemUpdate, MenuUpdate)
 from .resolvers import resolve_menu, resolve_menu_items, resolve_menus
 from .types import Menu, MenuItem
 
@@ -50,6 +50,7 @@ class MenuMutations(graphene.ObjectType):
 
     menu_item_create = MenuItemCreate.Field()
     menu_item_delete = MenuItemDelete.Field()
+    menu_item_bulk_create = MenuItemBulkCreate.Field()
     menu_item_bulk_delete = MenuItemBulkDelete.Field()
     menu_item_update = MenuItemUpdate.Field()
     menu_item_translate = MenuItemTranslate.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1047,6 +1047,11 @@ type MenuItem implements Node {
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
 }
 
+type MenuItemBulkCreate {
+  errors: [Error!]
+  count: Int!
+}
+
 type MenuItemBulkDelete {
   errors: [Error!]
   count: Int!
@@ -1237,6 +1242,7 @@ type Mutations {
   menuUpdate(id: ID!, input: MenuInput!): MenuUpdate
   menuItemCreate(input: MenuItemCreateInput!): MenuItemCreate
   menuItemDelete(id: ID!): MenuItemDelete
+  menuItemBulkCreate(input: [MenuItemCreateInput!]!): MenuItemBulkCreate
   menuItemBulkDelete(ids: [ID]!): MenuItemBulkDelete
   menuItemUpdate(id: ID!, input: MenuItemInput!): MenuItemUpdate
   menuItemTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): MenuItemTranslate

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -250,6 +250,28 @@ def test_create_menu_item(
     assert data['menu']['name'] == menu.name
 
 
+def test_bulk_create_menu_item(
+        staff_api_client, menu, permission_manage_menus):
+    query = """
+    mutation createMenuItems($input: [MenuItemCreateInput!]!){
+        menuItemBulkCreate(input: $input) {
+            count
+        }
+    }
+    """
+    name = 'item menu'
+    url = 'http://www.example.com'
+    menu_id = graphene.Node.to_global_id('Menu', menu.pk)
+    variables = {'input':
+            [{'name': name, 'url': url, 'menu': menu_id}]
+        }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_menus])
+    import pdb; pdb.set_trace()
+
+    content = get_graphql_content(response)
+
+
 def test_update_menu_item(
         staff_api_client, menu, menu_item, page, permission_manage_menus):
     query = """


### PR DESCRIPTION
Implement creation of multiple menu items. It turns out, we do not have right now ability to create multiple objects with one mutation, so this one is unique and may be not very elegant (end efficient).

I put `blocked` on this, as we discussed it is not needed right now.

### Screenshots

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
