### PR TITLE
Use django's csrfmiddleware instead of our custom

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -197,9 +197,9 @@ SECRET_KEY = os.environ.get("SECRET_KEY")
 
 MIDDLEWARE = [
     "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
     "saleor.core.middleware.django_session_middleware",
     "saleor.core.middleware.django_security_middleware",
-    "saleor.core.middleware.django_csrf_view_middleware",
     "saleor.core.middleware.django_auth_middleware",
     "saleor.core.middleware.django_messages_middleware",
     "saleor.core.middleware.django_locale_middleware",


### PR DESCRIPTION
Our custom csrf_middleware doesn't work as we expected. We will turn it off for know.