### PR TITLE
Change validation error when checking unique attribute values

### DIFF
--- a/saleor/graphql/product/descriptions.py
+++ b/saleor/graphql/product/descriptions.py
@@ -22,7 +22,7 @@ class AttributeValueDescriptions:
     ID = "The ID of a value displayed in the interface."
     NAME = "Name of a value displayed in the interface."
     SLUG = "Internal representation of a value (unique per attribute)."
-    TYPE = """Type of value (used only when `value` field is set)."""
-    VALUE = """Special value other than a textual name. Possible types are:
-    string (default), CSS color property, CSS gradient property, URL
-    (e.g. link to an image)."""
+    TYPE = "Type of value (used only when `value` field is set)."
+    VALUE = """DEPRECATED: This field is deprecated.
+    Special value other than a textual name. Possible types are: string (default),
+    CSS color property, CSS gradient property, URL (e.g. link to an image)."""

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -24,7 +24,10 @@ from ..types import Attribute, AttributeValue
 
 class AttributeValueCreateInput(graphene.InputObjectType):
     name = graphene.String(required=True, description=AttributeValueDescriptions.NAME)
-    value = graphene.String(description=AttributeValueDescriptions.VALUE)
+    value = graphene.String(
+        description=AttributeValueDescriptions.VALUE,
+        deprecation_reason="This field is depracated",
+    )
 
 
 class AttributeCreateInput(graphene.InputObjectType):
@@ -496,6 +499,13 @@ class AttributeClearPrivateMeta(ClearMetaBaseMutation):
         public = False
 
 
+def validate_value_is_unique(attribute: models.Attribute, value: models.AttributeValue):
+    """Check if the attribute value is unique within the attribute it belongs to."""
+    duplicated_values = attribute.values.exclude(pk=value.pk).filter(slug=value.slug)
+    if duplicated_values.exists():
+        raise ValidationError({"name": f"Value with slug {value.slug} already exists."})
+
+
 class AttributeValueCreate(ModelMutation):
     attribute = graphene.Field(Attribute, description="The updated attribute.")
 
@@ -519,6 +529,11 @@ class AttributeValueCreate(ModelMutation):
         cleaned_input = super().clean_input(info, instance, data)
         cleaned_input["slug"] = slugify(cleaned_input["name"])
         return cleaned_input
+
+    @classmethod
+    def clean_instance(cls, instance):
+        validate_value_is_unique(instance.attribute, instance)
+        super().clean_instance(instance)
 
     @classmethod
     def perform_mutation(cls, _root, info, attribute_id, input):
@@ -556,6 +571,11 @@ class AttributeValueUpdate(ModelMutation):
         if "name" in cleaned_input:
             cleaned_input["slug"] = slugify(cleaned_input["name"])
         return cleaned_input
+
+    @classmethod
+    def clean_instance(cls, instance):
+        validate_value_is_unique(instance.attribute, instance)
+        super().clean_instance(instance)
 
     @classmethod
     def success_response(cls, instance):

--- a/saleor/graphql/product/types/attributes.py
+++ b/saleor/graphql/product/types/attributes.py
@@ -51,7 +51,10 @@ class AttributeValue(CountableDjangoObjectType):
     name = graphene.String(description=AttributeValueDescriptions.NAME)
     slug = graphene.String(description=AttributeValueDescriptions.SLUG)
     type = AttributeValueType(description=AttributeValueDescriptions.TYPE)
-    value = graphene.String(description=AttributeValueDescriptions.VALUE)
+    value = graphene.String(
+        description=AttributeValueDescriptions.VALUE,
+        deprecation_reason="This field is deprecated",
+    )
     translation = graphene.Field(
         AttributeValueTranslation,
         language_code=graphene.Argument(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -283,7 +283,7 @@ type AttributeValue implements Node {
   name: String
   slug: String
   type: AttributeValueType
-  value: String
+  value: String @deprecated(reason: "This field is deprecated")
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   inputType: AttributeInputTypeEnum
 }


### PR DESCRIPTION
This PR changes the validation error returned by `attributeValueCreate` and `attributeValueUpdate` mutations when users provide values that already exist.

Prior to this change API would return an error not assigned to any field:

```
errors: [{field: null, message: "Attribute value with this Name and Attribute already exists."}]
```

This PR changes is to return the error for a `name` field which is present in the input:
```
errors: [{field: "name", message: "Value with slug {slug-here} already exists."}]
```

This allows us to nicely render the error in Dashboard 2.0.

This PR also deprecates the `value` field related to `AttributeValue` field which will no longer be used after "Enterprise-grade attributes" PR is merged. From then on we will use custom input types to store different types of attributes.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] The code is documented (docstrings, project documentation).
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
