### PR TITLE
Fix transforming attribute values to hstore

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -415,7 +415,9 @@ class ProductVariantForm(forms.ModelForm, AttributesMixin):
     def save(self, commit=True):
         attributes = self.get_saved_attributes()
         self.instance.attributes = attributes
-        attrs = self.instance.product.product_type.variant_attributes.all()
+        attrs = self.instance.product.product_type.variant_attributes.prefetch_related(
+            "values__translations"
+        )
         self.instance.name = get_name_from_attributes(self.instance, attrs)
         return super().save(commit=commit)
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -518,7 +518,9 @@ class ProductVariantCreate(ModelMutation):
 
     @classmethod
     def save(cls, info, instance, cleaned_input):
-        attributes = instance.product.product_type.variant_attributes.all()
+        attributes = instance.product.product_type.variant_attributes.prefetch_related(
+            "values__translations"
+        )
         instance.name = get_name_from_attributes(instance, attributes)
         instance.save()
 

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -1,6 +1,6 @@
 from django.utils.text import slugify
 
-from ...product.models import Attribute, AttributeValue
+from ...product.models import Attribute
 
 
 def attributes_to_hstore(attribute_value_input, attributes_queryset):
@@ -13,7 +13,11 @@ def attributes_to_hstore(attribute_value_input, attributes_queryset):
     attributes_map = {attr.slug: attr.id for attr in attributes_queryset}
 
     attributes_hstore = {}
-    values_map = dict(AttributeValue.objects.values_list("slug", "id"))
+
+    values_map = {}
+    for attr in attributes_queryset:
+        for value in attr.values.all():
+            values_map[value.slug] = value.id
 
     for attribute in attribute_value_input:
         attr_slug = attribute.get("slug")

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -18,7 +18,7 @@ def _update_variants_names(instance, saved_attributes):
     variants_to_be_updated = variants_to_be_updated.prefetch_related(
         "product__product_type__variant_attributes__values"
     ).all()
-    attributes = instance.variant_attributes.all()
+    attributes = instance.variant_attributes.prefetch_related("values__translations")
     for variant in variants_to_be_updated:
         variant.name = get_name_from_attributes(variant, attributes)
         variant.save(update_fields=["name"])

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -34,6 +34,24 @@ def test_attributes_to_hstore(product, color_attribute):
         attributes_to_hstore(input_data, attrs_qs)
 
 
+def test_attributes_to_hstore_duplicated_slug(product, color_attribute, size_attribute):
+    # It's possible to have a value with the same slug but for a different attribute.
+    # Ensure that `attributes_to_hstore` works in that case.
+
+    color_value = color_attribute.values.first()
+
+    # Create a fake duplicated value.
+    AttributeValue.objects.create(
+        slug=color_value.slug, name="Duplicated value", attribute=size_attribute
+    )
+
+    input_data = [{"slug": color_attribute.slug, "value": color_value.slug}]
+    attrs_qs = product.product_type.product_attributes.all()
+    ids = attributes_to_hstore(input_data, attrs_qs)
+    assert str(color_attribute.pk) in ids
+    assert ids[str(color_attribute.pk)] == str(color_value.pk)
+
+
 def test_attributes_query(user_api_client, product):
     attributes = Attribute.objects.prefetch_related("values")
     query = """


### PR DESCRIPTION
While testing attributes in Dashboard 2.0 I've discovered the following bug in the backend.

Attribute values are unique to an attribute they belong to, but we don't require them to be unique globally. This is OK in the current flow, but there was an issue in `attributes_to_hstore` which is supposed to map attributes and values to HStore representation. Instead of using a queryset of values specific to a particular attribute, it was using the queryset of all values from the database. As a result, an attribute might receive a value that doesn't belong to it.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.