### PR TITLE
fix #4158 rozor typo to razor

### DIFF
--- a/locale/ar/LC_MESSAGES/django.po
+++ b/locale/ar/LC_MESSAGES/django.po
@@ -1047,12 +1047,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/az/LC_MESSAGES/django.po
+++ b/locale/az/LC_MESSAGES/django.po
@@ -1017,12 +1017,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/bg/LC_MESSAGES/django.po
+++ b/locale/bg/LC_MESSAGES/django.po
@@ -1022,12 +1022,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/bn/LC_MESSAGES/django.po
+++ b/locale/bn/LC_MESSAGES/django.po
@@ -1017,12 +1017,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/ca/LC_MESSAGES/django.po
+++ b/locale/ca/LC_MESSAGES/django.po
@@ -1032,12 +1032,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "La moneda %(currency)s encara no està disponible."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Paga ara mitjançant Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Pagament total"
 

--- a/locale/cs/LC_MESSAGES/django.po
+++ b/locale/cs/LC_MESSAGES/django.po
@@ -1035,12 +1035,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/da/LC_MESSAGES/django.po
+++ b/locale/da/LC_MESSAGES/django.po
@@ -1029,12 +1029,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "%(currency)s valutaen er ikke understøttet."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Betal med Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Samlet betaling"
 

--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1045,12 +1045,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Die Währung %(currency)s wird nicht unterstützt."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Bezahlen Sie jetzt mit Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Gesamtzahlung"
 

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -1024,12 +1024,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:13
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1036,12 +1036,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/es_CO/LC_MESSAGES/django.po
+++ b/locale/es_CO/LC_MESSAGES/django.po
@@ -1017,12 +1017,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/et/LC_MESSAGES/django.po
+++ b/locale/et/LC_MESSAGES/django.po
@@ -1033,12 +1033,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "%(currency)s valuutat ei toetata."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Maksa kohe kasutades Razorpay'd"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Kogu makse"
 

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -1026,12 +1026,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "مبلغ کل قابل پرداخت"
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1035,12 +1035,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Payer maintenant avec Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Paiement total"
 

--- a/locale/hi/LC_MESSAGES/django.po
+++ b/locale/hi/LC_MESSAGES/django.po
@@ -1018,12 +1018,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/hu/LC_MESSAGES/django.po
+++ b/locale/hu/LC_MESSAGES/django.po
@@ -1021,12 +1021,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/hy/LC_MESSAGES/django.po
+++ b/locale/hy/LC_MESSAGES/django.po
@@ -1017,12 +1017,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/id/LC_MESSAGES/django.po
+++ b/locale/id/LC_MESSAGES/django.po
@@ -1025,12 +1025,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Mata uang  %(currency)s tidak didukung."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Bayar sekarang dengan Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Total pembayaran"
 

--- a/locale/it/LC_MESSAGES/django.po
+++ b/locale/it/LC_MESSAGES/django.po
@@ -1029,12 +1029,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/ja/LC_MESSAGES/django.po
+++ b/locale/ja/LC_MESSAGES/django.po
@@ -1011,12 +1011,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -1022,12 +1022,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "%(currency)s 통화는 지원되지 않습니다."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Razorpay로 지금 지불하십시오"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "총 지불액"
 

--- a/locale/mn/LC_MESSAGES/django.po
+++ b/locale/mn/LC_MESSAGES/django.po
@@ -1018,12 +1018,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/nb/LC_MESSAGES/django.po
+++ b/locale/nb/LC_MESSAGES/django.po
@@ -1020,12 +1020,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/nl/LC_MESSAGES/django.po
+++ b/locale/nl/LC_MESSAGES/django.po
@@ -1026,12 +1026,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/pl/LC_MESSAGES/django.po
+++ b/locale/pl/LC_MESSAGES/django.po
@@ -1057,12 +1057,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Waluta nie jest obsługiwana: %(currency)s"
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Zapłać teraz z Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Całkowita płatność"
 

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -1030,12 +1030,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Page agora com Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Pagamento total"
 

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -1044,12 +1044,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Page agora com Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Pagamento total"
 

--- a/locale/ro/LC_MESSAGES/django.po
+++ b/locale/ro/LC_MESSAGES/django.po
@@ -1035,12 +1035,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Plătește acum cu Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Total de plată"
 

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -1055,12 +1055,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Валюта %(currency)s не поддерживается."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Оплатить сейчас с помощью Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Общий платеж"
 

--- a/locale/sk/LC_MESSAGES/django.po
+++ b/locale/sk/LC_MESSAGES/django.po
@@ -1048,12 +1048,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/sl/LC_MESSAGES/django.po
+++ b/locale/sl/LC_MESSAGES/django.po
@@ -1039,12 +1039,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/sq/LC_MESSAGES/django.po
+++ b/locale/sq/LC_MESSAGES/django.po
@@ -1027,12 +1027,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr " %(currency)s nuk eshte e suportuar."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Pay now with Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Pagesa totale"
 

--- a/locale/sr/LC_MESSAGES/django.po
+++ b/locale/sr/LC_MESSAGES/django.po
@@ -1027,12 +1027,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -1029,12 +1029,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Valutan %(currency)s är stöds ej."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Betala nu med Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Total betalning"
 

--- a/locale/sw/LC_MESSAGES/django.po
+++ b/locale/sw/LC_MESSAGES/django.po
@@ -1017,12 +1017,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/th/LC_MESSAGES/django.po
+++ b/locale/th/LC_MESSAGES/django.po
@@ -1014,12 +1014,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/tr/LC_MESSAGES/django.po
+++ b/locale/tr/LC_MESSAGES/django.po
@@ -1035,12 +1035,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "%(currency)s para birimi desteklenmiyor."
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Razorpay ile ödeme"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Toplam ödeme"
 

--- a/locale/uk/LC_MESSAGES/django.po
+++ b/locale/uk/LC_MESSAGES/django.po
@@ -1043,12 +1043,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/vi/LC_MESSAGES/django.po
+++ b/locale/vi/LC_MESSAGES/django.po
@@ -1022,12 +1022,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr "Chưa hỗ trợ đồng %(currency)s"
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr "Thanh toán ngay với Razorpay"
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr "Thanh toán tổng cộng"
 

--- a/locale/zh_Hans/LC_MESSAGES/django.po
+++ b/locale/zh_Hans/LC_MESSAGES/django.po
@@ -1016,12 +1016,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/locale/zh_Hant/LC_MESSAGES/django.po
@@ -1011,12 +1011,12 @@ msgid "The %(currency)s currency is not supported."
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:14
-msgctxt "Rozorpay payment gateway primary button"
+msgctxt "Razorpay payment gateway primary button"
 msgid "Pay now with Razorpay"
 msgstr ""
 
 #: saleor/payment/gateways/razorpay/forms.py:16
-msgctxt "Rozorpay payment gateway secondary title"
+msgctxt "Razorpay payment gateway secondary title"
 msgid "Total payment"
 msgstr ""
 

--- a/saleor/payment/gateways/razorpay/forms.py
+++ b/saleor/payment/gateways/razorpay/forms.py
@@ -10,10 +10,10 @@ from .utils import get_amount_for_razorpay
 CHECKOUT_SCRIPT_URL = "https://checkout.razorpay.com/v1/checkout.js"
 
 PRIMARY_BTN_TEXT = pgettext_lazy(
-    "Rozorpay payment gateway primary button", "Pay now with Razorpay"
+    "Razorpay payment gateway primary button", "Pay now with Razorpay"
 )
 SECONDARY_TITLE = pgettext_lazy(
-    "Rozorpay payment gateway secondary title", "Total payment"
+    "Razorpay payment gateway secondary title", "Total payment"
 )
 
 


### PR DESCRIPTION
I want to merge this change because...

This PR fixes #4158 all 84  typo occurrences. 'Rozorpay' typo to 'Razorpay'
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
