### PR TITLE
Avoid PytestUnknownMarkWarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,8 @@ filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
 DJANGO_SETTINGS_MODULE = tests.settings
+markers =
+    integration
 
 [flake8]
 exclude =

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -100,7 +100,6 @@ def test_fetch_all_products(user_api_client, product):
     assert len(content["data"]["products"]["edges"]) == num_products
 
 
-@pytest.mark.djangodb
 def test_fetch_unavailable_products(user_api_client, product):
     Product.objects.update(is_published=False)
     query = """


### PR DESCRIPTION
I want to merge this change because...
 pytest is throwing warnings:

```
=============================== warnings summary ===============================
/lib/python3.7/site-packages/_pytest/mark/structures.py:337: PytestUnknownMarkWarning: Unknown pytest.mark.integration - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
```

More read: https://docs.pytest.org/en/latest/example/markers.html#registering-markers
