### PR TITLE
Added capability to filter attributes per global ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix bulk actions - #4618 by @dominik-zeglen
 - Remove dashboard 2.0 files - #4631 by @dominik-zeglen
 - Refactoring of password recovery system - #4617 by @fowczarek
+- Added capability to filter attributes per global ID - #4640 by @NyanKiyoshi.
 
 ## 2.8.0
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -223,6 +223,7 @@ class ProductTypeFilter(django_filters.FilterSet):
 class AttributeFilter(django_filters.FilterSet):
     # Search by attribute name and slug
     search = django_filters.CharFilter(method=filter_attributes_search)
+    ids = GlobalIDMultipleChoiceFilter(field_name="id")
 
     class Meta:
         model = Attribute

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -228,6 +228,7 @@ input AttributeFilterInput {
   filterableInDashboard: Boolean
   availableInGrid: Boolean
   search: String
+  ids: [ID]
 }
 
 input AttributeInput {

--- a/tests/api/test_attributes.py
+++ b/tests/api/test_attributes.py
@@ -1755,6 +1755,27 @@ def test_filter_attributes_if_available_in_grid(
     assert attributes[0]["node"]["slug"] == "size"
 
 
+def test_filter_attributes_by_global_id_list(api_client, attribute_list):
+    global_ids = [
+        graphene.Node.to_global_id("Attribute", attribute.pk)
+        for attribute in attribute_list[:2]
+    ]
+    variables = {"filters": {"ids": global_ids}}
+
+    expected_slugs = sorted([attribute_list[0].slug, attribute_list[1].slug])
+
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    assert len(attributes) == 2
+    received_slugs = sorted(
+        [attributes[0]["node"]["slug"], attributes[1]["node"]["slug"]]
+    )
+
+    assert received_slugs == expected_slugs
+
+
 ATTRIBUTES_SORT_QUERY = """
     query($sortBy: AttributeSortingInput) {
       attributes(first: 10, sortBy: $sortBy) {


### PR DESCRIPTION
Closes #4646.

~~Note that we cannot name it `ids` but only `id`. Providing a `field_name` is not possible. But could be implemented. Let me know if it would really be better. Worst case, we can always add this task to change this later on as it would be merged into a WiP branch.~~

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
