### PR TITLE
Return the attributes custom sorting in all graphql and 1.0 query

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -112,8 +112,12 @@ class ProductTypeForm(forms.ModelForm):
         variant_attrs_qs = product_attrs_qs = Attribute.objects.all()
 
         if self.instance.pk:
-            product_attrs_initial = self.instance.product_attributes.all()
-            variant_attrs_initial = self.instance.variant_attributes.all()
+            product_attrs_initial = (
+                self.instance.product_attributes.all().product_attributes_sorted()
+            )
+            variant_attrs_initial = (
+                self.instance.variant_attributes.all().variant_attributes_sorted()
+            )
         else:
             product_attrs_initial = []
             variant_attrs_initial = []
@@ -273,7 +277,7 @@ class ProductForm(forms.ModelForm, AttributesMixin):
         )
         self.available_attributes = product_type.product_attributes.prefetch_related(
             "values"
-        ).all()
+        ).product_attributes_sorted()
         self.prepare_fields_for_attributes()
         self.fields["collections"].initial = Collection.objects.filter(
             products__name=self.instance
@@ -369,8 +373,10 @@ class ProductVariantForm(forms.ModelForm, AttributesMixin):
             self.fields["price_override"].widget.attrs[
                 "placeholder"
             ] = self.instance.product.price.amount
-            qs = self.instance.product.product_type.variant_attributes.all()
-            self.available_attributes = qs.prefetch_related("values")
+            qs = self.instance.product.product_type.variant_attributes
+            self.available_attributes = qs.prefetch_related(
+                "values"
+            ).variant_attributes_sorted()
             self.prepare_fields_for_attributes()
 
         if include_taxes_in_prices():

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -153,7 +153,10 @@ def product_create(request, type_pk):
 @staff_member_required
 @permission_required("product.manage_products")
 def product_edit(request, pk):
-    product = get_object_or_404(Product.objects.prefetch_related("variants"), pk=pk)
+    product = get_object_or_404(
+        Product.objects.prefetch_related("variants", "product_type__attributeproduct"),
+        pk=pk,
+    )
     form = forms.ProductForm(request.POST or None, instance=product)
     edit_variant = not product.product_type.has_variants
     if edit_variant:

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -60,9 +60,9 @@ def resolve_attributes(
     if sort_by:
         is_asc = sort_by["direction"] == OrderDirection.ASC.value
         if sort_by["field"] == AttributeSortField.DASHBOARD_VARIANT_POSITION.value:
-            qs = qs.variant_attributes_sorted_for_dashboard(is_asc)
+            qs = qs.variant_attributes_sorted(is_asc)
         elif sort_by["field"] == AttributeSortField.DASHBOARD_PRODUCT_POSITION.value:
-            qs = qs.product_attributes_sorted_for_dashboard(is_asc)
+            qs = qs.product_attributes_sorted(is_asc)
         else:
             qs = sort_qs(qs, sort_by)
     else:

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import Dict
 
 import graphene
@@ -81,7 +82,7 @@ def resolve_attribute_list(attributes_json, attributes_qs):
     `attributes_qs` is the queryset of attribute objects. If it's prefetch
     beforehand along with the values, it saves database queries.
     """
-    attributes_map = {}  # type: Dict[str, models.Attribute]
+    attributes_map = OrderedDict()  # type: Dict[str, models.Attribute]
     values_map = {}  # type: Dict[str, models.AttributeValue]
     for attr in attributes_qs:
         attributes_map[str(attr.pk)] = attr
@@ -277,7 +278,7 @@ class ProductVariant(CountableDjangoObjectType, MetadataObjectType):
     def resolve_attributes(root: models.ProductVariant, info):
         attr_qs = root.product.product_type.variant_attributes.get_visible_to_user(
             info.context.user
-        )
+        ).variant_attributes_sorted()
         return resolve_attribute_list(root.attributes, attr_qs)
 
     @staticmethod
@@ -553,7 +554,7 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
     def resolve_attributes(root: models.Product, info):
         attributes_qs = root.product_type.product_attributes.get_visible_to_user(
             info.context.user
-        )
+        ).product_attributes_sorted()
         return resolve_attribute_list(root.attributes, attributes_qs)
 
     @staticmethod
@@ -665,14 +666,14 @@ class ProductType(CountableDjangoObjectType, MetadataObjectType):
         prefetch_related="product_attributes__attributeproduct"
     )
     def resolve_product_attributes(root: models.ProductType, *_args, **_kwargs):
-        return root.product_attributes.product_attributes_sorted_for_dashboard().all()
+        return root.product_attributes.product_attributes_sorted().all()
 
     @staticmethod
     @gql_optimizer.resolver_hints(
         prefetch_related="variant_attributes__attributevariant"
     )
     def resolve_variant_attributes(root: models.ProductType, *_args, **_kwargs):
-        return root.variant_attributes.variant_attributes_sorted_for_dashboard().all()
+        return root.variant_attributes.variant_attributes_sorted().all()
 
     @staticmethod
     def resolve_products(root: models.ProductType, info, **_kwargs):

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -522,10 +522,10 @@ class AttributeQuerySet(models.QuerySet):
 
         return self.order_by(sort_method, id_sort)
 
-    def product_attributes_sorted_for_dashboard(self, asc=True):
+    def product_attributes_sorted(self, asc=True):
         return self._get_sorted_m2m_field("attributeproduct", asc)
 
-    def variant_attributes_sorted_for_dashboard(self, asc=True):
+    def variant_attributes_sorted(self, asc=True):
         return self._get_sorted_m2m_field("attributevariant", asc)
 
 

--- a/saleor/product/utils/attributes.py
+++ b/saleor/product/utils/attributes.py
@@ -8,7 +8,8 @@ def get_product_attributes_data(product):
     """
     attributes = product.product_type.product_attributes.exclude(
         visible_in_storefront=False
-    )
+    ).product_attributes_sorted()
+
     attributes_map = {attribute.pk: attribute.translated for attribute in attributes}
     values_map = get_attributes_display_map(product, attributes)
     product_attributes = {}

--- a/saleor/product/utils/variants_picker.py
+++ b/saleor/product/utils/variants_picker.py
@@ -41,7 +41,9 @@ def get_variant_picker_data(
     variants = product.variants.all()
     data = {"variantAttributes": [], "variants": []}
 
-    variant_attributes = product.product_type.variant_attributes.all()
+    variant_attributes = (
+        product.product_type.variant_attributes.all().variant_attributes_sorted()
+    )
 
     # Collect only available variants
     filter_available_variants = defaultdict(list)

--- a/templates/dashboard/product/product_type/list.html
+++ b/templates/dashboard/product/product_type/list.html
@@ -60,14 +60,14 @@
                   </td>
                   <td>
                     {% if product_attributes %}
-                      {{ product_attributes|join:", " }}
+                      {{ product_attributes.product_attributes_sorted|join:", " }}
                     {% else %}
                       -
                     {% endif %}
                   </td>
                   <td>
                     {% if variant_attributes %}
-                      {{ variant_attributes|join:", " }}
+                      {{ variant_attributes.variant_attributes_sorted|join:", " }}
                     {% else %}
                       -
                     {% endif %}

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -1508,7 +1508,7 @@ def test_sort_attributes_within_product_type(
     m2m_attributes = getattr(product_type, relation_field)
     m2m_attributes.set(attributes)
 
-    sort_method = getattr(m2m_attributes, f"{relation_field}_sorted_for_dashboard")
+    sort_method = getattr(m2m_attributes, f"{relation_field}_sorted")
     attributes = list(sort_method())
 
     assert len(attributes) == 3


### PR DESCRIPTION
Blocked by https://github.com/mirumee/saleor/pull/4552.

Attributes are sorted for products and variants:
- [x] In GraphQL
- [x] In storefront 1.0
- [x] In dashboard 1.0

Note: we should sort the attributes this way until Django 3.0 is released as it is currently not possible to achieve it through the model's meta ordering because of a bug of Django 2.0.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
