### PR TITLE
Allow to pass empty list in bulk mutations

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -427,6 +427,9 @@ class BaseBulkMutation(BaseMutation):
     def perform_mutation(cls, _root, info, ids, **data):
         """Perform a mutation that deletes a list of model instances."""
         clean_instance_ids, errors = [], {}
+        # Allow to pass empty list for dummy mutation
+        if not ids:
+            return 0, errors
         instance_model = cls._meta.model
         model_type = registry.get_type_for_model(instance_model)
         instances = cls.get_nodes_or_error(ids, "id", model_type)

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -126,7 +126,7 @@ def voucher_list():
 
 
 def test_delete_attributes(
-    staff_api_client, attribute_list, permission_manage_products
+        staff_api_client, attribute_list, permission_manage_products
 ):
     query = """
     mutation attributeBulkDelete($ids: [ID]!) {
@@ -138,7 +138,8 @@ def test_delete_attributes(
 
     variables = {
         "ids": [
-            graphene.Node.to_global_id("Attribute", attr.id) for attr in attribute_list
+            graphene.Node.to_global_id("Attribute", attr.id) for attr in
+            attribute_list
         ]
     }
     response = staff_api_client.post_graphql(
@@ -153,7 +154,7 @@ def test_delete_attributes(
 
 
 def test_delete_attribute_values(
-    staff_api_client, attribute_value_list, permission_manage_products
+        staff_api_client, attribute_value_list, permission_manage_products
 ):
     query = """
     mutation attributeValueBulkDelete($ids: [ID]!) {
@@ -180,7 +181,8 @@ def test_delete_attribute_values(
     ).exists()
 
 
-def test_delete_categories(staff_api_client, category_list, permission_manage_products):
+def test_delete_categories(staff_api_client, category_list,
+                           permission_manage_products):
     query = """
     mutation categoryBulkDelete($ids: [ID]!) {
         categoryBulkDelete(ids: $ids) {
@@ -207,7 +209,7 @@ def test_delete_categories(staff_api_client, category_list, permission_manage_pr
 
 
 def test_delete_collections(
-    staff_api_client, collection_list, permission_manage_products
+        staff_api_client, collection_list, permission_manage_products
 ):
     query = """
     mutation collectionBulkDelete($ids: [ID]!) {
@@ -234,7 +236,8 @@ def test_delete_collections(
     ).exists()
 
 
-def test_delete_customers(staff_api_client, user_list, permission_manage_users):
+def test_delete_customers(staff_api_client, user_list,
+                          permission_manage_users):
     user_1, user_2, *users = user_list
 
     query = """
@@ -246,7 +249,8 @@ def test_delete_customers(staff_api_client, user_list, permission_manage_users):
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("User", user.id) for user in user_list]
+        "ids": [graphene.Node.to_global_id("User", user.id) for user in
+                user_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_users]
@@ -257,10 +261,12 @@ def test_delete_customers(staff_api_client, user_list, permission_manage_users):
     assert not User.objects.filter(
         id__in=[user.id for user in [user_1, user_2]]
     ).exists()
-    assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
+    assert User.objects.filter(
+        id__in=[user.id for user in users]).count() == len(users)
 
 
-def test_delete_draft_orders(staff_api_client, order_list, permission_manage_orders):
+def test_delete_draft_orders(staff_api_client, order_list,
+                             permission_manage_orders):
     order_1, order_2, *orders = order_list
     order_1.status = OrderStatus.DRAFT
     order_2.status = OrderStatus.DRAFT
@@ -276,7 +282,8 @@ def test_delete_draft_orders(staff_api_client, order_list, permission_manage_ord
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Order", order.id) for order in order_list]
+        "ids": [graphene.Node.to_global_id("Order", order.id) for order in
+                order_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_orders]
@@ -293,7 +300,7 @@ def test_delete_draft_orders(staff_api_client, order_list, permission_manage_ord
 
 
 def test_fail_to_delete_non_draft_order_lines(
-    staff_api_client, order_with_lines, permission_manage_orders
+        staff_api_client, order_with_lines, permission_manage_orders
 ):
     order = order_with_lines
     order_lines = [line for line in order]
@@ -308,7 +315,8 @@ def test_fail_to_delete_non_draft_order_lines(
         ]
     }
     response = staff_api_client.post_graphql(
-        MUTATION_DELETE_ORDER_LINES, variables, permissions=[permission_manage_orders]
+        MUTATION_DELETE_ORDER_LINES, variables,
+        permissions=[permission_manage_orders]
     )
 
     content = get_graphql_content(response)
@@ -317,7 +325,7 @@ def test_fail_to_delete_non_draft_order_lines(
 
 
 def test_delete_draft_order_lines(
-    staff_api_client, order_with_lines, permission_manage_orders
+        staff_api_client, order_with_lines, permission_manage_orders
 ):
     order = order_with_lines
     order_lines = [line for line in order]
@@ -333,7 +341,8 @@ def test_delete_draft_order_lines(
     }
 
     response = staff_api_client.post_graphql(
-        MUTATION_DELETE_ORDER_LINES, variables, permissions=[permission_manage_orders]
+        MUTATION_DELETE_ORDER_LINES, variables,
+        permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
 
@@ -364,10 +373,12 @@ def test_delete_menus(staff_api_client, menu_list, permission_manage_menus):
     content = get_graphql_content(response)
 
     assert content["data"]["menuBulkDelete"]["count"] == 3
-    assert not Menu.objects.filter(id__in=[menu.id for menu in menu_list]).exists()
+    assert not Menu.objects.filter(
+        id__in=[menu.id for menu in menu_list]).exists()
 
 
-def test_delete_menu_items(staff_api_client, menu_item_list, permission_manage_menus):
+def test_delete_menu_items(staff_api_client, menu_item_list,
+                           permission_manage_menus):
     query = """
     mutation menuItemBulkDelete($ids: [ID]!) {
         menuItemBulkDelete(ids: $ids) {
@@ -375,7 +386,6 @@ def test_delete_menu_items(staff_api_client, menu_item_list, permission_manage_m
         }
     }
     """
-
     variables = {
         "ids": [
             graphene.Node.to_global_id("MenuItem", menu_item.id)
@@ -387,10 +397,35 @@ def test_delete_menu_items(staff_api_client, menu_item_list, permission_manage_m
     )
     content = get_graphql_content(response)
 
-    assert content["data"]["menuItemBulkDelete"]["count"] == 3
+    assert content["data"]["menuItemBulkDelete"]["count"] == len(
+        menu_item_list)
     assert not MenuItem.objects.filter(
         id__in=[menu_item.id for menu_item in menu_item_list]
     ).exists()
+
+
+def test_delete_empty_list_of_ids(staff_api_client, permission_manage_menus):
+    query = """
+    mutation menuItemBulkDelete($ids: [ID]!) {
+        menuItemBulkDelete(ids: $ids) {
+            count
+        }
+    }
+    """
+    menu_item_list = []
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("MenuItem", menu_item.id)
+            for menu_item in menu_item_list
+        ]
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_menus]
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["menuItemBulkDelete"]["count"] == len(
+        menu_item_list)
 
 
 def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
@@ -403,7 +438,8 @@ def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Page", page.id) for page in page_list]
+        "ids": [graphene.Node.to_global_id("Page", page.id) for page in
+                page_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_pages]
@@ -411,10 +447,12 @@ def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
     content = get_graphql_content(response)
 
     assert content["data"]["pageBulkDelete"]["count"] == len(page_list)
-    assert not Page.objects.filter(id__in=[page.id for page in page_list]).exists()
+    assert not Page.objects.filter(
+        id__in=[page.id for page in page_list]).exists()
 
 
-def test_delete_products(staff_api_client, product_list, permission_manage_products):
+def test_delete_products(staff_api_client, product_list,
+                         permission_manage_products):
     query = """
     mutation productBulkDelete($ids: [ID]!) {
         productBulkDelete(ids: $ids) {
@@ -441,7 +479,7 @@ def test_delete_products(staff_api_client, product_list, permission_manage_produ
 
 
 def test_delete_product_images(
-    staff_api_client, product_with_images, permission_manage_products
+        staff_api_client, product_with_images, permission_manage_products
 ):
     images = product_with_images.images.all()
 
@@ -455,7 +493,8 @@ def test_delete_product_images(
 
     variables = {
         "ids": [
-            graphene.Node.to_global_id("ProductImage", image.id) for image in images
+            graphene.Node.to_global_id("ProductImage", image.id) for image in
+            images
         ]
     }
     response = staff_api_client.post_graphql(
@@ -470,7 +509,7 @@ def test_delete_product_images(
 
 
 def test_delete_product_types(
-    staff_api_client, product_type_list, permission_manage_products
+        staff_api_client, product_type_list, permission_manage_products
 ):
     query = """
     mutation productTypeBulkDelete($ids: [ID]!) {
@@ -498,7 +537,7 @@ def test_delete_product_types(
 
 
 def test_delete_product_variants(
-    staff_api_client, product_variant_list, permission_manage_products
+        staff_api_client, product_variant_list, permission_manage_products
 ):
     query = """
     mutation productVariantBulkDelete($ids: [ID]!) {
@@ -525,7 +564,8 @@ def test_delete_product_variants(
     ).exists()
 
 
-def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
+def test_delete_sales(staff_api_client, sale_list,
+                      permission_manage_discounts):
     query = """
     mutation saleBulkDelete($ids: [ID]!) {
         saleBulkDelete(ids: $ids) {
@@ -535,7 +575,8 @@ def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
+        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in
+                sale_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_discounts]
@@ -543,11 +584,12 @@ def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
     content = get_graphql_content(response)
 
     assert content["data"]["saleBulkDelete"]["count"] == 3
-    assert not Sale.objects.filter(id__in=[sale.id for sale in sale_list]).exists()
+    assert not Sale.objects.filter(
+        id__in=[sale.id for sale in sale_list]).exists()
 
 
 def test_delete_shipping_methods(
-    staff_api_client, shipping_method_list, permission_manage_shipping
+        staff_api_client, shipping_method_list, permission_manage_shipping
 ):
     query = """
     mutation shippingPriceBulkDelete($ids: [ID]!) {
@@ -575,7 +617,7 @@ def test_delete_shipping_methods(
 
 
 def test_delete_shipping_zones(
-    staff_api_client, shipping_zone_list, permission_manage_shipping
+        staff_api_client, shipping_zone_list, permission_manage_shipping
 ):
     query = """
     mutation shippingZoneBulkDelete($ids: [ID]!) {
@@ -603,7 +645,7 @@ def test_delete_shipping_zones(
 
 
 def test_delete_staff_members(
-    staff_api_client, user_list, permission_manage_staff, superuser
+        staff_api_client, user_list, permission_manage_staff, superuser
 ):
     *users, staff_1, staff_2 = user_list
     users.append(superuser)
@@ -617,7 +659,8 @@ def test_delete_staff_members(
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("User", user.id) for user in user_list]
+        "ids": [graphene.Node.to_global_id("User", user.id) for user in
+                user_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_staff]
@@ -628,10 +671,12 @@ def test_delete_staff_members(
     assert not User.objects.filter(
         id__in=[user.id for user in [staff_1, staff_2]]
     ).exists()
-    assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
+    assert User.objects.filter(
+        id__in=[user.id for user in users]).count() == len(users)
 
 
-def test_delete_vouchers(staff_api_client, voucher_list, permission_manage_discounts):
+def test_delete_vouchers(staff_api_client, voucher_list,
+                         permission_manage_discounts):
     query = """
     mutation voucherBulkDelete($ids: [ID]!) {
         voucherBulkDelete(ids: $ids) {

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -402,10 +402,7 @@ def test_delete_empty_list_of_ids(staff_api_client, permission_manage_menus):
     """
     menu_item_list = []
     variables = {
-        "ids": [
-            graphene.Node.to_global_id("MenuItem", menu_item.id)
-            for menu_item in menu_item_list
-        ]
+        "ids": menu_item_list
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_menus]

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -126,7 +126,7 @@ def voucher_list():
 
 
 def test_delete_attributes(
-        staff_api_client, attribute_list, permission_manage_products
+    staff_api_client, attribute_list, permission_manage_products
 ):
     query = """
     mutation attributeBulkDelete($ids: [ID]!) {
@@ -138,8 +138,7 @@ def test_delete_attributes(
 
     variables = {
         "ids": [
-            graphene.Node.to_global_id("Attribute", attr.id) for attr in
-            attribute_list
+            graphene.Node.to_global_id("Attribute", attr.id) for attr in attribute_list
         ]
     }
     response = staff_api_client.post_graphql(
@@ -154,7 +153,7 @@ def test_delete_attributes(
 
 
 def test_delete_attribute_values(
-        staff_api_client, attribute_value_list, permission_manage_products
+    staff_api_client, attribute_value_list, permission_manage_products
 ):
     query = """
     mutation attributeValueBulkDelete($ids: [ID]!) {
@@ -181,8 +180,7 @@ def test_delete_attribute_values(
     ).exists()
 
 
-def test_delete_categories(staff_api_client, category_list,
-                           permission_manage_products):
+def test_delete_categories(staff_api_client, category_list, permission_manage_products):
     query = """
     mutation categoryBulkDelete($ids: [ID]!) {
         categoryBulkDelete(ids: $ids) {
@@ -209,7 +207,7 @@ def test_delete_categories(staff_api_client, category_list,
 
 
 def test_delete_collections(
-        staff_api_client, collection_list, permission_manage_products
+    staff_api_client, collection_list, permission_manage_products
 ):
     query = """
     mutation collectionBulkDelete($ids: [ID]!) {
@@ -236,8 +234,7 @@ def test_delete_collections(
     ).exists()
 
 
-def test_delete_customers(staff_api_client, user_list,
-                          permission_manage_users):
+def test_delete_customers(staff_api_client, user_list, permission_manage_users):
     user_1, user_2, *users = user_list
 
     query = """
@@ -249,8 +246,7 @@ def test_delete_customers(staff_api_client, user_list,
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("User", user.id) for user in
-                user_list]
+        "ids": [graphene.Node.to_global_id("User", user.id) for user in user_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_users]
@@ -261,12 +257,10 @@ def test_delete_customers(staff_api_client, user_list,
     assert not User.objects.filter(
         id__in=[user.id for user in [user_1, user_2]]
     ).exists()
-    assert User.objects.filter(
-        id__in=[user.id for user in users]).count() == len(users)
+    assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
 
 
-def test_delete_draft_orders(staff_api_client, order_list,
-                             permission_manage_orders):
+def test_delete_draft_orders(staff_api_client, order_list, permission_manage_orders):
     order_1, order_2, *orders = order_list
     order_1.status = OrderStatus.DRAFT
     order_2.status = OrderStatus.DRAFT
@@ -282,8 +276,7 @@ def test_delete_draft_orders(staff_api_client, order_list,
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Order", order.id) for order in
-                order_list]
+        "ids": [graphene.Node.to_global_id("Order", order.id) for order in order_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_orders]
@@ -300,7 +293,7 @@ def test_delete_draft_orders(staff_api_client, order_list,
 
 
 def test_fail_to_delete_non_draft_order_lines(
-        staff_api_client, order_with_lines, permission_manage_orders
+    staff_api_client, order_with_lines, permission_manage_orders
 ):
     order = order_with_lines
     order_lines = [line for line in order]
@@ -315,8 +308,7 @@ def test_fail_to_delete_non_draft_order_lines(
         ]
     }
     response = staff_api_client.post_graphql(
-        MUTATION_DELETE_ORDER_LINES, variables,
-        permissions=[permission_manage_orders]
+        MUTATION_DELETE_ORDER_LINES, variables, permissions=[permission_manage_orders]
     )
 
     content = get_graphql_content(response)
@@ -325,7 +317,7 @@ def test_fail_to_delete_non_draft_order_lines(
 
 
 def test_delete_draft_order_lines(
-        staff_api_client, order_with_lines, permission_manage_orders
+    staff_api_client, order_with_lines, permission_manage_orders
 ):
     order = order_with_lines
     order_lines = [line for line in order]
@@ -341,8 +333,7 @@ def test_delete_draft_order_lines(
     }
 
     response = staff_api_client.post_graphql(
-        MUTATION_DELETE_ORDER_LINES, variables,
-        permissions=[permission_manage_orders]
+        MUTATION_DELETE_ORDER_LINES, variables, permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
 
@@ -373,12 +364,10 @@ def test_delete_menus(staff_api_client, menu_list, permission_manage_menus):
     content = get_graphql_content(response)
 
     assert content["data"]["menuBulkDelete"]["count"] == 3
-    assert not Menu.objects.filter(
-        id__in=[menu.id for menu in menu_list]).exists()
+    assert not Menu.objects.filter(id__in=[menu.id for menu in menu_list]).exists()
 
 
-def test_delete_menu_items(staff_api_client, menu_item_list,
-                           permission_manage_menus):
+def test_delete_menu_items(staff_api_client, menu_item_list, permission_manage_menus):
     query = """
     mutation menuItemBulkDelete($ids: [ID]!) {
         menuItemBulkDelete(ids: $ids) {
@@ -397,8 +386,7 @@ def test_delete_menu_items(staff_api_client, menu_item_list,
     )
     content = get_graphql_content(response)
 
-    assert content["data"]["menuItemBulkDelete"]["count"] == len(
-        menu_item_list)
+    assert content["data"]["menuItemBulkDelete"]["count"] == len(menu_item_list)
     assert not MenuItem.objects.filter(
         id__in=[menu_item.id for menu_item in menu_item_list]
     ).exists()
@@ -424,8 +412,7 @@ def test_delete_empty_list_of_ids(staff_api_client, permission_manage_menus):
     )
     content = get_graphql_content(response)
 
-    assert content["data"]["menuItemBulkDelete"]["count"] == len(
-        menu_item_list)
+    assert content["data"]["menuItemBulkDelete"]["count"] == len(menu_item_list)
 
 
 def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
@@ -438,8 +425,7 @@ def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Page", page.id) for page in
-                page_list]
+        "ids": [graphene.Node.to_global_id("Page", page.id) for page in page_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_pages]
@@ -447,12 +433,10 @@ def test_delete_pages(staff_api_client, page_list, permission_manage_pages):
     content = get_graphql_content(response)
 
     assert content["data"]["pageBulkDelete"]["count"] == len(page_list)
-    assert not Page.objects.filter(
-        id__in=[page.id for page in page_list]).exists()
+    assert not Page.objects.filter(id__in=[page.id for page in page_list]).exists()
 
 
-def test_delete_products(staff_api_client, product_list,
-                         permission_manage_products):
+def test_delete_products(staff_api_client, product_list, permission_manage_products):
     query = """
     mutation productBulkDelete($ids: [ID]!) {
         productBulkDelete(ids: $ids) {
@@ -479,7 +463,7 @@ def test_delete_products(staff_api_client, product_list,
 
 
 def test_delete_product_images(
-        staff_api_client, product_with_images, permission_manage_products
+    staff_api_client, product_with_images, permission_manage_products
 ):
     images = product_with_images.images.all()
 
@@ -493,8 +477,7 @@ def test_delete_product_images(
 
     variables = {
         "ids": [
-            graphene.Node.to_global_id("ProductImage", image.id) for image in
-            images
+            graphene.Node.to_global_id("ProductImage", image.id) for image in images
         ]
     }
     response = staff_api_client.post_graphql(
@@ -509,7 +492,7 @@ def test_delete_product_images(
 
 
 def test_delete_product_types(
-        staff_api_client, product_type_list, permission_manage_products
+    staff_api_client, product_type_list, permission_manage_products
 ):
     query = """
     mutation productTypeBulkDelete($ids: [ID]!) {
@@ -537,7 +520,7 @@ def test_delete_product_types(
 
 
 def test_delete_product_variants(
-        staff_api_client, product_variant_list, permission_manage_products
+    staff_api_client, product_variant_list, permission_manage_products
 ):
     query = """
     mutation productVariantBulkDelete($ids: [ID]!) {
@@ -564,8 +547,7 @@ def test_delete_product_variants(
     ).exists()
 
 
-def test_delete_sales(staff_api_client, sale_list,
-                      permission_manage_discounts):
+def test_delete_sales(staff_api_client, sale_list, permission_manage_discounts):
     query = """
     mutation saleBulkDelete($ids: [ID]!) {
         saleBulkDelete(ids: $ids) {
@@ -575,8 +557,7 @@ def test_delete_sales(staff_api_client, sale_list,
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in
-                sale_list]
+        "ids": [graphene.Node.to_global_id("Sale", sale.id) for sale in sale_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_discounts]
@@ -584,12 +565,11 @@ def test_delete_sales(staff_api_client, sale_list,
     content = get_graphql_content(response)
 
     assert content["data"]["saleBulkDelete"]["count"] == 3
-    assert not Sale.objects.filter(
-        id__in=[sale.id for sale in sale_list]).exists()
+    assert not Sale.objects.filter(id__in=[sale.id for sale in sale_list]).exists()
 
 
 def test_delete_shipping_methods(
-        staff_api_client, shipping_method_list, permission_manage_shipping
+    staff_api_client, shipping_method_list, permission_manage_shipping
 ):
     query = """
     mutation shippingPriceBulkDelete($ids: [ID]!) {
@@ -617,7 +597,7 @@ def test_delete_shipping_methods(
 
 
 def test_delete_shipping_zones(
-        staff_api_client, shipping_zone_list, permission_manage_shipping
+    staff_api_client, shipping_zone_list, permission_manage_shipping
 ):
     query = """
     mutation shippingZoneBulkDelete($ids: [ID]!) {
@@ -645,7 +625,7 @@ def test_delete_shipping_zones(
 
 
 def test_delete_staff_members(
-        staff_api_client, user_list, permission_manage_staff, superuser
+    staff_api_client, user_list, permission_manage_staff, superuser
 ):
     *users, staff_1, staff_2 = user_list
     users.append(superuser)
@@ -659,8 +639,7 @@ def test_delete_staff_members(
     """
 
     variables = {
-        "ids": [graphene.Node.to_global_id("User", user.id) for user in
-                user_list]
+        "ids": [graphene.Node.to_global_id("User", user.id) for user in user_list]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_staff]
@@ -671,12 +650,10 @@ def test_delete_staff_members(
     assert not User.objects.filter(
         id__in=[user.id for user in [staff_1, staff_2]]
     ).exists()
-    assert User.objects.filter(
-        id__in=[user.id for user in users]).count() == len(users)
+    assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
 
 
-def test_delete_vouchers(staff_api_client, voucher_list,
-                         permission_manage_discounts):
+def test_delete_vouchers(staff_api_client, voucher_list, permission_manage_discounts):
     query = """
     mutation voucherBulkDelete($ids: [ID]!) {
         voucherBulkDelete(ids: $ids) {

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -401,9 +401,7 @@ def test_delete_empty_list_of_ids(staff_api_client, permission_manage_menus):
     }
     """
     menu_item_list = []
-    variables = {
-        "ids": menu_item_list
-    }
+    variables = {"ids": menu_item_list}
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_menus]
     )


### PR DESCRIPTION
Front-end client may want sometimes run bulk mutations with empty list. CC @dominik-zeglen 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
