### PR TITLE
Ensure the debug toolbar is installed

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,5 +1,6 @@
 import ast
 import os.path
+import warnings
 
 import dj_database_url
 import dj_email_url
@@ -269,8 +270,19 @@ INSTALLED_APPS = [
 
 ENABLE_DEBUG_TOOLBAR = get_bool_from_env("ENABLE_DEBUG_TOOLBAR", False)
 if ENABLE_DEBUG_TOOLBAR:
-    MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
-    INSTALLED_APPS.append("debug_toolbar")
+    # Ensure the debug toolbar is actually installed before adding it
+    try:
+        __import__("debug_toolbar")
+    except ImportError as exc:
+        msg = (
+            f"{exc} -- Install the missing dependencies by "
+            f"running `pip install -r requirements_dev.txt`"
+        )
+        warnings.warn(msg)
+    else:
+        MIDDLEWARE.append("debug_toolbar.middleware.DebugToolbarMiddleware")
+        INSTALLED_APPS.append("debug_toolbar")
+
     DEBUG_TOOLBAR_PANELS = [
         # adds a request history to the debug toolbar
         "ddt_request_history.panels.request_history.RequestHistoryPanel",

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -50,12 +50,17 @@ translatable_urlpatterns = [
 urlpatterns = non_translatable_urlpatterns + i18n_patterns(*translatable_urlpatterns)
 
 if settings.DEBUG:
-    import debug_toolbar
+    try:
+        import debug_toolbar
+    except ImportError:
+        """The debug toolbar was not installed. Ignore the error.
+        settings.py should already have warned the user about it."""
+    else:
+        urlpatterns += [url(r"^__debug__/", include(debug_toolbar.urls))]
 
     urlpatterns += [
-        url(r"^__debug__/", include(debug_toolbar.urls)),
         # static files (images, css, javascript, etc.)
-        url(r"^static/(?P<path>.*)$", serve),
+        url(r"^static/(?P<path>.*)$", serve)
     ] + static("/media/", document_root=settings.MEDIA_ROOT)
 
 if settings.ENABLE_SILK:


### PR DESCRIPTION
If users didn't read the documentation on how to install the dependencies, instead of a confusing error trace that would make them open an issue, we invite them to install the missing dependencies.

> No module named 'debug_toolbar'
> Install the missing dependencies by running `pip install -r requirements_dev.txt`

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
