### PR TITLE
Fixed duplicate page slug in populatedb when the about page was edited

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -942,7 +942,7 @@ def create_page():
         "title": "About",
         "is_published": True,
     }
-    page, dummy = Page.objects.get_or_create(slug="about", **page_data)
+    page, dummy = Page.objects.get_or_create(slug="about", defaults=page_data)
     yield "Page %s created" % page.slug
 
 


### PR DESCRIPTION
This fixes the duplicate key error (on `slug`) when an user edited the about page then run `populatedb`.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
