### PR TITLE
Restore default django common middleware

### DIFF
--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -71,9 +71,6 @@ django_auth_middleware = django_only_middleware(
 django_csrf_view_middleware = django_only_middleware(
     django.middleware.csrf.CsrfViewMiddleware
 )
-django_common_middleware = django_only_middleware(
-    django.middleware.common.CommonMiddleware
-)
 django_security_middleware = django_only_middleware(
     django.middleware.security.SecurityMiddleware
 )

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -195,9 +195,9 @@ TEMPLATES = [
 SECRET_KEY = os.environ.get("SECRET_KEY")
 
 MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
     "saleor.core.middleware.django_session_middleware",
     "saleor.core.middleware.django_security_middleware",
-    "saleor.core.middleware.django_common_middleware",
     "saleor.core.middleware.django_csrf_view_middleware",
     "saleor.core.middleware.django_auth_middleware",
     "saleor.core.middleware.django_messages_middleware",


### PR DESCRIPTION
I want to merge this change because graphql endpoint requires django common middleware to work with HTTPS

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
