### PR TITLE
Fix validating menu items inputs

### DIFF
--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -129,8 +129,8 @@ def _validate_menu_item_instance(
     cleaned_input: dict, field: str, expected_model: Model
 ):
     """Check if the value to assign as a menu item matches the expected model."""
-    if field in cleaned_input:
-        item = cleaned_input[field]
+    item = cleaned_input.get(field)
+    if item is not None:
         if not isinstance(item, expected_model):
             msg = (
                 f"Enter a valid {expected_model._meta.verbose_name} ID "

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -20,6 +20,10 @@ def test_validate_menu_item_instance(category, page):
     with pytest.raises(ValidationError):
         _validate_menu_item_instance({"category": page}, "category", Category)
 
+    # test that validation passes with empty values passed in input
+    _validate_menu_item_instance({}, "category", Category)
+    _validate_menu_item_instance({"category": None}, "category", Category)
+
 
 def test_menu_query(user_api_client, menu):
     query = """


### PR DESCRIPTION
Related to changes made in #4524. It is possible that mutation to create/update menu items receive `null` items. This PR fixes the validation function to not fail in that case.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
