### PR TITLE
Define default paginate_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add filtering interface to product list - #4193 by @dominik-zeglen
 - Unify search API - #4200 by @dominik-zeglen
 - Close modals on click outside - #4236 - by @benekex2
+- Default default PAGINATE_BY - #4238 by @dominik-zeglen
 
 ## 2.6.0
 

--- a/saleor/static/dashboard-next/categories/views/CategoryDetails.tsx
+++ b/saleor/static/dashboard-next/categories/views/CategoryDetails.tsx
@@ -5,13 +5,13 @@ import * as React from "react";
 
 import ActionDialog from "@saleor/components/ActionDialog";
 import { WindowTitle } from "@saleor/components/WindowTitle";
-import { PAGINATE_BY } from "../../config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import usePaginator, {
   createPaginationState
 } from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import { TypedProductBulkDeleteMutation } from "../../products/mutations";

--- a/saleor/static/dashboard-next/categories/views/CategoryDetails.tsx
+++ b/saleor/static/dashboard-next/categories/views/CategoryDetails.tsx
@@ -5,10 +5,13 @@ import * as React from "react";
 
 import ActionDialog from "@saleor/components/ActionDialog";
 import { WindowTitle } from "@saleor/components/WindowTitle";
+import { PAGINATE_BY } from "../../config";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import { TypedProductBulkDeleteMutation } from "../../products/mutations";
@@ -46,8 +49,6 @@ export function getActiveTab(tabName: string): CategoryPageTab {
     ? CategoryPageTab.products
     : CategoryPageTab.categories;
 }
-
-const PAGINATE_BY = 20;
 
 export const CategoryDetails: React.StatelessComponent<
   CategoryDetailsProps

--- a/saleor/static/dashboard-next/categories/views/CategoryList.tsx
+++ b/saleor/static/dashboard-next/categories/views/CategoryList.tsx
@@ -6,7 +6,10 @@ import * as React from "react";
 import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import { CategoryListPage } from "../components/CategoryListPage/CategoryListPage";
@@ -23,8 +26,6 @@ import {
 interface CategoryListProps {
   params: CategoryListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const CategoryList: React.StatelessComponent<CategoryListProps> = ({
   params

--- a/saleor/static/dashboard-next/collections/views/CollectionDetails.tsx
+++ b/saleor/static/dashboard-next/collections/views/CollectionDetails.tsx
@@ -8,8 +8,10 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "../../config";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { DEFAULT_INITIAL_SEARCH_DATA, PAGINATE_BY } from "../../config";
 import SearchProducts from "../../containers/SearchProducts";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -35,8 +37,6 @@ interface CollectionDetailsProps {
   id: string;
   params: CollectionUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const CollectionDetails: React.StatelessComponent<
   CollectionDetailsProps

--- a/saleor/static/dashboard-next/collections/views/CollectionList.tsx
+++ b/saleor/static/dashboard-next/collections/views/CollectionList.tsx
@@ -8,7 +8,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import CollectionListPage from "../components/CollectionListPage/CollectionListPage";
@@ -30,8 +33,6 @@ import {
 interface CollectionListProps {
   params: CollectionListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const CollectionList: React.StatelessComponent<CollectionListProps> = ({
   params

--- a/saleor/static/dashboard-next/config.ts
+++ b/saleor/static/dashboard-next/config.ts
@@ -8,3 +8,5 @@ export const DEFAULT_INITIAL_SEARCH_DATA: SearchQueryVariables = {
   first: 5,
   query: ""
 };
+
+export const PAGINATE_BY = 20;

--- a/saleor/static/dashboard-next/customers/views/CustomerList.tsx
+++ b/saleor/static/dashboard-next/customers/views/CustomerList.tsx
@@ -7,7 +7,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import CustomerListPage from "../components/CustomerListPage";
@@ -20,8 +23,6 @@ import {
   CustomerListUrlQueryParams,
   customerUrl
 } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface CustomerListProps {
   params: CustomerListUrlQueryParams;

--- a/saleor/static/dashboard-next/discounts/views/SaleDetails.tsx
+++ b/saleor/static/dashboard-next/discounts/views/SaleDetails.tsx
@@ -10,11 +10,13 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
 import { categoryUrl } from "../../categories/urls";
 import { collectionUrl } from "../../collections/urls";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "../../config";
+import { DEFAULT_INITIAL_SEARCH_DATA, PAGINATE_BY } from "../../config";
 import SearchCategories from "../../containers/SearchCategories";
 import SearchCollections from "../../containers/SearchCollections";
 import SearchProducts from "../../containers/SearchProducts";
@@ -42,8 +44,6 @@ import {
   SaleUrlDialog,
   SaleUrlQueryParams
 } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface SaleDetailsProps {
   id: string;

--- a/saleor/static/dashboard-next/discounts/views/SaleList.tsx
+++ b/saleor/static/dashboard-next/discounts/views/SaleList.tsx
@@ -8,8 +8,11 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import SaleListPage from "../components/SaleListPage";
@@ -22,8 +25,6 @@ import {
   SaleListUrlQueryParams,
   saleUrl
 } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface SaleListProps {
   params: SaleListUrlQueryParams;

--- a/saleor/static/dashboard-next/discounts/views/VoucherDetails.tsx
+++ b/saleor/static/dashboard-next/discounts/views/VoucherDetails.tsx
@@ -10,11 +10,13 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
 import { categoryUrl } from "../../categories/urls";
 import { collectionUrl } from "../../collections/urls";
-import { DEFAULT_INITIAL_SEARCH_DATA } from "../../config";
+import { DEFAULT_INITIAL_SEARCH_DATA, PAGINATE_BY } from "../../config";
 import SearchCategories from "../../containers/SearchCategories";
 import SearchCollections from "../../containers/SearchCollections";
 import SearchProducts from "../../containers/SearchProducts";
@@ -46,8 +48,6 @@ import {
   VoucherUrlDialog,
   VoucherUrlQueryParams
 } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface VoucherDetailsProps {
   id: string;

--- a/saleor/static/dashboard-next/discounts/views/VoucherList.tsx
+++ b/saleor/static/dashboard-next/discounts/views/VoucherList.tsx
@@ -8,8 +8,11 @@ import { WindowTitle } from "@saleor/components/WindowTitle";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import VoucherListPage from "../components/VoucherListPage";
@@ -22,8 +25,6 @@ import {
   VoucherListUrlQueryParams,
   voucherUrl
 } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface VoucherListProps {
   params: VoucherListUrlQueryParams;

--- a/saleor/static/dashboard-next/navigation/views/MenuList.tsx
+++ b/saleor/static/dashboard-next/navigation/views/MenuList.tsx
@@ -6,7 +6,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import { configurationMenuUrl } from "../../configuration";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -22,8 +25,6 @@ import { MenuBulkDelete } from "../types/MenuBulkDelete";
 import { MenuCreate } from "../types/MenuCreate";
 import { MenuDelete } from "../types/MenuDelete";
 import { menuListUrl, MenuListUrlQueryParams, menuUrl } from "../urls";
-
-const PAGINATE_BY = 20;
 
 interface MenuListProps {
   params: MenuListUrlQueryParams;

--- a/saleor/static/dashboard-next/orders/views/OrderDraftList.tsx
+++ b/saleor/static/dashboard-next/orders/views/OrderDraftList.tsx
@@ -7,7 +7,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import OrderDraftListPage from "../components/OrderDraftListPage";
@@ -27,8 +30,6 @@ import {
 interface OrderDraftListProps {
   params: OrderDraftListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const OrderDraftList: React.StatelessComponent<OrderDraftListProps> = ({
   params

--- a/saleor/static/dashboard-next/orders/views/OrderList.tsx
+++ b/saleor/static/dashboard-next/orders/views/OrderList.tsx
@@ -4,7 +4,10 @@ import * as React from "react";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
 import { OrderStatusFilter } from "../../types/globalTypes";
@@ -28,8 +31,6 @@ import {
 interface OrderListProps {
   params: OrderListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const OrderList: React.StatelessComponent<OrderListProps> = ({
   params

--- a/saleor/static/dashboard-next/pages/views/PageList.tsx
+++ b/saleor/static/dashboard-next/pages/views/PageList.tsx
@@ -8,7 +8,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import { configurationMenuUrl } from "../../configuration";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -28,8 +31,6 @@ import {
 interface PageListProps {
   params: PageListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const PageList: React.StatelessComponent<PageListProps> = ({
   params

--- a/saleor/static/dashboard-next/productTypes/views/ProductTypeList.tsx
+++ b/saleor/static/dashboard-next/productTypes/views/ProductTypeList.tsx
@@ -7,7 +7,10 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import { configurationMenuUrl } from "../../configuration";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -25,8 +28,6 @@ import {
 interface ProductTypeListProps {
   params: ProductTypeListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const ProductTypeList: React.StatelessComponent<
   ProductTypeListProps

--- a/saleor/static/dashboard-next/products/views/ProductList/ProductList.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductList/ProductList.tsx
@@ -13,8 +13,11 @@ import useBulkActions from "@saleor/hooks/useBulkActions";
 import useLocale from "@saleor/hooks/useLocale";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
+import { PAGINATE_BY } from "../../../config";
 import i18n from "../../../i18n";
 import { getMutationState, maybe } from "../../../misc";
 import ProductListCard from "../../components/ProductListCard";
@@ -47,8 +50,6 @@ import {
 interface ProductListProps {
   params: ProductListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const ProductList: React.StatelessComponent<ProductListProps> = ({
   params

--- a/saleor/static/dashboard-next/shipping/views/ShippingZonesList.tsx
+++ b/saleor/static/dashboard-next/shipping/views/ShippingZonesList.tsx
@@ -7,8 +7,11 @@ import ActionDialog from "@saleor/components/ActionDialog";
 import useBulkActions from "@saleor/hooks/useBulkActions";
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
+import { PAGINATE_BY } from "../../config";
 import { configurationMenuUrl } from "../../configuration";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -32,8 +35,6 @@ import {
 interface ShippingZonesListProps {
   params: ShippingZonesListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const ShippingZonesList: React.StatelessComponent<
   ShippingZonesListProps

--- a/saleor/static/dashboard-next/staff/views/StaffList.tsx
+++ b/saleor/static/dashboard-next/staff/views/StaffList.tsx
@@ -2,7 +2,10 @@ import * as React from "react";
 
 import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
+import { PAGINATE_BY } from "../../config";
 import { configurationMenuUrl } from "../../configuration";
 import i18n from "../../i18n";
 import { getMutationState, maybe } from "../../misc";
@@ -22,8 +25,6 @@ import {
 interface StaffListProps {
   params: StaffListUrlQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 export const StaffList: React.StatelessComponent<StaffListProps> = ({
   params

--- a/saleor/static/dashboard-next/translations/views/TranslationsEntities.tsx
+++ b/saleor/static/dashboard-next/translations/views/TranslationsEntities.tsx
@@ -2,8 +2,11 @@ import { stringify as stringifyQs } from "qs";
 import * as React from "react";
 
 import useNavigator from "@saleor/hooks/useNavigator";
-import usePaginator, { createPaginationState } from "@saleor/hooks/usePaginator";
+import usePaginator, {
+  createPaginationState
+} from "@saleor/hooks/usePaginator";
 import useShop from "@saleor/hooks/useShop";
+import { PAGINATE_BY } from "../../config";
 import { maybe } from "../../misc";
 import { Pagination } from "../../types";
 import TranslationsEntitiesList from "../components/TranslationsEntitiesList";
@@ -34,8 +37,6 @@ interface TranslationsEntitiesProps {
   language: string;
   params: TranslationsEntitiesListQueryParams;
 }
-
-const PAGINATE_BY = 20;
 
 function sumTranslations(
   acc: number,


### PR DESCRIPTION
I want to merge this change because having multiple `const PAGINATE_BY = 20` annoyed me.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
