### PR TITLE
Add slug field to ProductType

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -448,6 +448,8 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
         resolver=resolve_translation,
     )
 
+    slug = graphene.String(required=True, description="The slug of a product.")
+
     class Meta:
         description = """Represents an individual item for sale in the
         storefront."""
@@ -600,6 +602,10 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
     @staticmethod
     def resolve_meta(root, _info):
         return resolve_meta(root, _info)
+
+    @staticmethod
+    def resolve_slug(root: models.Product, *_args):
+        return root.get_slug()
 
 
 class ProductType(CountableDjangoObjectType, MetadataObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2327,6 +2327,7 @@ type Product implements Node {
   collections: [Collection]
   availableOn: Date @deprecated(reason: "availableOn is deprecated, use publicationDate instead")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
+  slug: String!
 }
 
 type ProductBulkDelete {

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -134,6 +134,7 @@ def test_product_query(staff_api_client, product, permission_manage_products):
                         id
                         name
                         url
+                        slug
                         thumbnailUrl
                         thumbnail{
                             url
@@ -194,6 +195,7 @@ def test_product_query(staff_api_client, product, permission_manage_products):
     product_data = product_edges_data[0]["node"]
     assert product_data["name"] == product.name
     assert product_data["url"] == product.get_absolute_url()
+    assert product_data["slug"] == product.get_slug()
     gross = product_data["pricing"]["priceRange"]["start"]["gross"]
     assert float(gross["amount"]) == float(product.price.amount)
     from saleor.product.utils.costs import get_product_costs_data


### PR DESCRIPTION
I want to merge this change because I need slug field in `ProductType`


### Screenshots

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
