### PR TITLE
Users can how add multiple "Add to Cart" forms in a single page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix multiple checkbox selected behavior - #4146 by @benekex2
 - GraphQL now prints exceptions to stderr as well as returning them or not - #4148 by @NyanKiyoshi
 - Refactored API resolvers to staticmethods with root typing - #4155 by @NyanKiyoshi
+- Users can how add multiple "Add to Cart" forms in a single page - #4165 by @NyanKiyoshi
 
 ## 2.6.0
 

--- a/saleor/static/js/components/checkout.js
+++ b/saleor/static/js/components/checkout.js
@@ -40,10 +40,11 @@ export default $(document).ready((e) => {
   });
   $('.product-form button').click((e) => {
     e.preventDefault();
-    let quantity = $('#id_quantity').val();
-    let variant = $('#id_variant').val();
+    let $target = $(e.target.form);
+    let quantity = $target.find('input[name="quantity"]').val();
+    let variant = $target.find('input[name="variant"]').val();
     $.ajax({
-      url: $('.product-form').attr('action'),
+      url: $target.attr('action'),
       type: 'POST',
       data: {
         variant: variant,


### PR DESCRIPTION
Some users might want to be able to add multiple cart forms in a single page.

Note: we need to keep the IDs in the templates as they are needed for some other logics that are not causing any problem.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
