### PR TITLE
GraphQL now prints exceptions to stderr as well as returning them or not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add support for Google Cloud Storage - #4127 by @chetabahana
 - Fix wrong calculation of subtotal in cart page - #4145 by @korycins
 - Fix multiple checkbox selected behavior - #4146 by @benekex2
+- GraphQL now prints exceptions to stderr as well as returning them or not - #4148 by @NyanKiyoshi
 
 ## 2.6.0
 


### PR DESCRIPTION
As a sysadmin/maintainer, I would like to be able to log exceptions occurring in production when executing the GraphQL API.

As a backend developer, I would like to be able to easily read in my console the errors occurring when working with GraphQL.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
