### PR TITLE
Add drag'n'drop attribute reordering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add attribute visibility config - #4449 by @dominik-zeglen
 - Add slug generation = #4488 by @dominik-zeglen
 - Dropped `null` in `sort_order` fields to make it easier to reorder in API - #4481 by @NyanKiyoshi
-
 - Add drag'n'drop attribute reordering in product type view - #4492 by @dominik-zeglen
 
 ## [Unreleased]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add slug generation = #4488 by @dominik-zeglen
 - Dropped `null` in `sort_order` fields to make it easier to reorder in API - #4481 by @NyanKiyoshi
 
+- Add drag'n'drop attribute reordering in product type view - #4492 by @dominik-zeglen
+
 ## [Unreleased]
 
 - Fix product type taxes select - #4453 by @benekex2

--- a/package-lock.json
+++ b/package-lock.json
@@ -8827,6 +8827,14 @@
         "@types/react-router": "*"
       }
     },
+    "@types/react-sortable-hoc": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@types/react-sortable-hoc/-/react-sortable-hoc-0.6.5.tgz",
+      "integrity": "sha512-0Ms36xuds/pByIQFobwlDGPaUPSF6jOZUhOqf/0SaX/ZC0z9a/vwwWigEJomTvlshyjlKwB6JXV9TK+8keXq7w==",
+      "requires": {
+        "@types/react": "*"
+      }
+    },
     "@types/react-sortable-tree": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/@types/react-sortable-tree/-/react-sortable-tree-0.3.6.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react-dropzone": "^4.2.2",
     "@types/react-helmet": "^5.0.8",
     "@types/react-infinite-scroller": "^1.2.1",
+    "@types/react-sortable-hoc": "^0.6.5",
     "@types/react-sortable-tree": "^0.3.6",
     "@types/storybook__addon-storyshots": "^3.4.9",
     "@types/string-similarity": "^1.2.1",

--- a/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
@@ -11,7 +11,7 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import i18n from "@saleor/i18n";
 import { maybe } from "@saleor/misc";
-import { ReorderEvent, UserError } from "@saleor/types";
+import { ReorderAction, UserError } from "@saleor/types";
 import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
 import {
   AttributeDetailsFragment,
@@ -32,7 +32,7 @@ export interface AttributePageProps {
   onSubmit: (data: AttributePageFormData) => void;
   onValueAdd: () => void;
   onValueDelete: (id: string) => void;
-  onValueReorder: ReorderEvent;
+  onValueReorder: ReorderAction;
   onValueUpdate: (id: string) => void;
 }
 

--- a/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
@@ -11,7 +11,7 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import i18n from "@saleor/i18n";
 import { maybe } from "@saleor/misc";
-import { UserError } from "@saleor/types";
+import { ReorderEvent, UserError } from "@saleor/types";
 import { AttributeInputTypeEnum } from "@saleor/types/globalTypes";
 import {
   AttributeDetailsFragment,
@@ -32,6 +32,7 @@ export interface AttributePageProps {
   onSubmit: (data: AttributePageFormData) => void;
   onValueAdd: () => void;
   onValueDelete: (id: string) => void;
+  onValueReorder: ReorderEvent;
   onValueUpdate: (id: string) => void;
 }
 
@@ -56,6 +57,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
   onSubmit,
   onValueAdd,
   onValueDelete,
+  onValueReorder,
   onValueUpdate
 }) => {
   const initialForm: AttributePageFormData =
@@ -126,6 +128,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
                 values={values}
                 onValueAdd={onValueAdd}
                 onValueDelete={onValueDelete}
+                onValueReorder={onValueReorder}
                 onValueUpdate={onValueUpdate}
               />
             </div>

--- a/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
@@ -3,17 +3,20 @@ import Card from "@material-ui/core/Card";
 import IconButton from "@material-ui/core/IconButton";
 import { Theme } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import DeleteIcon from "@material-ui/icons/Delete";
 import makeStyles from "@material-ui/styles/makeStyles";
 import React from "react";
-import { SortableContainer, SortableElement } from "react-sortable-hoc";
+import { SortableElement } from "react-sortable-hoc";
 
 import CardTitle from "@saleor/components/CardTitle";
 import Skeleton from "@saleor/components/Skeleton";
+import {
+  SortableTableBody,
+  SortableTableRow
+} from "@saleor/components/SortableTable";
 import i18n from "@saleor/i18n";
 import Draggable from "@saleor/icons/Draggable";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
@@ -62,57 +65,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   }
 }));
 
-interface SortableTableBodyProps {
-  children: React.ReactNode | React.ReactNodeArray;
-}
-
-const SortableTableBody = SortableContainer<SortableTableBodyProps>(
-  ({ children }) => <TableBody>{children}</TableBody>,
-  {
-    withRef: true
-  }
-);
-
-interface SortableTableRowProps {
-  disabled: boolean;
-  value: AttributeDetailsFragment_values;
-  onValueDelete: (id: string) => void;
-  onValueUpdate: (id: string) => void;
-}
-
-const SortableTableRow = SortableElement<SortableTableRowProps>(
-  ({ disabled, value, onValueDelete, onValueUpdate }) => {
-    const classes = useStyles({});
-
-    return (
-      <TableRow
-        className={!!value ? classes.link : undefined}
-        hover={!!value}
-        onClick={!!value ? () => onValueUpdate(value.id) : undefined}
-        key={maybe(() => value.id)}
-      >
-        <TableCell className={classes.columnDrag}>
-          <Draggable className={classes.dragIcon} />
-        </TableCell>
-        <TableCell className={classes.columnAdmin}>
-          {maybe(() => value.slug) ? value.slug : <Skeleton />}
-        </TableCell>
-        <TableCell className={classes.columnStore}>
-          {maybe(() => value.name) ? value.name : <Skeleton />}
-        </TableCell>
-        <TableCell className={classes.iconCell}>
-          <IconButton
-            disabled={disabled}
-            onClick={stopPropagation(() => onValueDelete(value.id))}
-          >
-            <DeleteIcon color="primary" />
-          </IconButton>
-        </TableCell>
-      </TableRow>
-    );
-  }
-);
-
 const AttributeValues: React.FC<AttributeValuesProps> = ({
   disabled,
   onValueAdd,
@@ -158,13 +110,27 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
               : undefined,
             (value, valueIndex) => (
               <SortableTableRow
-                disabled={disabled}
-                value={value}
-                onValueDelete={onValueDelete}
-                onValueUpdate={onValueUpdate}
-                key={maybe(() => value.id, "skeleton")}
+                className={!!value ? classes.link : undefined}
+                hover={!!value}
+                onClick={!!value ? () => onValueUpdate(value.id) : undefined}
+                key={maybe(() => value.id)}
                 index={valueIndex}
-              />
+              >
+                <TableCell className={classes.columnAdmin}>
+                  {maybe(() => value.slug) ? value.slug : <Skeleton />}
+                </TableCell>
+                <TableCell className={classes.columnStore}>
+                  {maybe(() => value.name) ? value.name : <Skeleton />}
+                </TableCell>
+                <TableCell className={classes.iconCell}>
+                  <IconButton
+                    disabled={disabled}
+                    onClick={stopPropagation(() => onValueDelete(value.id))}
+                  >
+                    <DeleteIcon color="primary" />
+                  </IconButton>
+                </TableCell>
+              </SortableTableRow>
             ),
             () => (
               <TableRow>

--- a/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
@@ -18,7 +18,7 @@ import {
 } from "@saleor/components/SortableTable";
 import i18n from "@saleor/i18n";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
-import { ReorderEvent } from "@saleor/types";
+import { ReorderAction } from "@saleor/types";
 import { AttributeDetailsFragment_values } from "../../types/AttributeDetailsFragment";
 
 export interface AttributeValuesProps {
@@ -26,7 +26,7 @@ export interface AttributeValuesProps {
   values: AttributeDetailsFragment_values[];
   onValueAdd: () => void;
   onValueDelete: (id: string) => void;
-  onValueReorder: ReorderEvent;
+  onValueReorder: ReorderAction;
   onValueUpdate: (id: string) => void;
 }
 
@@ -42,15 +42,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   dragIcon: {
     cursor: "grab"
-  },
-  ghost: {
-    "& td": {
-      borderBottom: "none"
-    },
-    background: theme.palette.background.paper,
-    fontFamily: theme.typography.fontFamily,
-    fontSize: theme.overrides.MuiTableCell.root.fontSize,
-    opacity: 0.5
   },
   iconCell: {
     "&:last-child": {
@@ -96,12 +87,7 @@ const AttributeValues: React.FC<AttributeValuesProps> = ({
             <TableCell />
           </TableRow>
         </TableHead>
-        <SortableTableBody
-          helperClass={classes.ghost}
-          axis="y"
-          lockAxis="y"
-          onSortEnd={onValueReorder}
-        >
+        <SortableTableBody onSortEnd={onValueReorder}>
           {renderCollection(
             values
               ? values.sort((a, b) => (a.sortOrder > b.sortOrder ? 1 : -1))

--- a/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributeValues/AttributeValues.tsx
@@ -9,7 +9,6 @@ import TableRow from "@material-ui/core/TableRow";
 import DeleteIcon from "@material-ui/icons/Delete";
 import makeStyles from "@material-ui/styles/makeStyles";
 import React from "react";
-import { SortableElement } from "react-sortable-hoc";
 
 import CardTitle from "@saleor/components/CardTitle";
 import Skeleton from "@saleor/components/Skeleton";
@@ -18,7 +17,6 @@ import {
   SortableTableRow
 } from "@saleor/components/SortableTable";
 import i18n from "@saleor/i18n";
-import Draggable from "@saleor/icons/Draggable";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
 import { ReorderEvent } from "@saleor/types";
 import { AttributeDetailsFragment_values } from "../../types/AttributeDetailsFragment";

--- a/saleor/static/dashboard-next/attributes/views/AttributeCreate/AttributeCreate.tsx
+++ b/saleor/static/dashboard-next/attributes/views/AttributeCreate/AttributeCreate.tsx
@@ -113,6 +113,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ params }) => {
               }
               onValueAdd={() => openModal("add-value")}
               onValueDelete={id => openModal("remove-value", id)}
+              onValueReorder={() => undefined}
               onValueUpdate={id => openModal("edit-value", id)}
               saveButtonBarState={createTransitionState}
               values={values.map((value, valueIndex) => ({

--- a/saleor/static/dashboard-next/attributes/views/AttributeDetails/AttributeDetails.tsx
+++ b/saleor/static/dashboard-next/attributes/views/AttributeDetails/AttributeDetails.tsx
@@ -186,6 +186,7 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({ id, params }) => {
                                   onValueDelete={id =>
                                     openModal("remove-value", id)
                                   }
+                                  onValueReorder={() => undefined}
                                   onValueUpdate={id =>
                                     openModal("edit-value", id)
                                   }

--- a/saleor/static/dashboard-next/components/AssignAttributeDialog/AssignAttributeDialog.tsx
+++ b/saleor/static/dashboard-next/components/AssignAttributeDialog/AssignAttributeDialog.tsx
@@ -3,6 +3,7 @@ import CircularProgress from "@material-ui/core/CircularProgress";
 import Dialog from "@material-ui/core/Dialog";
 import DialogActions from "@material-ui/core/DialogActions";
 import DialogContent from "@material-ui/core/DialogContent";
+import DialogContentText from "@material-ui/core/DialogContentText";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import { createStyles, withStyles, WithStyles } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
@@ -40,6 +41,7 @@ const styles = createStyles({
 
 export interface AssignAttributeDialogProps {
   confirmButtonState: ConfirmButtonTransitionState;
+  errors: string[];
   open: boolean;
   attributes: SearchAttributes_attributes_edges_node[];
   loading: boolean;
@@ -60,6 +62,7 @@ const AssignAttributeDialog = withStyles(styles, {
     attributes,
     classes,
     confirmButtonState,
+    errors,
     loading,
     open,
     selected,
@@ -138,6 +141,13 @@ const AssignAttributeDialog = withStyles(styles, {
                 </TableBody>
               </Table>
             </DialogContent>
+            {errors.length > 0 && (
+              <DialogContent>
+                {errors.map(error => (
+                  <DialogContentText color="error">{error}</DialogContentText>
+                ))}
+              </DialogContent>
+            )}
             <DialogActions>
               <Button onClick={onClose}>
                 {i18n.t("Cancel", { context: "button" })}

--- a/saleor/static/dashboard-next/components/SortableTable/SortableHandle.tsx
+++ b/saleor/static/dashboard-next/components/SortableTable/SortableHandle.tsx
@@ -1,0 +1,28 @@
+import { Theme } from "@material-ui/core/styles";
+import TableCell from "@material-ui/core/TableCell";
+import makeStyles from "@material-ui/styles/makeStyles";
+import * as React from "react";
+import { SortableHandle as SortableHandleHoc } from "react-sortable-hoc";
+
+import Draggable from "@saleor/icons/Draggable";
+
+const useStyles = makeStyles((theme: Theme) => ({
+  columnDrag: {
+    width: 48 + theme.spacing.unit * 1.5
+  },
+  dragIcon: {
+    cursor: "grab"
+  }
+}));
+
+const SortableHandle = SortableHandleHoc(() => {
+  const classes = useStyles({});
+
+  return (
+    <TableCell className={classes.columnDrag}>
+      <Draggable className={classes.dragIcon} />
+    </TableCell>
+  );
+});
+
+export default SortableHandle;

--- a/saleor/static/dashboard-next/components/SortableTable/SortableHandle.tsx
+++ b/saleor/static/dashboard-next/components/SortableTable/SortableHandle.tsx
@@ -8,10 +8,11 @@ import Draggable from "@saleor/icons/Draggable";
 
 const useStyles = makeStyles((theme: Theme) => ({
   columnDrag: {
+    "&:first-child": {
+      paddingRight: theme.spacing.unit * 2
+    },
+    cursor: "grab",
     width: 48 + theme.spacing.unit * 1.5
-  },
-  dragIcon: {
-    cursor: "grab"
   }
 }));
 
@@ -20,7 +21,7 @@ const SortableHandle = SortableHandleHoc(() => {
 
   return (
     <TableCell className={classes.columnDrag}>
-      <Draggable className={classes.dragIcon} />
+      <Draggable />
     </TableCell>
   );
 });

--- a/saleor/static/dashboard-next/components/SortableTable/SortableTableBody.tsx
+++ b/saleor/static/dashboard-next/components/SortableTable/SortableTableBody.tsx
@@ -1,13 +1,45 @@
-import TableBody from "@material-ui/core/TableBody";
+import { Theme } from "@material-ui/core/styles";
+import TableBody, { TableBodyProps } from "@material-ui/core/TableBody";
+import makeStyles from "@material-ui/styles/makeStyles";
 import * as React from "react";
 import { SortableContainer } from "react-sortable-hoc";
 
-interface SortableTableBodyProps {
-  children: React.ReactNode | React.ReactNodeArray;
+import { ReorderAction } from "@saleor/types";
+
+const InnerSortableTableBody = SortableContainer<TableBodyProps>(
+  ({ children, ...props }) => <TableBody {...props}>{children}</TableBody>
+);
+
+export interface SortableTableBodyProps {
+  onSortEnd: ReorderAction;
 }
 
-const SortableTableBody = SortableContainer<SortableTableBodyProps>(
-  ({ children }) => <TableBody>{children}</TableBody>
-);
+const useStyles = makeStyles((theme: Theme) => ({
+  ghost: {
+    "& td": {
+      borderBottom: "none"
+    },
+    background: theme.palette.background.paper,
+    fontFamily: theme.typography.fontFamily,
+    fontSize: theme.overrides.MuiTableCell.root.fontSize,
+    opacity: 0.5
+  }
+}));
+
+const SortableTableBody: React.FC<
+  TableBodyProps & SortableTableBodyProps
+> = props => {
+  const classes = useStyles({});
+
+  return (
+    <InnerSortableTableBody
+      helperClass={classes.ghost}
+      axis="y"
+      lockAxis="y"
+      useDragHandle
+      {...props}
+    />
+  );
+};
 
 export default SortableTableBody;

--- a/saleor/static/dashboard-next/components/SortableTable/SortableTableBody.tsx
+++ b/saleor/static/dashboard-next/components/SortableTable/SortableTableBody.tsx
@@ -1,0 +1,13 @@
+import TableBody from "@material-ui/core/TableBody";
+import * as React from "react";
+import { SortableContainer } from "react-sortable-hoc";
+
+interface SortableTableBodyProps {
+  children: React.ReactNode | React.ReactNodeArray;
+}
+
+const SortableTableBody = SortableContainer<SortableTableBodyProps>(
+  ({ children }) => <TableBody>{children}</TableBody>
+);
+
+export default SortableTableBody;

--- a/saleor/static/dashboard-next/components/SortableTable/SortableTableRow.tsx
+++ b/saleor/static/dashboard-next/components/SortableTable/SortableTableRow.tsx
@@ -1,0 +1,15 @@
+import TableRow, { TableRowProps } from "@material-ui/core/TableRow";
+import * as React from "react";
+import { SortableElement } from "react-sortable-hoc";
+import SortableHandle from "./SortableHandle";
+
+const SortableTableRow = SortableElement<TableRowProps>(
+  ({ children, ...props }) => (
+    <TableRow {...props}>
+      <SortableHandle />
+      {children}
+    </TableRow>
+  )
+);
+
+export default SortableTableRow;

--- a/saleor/static/dashboard-next/components/SortableTable/index.ts
+++ b/saleor/static/dashboard-next/components/SortableTable/index.ts
@@ -1,0 +1,5 @@
+export * from "./SortableTableBody";
+export { default as SortableTableBody } from "./SortableTableBody";
+
+export * from "./SortableTableRow";
+export { default as SortableTableRow } from "./SortableTableRow";

--- a/saleor/static/dashboard-next/components/TableHead/TableHead.tsx
+++ b/saleor/static/dashboard-next/components/TableHead/TableHead.tsx
@@ -21,6 +21,7 @@ import Checkbox from "../Checkbox";
 
 export interface TableHeadProps extends MuiTableHeadProps {
   disabled: boolean;
+  dragRows?: boolean;
   selected: number;
   items: Node[];
   toolbar: React.ReactNode | React.ReactNodeArray;
@@ -50,6 +51,10 @@ const styles = (theme: Theme) =>
       height: 47,
       marginRight: -theme.spacing.unit * 2
     },
+    dragRows: {
+      padding: 0,
+      width: 52
+    },
     padding: {
       "&:last-child": {
         padding: 0
@@ -77,6 +82,7 @@ const TableHead = withStyles(styles, {
     classes,
     children,
     disabled,
+    dragRows,
     items,
     selected,
     toggleAll,
@@ -86,11 +92,19 @@ const TableHead = withStyles(styles, {
     return (
       <MuiTableHead {...muiTableHeadProps}>
         <TableRow>
+          {dragRows && (
+            <TableCell
+              className={classNames({
+                [classes.checkboxSelected]: selected
+              })}
+            />
+          )}
           {(items === undefined || items.length > 0) && (
             <TableCell
               padding="checkbox"
               className={classNames({
-                [classes.checkboxSelected]: selected
+                [classes.checkboxSelected]: selected,
+                [classes.dragRows]: dragRows
               })}
             >
               <Checkbox

--- a/saleor/static/dashboard-next/components/TableHead/TableHead.tsx
+++ b/saleor/static/dashboard-next/components/TableHead/TableHead.tsx
@@ -86,13 +86,13 @@ const TableHead = withStyles(styles, {
     return (
       <MuiTableHead {...muiTableHeadProps}>
         <TableRow>
-          <TableCell
-            padding="checkbox"
-            className={classNames({
-              [classes.checkboxSelected]: selected
-            })}
-          >
-            {items && items.length > 0 ? (
+          {(items === undefined || items.length > 0) && (
+            <TableCell
+              padding="checkbox"
+              className={classNames({
+                [classes.checkboxSelected]: selected
+              })}
+            >
               <Checkbox
                 className={classNames({
                   [classes.checkboxPartialSelect]:
@@ -102,8 +102,8 @@ const TableHead = withStyles(styles, {
                 disabled={disabled}
                 onChange={() => toggleAll(items, selected)}
               />
-            ) : null}
-          </TableCell>
+            </TableCell>
+          )}
           {selected ? (
             <>
               <TableCell className={classNames(classes.root)} colSpan={50}>

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -122,7 +122,7 @@ const ProductTypeAttributes = withStyles(styles, {
                       : undefined
                   }
                   key={maybe(() => attribute.id)}
-                  index={attributeIndex}
+                  index={attributeIndex || 0}
                 >
                   <TableCell padding="checkbox">
                     <Checkbox

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -8,7 +8,6 @@ import {
   WithStyles
 } from "@material-ui/core/styles";
 import Table from "@material-ui/core/Table";
-import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableRow from "@material-ui/core/TableRow";
 import DeleteIcon from "@material-ui/icons/Delete";
@@ -17,10 +16,14 @@ import React from "react";
 import CardTitle from "@saleor/components/CardTitle";
 import Checkbox from "@saleor/components/Checkbox";
 import Skeleton from "@saleor/components/Skeleton";
+import {
+  SortableTableBody,
+  SortableTableRow
+} from "@saleor/components/SortableTable";
 import TableHead from "@saleor/components/TableHead";
 import i18n from "@saleor/i18n";
 import { maybe, renderCollection, stopPropagation } from "@saleor/misc";
-import { ListActions } from "@saleor/types";
+import { ListActions, ReorderAction } from "@saleor/types";
 import { AttributeTypeEnum } from "@saleor/types/globalTypes";
 import {
   ProductTypeDetails_productType_productAttributes,
@@ -33,7 +36,7 @@ const styles = (theme: Theme) =>
       "&:last-child": {
         paddingRight: 0
       },
-      width: 48 + theme.spacing.unit / 2
+      width: 48 + theme.spacing.unit * 1.5
     },
     link: {
       cursor: "pointer"
@@ -51,6 +54,7 @@ interface ProductTypeAttributesProps extends ListActions {
   type: string;
   onAttributeAssign: (type: AttributeTypeEnum) => void;
   onAttributeClick: (id: string) => void;
+  onAttributeReorder: ReorderAction;
   onAttributeUnassign: (id: string) => void;
 }
 
@@ -69,6 +73,7 @@ const ProductTypeAttributes = withStyles(styles, {
     type,
     onAttributeAssign,
     onAttributeClick,
+    onAttributeReorder,
     onAttributeUnassign
   }: ProductTypeAttributesProps & WithStyles<typeof styles>) => (
     <Card>
@@ -91,6 +96,7 @@ const ProductTypeAttributes = withStyles(styles, {
       <Table>
         <TableHead
           disabled={disabled}
+          dragRows
           selected={selected}
           items={attributes}
           toggleAll={toggleAll}
@@ -99,14 +105,14 @@ const ProductTypeAttributes = withStyles(styles, {
           <TableCell>{i18n.t("Attribute name")}</TableCell>
           <TableCell />
         </TableHead>
-        <TableBody>
+        <SortableTableBody onSortEnd={onAttributeReorder}>
           {renderCollection(
             attributes,
-            attribute => {
+            (attribute, attributeIndex) => {
               const isSelected = attribute ? isChecked(attribute.id) : false;
 
               return (
-                <TableRow
+                <SortableTableRow
                   selected={isSelected}
                   className={!!attribute ? classes.link : undefined}
                   hover={!!attribute}
@@ -116,6 +122,7 @@ const ProductTypeAttributes = withStyles(styles, {
                       : undefined
                   }
                   key={maybe(() => attribute.id)}
+                  index={attributeIndex}
                 >
                   <TableCell padding="checkbox">
                     <Checkbox
@@ -140,7 +147,7 @@ const ProductTypeAttributes = withStyles(styles, {
                       <DeleteIcon color="primary" />
                     </IconButton>
                   </TableCell>
-                </TableRow>
+                </SortableTableRow>
               );
             },
             () => (
@@ -151,7 +158,7 @@ const ProductTypeAttributes = withStyles(styles, {
               </TableRow>
             )
           )}
-        </TableBody>
+        </SortableTableBody>
       </Table>
     </Card>
   )

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeCreatePage/ProductTypeCreatePage.tsx
@@ -10,10 +10,10 @@ import PageHeader from "@saleor/components/PageHeader";
 import SaveButtonBar from "@saleor/components/SaveButtonBar";
 import { ChangeEvent, FormChange } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
+import i18n from "@saleor/i18n";
 import { ProductTypeDetails_taxTypes } from "@saleor/productTypes/types/ProductTypeDetails";
 import { UserError } from "@saleor/types";
-import i18n from "../../../i18n";
-import { WeightUnitsEnum } from "../../../types/globalTypes";
+import { WeightUnitsEnum } from "@saleor/types/globalTypes";
 import ProductTypeDetails from "../ProductTypeDetails/ProductTypeDetails";
 import ProductTypeShipping from "../ProductTypeShipping/ProductTypeShipping";
 import ProductTypeTaxes from "../ProductTypeTaxes/ProductTypeTaxes";
@@ -76,7 +76,7 @@ const ProductTypeCreatePage: React.StatelessComponent<
       onSubmit={onSubmit}
       confirmLeave
     >
-      {({ change, data, hasChanged, submit }) => (
+      {({ change, data, errors: formErrors, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>{i18n.t("Product Types")}</AppHeader>
           <PageHeader title={pageTitle} />
@@ -85,6 +85,7 @@ const ProductTypeCreatePage: React.StatelessComponent<
               <ProductTypeDetails
                 data={data}
                 disabled={disabled}
+                errors={formErrors}
                 onChange={change}
               />
               <CardSpacer />

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeDetails/ProductTypeDetails.tsx
@@ -5,7 +5,8 @@ import TextField from "@material-ui/core/TextField";
 import React from "react";
 
 import CardTitle from "@saleor/components/CardTitle";
-import i18n from "../../../i18n";
+import i18n from "@saleor/i18n";
+import { FormErrors } from "@saleor/types";
 
 const styles = createStyles({
   root: {
@@ -18,17 +19,20 @@ interface ProductTypeDetailsProps extends WithStyles<typeof styles> {
     name: string;
   };
   disabled: boolean;
+  errors: FormErrors<"name">;
   onChange: (event: React.ChangeEvent<any>) => void;
 }
 
 const ProductTypeDetails = withStyles(styles, { name: "ProductTypeDetails" })(
-  ({ classes, data, disabled, onChange }: ProductTypeDetailsProps) => (
+  ({ classes, data, disabled, errors, onChange }: ProductTypeDetailsProps) => (
     <Card className={classes.root}>
       <CardTitle title={i18n.t("Information")} />
       <CardContent>
         <TextField
           disabled={disabled}
+          error={!!errors.name}
           fullWidth
+          helperText={errors.name}
           label={i18n.t("Product Type Name")}
           name="name"
           onChange={onChange}

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -127,7 +127,7 @@ const ProductTypeDetailsPage: React.StatelessComponent<
       onSubmit={onSubmit}
       confirmLeave
     >
-      {({ change, data, hasChanged, submit }) => (
+      {({ change, data, errors: formErrors, hasChanged, submit }) => (
         <Container>
           <AppHeader onBack={onBack}>{i18n.t("Product Types")}</AppHeader>
           <PageHeader title={pageTitle} />
@@ -136,6 +136,7 @@ const ProductTypeDetailsPage: React.StatelessComponent<
               <ProductTypeDetails
                 data={data}
                 disabled={disabled}
+                errors={formErrors}
                 onChange={change}
               />
               <CardSpacer />

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeDetailsPage/ProductTypeDetailsPage.tsx
@@ -13,7 +13,7 @@ import { ChangeEvent, FormChange } from "@saleor/hooks/useForm";
 import useStateFromProps from "@saleor/hooks/useStateFromProps";
 import i18n from "@saleor/i18n";
 import { maybe } from "@saleor/misc";
-import { ListActions, UserError } from "@saleor/types";
+import { ListActions, ReorderEvent, UserError } from "@saleor/types";
 import { AttributeTypeEnum, WeightUnitsEnum } from "@saleor/types/globalTypes";
 import {
   ProductTypeDetails_productType,
@@ -51,6 +51,7 @@ export interface ProductTypeDetailsPageProps {
   variantAttributeList: ListActions;
   onAttributeAdd: (type: AttributeTypeEnum) => void;
   onAttributeClick: (id: string) => void;
+  onAttributeReorder: (event: ReorderEvent, type: AttributeTypeEnum) => void;
   onAttributeUnassign: (id: string) => void;
   onBack: () => void;
   onDelete: () => void;
@@ -83,6 +84,7 @@ const ProductTypeDetailsPage: React.StatelessComponent<
   variantAttributeList,
   onAttributeAdd,
   onAttributeUnassign,
+  onAttributeReorder,
   onAttributeClick,
   onBack,
   onDelete,
@@ -158,6 +160,9 @@ const ProductTypeDetailsPage: React.StatelessComponent<
                 type={AttributeTypeEnum.PRODUCT}
                 onAttributeAssign={onAttributeAdd}
                 onAttributeClick={onAttributeClick}
+                onAttributeReorder={(event: ReorderEvent) =>
+                  onAttributeReorder(event, AttributeTypeEnum.PRODUCT)
+                }
                 onAttributeUnassign={onAttributeUnassign}
                 {...productAttributeList}
               />
@@ -178,6 +183,9 @@ const ProductTypeDetailsPage: React.StatelessComponent<
                     type={AttributeTypeEnum.VARIANT}
                     onAttributeAssign={onAttributeAdd}
                     onAttributeClick={onAttributeClick}
+                    onAttributeReorder={(event: ReorderEvent) =>
+                      onAttributeReorder(event, AttributeTypeEnum.VARIANT)
+                    }
                     onAttributeUnassign={onAttributeUnassign}
                     {...variantAttributeList}
                   />

--- a/saleor/static/dashboard-next/productTypes/containers/ProductTypeOperations.tsx
+++ b/saleor/static/dashboard-next/productTypes/containers/ProductTypeOperations.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { getMutationProviderData } from "../../misc";
 import { PartialMutationProviderOutput } from "../../types";
 import {
+  ProductTypeAttributeReorderMutation,
   TypedAssignAttributeMutation,
   TypedProductTypeDeleteMutation,
   TypedProductTypeUpdateMutation,
@@ -12,6 +13,10 @@ import {
   AssignAttribute,
   AssignAttributeVariables
 } from "../types/AssignAttribute";
+import {
+  ProductTypeAttributeReorder,
+  ProductTypeAttributeReorderVariables
+} from "../types/ProductTypeAttributeReorder";
 import {
   ProductTypeDelete,
   ProductTypeDeleteVariables
@@ -39,6 +44,10 @@ interface ProductTypeOperationsProps {
       ProductTypeDelete,
       ProductTypeDeleteVariables
     >;
+    reorderAttribute: PartialMutationProviderOutput<
+      ProductTypeAttributeReorder,
+      ProductTypeAttributeReorderVariables
+    >;
     updateProductType: PartialMutationProviderOutput<
       ProductTypeUpdate,
       ProductTypeUpdateVariables
@@ -46,6 +55,7 @@ interface ProductTypeOperationsProps {
   }) => React.ReactNode;
   onAssignAttribute: (data: AssignAttribute) => void;
   onUnassignAttribute: (data: UnassignAttribute) => void;
+  onProductTypeAttributeReorder: (data: ProductTypeAttributeReorder) => void;
   onProductTypeDelete: (data: ProductTypeDelete) => void;
   onProductTypeUpdate: (data: ProductTypeUpdate) => void;
 }
@@ -56,6 +66,7 @@ const ProductTypeOperations: React.StatelessComponent<
   children,
   onAssignAttribute,
   onUnassignAttribute,
+  onProductTypeAttributeReorder,
   onProductTypeDelete,
   onProductTypeUpdate
 }) => {
@@ -69,22 +80,31 @@ const ProductTypeOperations: React.StatelessComponent<
                 <TypedUnassignAttributeMutation
                   onCompleted={onUnassignAttribute}
                 >
-                  {(...unassignAttribute) =>
-                    children({
-                      assignAttribute: getMutationProviderData(
-                        ...assignAttribute
-                      ),
-                      deleteProductType: getMutationProviderData(
-                        ...deleteProductType
-                      ),
-                      unassignAttribute: getMutationProviderData(
-                        ...unassignAttribute
-                      ),
-                      updateProductType: getMutationProviderData(
-                        ...updateProductType
-                      )
-                    })
-                  }
+                  {(...unassignAttribute) => (
+                    <ProductTypeAttributeReorderMutation
+                      onCompleted={onProductTypeAttributeReorder}
+                    >
+                      {(...reorderAttribute) =>
+                        children({
+                          assignAttribute: getMutationProviderData(
+                            ...assignAttribute
+                          ),
+                          deleteProductType: getMutationProviderData(
+                            ...deleteProductType
+                          ),
+                          reorderAttribute: getMutationProviderData(
+                            ...reorderAttribute
+                          ),
+                          unassignAttribute: getMutationProviderData(
+                            ...unassignAttribute
+                          ),
+                          updateProductType: getMutationProviderData(
+                            ...updateProductType
+                          )
+                        })
+                      }
+                    </ProductTypeAttributeReorderMutation>
+                  )}
                 </TypedUnassignAttributeMutation>
               )}
             </TypedAssignAttributeMutation>

--- a/saleor/static/dashboard-next/productTypes/mutations.ts
+++ b/saleor/static/dashboard-next/productTypes/mutations.ts
@@ -7,6 +7,10 @@ import {
   AssignAttributeVariables
 } from "./types/AssignAttribute";
 import {
+  ProductTypeAttributeReorder,
+  ProductTypeAttributeReorderVariables
+} from "./types/ProductTypeAttributeReorder";
+import {
   ProductTypeBulkDelete,
   ProductTypeBulkDeleteVariables
 } from "./types/ProductTypeBulkDelete";
@@ -135,3 +139,30 @@ export const TypedProductTypeCreateMutation = TypedMutation<
   ProductTypeCreate,
   ProductTypeCreateVariables
 >(productTypeCreateMutation);
+
+const productTypeAttributeReorder = gql`
+  ${productTypeDetailsFragment}
+  mutation ProductTypeAttributeReorder(
+    $move: AttributeReorderInput!
+    $productTypeId: ID!
+    $type: AttributeTypeEnum!
+  ) {
+    productTypeReorderAttributes(
+      moves: [$move]
+      productTypeId: $productTypeId
+      type: $type
+    ) {
+      errors {
+        field
+        message
+      }
+      productType {
+        ...ProductTypeDetailsFragment
+      }
+    }
+  }
+`;
+export const ProductTypeAttributeReorderMutation = TypedMutation<
+  ProductTypeAttributeReorder,
+  ProductTypeAttributeReorderVariables
+>(productTypeAttributeReorder);

--- a/saleor/static/dashboard-next/productTypes/types/ProductTypeAttributeReorder.ts
+++ b/saleor/static/dashboard-next/productTypes/types/ProductTypeAttributeReorder.ts
@@ -1,0 +1,63 @@
+/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+import { AttributeReorderInput, AttributeTypeEnum, TaxRateType } from "./../../types/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: ProductTypeAttributeReorder
+// ====================================================
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes_errors {
+  __typename: "Error";
+  field: string | null;
+  message: string | null;
+}
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes_productType_productAttributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes_productType_variantAttributes {
+  __typename: "Attribute";
+  id: string;
+  name: string | null;
+  slug: string | null;
+}
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes_productType_weight {
+  __typename: "Weight";
+  unit: string;
+  value: number;
+}
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes_productType {
+  __typename: "ProductType";
+  id: string;
+  name: string;
+  hasVariants: boolean;
+  isShippingRequired: boolean;
+  taxRate: TaxRateType | null;
+  productAttributes: (ProductTypeAttributeReorder_productTypeReorderAttributes_productType_productAttributes | null)[] | null;
+  variantAttributes: (ProductTypeAttributeReorder_productTypeReorderAttributes_productType_variantAttributes | null)[] | null;
+  weight: ProductTypeAttributeReorder_productTypeReorderAttributes_productType_weight | null;
+}
+
+export interface ProductTypeAttributeReorder_productTypeReorderAttributes {
+  __typename: "ProductTypeReorderAttributes";
+  errors: ProductTypeAttributeReorder_productTypeReorderAttributes_errors[] | null;
+  productType: ProductTypeAttributeReorder_productTypeReorderAttributes_productType | null;
+}
+
+export interface ProductTypeAttributeReorder {
+  productTypeReorderAttributes: ProductTypeAttributeReorder_productTypeReorderAttributes | null;
+}
+
+export interface ProductTypeAttributeReorderVariables {
+  move: AttributeReorderInput;
+  productTypeId: string;
+  type: AttributeTypeEnum;
+}

--- a/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
@@ -31,6 +31,7 @@ import {
   ProductTypeUrlQueryParams
 } from "../../urls";
 import { ProductTypeUpdateErrors } from "./errors";
+import { ReorderEvent } from "@saleor/types";
 
 interface ProductTypeUpdateProps {
   id: string;
@@ -210,6 +211,25 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                     )
                   );
 
+                  const handleAttributeReorder = (
+                    event: ReorderEvent,
+                    type: AttributeTypeEnum
+                  ) => {
+                    const attributes =
+                      type === AttributeTypeEnum.PRODUCT
+                        ? data.productType.productAttributes
+                        : data.productType.variantAttributes;
+
+                    reorderAttribute.mutate({
+                      move: {
+                        id: attributes[event.oldIndex].id,
+                        sortOrder: event.newIndex - event.oldIndex
+                      },
+                      productTypeId: id,
+                      type
+                    });
+                  };
+
                   return (
                     <>
                       <WindowTitle title={maybe(() => data.productType.name)} />
@@ -234,19 +254,7 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                         onAttributeClick={attributeId =>
                           navigate(attributeUrl(attributeId))
                         }
-                        onAttributeReorder={(event, type) =>
-                          reorderAttribute.mutate({
-                            move: {
-                              id:
-                                data.productType.productAttributes[
-                                  event.oldIndex
-                                ].id,
-                              sortOrder: event.newIndex - event.oldIndex
-                            },
-                            productTypeId: id,
-                            type
-                          })
-                        }
+                        onAttributeReorder={handleAttributeReorder}
                         onAttributeUnassign={attributeId =>
                           navigate(
                             productTypeUrl(id, {
@@ -329,6 +337,13 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                                     )
                                   )}
                                   confirmButtonState={assignTransactionState}
+                                  errors={maybe(
+                                    () =>
+                                      assignAttribute.opts.data.attributeAssign.errors.map(
+                                        err => err.message
+                                      ),
+                                    []
+                                  )}
                                   loading={result.loading}
                                   onClose={closeModal}
                                   onSubmit={handleAssignAttribute}
@@ -343,7 +358,7 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                                     navigate(
                                       productTypeUrl(id, {
                                         ...params,
-                                        ids: ids.includes(id)
+                                        ids: ids.includes(attributeId)
                                           ? params.ids.filter(
                                               selectedId =>
                                                 selectedId !== attributeId

--- a/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
@@ -11,7 +11,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import i18n from "@saleor/i18n";
 import { getMutationState, maybe } from "@saleor/misc";
-import { productType } from "@saleor/productTypes/fixtures";
+import { ReorderEvent } from "@saleor/types";
 import { AttributeTypeEnum } from "@saleor/types/globalTypes";
 import ProductTypeAttributeUnassignDialog from "../../components/ProductTypeAttributeUnassignDialog";
 import ProductTypeBulkAttributeUnassignDialog from "../../components/ProductTypeBulkAttributeUnassignDialog";
@@ -31,7 +31,6 @@ import {
   ProductTypeUrlQueryParams
 } from "../../urls";
 import { ProductTypeUpdateErrors } from "./errors";
-import { ReorderEvent } from "@saleor/types";
 
 interface ProductTypeUpdateProps {
   id: string;

--- a/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
@@ -120,6 +120,7 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
 
             return (
               <ProductTypeOperations
+                productType={maybe(() => data.productType)}
                 onAssignAttribute={handleAttributeAssignSuccess}
                 onUnassignAttribute={handleAttributeUnassignSuccess}
                 onProductTypeDelete={handleProductTypeDeleteSuccess}

--- a/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
+++ b/saleor/static/dashboard-next/productTypes/views/ProductTypeUpdate/index.tsx
@@ -11,6 +11,7 @@ import useNavigator from "@saleor/hooks/useNavigator";
 import useNotifier from "@saleor/hooks/useNotifier";
 import i18n from "@saleor/i18n";
 import { getMutationState, maybe } from "@saleor/misc";
+import { productType } from "@saleor/productTypes/fixtures";
 import { AttributeTypeEnum } from "@saleor/types/globalTypes";
 import ProductTypeAttributeUnassignDialog from "../../components/ProductTypeAttributeUnassignDialog";
 import ProductTypeBulkAttributeUnassignDialog from "../../components/ProductTypeBulkAttributeUnassignDialog";
@@ -123,12 +124,14 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                 onUnassignAttribute={handleAttributeUnassignSuccess}
                 onProductTypeDelete={handleProductTypeDeleteSuccess}
                 onProductTypeUpdate={handleProductTypeUpdateSuccess}
+                onProductTypeAttributeReorder={() => undefined}
               >
                 {({
                   assignAttribute,
                   deleteProductType,
                   unassignAttribute,
-                  updateProductType
+                  updateProductType,
+                  reorderAttribute
                 }) => {
                   const handleProductTypeDelete = () =>
                     deleteProductType.mutate({ id });
@@ -230,6 +233,19 @@ export const ProductTypeUpdate: React.FC<ProductTypeUpdateProps> = ({
                         }
                         onAttributeClick={attributeId =>
                           navigate(attributeUrl(attributeId))
+                        }
+                        onAttributeReorder={(event, type) =>
+                          reorderAttribute.mutate({
+                            move: {
+                              id:
+                                data.productType.productAttributes[
+                                  event.oldIndex
+                                ].id,
+                              sortOrder: event.newIndex - event.oldIndex
+                            },
+                            productTypeId: id,
+                            type
+                          })
                         }
                         onAttributeUnassign={attributeId =>
                           navigate(

--- a/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
@@ -12,6 +12,7 @@ import {
 import CardTitle from "@saleor/components/CardTitle";
 import ImageTile from "@saleor/components/ImageTile";
 import ImageUpload from "@saleor/components/ImageUpload";
+import { ReorderEvent } from "@saleor/types";
 import React from "react";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 import i18n from "../../../i18n";
@@ -113,17 +114,21 @@ interface ProductImagesProps extends WithStyles<typeof styles> {
   loading?: boolean;
   onImageDelete: (id: string) => () => void;
   onImageEdit: (id: string) => () => void;
+  onImageReorder?: ReorderEvent;
   onImageUpload(file: File);
-  onImageReorder?(event: { oldIndex: number; newIndex: number });
 }
 
-interface ImageListContainerProps extends WithStyles<typeof styles> {
-  items: any;
-  onImageDelete: (id: string) => () => void;
-  onImageEdit: (id: string) => () => void;
+interface SortableImageProps {
+  image: {
+    id: string;
+    alt?: string;
+    url: string;
+  };
+  onImageEdit: (id: string) => void;
+  onImageDelete: () => void;
 }
 
-const SortableImage = SortableElement(
+const SortableImage = SortableElement<SortableImageProps>(
   ({ image, onImageEdit, onImageDelete }) => (
     <ImageTile
       image={image}
@@ -133,7 +138,14 @@ const SortableImage = SortableElement(
   )
 );
 
-const ImageListContainer = SortableContainer(
+interface ImageListContainerProps {
+  className: string;
+  items: any;
+  onImageDelete: (id: string) => () => void;
+  onImageEdit: (id: string) => () => void;
+}
+
+const ImageListContainer = SortableContainer<ImageListContainerProps>(
   withStyles(styles, { name: "ImageListContainer" })(
     ({
       classes,
@@ -141,7 +153,7 @@ const ImageListContainer = SortableContainer(
       onImageDelete,
       onImageEdit,
       ...props
-    }: ImageListContainerProps) => {
+    }: ImageListContainerProps & WithStyles<typeof styles>) => {
       return (
         <div {...props}>
           {items.map((image, index) => (

--- a/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
+++ b/saleor/static/dashboard-next/products/components/ProductImages/ProductImages.tsx
@@ -12,7 +12,7 @@ import {
 import CardTitle from "@saleor/components/CardTitle";
 import ImageTile from "@saleor/components/ImageTile";
 import ImageUpload from "@saleor/components/ImageUpload";
-import { ReorderEvent } from "@saleor/types";
+import { ReorderAction } from "@saleor/types";
 import React from "react";
 import { SortableContainer, SortableElement } from "react-sortable-hoc";
 import i18n from "../../../i18n";
@@ -114,7 +114,7 @@ interface ProductImagesProps extends WithStyles<typeof styles> {
   loading?: boolean;
   onImageDelete: (id: string) => () => void;
   onImageEdit: (id: string) => () => void;
-  onImageReorder?: ReorderEvent;
+  onImageReorder?: ReorderAction;
   onImageUpload(file: File);
 }
 

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -1302,6 +1302,12 @@ exports[`Storyshots Generics / Assign attributes dialog default 1`] = `
 />
 `;
 
+exports[`Storyshots Generics / Assign attributes dialog errors 1`] = `
+<div
+  style="padding:24px"
+/>
+`;
+
 exports[`Storyshots Generics / Assign attributes dialog loading 1`] = `
 <div
   style="padding:24px"
@@ -6955,6 +6961,10 @@ exports[`Storyshots Views / Attributes / Attribute details create 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -6979,12 +6989,49 @@ exports[`Storyshots Views / Attributes / Attribute details create 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     john-doe
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     John Doe
                   </td>
@@ -7022,12 +7069,49 @@ exports[`Storyshots Views / Attributes / Attribute details create 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     milionare-pirate
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     Milionare Pirate
                   </td>
@@ -7446,6 +7530,10 @@ exports[`Storyshots Views / Attributes / Attribute details default 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -7470,12 +7558,49 @@ exports[`Storyshots Views / Attributes / Attribute details default 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     john-doe
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     John Doe
                   </td>
@@ -7513,12 +7638,49 @@ exports[`Storyshots Views / Attributes / Attribute details default 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     milionare-pirate
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     Milionare Pirate
                   </td>
@@ -7965,6 +8127,10 @@ exports[`Storyshots Views / Attributes / Attribute details form errors 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -7989,12 +8155,49 @@ exports[`Storyshots Views / Attributes / Attribute details form errors 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     john-doe
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     John Doe
                   </td>
@@ -8032,12 +8235,49 @@ exports[`Storyshots Views / Attributes / Attribute details form errors 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     milionare-pirate
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     Milionare Pirate
                   </td>
@@ -8491,6 +8731,10 @@ exports[`Storyshots Views / Attributes / Attribute details loading 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -8515,7 +8759,44 @@ exports[`Storyshots Views / Attributes / Attribute details loading 1`] = `
                   class="MuiTableRow-root-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     <span
                       class="Skeleton-skeleton-id"
@@ -8524,7 +8805,7 @@ exports[`Storyshots Views / Attributes / Attribute details loading 1`] = `
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     <span
                       class="Skeleton-skeleton-id"
@@ -8954,6 +9235,10 @@ exports[`Storyshots Views / Attributes / Attribute details multiple select input
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -8978,12 +9263,49 @@ exports[`Storyshots Views / Attributes / Attribute details multiple select input
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     john-doe
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     John Doe
                   </td>
@@ -9021,12 +9343,49 @@ exports[`Storyshots Views / Attributes / Attribute details multiple select input
                   class="MuiTableRow-root-id MuiTableRow-hover-id Hook-link-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     milionare-pirate
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     Milionare Pirate
                   </td>
@@ -9468,6 +9827,10 @@ exports[`Storyshots Views / Attributes / Attribute details no values 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnDrag-id"
+                    scope="col"
+                  />
+                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id Hook-columnAdmin-id"
                     scope="col"
                   >
@@ -9492,7 +9855,44 @@ exports[`Storyshots Views / Attributes / Attribute details no values 1`] = `
                   class="MuiTableRow-root-id"
                 >
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnAdmin-id"
                   >
                     <span
                       class="Skeleton-skeleton-id"
@@ -9501,7 +9901,7 @@ exports[`Storyshots Views / Attributes / Attribute details no values 1`] = `
                     </span>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnStore-id"
                   >
                     <span
                       class="Skeleton-skeleton-id"
@@ -10534,7 +10934,21 @@ exports[`Storyshots Views / Attributes / Attribute list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id Hook-colSlug-id"
               scope="col"
@@ -10777,10 +11191,6 @@ exports[`Storyshots Views / Attributes / Attribute list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id Hook-colSlug-id"
               scope="col"
@@ -11757,10 +12167,6 @@ exports[`Storyshots Views / Categories / Category list empty 1`] = `
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
             <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
-            <th
               class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
               scope="col"
             >
@@ -11936,7 +12342,19 @@ exports[`Storyshots Views / Categories / Category list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id Checkbox-root-id"
+                tabindex="0"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id"
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
               scope="col"
@@ -13803,10 +14221,6 @@ Ctrl + K"
               class="MuiTableRow-root-id MuiTableRow-head-id"
             >
               <th
-                class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                scope="col"
-              />
-              <th
                 class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
                 scope="col"
               >
@@ -14479,7 +14893,21 @@ Ctrl + K"
               <th
                 class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
                 scope="col"
-              />
+              >
+                <button
+                  class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                  disabled=""
+                  tabindex="-1"
+                  type="button"
+                >
+                  <input
+                    class="Checkbox-box-id Checkbox-disabled-id"
+                    disabled=""
+                    type="checkbox"
+                    value="false"
+                  />
+                </button>
+              </th>
               <th
                 class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
                 scope="col"
@@ -15475,10 +15903,6 @@ Ctrl + K"
               class="MuiTableRow-root-id MuiTableRow-head-id"
             >
               <th
-                class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                scope="col"
-              />
-              <th
                 class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
                 scope="col"
               >
@@ -16432,10 +16856,6 @@ Ctrl + K"
             <tr
               class="MuiTableRow-root-id MuiTableRow-head-id"
             >
-              <th
-                class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                scope="col"
-              />
               <th
                 class="MuiTableCell-root-id MuiTableCell-head-id"
                 scope="col"
@@ -17400,10 +17820,6 @@ Ctrl + K"
             <tr
               class="MuiTableRow-root-id MuiTableRow-head-id"
             >
-              <th
-                class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                scope="col"
-              />
               <th
                 class="MuiTableCell-root-id MuiTableCell-head-id CategoryList-colName-id"
                 scope="col"
@@ -19404,7 +19820,21 @@ Ctrl + K"
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
                     scope="col"
-                  />
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                      disabled=""
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id Checkbox-disabled-id"
+                        disabled=""
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
                     scope="col"
@@ -20583,10 +21013,6 @@ Ctrl + K"
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                    scope="col"
-                  />
-                  <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
                     scope="col"
                   >
@@ -21345,7 +21771,21 @@ exports[`Storyshots Views / Collections / Collection list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id CollectionList-colName-id"
               scope="col"
@@ -30838,7 +31278,21 @@ exports[`Storyshots Views / Customers / Customer list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id CustomerList-colName-id"
               scope="col"
@@ -31045,10 +31499,6 @@ exports[`Storyshots Views / Customers / Customer list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id CustomerList-colName-id"
               scope="col"
@@ -33694,7 +34144,21 @@ exports[`Storyshots Views / Discounts / Sale details loading 1`] = `
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
                     scope="col"
-                  />
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                      disabled=""
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id Checkbox-disabled-id"
+                        disabled=""
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id DiscountCategories-wideColumn-id"
                     scope="col"
@@ -35239,7 +35703,19 @@ exports[`Storyshots Views / Discounts / Sale list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id Checkbox-root-id"
+                tabindex="0"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id"
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id SaleList-colName-id"
               scope="col"
@@ -35464,10 +35940,6 @@ exports[`Storyshots Views / Discounts / Sale list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id SaleList-colName-id"
               scope="col"
@@ -39405,7 +39877,19 @@ exports[`Storyshots Views / Discounts / Voucher list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id Checkbox-root-id"
+                tabindex="0"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id"
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id VoucherList-colName-id"
               scope="col"
@@ -39660,10 +40144,6 @@ exports[`Storyshots Views / Discounts / Voucher list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id VoucherList-colName-id"
               scope="col"
@@ -42753,7 +43233,21 @@ exports[`Storyshots Views / Navigation / Menu list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MenuList-colTitle-id"
               scope="col"
@@ -42981,10 +43475,6 @@ exports[`Storyshots Views / Navigation / Menu list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MenuList-colTitle-id"
               scope="col"
@@ -44295,7 +44785,21 @@ exports[`Storyshots Views / Orders / Draft order list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id OrderDraftList-colNumber-id"
               scope="col"
@@ -44523,10 +45027,6 @@ exports[`Storyshots Views / Orders / Draft order list when no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id OrderDraftList-colNumber-id"
               scope="col"
@@ -61018,7 +61518,21 @@ exports[`Storyshots Views / Orders / Order list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id OrderList-colNumber-id"
               scope="col"
@@ -61384,10 +61898,6 @@ exports[`Storyshots Views / Orders / Order list when no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id OrderList-colNumber-id"
               scope="col"
@@ -66131,7 +66641,21 @@ exports[`Storyshots Views / Pages / Page list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id PageList-colTitle-id"
               scope="col"
@@ -66345,10 +66869,6 @@ exports[`Storyshots Views / Pages / Page list no data 1`] = `
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
             <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
-            <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingDense-id PageList-colTitle-id"
               scope="col"
             >
@@ -66531,6 +67051,212 @@ exports[`Storyshots Views / Product types / Create product type default 1`] = `
                     value=""
                   />
                 </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardSpacer-spacer-id"
+          />
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id ProductTypeTaxes-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Taxes
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <div
+                class="SingleAutocompleteSelectField-container-id"
+              >
+                <div
+                  class="MuiFormControl-root-id MuiFormControl-fullWidth-id"
+                >
+                  <label
+                    class="MuiFormLabel-root-id MuiInputLabel-root-id MuiInputLabel-formControl-id MuiInputLabel-animated-id MuiInputLabel-filled-id"
+                    data-shrink="false"
+                  >
+                    Taxes
+                  </label>
+                  <div
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    class="MuiInputBase-root-id MuiFilledInput-root-id MuiFilledInput-underline-id MuiInputBase-fullWidth-id MuiInputBase-formControl-id MuiInputBase-adornedEnd-id MuiFilledInput-adornedEnd-id"
+                    role="combobox"
+                  >
+                    <input
+                      aria-invalid="false"
+                      autocomplete="off"
+                      class="MuiInputBase-input-id MuiFilledInput-input-id MuiInputBase-inputAdornedEnd-id MuiFilledInput-inputAdornedEnd-id"
+                      type="text"
+                      value=""
+                    />
+                    <div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-id"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <g
+                          style="fill-rule:evenodd"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div>
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Shipping
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <button
+                  class="MuiButtonBase-root-id Checkbox-root-id"
+                  tabindex="0"
+                  type="button"
+                >
+                  <input
+                    class="Checkbox-box-id"
+                    name="isShippingRequired"
+                    type="checkbox"
+                    value="false"
+                  />
+                </button>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  Is this product shippable?
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Storyshots Views / Product types / Create product type form errors 1`] = `
+<div
+  style="padding:24px"
+>
+  <form>
+    <div
+      class="Container-root-id"
+    >
+      <div
+        class="ExtendedPageHeader-root-id"
+      >
+        <h5
+          class="MuiTypography-root-id MuiTypography-h5-id Component-title-id"
+        >
+          Create product type
+        </h5>
+        <div
+          class="ExtendedPageHeader-action-id"
+        />
+      </div>
+      <div
+        class="Grid-root-id Grid-default-id"
+      >
+        <div>
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id ProductTypeDetails-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Information
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <div
+                class="MuiFormControl-root-id MuiFormControl-fullWidth-id"
+              >
+                <label
+                  class="MuiFormLabel-root-id MuiFormLabel-error-id MuiInputLabel-error-id MuiInputLabel-root-id MuiInputLabel-formControl-id MuiInputLabel-animated-id MuiInputLabel-filled-id"
+                  data-shrink="false"
+                >
+                  Product Type Name
+                </label>
+                <div
+                  class="MuiInputBase-root-id MuiFilledInput-root-id MuiFilledInput-underline-id MuiInputBase-error-id MuiFilledInput-error-id MuiInputBase-fullWidth-id MuiInputBase-formControl-id"
+                >
+                  <input
+                    aria-invalid="true"
+                    class="MuiInputBase-input-id MuiFilledInput-input-id"
+                    name="name"
+                    type="text"
+                    value=""
+                  />
+                </div>
+                <p
+                  class="MuiFormHelperText-root-id MuiFormHelperText-contained-id MuiFormHelperText-error-id"
+                >
+                  Generic form error
+                </p>
               </div>
             </div>
           </div>
@@ -67065,7 +67791,11 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    scope="col"
+                  />
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id TableHead-dragRows-id"
                     scope="col"
                   >
                     <button
@@ -67098,6 +67828,43 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                 <tr
                   class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
                 >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
                   <td
                     class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
                   >
@@ -67152,6 +67919,43 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
                 >
                   <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
                     class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
                   >
                     <button
@@ -67204,6 +68008,626 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                 <tr
                   class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
                 >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id Checkbox-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id"
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                  >
+                    Publisher
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiIconButton-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label-id"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                          />
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div
+            class="CardSpacer-spacer-id"
+          />
+          <label
+            class="MuiFormControlLabel-root-id"
+          >
+            <button
+              class="MuiButtonBase-root-id Checkbox-root-id"
+              tabindex="0"
+              type="button"
+            >
+              <input
+                class="Checkbox-box-id"
+                name="hasVariants"
+                type="checkbox"
+                value="false"
+              />
+            </button>
+            <span
+              class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+            >
+              This product type has variants
+            </span>
+          </label>
+        </div>
+        <div>
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Shipping
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <button
+                  class="MuiButtonBase-root-id Checkbox-root-id"
+                  tabindex="0"
+                  type="button"
+                >
+                  <input
+                    class="Checkbox-box-id"
+                    name="isShippingRequired"
+                    type="checkbox"
+                    value="false"
+                  />
+                </button>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  Is this product shippable?
+                </span>
+              </label>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </form>
+</div>
+`;
+
+exports[`Storyshots Views / Product types / Product type details form errors 1`] = `
+<div
+  style="padding:24px"
+>
+  <form>
+    <div
+      class="Container-root-id"
+    >
+      <div
+        class="ExtendedPageHeader-root-id"
+      >
+        <h5
+          class="MuiTypography-root-id MuiTypography-h5-id Component-title-id"
+        >
+          E-books
+        </h5>
+        <div
+          class="ExtendedPageHeader-action-id"
+        />
+      </div>
+      <div
+        class="Grid-root-id Grid-default-id"
+      >
+        <div>
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id ProductTypeDetails-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Information
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <div
+                class="MuiFormControl-root-id MuiFormControl-fullWidth-id"
+              >
+                <label
+                  class="MuiFormLabel-root-id MuiFormLabel-error-id MuiInputLabel-error-id MuiFormLabel-filled-id MuiInputLabel-root-id MuiInputLabel-formControl-id MuiInputLabel-animated-id MuiInputLabel-shrink-id MuiInputLabel-filled-id"
+                  data-shrink="true"
+                >
+                  Product Type Name
+                </label>
+                <div
+                  class="MuiInputBase-root-id MuiFilledInput-root-id MuiFilledInput-underline-id MuiInputBase-error-id MuiFilledInput-error-id MuiInputBase-fullWidth-id MuiInputBase-formControl-id"
+                >
+                  <input
+                    aria-invalid="true"
+                    class="MuiInputBase-input-id MuiFilledInput-input-id"
+                    name="name"
+                    type="text"
+                    value="E-books"
+                  />
+                </div>
+                <p
+                  class="MuiFormHelperText-root-id MuiFormHelperText-contained-id MuiFormHelperText-error-id MuiFormHelperText-filled-id"
+                >
+                  Generic form error
+                </p>
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardSpacer-spacer-id"
+          />
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id ProductTypeTaxes-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Taxes
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              />
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <div
+              class="MuiCardContent-root-id"
+            >
+              <div
+                class="SingleAutocompleteSelectField-container-id"
+              >
+                <div
+                  class="MuiFormControl-root-id MuiFormControl-fullWidth-id"
+                >
+                  <label
+                    class="MuiFormLabel-root-id MuiFormLabel-filled-id MuiInputLabel-root-id MuiInputLabel-formControl-id MuiInputLabel-animated-id MuiInputLabel-shrink-id MuiInputLabel-filled-id"
+                    data-shrink="true"
+                  >
+                    Taxes
+                  </label>
+                  <div
+                    aria-autocomplete="list"
+                    aria-expanded="false"
+                    class="MuiInputBase-root-id MuiFilledInput-root-id MuiFilledInput-underline-id MuiInputBase-fullWidth-id MuiInputBase-formControl-id MuiInputBase-adornedEnd-id MuiFilledInput-adornedEnd-id"
+                    role="combobox"
+                  >
+                    <input
+                      aria-invalid="false"
+                      autocomplete="off"
+                      class="MuiInputBase-input-id MuiFilledInput-input-id MuiInputBase-inputAdornedEnd-id MuiFilledInput-inputAdornedEnd-id"
+                      type="text"
+                      value="PH405458"
+                    />
+                    <div>
+                      <svg
+                        aria-hidden="true"
+                        class="MuiSvgIcon-root-id"
+                        focusable="false"
+                        role="presentation"
+                        viewBox="0 0 24 24"
+                      >
+                        <g
+                          style="fill-rule:evenodd"
+                        >
+                          <path
+                            d="M7 10l5 5 5-5z"
+                          />
+                        </g>
+                      </svg>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="CardSpacer-spacer-id"
+          />
+          <div
+            class="MuiPaper-root-id MuiPaper-elevation1-id MuiPaper-rounded-id MuiCard-root-id"
+          >
+            <div
+              class="CardTitle-root-id"
+            >
+              <span
+                class="MuiTypography-root-id MuiTypography-h5-id CardTitle-title-id"
+              >
+                Product Attributes
+              </span>
+              <div
+                class="CardTitle-toolbar-id"
+              >
+                <button
+                  class="MuiButtonBase-root-id MuiButton-root-id MuiButton-text-id MuiButton-textPrimary-id MuiButton-flat-id MuiButton-flatPrimary-id"
+                  tabindex="0"
+                  type="button"
+                >
+                  <span
+                    class="MuiButton-label-id"
+                  >
+                    Assign attribute
+                  </span>
+                </button>
+              </div>
+            </div>
+            <div
+              class="CardTitle-children-id"
+            />
+            <hr
+              class="CardTitle-hr-id"
+            />
+            <table
+              class="MuiTable-root-id"
+            >
+              <thead
+                class="MuiTableHead-root-id"
+              >
+                <tr
+                  class="MuiTableRow-root-id MuiTableRow-head-id"
+                >
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    scope="col"
+                  />
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id TableHead-dragRows-id"
+                    scope="col"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id Checkbox-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id"
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    scope="col"
+                  >
+                    Attribute name
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    scope="col"
+                  />
+                </tr>
+              </thead>
+              <tbody
+                class="MuiTableBody-root-id"
+              >
+                <tr
+                  class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
+                >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id Checkbox-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id"
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                  >
+                    Author
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiIconButton-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label-id"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                          />
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
+                >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id Checkbox-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id"
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                  >
+                    Language
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiIconButton-root-id"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiIconButton-label-id"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          class="MuiSvgIcon-root-id MuiSvgIcon-colorPrimary-id"
+                          focusable="false"
+                          role="presentation"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            d="M6 19c0 1.1.9 2 2 2h8c1.1 0 2-.9 2-2V7H6v12zM19 4h-3.5l-1-1h-5l-1 1H5v2h14V4z"
+                          />
+                          <path
+                            d="M0 0h24v24H0z"
+                            fill="none"
+                          />
+                        </svg>
+                      </span>
+                    </button>
+                  </td>
+                </tr>
+                <tr
+                  class="MuiTableRow-root-id MuiTableRow-hover-id ProductTypeAttributes-link-id"
+                >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
                   <td
                     class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
                   >
@@ -67534,9 +68958,27 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id"
                     scope="col"
                   />
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id TableHead-dragRows-id"
+                    scope="col"
+                  >
+                    <button
+                      class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                      disabled=""
+                      tabindex="-1"
+                      type="button"
+                    >
+                      <input
+                        class="Checkbox-box-id Checkbox-disabled-id"
+                        disabled=""
+                        type="checkbox"
+                        value="false"
+                      />
+                    </button>
+                  </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
                     scope="col"
@@ -67555,6 +68997,43 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                 <tr
                   class="MuiTableRow-root-id"
                 >
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id Hook-columnDrag-id"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      class="MuiSvgIcon-root-id"
+                      focusable="false"
+                      role="presentation"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        clip-rule="evenodd"
+                        d="M3.5 2C3.5 2.82843 2.82843 3.5 2 3.5C1.17157 3.5 0.5 2.82843 0.5 2C0.5 1.17157 1.17157 0.5 2 0.5C2.82843 0.5 3.5 1.17157 3.5 2ZM4 2C4 3.10457 3.10457 4 2 4C0.895431 4 0 3.10457 0 2C0 0.895431 0.895431 0 2 0C3.10457 0 4 0.895431 4 2ZM9.5 2C9.5 2.82843 8.82843 3.5 8 3.5C7.17157 3.5 6.5 2.82843 6.5 2C6.5 1.17157 7.17157 0.5 8 0.5C8.82843 0.5 9.5 1.17157 9.5 2ZM10 2C10 3.10457 9.10457 4 8 4C6.89543 4 6 3.10457 6 2C6 0.895431 6.89543 0 8 0C9.10457 0 10 0.895431 10 2ZM8 9.5C8.82843 9.5 9.5 8.82843 9.5 8C9.5 7.17157 8.82843 6.5 8 6.5C7.17157 6.5 6.5 7.17157 6.5 8C6.5 8.82843 7.17157 9.5 8 9.5ZM8 10C9.10457 10 10 9.10457 10 8C10 6.89543 9.10457 6 8 6C6.89543 6 6 6.89543 6 8C6 9.10457 6.89543 10 8 10ZM3.5 8C3.5 8.82843 2.82843 9.5 2 9.5C1.17157 9.5 0.5 8.82843 0.5 8C0.5 7.17157 1.17157 6.5 2 6.5C2.82843 6.5 3.5 7.17157 3.5 8ZM4 8C4 9.10457 3.10457 10 2 10C0.895431 10 0 9.10457 0 8C0 6.89543 0.895431 6 2 6C3.10457 6 4 6.89543 4 8ZM2 15.5C2.82843 15.5 3.5 14.8284 3.5 14C3.5 13.1716 2.82843 12.5 2 12.5C1.17157 12.5 0.5 13.1716 0.5 14C0.5 14.8284 1.17157 15.5 2 15.5ZM2 16C3.10457 16 4 15.1046 4 14C4 12.8954 3.10457 12 2 12C0.895431 12 0 12.8954 0 14C0 15.1046 0.895431 16 2 16ZM9.5 14C9.5 14.8284 8.82843 15.5 8 15.5C7.17157 15.5 6.5 14.8284 6.5 14C6.5 13.1716 7.17157 12.5 8 12.5C8.82843 12.5 9.5 13.1716 9.5 14ZM10 14C10 15.1046 9.10457 16 8 16C6.89543 16 6 15.1046 6 14C6 12.8954 6.89543 12 8 12C9.10457 12 10 12.8954 10 14Z"
+                        fill="url(#paint0_linear)"
+                        fill-rule="evenodd"
+                        style="transform:translate(7px, 4px)"
+                      />
+                      <defs>
+                        <linearGradient
+                          gradientUnits="userSpaceOnUse"
+                          id="paint0_linear"
+                          x1="0"
+                          x2="16.0896"
+                          y1="0"
+                          y2="10.4478"
+                        >
+                          <stop
+                            stop-color="#13BEBB"
+                          />
+                          <stop
+                            offset="1"
+                            stop-color="#3EE7CD"
+                          />
+                        </linearGradient>
+                      </defs>
+                    </svg>
+                  </td>
                   <td
                     class="MuiTableCell-root-id MuiTableCell-body-id MuiTableCell-paddingCheckbox-id"
                   >
@@ -68134,7 +69613,21 @@ exports[`Storyshots Views / Product types / Product types list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeList-colName-id"
               scope="col"
@@ -79466,7 +80959,21 @@ exports[`Storyshots Views / Products / Product list loading 1`] = `
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
               scope="col"
-            />
+            >
+              <button
+                class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                disabled=""
+                tabindex="-1"
+                type="button"
+              >
+                <input
+                  class="Checkbox-box-id Checkbox-disabled-id"
+                  disabled=""
+                  type="checkbox"
+                  value="false"
+                />
+              </button>
+            </th>
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id"
               scope="col"
@@ -79829,10 +81336,6 @@ exports[`Storyshots Views / Products / Product list no data 1`] = `
           <tr
             class="MuiTableRow-root-id MuiTableRow-head-id"
           >
-            <th
-              class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-              scope="col"
-            />
             <th
               class="MuiTableCell-root-id MuiTableCell-head-id"
               scope="col"
@@ -84947,7 +86450,21 @@ exports[`Storyshots Views / Shipping / Shipping zones list loading 1`] = `
                 <th
                   class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
                   scope="col"
-                />
+                >
+                  <button
+                    class="MuiButtonBase-root-id MuiButtonBase-disabled-id Checkbox-root-id"
+                    disabled=""
+                    tabindex="-1"
+                    type="button"
+                  >
+                    <input
+                      class="Checkbox-box-id Checkbox-disabled-id"
+                      disabled=""
+                      type="checkbox"
+                      value="false"
+                    />
+                  </button>
+                </th>
                 <th
                   class="MuiTableCell-root-id MuiTableCell-head-id ShippingZonesList-colName-id"
                   scope="col"
@@ -85280,10 +86797,6 @@ exports[`Storyshots Views / Shipping / Shipping zones list no data 1`] = `
               <tr
                 class="MuiTableRow-root-id MuiTableRow-head-id"
               >
-                <th
-                  class="MuiTableCell-root-id MuiTableCell-head-id MuiTableCell-paddingCheckbox-id"
-                  scope="col"
-                />
                 <th
                   class="MuiTableCell-root-id MuiTableCell-head-id ShippingZonesList-colName-id"
                   scope="col"

--- a/saleor/static/dashboard-next/storybook/stories/attributes/AttributePage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/attributes/AttributePage.tsx
@@ -18,6 +18,7 @@ const props: AttributePageProps = {
   onSubmit: () => undefined,
   onValueAdd: () => undefined,
   onValueDelete: () => undefined,
+  onValueReorder: () => undefined,
   onValueUpdate: () => undefined,
   saveButtonBarState: "default",
   values: attribute.values

--- a/saleor/static/dashboard-next/storybook/stories/components/AssignAttributeDialog.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/components/AssignAttributeDialog.tsx
@@ -2,6 +2,7 @@ import { storiesOf } from "@storybook/react";
 import * as React from "react";
 
 import { attributes } from "@saleor/attributes/fixtures";
+import { formError } from "@saleor/storybook/misc";
 import AssignAttributeDialog, {
   AssignAttributeDialogProps
 } from "../../../components/AssignAttributeDialog";
@@ -10,6 +11,7 @@ import Decorator from "../../Decorator";
 const props: AssignAttributeDialogProps = {
   attributes: attributes.slice(0, 5),
   confirmButtonState: "default",
+  errors: [],
   loading: false,
   onClose: () => undefined,
   onFetch: () => undefined,
@@ -24,4 +26,7 @@ storiesOf("Generics / Assign attributes dialog", module)
   .add("default", () => <AssignAttributeDialog {...props} />)
   .add("loading", () => (
     <AssignAttributeDialog {...props} attributes={undefined} loading={true} />
+  ))
+  .add("errors", () => (
+    <AssignAttributeDialog {...props} errors={[formError("").message]} />
   ));

--- a/saleor/static/dashboard-next/storybook/stories/productTypes/ProductTypeCreatePage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/productTypes/ProductTypeCreatePage.tsx
@@ -2,8 +2,10 @@ import { Omit } from "@material-ui/core";
 import { storiesOf } from "@storybook/react";
 import React from "react";
 
+import { formError } from "@saleor/storybook/misc";
 import ProductTypeCreatePage, {
-  ProductTypeCreatePageProps
+  ProductTypeCreatePageProps,
+  ProductTypeForm
 } from "../../../productTypes/components/ProductTypeCreatePage";
 import { WeightUnitsEnum } from "../../../types/globalTypes";
 import Decorator from "../../Decorator";
@@ -24,4 +26,10 @@ storiesOf("Views / Product types / Create product type", module)
   .add("default", () => <ProductTypeCreatePage {...props} />)
   .add("loading", () => (
     <ProductTypeCreatePage {...props} disabled={true} pageTitle={undefined} />
+  ))
+  .add("form errors", () => (
+    <ProductTypeCreatePage
+      {...props}
+      errors={(["name"] as Array<keyof ProductTypeForm>).map(formError)}
+    />
   ));

--- a/saleor/static/dashboard-next/storybook/stories/productTypes/ProductTypeDetailsPage.tsx
+++ b/saleor/static/dashboard-next/storybook/stories/productTypes/ProductTypeDetailsPage.tsx
@@ -3,8 +3,10 @@ import { storiesOf } from "@storybook/react";
 import React from "react";
 
 import { listActionsProps } from "@saleor/fixtures";
+import { formError } from "@saleor/storybook/misc";
 import ProductTypeDetailsPage, {
-  ProductTypeDetailsPageProps
+  ProductTypeDetailsPageProps,
+  ProductTypeForm
 } from "../../../productTypes/components/ProductTypeDetailsPage";
 import { productType } from "../../../productTypes/fixtures";
 import { WeightUnitsEnum } from "../../../types/globalTypes";
@@ -16,6 +18,7 @@ const props: Omit<ProductTypeDetailsPageProps, "classes"> = {
   errors: [],
   onAttributeAdd: () => undefined,
   onAttributeClick: () => undefined,
+  onAttributeReorder: () => undefined,
   onAttributeUnassign: () => undefined,
   onBack: () => undefined,
   onDelete: () => undefined,
@@ -37,5 +40,11 @@ storiesOf("Views / Product types / Product type details", module)
       disabled={true}
       pageTitle={undefined}
       productType={undefined}
+    />
+  ))
+  .add("form errors", () => (
+    <ProductTypeDetailsPage
+      {...props}
+      errors={(["name"] as Array<keyof ProductTypeForm>).map(formError)}
     />
   ));

--- a/saleor/static/dashboard-next/theme.ts
+++ b/saleor/static/dashboard-next/theme.ts
@@ -234,7 +234,14 @@ export default (colors: IThemeColors): Theme =>
           fontWeight: 400
         },
         paddingCheckbox: {
-          width: 72
+          "&:first-child": {
+            padding: "0 12px",
+            width: 72
+          },
+          "&:not(first-child)": {
+            padding: 0,
+            width: 52
+          }
         },
         root: {
           "&:first-child": {

--- a/saleor/static/dashboard-next/types.ts
+++ b/saleor/static/dashboard-next/types.ts
@@ -89,7 +89,8 @@ export type BulkAction = Partial<{
   ids: string[];
 }>;
 
-export type ReorderEvent = (event: {
+export interface ReorderEvent {
   oldIndex: number;
   newIndex: number;
-}) => void;
+}
+export type ReorderAction = (event: ReorderEvent) => void;

--- a/saleor/static/dashboard-next/types.ts
+++ b/saleor/static/dashboard-next/types.ts
@@ -88,3 +88,8 @@ export type SingleAction = Partial<{
 export type BulkAction = Partial<{
   ids: string[];
 }>;
+
+export type ReorderEvent = (event: {
+  oldIndex: number;
+  newIndex: number;
+}) => void;

--- a/saleor/static/dashboard-next/types/globalTypes.ts
+++ b/saleor/static/dashboard-next/types/globalTypes.ts
@@ -265,6 +265,11 @@ export interface AttributeInput {
   value: string;
 }
 
+export interface AttributeReorderInput {
+  id: string;
+  sortOrder?: number | null;
+}
+
 export interface AttributeUpdateInput {
   name?: string | null;
   slug?: string | null;


### PR DESCRIPTION
I want to merge this change because it allows users to reorder attributes in product type view.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
