### PR TITLE
Fix calling get_client_token for Braintree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Adding a non existent variant to a checkout no longer crashes - #4166 by @NyanKiyoshi
 - Category delete modal improvements - #4171 by @benekex2
 - Products are now sortable within collections - #4123 by @NyanKiyoshi
-- Fix calling get_client_token for Braintree - #4182 by @maarcingebala
+- Fix incorrect argument in `get_client_token` in Braintree integration - #4182 by @maarcingebala
 
 ## 2.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Adding a non existent variant to a checkout no longer crashes - #4166 by @NyanKiyoshi
 - Category delete modal improvements - #4171 by @benekex2
 - Products are now sortable within collections - #4123 by @NyanKiyoshi
+- Fix calling get_client_token for Braintree - #4182 by @maarcingebala
 
 ## 2.6.0
 

--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List
+from typing import Dict, List
 
 import braintree as braintree_sdk
 from django.core.exceptions import ImproperlyConfigured
@@ -109,8 +109,8 @@ def get_braintree_gateway(sandbox_mode, merchant_id, public_key, private_key):
     return gateway
 
 
-def get_client_token(connection_params: Dict[str, Any]) -> str:
-    gateway = get_braintree_gateway(**connection_params)
+def get_client_token(config: GatewayConfig) -> str:
+    gateway = get_braintree_gateway(**config.connection_params)
     client_token = gateway.client_token.generate()
     return client_token
 

--- a/tests/gateway/test_braintree.py
+++ b/tests/gateway/test_braintree.py
@@ -202,13 +202,13 @@ def test_get_braintree_gateway_inproperly_configured(gateway_config):
 
 @patch("saleor.payment.gateways.braintree.get_braintree_gateway")
 def test_get_client_token(mock_gateway, gateway_config):
-    client_token = "client-token"
-    mock_generate = Mock(return_value="client-token")
+    expected_token = "client-token"
+    mock_generate = Mock(return_value=expected_token)
     mock_gateway.return_value = Mock(client_token=Mock(generate=mock_generate))
-    result = get_client_token(gateway_config)
+    token = get_client_token(gateway_config)
     mock_gateway.assert_called_once_with(**gateway_config.connection_params)
     mock_generate.assert_called_once_with()
-    assert result == client_token
+    assert token == expected_token
 
 
 @pytest.mark.integration

--- a/tests/gateway/test_braintree.py
+++ b/tests/gateway/test_braintree.py
@@ -205,7 +205,7 @@ def test_get_client_token(mock_gateway, gateway_config):
     client_token = "client-token"
     mock_generate = Mock(return_value="client-token")
     mock_gateway.return_value = Mock(client_token=Mock(generate=mock_generate))
-    result = get_client_token(gateway_config.connection_params)
+    result = get_client_token(gateway_config)
     mock_gateway.assert_called_once_with(**gateway_config.connection_params)
     mock_generate.assert_called_once_with()
     assert result == client_token


### PR DESCRIPTION
Fixes incorrect `get_client_token` signature for Braintree payment gateway which was causing this error:

```
Traceback (most recent call last):
  File "/Users/marcin/.pyenv/versions/saleor3.7/lib/python3.7/site-packages/promise/promise.py", line 487, in _resolve_from_executor
    executor(resolve, reject)
  File "/Users/marcin/.pyenv/versions/saleor3.7/lib/python3.7/site-packages/promise/promise.py", line 754, in executor
    return resolve(f(*args, **kwargs))
  File "/Users/marcin/.pyenv/versions/saleor3.7/lib/python3.7/site-packages/graphql/execution/middleware.py", line 76, in make_it_promise
    return next(*args, **kwargs)
  File "/Users/marcin/mirumee/saleor/saleor/graphql/payment/schema.py", line 27, in resolve_payment_client_token
    return resolve_payment_client_token(gateway)
  File "/Users/marcin/mirumee/saleor/saleor/graphql/payment/resolvers.py", line 17, in resolve_payment_client_token
    return gateway_get_client_token(gateway)
  File "/Users/marcin/mirumee/saleor/saleor/payment/utils.py", line 234, in gateway_get_client_token
    return gateway.get_client_token(config=gateway_config)
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
