### PR TITLE
Reset query after modal close

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix attribute errors displaying - #4505 by @dominik-zeglen
 - Reset errors after closing modal - #4536 by @dominik-zeglen
 - Add slug column to product type's attribute list - #4538 by @dominik-zeglen
+- Reset query after modal close - #4554 by @dominik-zeglen
 
 ## [Unreleased]
 

--- a/saleor/static/dashboard-next/components/AssignAttributeDialog/AssignAttributeDialog.tsx
+++ b/saleor/static/dashboard-next/components/AssignAttributeDialog/AssignAttributeDialog.tsx
@@ -71,8 +71,10 @@ const AssignAttributeDialog: React.FC<AssignAttributeDialogProps> = ({
   onToggle
 }: AssignAttributeDialogProps) => {
   const classes = useStyles({});
-  const [query, onQueryChange] = useSearchQuery(onFetch);
+  const [query, onQueryChange, resetQuery] = useSearchQuery(onFetch);
   const errors = useModalDialogErrors(apiErrors, open);
+
+  React.useEffect(resetQuery, [open]);
 
   return (
     <Dialog onClose={onClose} open={open} fullWidth maxWidth="sm">

--- a/saleor/static/dashboard-next/hooks/useSearchQuery.ts
+++ b/saleor/static/dashboard-next/hooks/useSearchQuery.ts
@@ -2,7 +2,7 @@ import React from "react";
 
 import { ChangeEvent } from "@saleor/hooks/useForm";
 
-export type UseSearchQuery = [string, (event: ChangeEvent) => void];
+export type UseSearchQuery = [string, (event: ChangeEvent) => void, () => void];
 function useSearchQuery(
   onFetch: (query: string) => void,
   initial?: string
@@ -15,7 +15,15 @@ function useSearchQuery(
     setQuery(value);
   };
 
-  return [query, change];
+  const reset = () =>
+    change({
+      target: {
+        name: "",
+        value: initial || ""
+      }
+    });
+
+  return [query, change, reset];
 }
 
 export default useSearchQuery;


### PR DESCRIPTION
I want to merge this change because it resets search input value after modal window closing.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
