### PR TITLE
Adding a non existent variant to a checkout no longer crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - GraphQL now prints exceptions to stderr as well as returning them or not - #4148 by @NyanKiyoshi
 - Refactored API resolvers to staticmethods with root typing - #4155 by @NyanKiyoshi
 - Users can how add multiple "Add to Cart" forms in a single page - #4165 by @NyanKiyoshi
+- Adding a non existent variant to a checkout no longer crashes - #4166 by @NyanKiyoshi
 
 ## 2.6.0
 

--- a/saleor/checkout/forms.py
+++ b/saleor/checkout/forms.py
@@ -4,7 +4,7 @@ from typing import Any
 
 from django import forms
 from django.conf import settings
-from django.core.exceptions import NON_FIELD_ERRORS, ObjectDoesNotExist
+from django.core.exceptions import NON_FIELD_ERRORS
 from django.utils.encoding import smart_text
 from django.utils.safestring import mark_safe
 from django.utils.translation import npgettext_lazy, pgettext_lazy
@@ -85,9 +85,8 @@ class AddToCheckoutForm(forms.Form):
         quantity = cleaned_data.get("quantity")
         if quantity is None:
             return cleaned_data
-        try:
-            variant = self.get_variant(cleaned_data)
-        except ObjectDoesNotExist:
+        variant = self.get_variant(cleaned_data)
+        if variant is None:
             self.add_error_i18n(NON_FIELD_ERRORS, "variant-does-not-exists")
         else:
             line = self.checkout.get_line(variant)

--- a/tests/test_cart.py
+++ b/tests/test_cart.py
@@ -5,7 +5,6 @@ from uuid import uuid4
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core import signing
-from django.core.exceptions import ObjectDoesNotExist
 from django.urls import reverse
 from measurement.measures import Weight
 from prices import Money, TaxedMoney
@@ -379,20 +378,6 @@ def test_add_to_checkout_form(checkout, product):
     data = {}
 
     form = forms.AddToCheckoutForm(data=data, checkout=checkout, product=product)
-    assert not form.is_valid()
-
-
-def test_form_when_variant_does_not_exist():
-    checkout_lines = []
-    checkout = Mock(
-        add=lambda variant, quantity: checkout_lines.append(Mock()),
-        get_line=Mock(return_value=Mock(quantity=1)),
-    )
-
-    form = forms.AddToCheckoutForm(
-        data={"quantity": 1}, checkout=checkout, product=Mock()
-    )
-    form.get_variant = Mock(side_effect=ObjectDoesNotExist)
     assert not form.is_valid()
 
 

--- a/tests/test_product.py
+++ b/tests/test_product.py
@@ -209,6 +209,19 @@ def test_view_invalid_add_to_checkout(client, product, request_checkout):
     assert request_checkout.quantity == 2
 
 
+def test_view_add_to_checkout_invalid_variant(client, product, request_checkout):
+    response = client.post(
+        reverse(
+            "product:add-to-checkout",
+            kwargs={"slug": product.get_slug(), "product_id": product.pk},
+        ),
+        {"variant": 1234, "quantity": 1},
+        HTTP_X_REQUESTED_WITH="XMLHttpRequest",
+    )
+    assert response.status_code == 400
+    assert request_checkout.quantity == 0
+
+
 def test_view_add_to_checkout(authorized_client, product, user_checkout):
     variant = product.variants.first()
 


### PR DESCRIPTION
This fixes this error:
```
File "/Users/Development/saleor/saleor/product/views.py" in product_add_to_checkout
  144.     if form.is_valid():

File "/Users/Development/saleor-venv/lib/python3.7/site-packages/django/forms/forms.py" in is_valid
  185.         return self.is_bound and not self.errors

File "/Users/Development/saleor-venv/lib/python3.7/site-packages/django/forms/forms.py" in errors
  180.             self.full_clean()

File "/Users/Development/saleor-venv/lib/python3.7/site-packages/django/forms/forms.py" in full_clean
  382.         self._clean_form()

File "/Users/Development/saleor-venv/lib/python3.7/site-packages/django/forms/forms.py" in _clean_form
  409.             cleaned_data = self.clean()

File "/Users/Development/saleor/saleor/checkout/forms.py" in clean
  93.             line = self.checkout.get_line(variant)

File "/Users/Development/saleor/saleor/checkout/models.py" in get_line
  125.         return next(matching_lines, None)

File "/Users/Development/saleor/saleor/checkout/models.py" in <genexpr>
  124.         matching_lines = (line for line in self if line.variant.pk == variant.pk)

Exception Type: AttributeError at /en/products/white-parrot-cushion-86/add/
Exception Value: 'NoneType' object has no attribute 'pk'
```

Note: I checked, no override is raising such exception ("ObjectDoesNotExist") they are only returning the form field that already resolved the variant.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
