### PR TITLE
Disable error reporting due to the client being disconnected in uWSGI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - The checkout process of digital orders no longer require shipping information over the API - #4573 by @NyanKiyoshi
 - Add e2e test config - #4553 by @dominik-zeglen
 - Fix MUI warnings - #4588 by @dominik-zeglen
+- Disabled unneeded reports from uWSGI about broken pipe and write errors from disconnected clients. Preventing from spamming sentry users. - #4596 by @NyanKiyoshi
 
 ## 2.8.0
 

--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -9,3 +9,5 @@ module = saleor.wsgi:application
 processes = 4
 static-map = /static=/app/static
 mimefile = /etc/mime.types
+ignore-sigpipe = true
+ignore-write-errors = true


### PR DESCRIPTION
This disables the [write exception](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#disable-write-exception) (`IOError`) and [broken pipe exceptions](https://uwsgi-docs.readthedocs.io/en/latest/Options.html#ignore-sigpipe) (`OSError`) from being reported as they are handled errors from uWSGI coming from clients having a bad connection or that got disconnected from the server.

This should prevent uWSGI from flooding sentry users with broken pipes. It can be tested by sending a `SIGPIPE` signal to one of the uWSGI workers.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
