### PR TITLE
Fixed internal error when adding a note to an anonymous order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed internal error when creating a checkout with a voucher code - #4292 by @NyanKiyoshi
 - Add filter tab name as required - #4269 by @benekex2
 - A few unused panels are now disabled by default from the debug toolbar; this should improve loading time when debugging - #4301 by @NyanKiyoshi
+- Fixed internal error when adding a note to an anonymous order - #4319 by @NyanKiyoshi
 
 ## 2.7.0
 

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -222,16 +222,19 @@ def fulfillment_tracking_updated_event(
 
 
 def order_note_added_event(*, order: Order, user: UserType, message: str) -> OrderEvent:
-    if order.user.pk == user.pk:
-        account_events.customer_added_to_note_order_event(
-            user=user, order=order, message=message
-        )
+    kwargs = {}
+    if user is not None and not user.is_anonymous:
+        if order.user is not None and order.user.pk == user.pk:
+            account_events.customer_added_to_note_order_event(
+                user=user, order=order, message=message
+            )
+        kwargs["user"] = user
 
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.NOTE_ADDED,
-        user=user,
         parameters={"message": message},
+        **kwargs,
     )
 
 

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -553,6 +553,50 @@ def test_add_order_note_view(order, authorized_client, customer_user):
     assert note_event.parameters == {"message": customer_note}
 
 
+def test_add_order_note_view_anonymous_order(order, authorized_client, customer_user):
+    order.user_email = customer_user.email
+    order.user = None
+    order.save(update_fields=["user_email", "user"])
+    url = reverse("order:details", kwargs={"token": order.token})
+    customer_note = "bla-bla note"
+    data = {"customer_note": customer_note}
+
+    response = authorized_client.post(url, data)
+    assert response.status_code == 302
+
+    # Ensure an order event was triggered
+    note_event = order_events.OrderEvent.objects.last()  # type: order_events.OrderEvent
+    assert note_event.type == order_events.OrderEvents.NOTE_ADDED
+    assert note_event.user == customer_user
+    assert note_event.order == order
+    assert note_event.parameters == {"message": customer_note}
+
+    # Ensure a customer event was not triggered because the order has no user
+    assert not account_events.CustomerEvent.objects.exists()
+
+
+def test_anonymously_add_order_note_view_anonymous_order(order, client, customer_user):
+    order.user_email = customer_user.email
+    order.user = None
+    order.save(update_fields=["user_email", "user"])
+    url = reverse("order:details", kwargs={"token": order.token})
+    customer_note = "bla-bla note"
+    data = {"customer_note": customer_note}
+
+    response = client.post(url, data)
+    assert response.status_code == 302
+
+    # Ensure an order event was triggered
+    note_event = order_events.OrderEvent.objects.last()  # type: order_events.OrderEvent
+    assert note_event.type == order_events.OrderEvents.NOTE_ADDED
+    assert note_event.user is None
+    assert note_event.order == order
+    assert note_event.parameters == {"message": customer_note}
+
+    # Ensure a customer event was not triggered because the order has no user
+    assert not account_events.CustomerEvent.objects.exists()
+
+
 def _calculate_order_weight_from_lines(order):
     weight = zero_weight()
     for line in order:


### PR DESCRIPTION
```
AttributeError: 'NoneType' object has no attribute 'pk'
  File "django/core/handlers/exception.py", line 34, in inner
    response = get_response(request)
  File "django/core/handlers/base.py", line 115, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "django/core/handlers/base.py", line 113, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "saleor/order/views.py", line 45, in details
    note_form.save(user=request.user)
  File "saleor/order/forms.py", line 76, in save
    order=self.instance, user=user, message=self.instance.customer_note
  File "saleor/order/events.py", line 225, in order_note_added_event
    if order.user.pk == user.pk:
```

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
