### PR TITLE
Fix using get_client_token in Storefront 1.0

### DIFF
--- a/docs/guides/payments.rst
+++ b/docs/guides/payments.rst
@@ -17,7 +17,7 @@ Your changes should live under the
     After completing those steps you will also need to integrate your payment
     gateway into your SPA Storefront's workflow.
 
-get_client_token(connection_params)
+get_client_token(config)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A client token is a signed data blob that includes configuration and
@@ -31,8 +31,8 @@ Example
 
 .. code-block:: python
 
-    def get_client_token(connection_params: Dict) -> str:
-        gateway = get_payment_gateway(**connection_params)
+    def get_client_token(config: GatewayConfig) -> str:
+        gateway = get_payment_gateway(**config.connection_params)
         client_token = gateway.client_token.generate()
         return client_token
 

--- a/saleor/order/views.py
+++ b/saleor/order/views.py
@@ -131,7 +131,7 @@ def start_payment(request, order, gateway):
                     return redirect("order:payment-success", token=order.token)
                 return redirect(order.get_absolute_url())
 
-    client_token = payment_gateway.get_client_token(connection_params=connection_params)
+    client_token = payment_gateway.get_client_token(config=gateway_config)
     ctx = {
         "form": form,
         "payment": payment,


### PR DESCRIPTION
Singature of `get_client_token` was broken in Storefront 1.0 when using it with Braintree.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
