### PR TITLE
Fix generating random avatars when updating staff accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Create general abstraction for object metadata - #4447 by @salwator
 - Contrast improvements - #4508 by @benekex2
 - Allow selecting the number of rows displayed in dashboard's list views - #4414 by @benekex2
+- Fix generating random avatars when updating staff accounts - #4521 by @maarcingebala
 
 ## 2.8.0
 

--- a/saleor/graphql/account/mutations.py
+++ b/saleor/graphql/account/mutations.py
@@ -368,9 +368,12 @@ class StaffCreate(ModelMutation):
 
     @classmethod
     def save(cls, info, user, cleaned_input):
-        user.avatar = get_random_avatar()
+        create_avatar = not user.avatar
+        if create_avatar:
+            user.avatar = get_random_avatar()
         user.save()
-        create_user_avatar_thumbnails.delay(user_id=user.pk)
+        if create_avatar:
+            create_user_avatar_thumbnails.delay(user_id=user.pk)
         if cleaned_input.get("send_password_email"):
             send_set_password_staff_email.delay(user.pk)
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1159,6 +1159,7 @@ def test_staff_update_doesnt_change_existing_avatar(
     # Create random avatar
     staff_user.avatar = get_random_avatar()
     staff_user.save()
+    original_path = staff_user.avatar.path
 
     id = graphene.Node.to_global_id("User", staff_user.id)
     variables = {"id": id, "permissions": [], "is_active": False}
@@ -1171,6 +1172,8 @@ def test_staff_update_doesnt_change_existing_avatar(
 
     # Make sure that random avatar isn't recreated when there is one already set.
     mock_get_random_avatar.assert_not_called()
+    staff_user.refresh_from_db()
+    assert staff_user.avatar.path == original_path
 
 
 def test_staff_delete(staff_api_client, permission_manage_staff):


### PR DESCRIPTION
The `staffUpdate` mutation would generate a new avatar image, even if one was already set. This PR changes this behavior to generate a new avatar if it's empty.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
