### PR TITLE
Fixed internal error when creating a checkout with a voucher code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix quantity height in draft order edit - #4273 by @benekex2
 - Fix checkbox clickable area size - #4280 by @dominik-zeglen
 - Fix exploding object select in menu section - #4282 by @dominik-zeglen
-- Add default state to rich text editor = #4281 by @dominik-zeglen
+- Add default state to rich text editor - #4281 by @dominik-zeglen
+- Fixed internal error when creating a checkout with a voucher code - #4292 by @NyanKiyoshi
 
 
 ## 2.6.0

--- a/saleor/checkout/views/summary.py
+++ b/saleor/checkout/views/summary.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.db import transaction
 from django.shortcuts import redirect
 from django.template.response import TemplateResponse
 from django.utils.translation import pgettext
@@ -19,6 +20,7 @@ from ..utils import (
 )
 
 
+@transaction.atomic()
 def _handle_order_placement(request, checkout):
     """Try to create an order and redirect the user as necessary.
 


### PR DESCRIPTION
Closes #4291

This is a fix that will need further rework, because we have issues with managing the voucher usage count:
  1. If we were to do a transaction on the whole mutation, and the charge API call to the payment gateway was to be slow–or a lot of people were to be using the same voucher around the same time,  they we would be getting locked by the row, and thus would have a long loading time.
  1. UserB could use the same voucher code when UserA was getting charged for his voucher. UserB gets the error "Voucher is expired" but after that, if charging UserA fails, UserC will then use the voucher code and it will no longer be expired because it was updated.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
