### PR TITLE
Display attribute slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Rework adding attribute values - #4504 by @dominik-zeglen
 - Fix minor bugs - #4503 by @dominik-zeglen
 - Fix attribute errors displaying - #4505 by @dominik-zeglen
+- Add slug column to product type's attribute list - #4538 by @dominik-zeglen
 
 ## [Unreleased]
 

--- a/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
+++ b/saleor/static/dashboard-next/productTypes/components/ProductTypeAttributes/ProductTypeAttributes.tsx
@@ -32,6 +32,10 @@ import {
 
 const styles = (theme: Theme) =>
   createStyles({
+    colName: {},
+    colSlug: {
+      width: 300
+    },
     iconCell: {
       "&:last-child": {
         paddingRight: 0
@@ -102,7 +106,10 @@ const ProductTypeAttributes = withStyles(styles, {
           toggleAll={toggleAll}
           toolbar={toolbar}
         >
-          <TableCell>{i18n.t("Attribute name")}</TableCell>
+          <TableCell className={classes.colName}>
+            {i18n.t("Attribute name")}
+          </TableCell>
+          <TableCell className={classes.colName}>{i18n.t("Slug")}</TableCell>
           <TableCell />
         </TableHead>
         <SortableTableBody onSortEnd={onAttributeReorder}>
@@ -131,9 +138,16 @@ const ProductTypeAttributes = withStyles(styles, {
                       onChange={() => toggle(attribute.id)}
                     />
                   </TableCell>
-                  <TableCell>
+                  <TableCell className={classes.colName}>
                     {maybe(() => attribute.name) ? (
                       attribute.name
+                    ) : (
+                      <Skeleton />
+                    )}
+                  </TableCell>
+                  <TableCell className={classes.colSlug}>
+                    {maybe(() => attribute.slug) ? (
+                      attribute.slug
                     ) : (
                       <Skeleton />
                     )}

--- a/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
+++ b/saleor/static/dashboard-next/storybook/__snapshots__/Stories.test.ts.snap
@@ -68079,10 +68079,16 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                     </button>
                   </th>
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
                     scope="col"
                   >
                     Attribute name
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
+                    scope="col"
+                  >
+                    Slug
                   </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
@@ -68149,11 +68155,16 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Author
                   </td>
                   <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    author
+                  </td>
+                  <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
                   >
                     <button
@@ -68239,11 +68250,16 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Language
                   </td>
                   <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    language
+                  </td>
+                  <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
                   >
                     <button
@@ -68329,9 +68345,14 @@ exports[`Storyshots Views / Product types / Product type details default 1`] = `
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Publisher
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    publisher
                   </td>
                   <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
@@ -68662,10 +68683,16 @@ exports[`Storyshots Views / Product types / Product type details form errors 1`]
                     </button>
                   </th>
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
                     scope="col"
                   >
                     Attribute name
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
+                    scope="col"
+                  >
+                    Slug
                   </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
@@ -68732,11 +68759,16 @@ exports[`Storyshots Views / Product types / Product type details form errors 1`]
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Author
                   </td>
                   <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    author
+                  </td>
+                  <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
                   >
                     <button
@@ -68822,11 +68854,16 @@ exports[`Storyshots Views / Product types / Product type details form errors 1`]
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Language
                   </td>
                   <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    language
+                  </td>
+                  <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
                   >
                     <button
@@ -68912,9 +68949,14 @@ exports[`Storyshots Views / Product types / Product type details form errors 1`]
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
                   >
                     Publisher
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
+                  >
+                    publisher
                   </td>
                   <td
                     class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-iconCell-id"
@@ -69248,10 +69290,16 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                     </button>
                   </th>
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
                     scope="col"
                   >
                     Attribute name
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
+                    scope="col"
+                  >
+                    Slug
                   </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"
@@ -69320,7 +69368,16 @@ exports[`Storyshots Views / Product types / Product type details loading 1`] = `
                     </button>
                   </td>
                   <td
-                    class="MuiTableCell-root-id MuiTableCell-body-id"
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colName-id"
+                  >
+                    <span
+                      class="Skeleton-skeleton-id"
+                    >
+                      ‌
+                    </span>
+                  </td>
+                  <td
+                    class="MuiTableCell-root-id MuiTableCell-body-id ProductTypeAttributes-colSlug-id"
                   >
                     <span
                       class="Skeleton-skeleton-id"
@@ -69636,10 +69693,16 @@ exports[`Storyshots Views / Product types / Product type details no attributes 1
                   class="MuiTableRow-root-id MuiTableRow-head-id"
                 >
                   <th
-                    class="MuiTableCell-root-id MuiTableCell-head-id"
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
                     scope="col"
                   >
                     Attribute name
+                  </th>
+                  <th
+                    class="MuiTableCell-root-id MuiTableCell-head-id ProductTypeAttributes-colName-id"
+                    scope="col"
+                  >
+                    Slug
                   </th>
                   <th
                     class="MuiTableCell-root-id MuiTableCell-head-id"


### PR DESCRIPTION
I want to merge this change because it adds "slug" column to product type's attribute list.

### Screenshots

<img width="850" alt="Screenshot 2019-07-26 at 14 56 18" src="https://user-images.githubusercontent.com/6833443/61952990-937e9a80-afb5-11e9-8868-b2f829d274e4.png">


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
