### PR TITLE
Disable polling in Playgroud by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix incorrect argument in `get_client_token` in Braintree integration - #4182 by @maarcingebala
 - Fix resolving attribute values when transforming them to HStore - #4161 by @maarcingebala
 - Fix margin calculations when product/variant price is set to zero - #4170 by @MahmoudRizk
+- Disable polling in Playgroud by default - #4188 by @maarcingebala
 
 ## 2.6.0
 

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -44,7 +44,9 @@
   </div>
   <script>window.addEventListener('load', function (event) {
       GraphQLPlayground.init(document.getElementById('root'), {
-        // options as 'endpoint' belong here
+        settings: {
+          'schema.polling.enable': false
+        }
       })
     })</script>
 </body>


### PR DESCRIPTION
The "polling" feature of new Playground makes it really slow on a local machine, so I suggest that we disable it by default and users will re-enable it manually if they want to use it.