### PR TITLE
Add "value required" switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Dropped `null` in `sort_order` fields to make it easier to reorder in API - #4481 by @NyanKiyoshi
 - Add drag'n'drop attribute reordering in product type view - #4492 by @dominik-zeglen
 - Fix attribute picker = #4501 by @dominik-zeglen
+- Add "value required" switch - #4498 by @dominik-zeglen
 
 ## [Unreleased]
 

--- a/saleor/static/dashboard-next/attributes/components/AttributeDetails/AttributeDetails.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributeDetails/AttributeDetails.tsx
@@ -5,6 +5,7 @@ import React from "react";
 import slugify from "slugify";
 
 import CardTitle from "@saleor/components/CardTitle";
+import ControlledSwitch from "@saleor/components/ControlledSwitch";
 import FormSpacer from "@saleor/components/FormSpacer";
 import SingleSelectField from "@saleor/components/SingleSelectField";
 import i18n from "@saleor/i18n";
@@ -80,6 +81,15 @@ const AttributeDetails: React.FC<AttributeDetailsProps> = ({
         name="inputType"
         onChange={onChange}
         value={data.inputType}
+      />
+      <FormSpacer />
+      <ControlledSwitch
+        checked={data.valueRequired}
+        label={i18n.t("Value Required", {
+          context: "attribute must have value"
+        })}
+        name={"valueRequired" as keyof AttributePageFormData}
+        onChange={onChange}
       />
     </CardContent>
   </Card>

--- a/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
+++ b/saleor/static/dashboard-next/attributes/components/AttributePage/AttributePage.tsx
@@ -43,6 +43,7 @@ export interface AttributePageFormData {
   name: string;
   slug: string;
   storefrontSearchPosition: string;
+  valueRequired: boolean;
   visibleInStorefront: boolean;
 }
 
@@ -69,6 +70,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
           name: "",
           slug: "",
           storefrontSearchPosition: "",
+          valueRequired: false,
           visibleInStorefront: false
         }
       : {
@@ -90,6 +92,7 @@ const AttributePage: React.FC<AttributePageProps> = ({
             () => attribute.storefrontSearchPosition.toString(),
             ""
           ),
+          valueRequired: maybe(() => attribute.valueRequired, false),
           visibleInStorefront: maybe(() => attribute.visibleInStorefront, false)
         };
 

--- a/saleor/static/dashboard-next/attributes/fixtures.ts
+++ b/saleor/static/dashboard-next/attributes/fixtures.ts
@@ -13,6 +13,7 @@ export const attribute = {
   name: "Author",
   slug: "author",
   storefrontSearchPosition: 2,
+  valueRequired: true,
   values: [
     {
       __typename: "AttributeValue" as "AttributeValue",

--- a/saleor/static/dashboard-next/attributes/queries.ts
+++ b/saleor/static/dashboard-next/attributes/queries.ts
@@ -24,6 +24,7 @@ export const attributeDetailsFragment = gql`
     ...AttributeFragment
     inputType
     storefrontSearchPosition
+    valueRequired
     values {
       id
       name

--- a/saleor/static/dashboard-next/attributes/types/AttributeCreate.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeCreate.ts
@@ -34,6 +34,7 @@ export interface AttributeCreate_attributeCreate_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeCreate_attributeCreate_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/attributes/types/AttributeDetails.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeDetails.ts
@@ -28,6 +28,7 @@ export interface AttributeDetails_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeDetails_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/attributes/types/AttributeDetailsFragment.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeDetailsFragment.ts
@@ -28,5 +28,6 @@ export interface AttributeDetailsFragment {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeDetailsFragment_values | null)[] | null;
 }

--- a/saleor/static/dashboard-next/attributes/types/AttributeUpdate.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeUpdate.ts
@@ -34,6 +34,7 @@ export interface AttributeUpdate_attributeUpdate_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeUpdate_attributeUpdate_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/attributes/types/AttributeValueCreate.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeValueCreate.ts
@@ -34,6 +34,7 @@ export interface AttributeValueCreate_attributeValueCreate_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeValueCreate_attributeValueCreate_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/attributes/types/AttributeValueDelete.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeValueDelete.ts
@@ -34,6 +34,7 @@ export interface AttributeValueDelete_attributeValueDelete_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeValueDelete_attributeValueDelete_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/attributes/types/AttributeValueUpdate.ts
+++ b/saleor/static/dashboard-next/attributes/types/AttributeValueUpdate.ts
@@ -34,6 +34,7 @@ export interface AttributeValueUpdate_attributeValueUpdate_attribute {
   filterableInStorefront: boolean | null;
   inputType: AttributeInputTypeEnum | null;
   storefrontSearchPosition: number | null;
+  valueRequired: boolean | null;
   values: (AttributeValueUpdate_attributeValueUpdate_attribute_values | null)[] | null;
 }
 

--- a/saleor/static/dashboard-next/fixtures.ts
+++ b/saleor/static/dashboard-next/fixtures.ts
@@ -1,9 +1,9 @@
 import { Filter } from "./components/TableFilter";
 import {
+  FetchMoreProps,
   FilterPageProps,
   ListActions,
-  PageListProps,
-  FetchMoreProps
+  PageListProps
 } from "./types";
 
 const pageInfo = {

--- a/saleor/static/dashboard-next/products/views/ProductCreate.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductCreate.tsx
@@ -44,6 +44,13 @@ export const ProductUpdate: React.StatelessComponent<
                       text: i18n.t("Product created")
                     });
                     navigate(productUrl(data.productCreate.product.id));
+                  } else {
+                    const attributeError = data.productCreate.errors.find(
+                      err => err.field === "attributes"
+                    );
+                    if (!!attributeError) {
+                      notify({ text: attributeError.message });
+                    }
                   }
                 };
 

--- a/saleor/static/dashboard-next/products/views/ProductUpdate.tsx
+++ b/saleor/static/dashboard-next/products/views/ProductUpdate.tsx
@@ -25,6 +25,7 @@ import {
   ProductImageCreate,
   ProductImageCreateVariables
 } from "../types/ProductImageCreate";
+import { ProductUpdate } from "../types/ProductUpdate";
 import { ProductVariantBulkDelete } from "../types/ProductVariantBulkDelete";
 import {
   productImageUrl,
@@ -65,8 +66,19 @@ export const ProductUpdate: React.StatelessComponent<ProductUpdateProps> = ({
                   notify({ text: i18n.t("Product removed") });
                   navigate(productListUrl());
                 };
-                const handleUpdate = () =>
-                  notify({ text: i18n.t("Saved changes") });
+                const handleUpdate = (data: ProductUpdate) => {
+                  if (data.productUpdate.errors.length === 0) {
+                    notify({ text: i18n.t("Saved changes") });
+                  } else {
+                    const attributeError = data.productUpdate.errors.find(
+                      err => err.field === "attributes"
+                    );
+                    if (!!attributeError) {
+                      notify({ text: attributeError.message });
+                    }
+                  }
+                };
+
                 const handleImageCreate = (data: ProductImageCreate) => {
                   const imageError = data.productImageCreate.errors.find(
                     error =>

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -6913,6 +6913,50 @@ exports[`Storyshots Views / Attributes / Attribute details create 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div
@@ -7482,6 +7526,50 @@ exports[`Storyshots Views / Attributes / Attribute details default 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div
@@ -8079,6 +8167,50 @@ exports[`Storyshots Views / Attributes / Attribute details form errors 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div
@@ -8683,6 +8815,50 @@ exports[`Storyshots Views / Attributes / Attribute details loading 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div
@@ -9187,6 +9363,50 @@ exports[`Storyshots Views / Attributes / Attribute details multiple select input
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div
@@ -9779,6 +9999,50 @@ exports[`Storyshots Views / Attributes / Attribute details no values 1`] = `
                   </div>
                 </div>
               </div>
+              <div
+                class="FormSpacer-spacer-id"
+              />
+              <label
+                class="MuiFormControlLabel-root-id"
+              >
+                <span
+                  class="MuiSwitch-root-id"
+                >
+                  <span
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                  >
+                    <span
+                      class="MuiIconButton-label-id"
+                    >
+                      <span
+                        class="MuiSwitch-icon-id"
+                      />
+                      <input
+                        class="MuiPrivateSwitchBase-input-id"
+                        name="valueRequired"
+                        type="checkbox"
+                      />
+                    </span>
+                  </span>
+                  <span
+                    class="MuiSwitch-bar-id"
+                  />
+                </span>
+                <span
+                  class="MuiTypography-root-id MuiTypography-body2-id MuiFormControlLabel-label-id"
+                >
+                  <div
+                    class="ControlledSwitch-label-id"
+                  >
+                    <span
+                      class="ControlledSwitch-labelText-id"
+                    >
+                      Value Required
+                    </span>
+                    <div />
+                  </div>
+                </span>
+              </label>
             </div>
           </div>
           <div

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -7536,15 +7536,16 @@ exports[`Storyshots Views / Attributes / Attribute details default 1`] = `
                   class="MuiSwitch-root-id"
                 >
                   <span
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id MuiPrivateSwitchBase-checked-id MuiSwitch-checked-id"
                   >
                     <span
                       class="MuiIconButton-label-id"
                     >
                       <span
-                        class="MuiSwitch-icon-id"
+                        class="MuiSwitch-icon-id MuiSwitch-iconChecked-id"
                       />
                       <input
+                        checked=""
                         class="MuiPrivateSwitchBase-input-id"
                         name="valueRequired"
                         type="checkbox"
@@ -8177,15 +8178,16 @@ exports[`Storyshots Views / Attributes / Attribute details form errors 1`] = `
                   class="MuiSwitch-root-id"
                 >
                   <span
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id MuiPrivateSwitchBase-checked-id MuiSwitch-checked-id"
                   >
                     <span
                       class="MuiIconButton-label-id"
                     >
                       <span
-                        class="MuiSwitch-icon-id"
+                        class="MuiSwitch-icon-id MuiSwitch-iconChecked-id"
                       />
                       <input
+                        checked=""
                         class="MuiPrivateSwitchBase-input-id"
                         name="valueRequired"
                         type="checkbox"
@@ -9373,15 +9375,16 @@ exports[`Storyshots Views / Attributes / Attribute details multiple select input
                   class="MuiSwitch-root-id"
                 >
                   <span
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id MuiPrivateSwitchBase-checked-id MuiSwitch-checked-id"
                   >
                     <span
                       class="MuiIconButton-label-id"
                     >
                       <span
-                        class="MuiSwitch-icon-id"
+                        class="MuiSwitch-icon-id MuiSwitch-iconChecked-id"
                       />
                       <input
+                        checked=""
                         class="MuiPrivateSwitchBase-input-id"
                         name="valueRequired"
                         type="checkbox"
@@ -10009,15 +10012,16 @@ exports[`Storyshots Views / Attributes / Attribute details no values 1`] = `
                   class="MuiSwitch-root-id"
                 >
                   <span
-                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id"
+                    class="MuiButtonBase-root-id MuiIconButton-root-id MuiPrivateSwitchBase-root-id MuiSwitch-switchBase-id MuiSwitch-colorPrimary-id MuiPrivateSwitchBase-checked-id MuiSwitch-checked-id"
                   >
                     <span
                       class="MuiIconButton-label-id"
                     >
                       <span
-                        class="MuiSwitch-icon-id"
+                        class="MuiSwitch-icon-id MuiSwitch-iconChecked-id"
                       />
                       <input
+                        checked=""
                         class="MuiPrivateSwitchBase-input-id"
                         name="valueRequired"
                         type="checkbox"


### PR DESCRIPTION
I want to merge this change because it adds `valueRequired` input to attribute details view.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
