### PR TITLE
Fix filters order in storefront

### DIFF
--- a/saleor/product/filters.py
+++ b/saleor/product/filters.py
@@ -50,7 +50,7 @@ class ProductFilter(SortedFilterSet):
                 widget=CheckboxSelectMultiple,
                 choices=self._get_attribute_choices(attribute),
             )
-        self.filters = filters
+        self.filters.update(filters)
 
     def _get_attributes(self):
         q_product_attributes = self._get_product_attributes_lookup()

--- a/tests/test_category.py
+++ b/tests/test_category.py
@@ -5,10 +5,10 @@ def test_product_category_filter_filters_from_child_category(
     product_type, categories_tree
 ):
     product_filter = ProductCategoryFilter(data={}, category=categories_tree)
-    (product_attributes, variant_attributes) = product_filter._get_attributes()
+    attributes = product_filter._get_attributes()
 
-    attribut = product_type.product_attributes.get()
-    variant = product_type.variant_attributes.get()
+    product_attr = product_type.product_attributes.get()
+    variant_attr = product_type.variant_attributes.get()
 
-    assert attribut in product_attributes
-    assert variant in variant_attributes
+    assert product_attr in attributes
+    assert variant_attr in attributes


### PR DESCRIPTION
Storefront filters weren't correctly using `storefront_search_position` field. I've changed the way filters are constructed so that we first get all attributes (both product and variant ones), join them together and sort the chain queryset in Python.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
