### PR TITLE
Add default state to rich text editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Reset selected items when tab switch - #4268 by @benekex2
 - Fix collection search - #4267 by @dominik-zeglen
 - Fix quantity height in draft order edit - #4273 by @benekex2
+- Add default state to rich text editor = #4281 by @dominik-zeglen
 
 
 ## 2.6.0

--- a/saleor/static/dashboard-next/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
+++ b/saleor/static/dashboard-next/categories/components/CategoryCreatePage/CategoryCreatePage.tsx
@@ -1,4 +1,4 @@
-import { RawDraftContentState } from "draft-js";
+import { ContentState, convertToRaw, RawDraftContentState } from "draft-js";
 import * as React from "react";
 
 import AppHeader from "@saleor/components/AppHeader";
@@ -21,7 +21,7 @@ interface FormData {
 }
 
 const initialData: FormData = {
-  description: null,
+  description: convertToRaw(ContentState.createFromText("")),
   name: "",
   seoDescription: "",
   seoTitle: ""

--- a/saleor/static/dashboard-next/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
+++ b/saleor/static/dashboard-next/collections/components/CollectionCreatePage/CollectionCreatePage.tsx
@@ -1,6 +1,6 @@
 import Card from "@material-ui/core/Card";
 import CardContent from "@material-ui/core/CardContent";
-import { RawDraftContentState } from "draft-js";
+import { ContentState, convertToRaw, RawDraftContentState } from "draft-js";
 import * as React from "react";
 
 import AppHeader from "@saleor/components/AppHeader";
@@ -47,7 +47,7 @@ const initialForm: CollectionCreatePageFormData = {
     value: null
   },
   backgroundImageAlt: "",
-  description: null,
+  description: convertToRaw(ContentState.createFromText("")),
   isPublished: false,
   name: "",
   publicationDate: "",


### PR DESCRIPTION
I want to merge this change because it allows the user to create categories and collections without setting any description to them.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
