### PR TITLE
Properly resolve IDs when adding attributes to products

### DIFF
--- a/saleor/graphql/product/interfaces.py
+++ b/saleor/graphql/product/interfaces.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+from typing import List
+
+from ...product import models
+
+
+@dataclass(frozen=True)
+class ResolvedAttributeInput:
+    instance: models.Attribute
+    values: List[str]

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -337,7 +337,12 @@ class AttributeValueInput(InputObjectType):
     )
     slug = graphene.String(description="Slug of an attribute.")
     values = graphene.List(
-        graphene.String, required=True, description="Value of an attribute."
+        graphene.String,
+        required=True,
+        description=(
+            "The value or slug of an attribute to resolve. "
+            "If the passed value is non-existent, it will be created."
+        ),
     )
 
 

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -1,9 +1,14 @@
 from collections import defaultdict
-from typing import List
+from typing import Dict, List
 
+import graphene
 from django.utils.text import slugify
 
 from ...product import AttributeInputType, models
+from .interfaces import ResolvedAttributeInput
+
+attribute_input_type = List[ResolvedAttributeInput]
+attribute_map_type = Dict[str, models.Attribute]
 
 
 def validate_attribute_input(instance: models.Attribute, values: List[str]):
@@ -16,33 +21,24 @@ def validate_attribute_input(instance: models.Attribute, values: List[str]):
         raise ValueError(f"A {instance.input_type} attribute must take only one value")
 
 
-def attributes_to_json(attribute_value_input: List[dict], attributes_queryset):
-    """Transform attributes to the HStore representation.
+def _resolve_attributes_input(
+    attribute_input: List[dict],
+    attributes_map_by_slug: attribute_map_type,
+    attributes_map_by_id: attribute_map_type,
+) -> attribute_input_type:
+    """This resolves a raw GraphQL input to proper attribute. Its job is to ensure
+    a backward compatibility with passing attributes by slug."""
 
-    Attributes configuration per product is stored in a HStore field as
-    a dict of IDs. This function transforms the list of `AttributeValueInput`
-    objects to this format.
-    """
-    attributes_map_by_slug = {}
-    attributes_map_by_id = {}
+    resolved_input = []  # type: List[ResolvedAttributeInput]
 
-    for attr in attributes_queryset:
-        attributes_map_by_slug[attr.slug] = attr
-        attributes_map_by_id[attr.id] = attr
-
-    attributes_json = defaultdict(list)
-    passed_slugs = set()
-
-    values_map = {}
-    for attr in attributes_queryset:
-        for value in attr.values.all():
-            values_map[value.slug] = value.id
-
-    for attribute_input in attribute_value_input:
+    for attribute_input in attribute_input:
         if "slug" in attribute_input:
             attribute = attributes_map_by_slug.get(attribute_input["slug"])
         elif "id" in attribute_input:
-            attribute = attributes_map_by_id.get(attribute_input["id"])
+            type_, attribute_id = graphene.Node.from_global_id(attribute_input["id"])
+            if type_ != "Attribute":
+                raise ValueError(f"Couldn't resolve to a node: {attribute_input['id']}")
+            attribute = attributes_map_by_id.get(attribute_id)
         else:
             raise ValueError("The value ID or slug was not provided")
 
@@ -51,21 +47,58 @@ def attributes_to_json(attribute_value_input: List[dict], attributes_queryset):
                 "The given attribute doesn't belong to given product type."
             )
 
-        passed_slugs.add(attribute.slug)
-
         values = attribute_input.get("values")
         validate_attribute_input(attribute, values)
 
-        for value in values:
+        resolved_input.append(ResolvedAttributeInput(instance=attribute, values=values))
+
+    return resolved_input
+
+
+def attributes_to_json(
+    raw_input: List[dict], attributes_queryset
+) -> Dict[str, List[str]]:
+    """Transform attributes to the HStore representation.
+
+    Attributes configuration per product is stored in a HStore field as
+    a dict of IDs. This function transforms the list of `AttributeValueInput`
+    objects to this format.
+    """
+
+    attributes_json = defaultdict(list)
+    passed_slugs = set()
+
+    attributes_map_by_slug = {}  # type: attribute_map_type
+    attributes_map_by_id = {}  # type: attribute_map_type
+
+    for attr in attributes_queryset:
+        attributes_map_by_slug[attr.slug] = attr
+        attributes_map_by_id[str(attr.id)] = attr
+
+    resolved_input = _resolve_attributes_input(
+        raw_input, attributes_map_by_slug, attributes_map_by_id
+    )
+
+    values_map = {}
+    for attr in attributes_queryset:
+        for value in attr.values.all():
+            values_map[value.slug] = value.id
+
+    for item in resolved_input:
+        passed_slugs.add(item.instance.slug)
+
+        for value in item.values:
             value_id = values_map.get(value)
 
             if value_id is None:
                 # `value_id` was not found; create a new AttributeValue
                 # instance from the provided `value`.
-                obj = attribute.values.get_or_create(name=value, slug=slugify(value))[0]
+                obj = item.instance.values.get_or_create(
+                    name=value, slug=slugify(value)
+                )[0]
                 value_id = obj.pk
 
-            attributes_json[str(attribute.pk)].append(str(value_id))
+            attributes_json[str(item.instance.pk)].append(str(value_id))
 
     # Check that all required attributes were passed
     for missing_slug in attributes_map_by_slug.keys() ^ passed_slugs:

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -719,11 +719,11 @@ def test_create_product(
     # Default attribute defined in product_type fixture
     color_attr = product_type.product_attributes.get(name="Color")
     color_value_slug = color_attr.values.first().slug
-    color_attr_slug = color_attr.slug
+    color_attr_id = graphene.Node.to_global_id("Attribute", color_attr.id)
 
     # Add second attribute
     product_type.product_attributes.add(size_attribute)
-    size_attr_slug = product_type.product_attributes.get(name="Size").slug
+    size_attr_id = graphene.Node.to_global_id("Attribute", size_attribute.id)
     non_existent_attr_value = "The cake is a lie"
 
     # test creating root product
@@ -738,8 +738,8 @@ def test_create_product(
         "taxRate": product_tax_rate,
         "basePrice": product_price,
         "attributes": [
-            {"slug": color_attr_slug, "values": [color_value_slug]},
-            {"slug": size_attr_slug, "values": [non_existent_attr_value]},
+            {"id": color_attr_id, "values": [color_value_slug]},
+            {"id": size_attr_id, "values": [non_existent_attr_value]},
         ],
     }
 
@@ -1077,11 +1077,14 @@ def test_update_product_can_only_assign_multiple_values_to_valid_input_types(
         name="multi", slug="multi-vals", input_type=AttributeInputType.MULTISELECT
     )
     multi_values_attr.product_types.add(product.product_type)
+    multi_values_attr_id = graphene.Node.to_global_id("Attribute", multi_values_attr.id)
+
+    color_attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.id)
 
     # Try to assign multiple values from an attribute that does not support such things
     variables = {
         "productId": graphene.Node.to_global_id("Product", product.pk),
-        "attributes": [{"slug": color_attribute.slug, "values": ["red", "blue"]}],
+        "attributes": [{"id": color_attribute_id, "values": ["red", "blue"]}],
     }
     data = get_graphql_content(
         staff_api_client.post_graphql(SET_ATTRIBUTES_TO_PRODUCT_QUERY, variables)
@@ -1094,11 +1097,11 @@ def test_update_product_can_only_assign_multiple_values_to_valid_input_types(
     ]
 
     # Try to assign multiple values from a valid attribute
-    variables["attributes"] = [{"slug": multi_values_attr.slug, "values": ["a", "b"]}]
+    variables["attributes"] = [{"id": multi_values_attr_id, "values": ["a", "b"]}]
     data = get_graphql_content(
         staff_api_client.post_graphql(SET_ATTRIBUTES_TO_PRODUCT_QUERY, variables)
     )["data"]["productUpdate"]
-    assert data["errors"] == []
+    assert not data["errors"]
 
 
 def test_update_product_without_variants(


### PR DESCRIPTION
This fixes an issue with the attributes not being properly resolved when adding attributes to products. It was expecting a int but was getting a non-resolved string ID.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.

---


_Never start working on new feature after 9 hours of work. Otherwise it will attract bugs because I will forget to write an integration test._

<div align='center'><img src='https://sayingimages.com/wp-content/uploads/feeling-depress-fail-meme.jpg' height='255'></div>