### PR TITLE
Fix references to cart in Storefront 1.0

### DIFF
--- a/saleor/static/js/components/checkout.js
+++ b/saleor/static/js/components/checkout.js
@@ -57,9 +57,9 @@ export default $(document).ready((e) => {
       }
     });
   });
-  $('.checkout__clear').click((e) => {
+  $('.checkout-preview__clear').click((e) => {
     $.ajax({
-      url: $('.checkout__clear').data('action'),
+      url: $('.checkout-preview__clear').data('action'),
       method: 'POST',
       data: {},
       success: (response) => {

--- a/saleor/static/js/components/variantPicker/VariantPicker.js
+++ b/saleor/static/js/components/variantPicker/VariantPicker.js
@@ -164,7 +164,7 @@ export default observer(class VariantPicker extends Component {
               className={addToCheckoutBtnClasses}
               onClick={this.handleAddToCheckout}
               disabled={disableAddToCheckout}>
-              {pgettext('Product details primary action', 'Add to checkout')}
+              {pgettext('Product details primary action', 'Add to cart')}
             </button>
           </div>
         </div>

--- a/saleor/static/scss/layouts/_checkout.scss
+++ b/saleor/static/scss/layouts/_checkout.scss
@@ -363,8 +363,8 @@
       width: 100%;
     }
   }
-  &__clear{
-    @media (max-width: 400px){
+  &__clear {
+    @media (max-width: 400px) {
       margin-top: $global-margin;
     }
     @media (min-width: 470px) {
@@ -373,6 +373,7 @@
     @media (max-width: 370px) {
       width: 100%;
     }
+    margin-right: $global-margin;
   }
   &-item-delete {
     cursor: pointer;

--- a/templates/base.html
+++ b/templates/base.html
@@ -145,7 +145,7 @@
             <div class="navbar__brand__checkout float-right">
               <a rel="nofollow" class="checkout__icon" href="{% url "checkout:index" %}">
                 <span class="checkout-label d-none d-md-inline-block">
-                  {% trans "Your Checkout" context "Main navigation item" %}
+                  {% trans "Your cart" context "Main navigation item" %}
                 </span>
                 <div class="navbar__brand__checkout__icon">
                   <svg data-src="{% static "images/checkout.svg" %}" width="24" height="24"/>
@@ -205,7 +205,7 @@
             <hr />
             <li>
               <a rel="nofollow" href="{% url "checkout:index" %}">
-                {% trans "Your Checkout" context "Main navigation item" %}
+                {% trans "Your cart" context "Main navigation item" %}
               </a>
             </li>
             {% if user.is_authenticated %}

--- a/templates/checkout/index.html
+++ b/templates/checkout/index.html
@@ -4,12 +4,12 @@
 {% load price from taxed_prices %}
 {% load static %}
 
-{% block title %}{% trans "Your checkout" context "Checkout page title" %} — {{ block.super }}{% endblock %}
+{% block title %}{% trans "Your cart" context "Checkout page title" %} — {{ block.super }}{% endblock %}
 
 {% block breadcrumb %}
   <ul class="breadcrumbs list-unstyled">
     <li><a href="{% url 'home' %}">{% trans "Home" context "Main navigation item" %}</a></li>
-    <li><a rel="nofollow" href="{% url 'checkout:index' %}">{% trans "Checkout" context "Checkout breadcrumb" %}</a></li>
+    <li><a rel="nofollow" href="{% url 'checkout:index' %}">{% trans "Cart" context "Checkout breadcrumb" %}</a></li>
   </ul>
 {% endblock breadcrumb %}
 
@@ -80,15 +80,15 @@
             <a href="{% url "checkout:login" %}" class="btn btn-primary float-right checkout-preview__submit">
             {% trans "Checkout" context "Checkout primary action" %}
           </a>
-            <button class="btn secondary float-right checkout__clear" data-action="{% url 'checkout:clear' %}">
-            {% trans "Clear checkout" context "checkout page: secondary action, empty the checkout" %}
+            <button class="btn secondary float-right checkout-preview__clear" data-action="{% url 'checkout:clear' %}">
+            {% trans "Clear cart" context "checkout page: secondary action, empty the checkout" %}
           </button>
         </div>
       </div>
     {% else %}
       <div class="checkout-preview__empty">
         <img class="lazyload lazypreload" data-src="{% static 'images/empty-checkout-bg.png' %}" data-srcset="{% static 'images/empty-checkout-bg.png' %} 1x, {% static 'images/empty-checkout-bg2x.png' %} 2x">
-        <h2>{% trans "There are no products in your shopping checkout." context "Empty checkout message" %}</h2>
+        <h2>{% trans "There are no products in your shopping cart." context "Empty checkout message" %}</h2>
         <a href="{% url 'home' %}" class="btn btn-primary">{% trans "Check out our sales" context "Empty checkout link" %}</a>
       </div>
     {% endif %}

--- a/templates/checkout_dropdown.html
+++ b/templates/checkout_dropdown.html
@@ -51,7 +51,7 @@
     <div class="row checkout-preview-dropdown__actions">
       <div class="col-md-1"></div>
       <div class="col-md-5">
-        <a href="{% url "checkout:index" %}" class="btn secondary narrow float-md-right">{% trans "Go to checkout" context "Checkout dropdown secondary action" %}</a>
+        <a href="{% url "checkout:index" %}" class="btn secondary narrow float-md-right">{% trans "Go to cart" context "Checkout dropdown secondary action" %}</a>
       </div>
       <div class="col-md-5">
         <a href="{% url "checkout:login" %}" class="btn btn-primary narrow float-md-right">{% trans "Checkout" context "Checkout dropdown primary action" %}</a>
@@ -59,7 +59,7 @@
     </div>
   {% else %}
     <div class="text-md-center checkout-preview-dropdown__empty">
-      <h3>{% trans "There are no products in your shopping checkout." context "Empty checkout message" %}</h3>
+      <h3>{% trans "There are no products in your shopping cart." context "Empty checkout message" %}</h3>
       <img data-src="{% static 'images/empty-checkout-bg.png' %}"
            data-srcset="{% static 'images/empty-checkout-bg.png' %} 1x, {% static 'images/empty-checkout-bg2x.png' %} 2x"
            src="{% placeholder size=255 %}"

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -175,7 +175,7 @@
 
               <div class="form-group product__info__button">
                 <button class="btn btn-primary">
-                  {% trans "Add to checkout" context "Product details primary action" %}
+                  {% trans "Add to cart" context "Product details primary action" %}
                 </button>
               </div>
             </form>


### PR DESCRIPTION
After renaming Checkout to Cart in backend we accidentally changed some references to cart in Storefront 1.0. Also fixed margin issue on the cart page.

Before:
![image](https://user-images.githubusercontent.com/5421321/57789578-833a7b80-7739-11e9-9e62-03957ae844cf.png)


After:
![image](https://user-images.githubusercontent.com/5421321/57789534-6605ad00-7739-11e9-973c-bbfaaf4d4479.png)


### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
