### PR TITLE
Change AddressValidationRules API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add mutation to change the authenticated user's password - #4656 by @fowczarek
 - Add an functionality to sort products by their "minimal variant price" - #4416 by @derenio
 - New stripe gateway implementation based on Stripe PaymentIntents API - #4606 by @salwator
+- Change AddressValidationRules API - #4655 by @Kwaidan00
 
 ## 2.8.0
 

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -48,7 +48,7 @@ def resolve_staff_users(info, query):
     return gql_optimizer.query(qs, info)
 
 
-def resolve_address_validator(
+def resolve_address_validation_rules(
     info,
     country_code: str,
     country_area: Optional[str],

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -1,11 +1,11 @@
 from itertools import chain
+from typing import Optional
 
 import graphene_django_optimizer as gql_optimizer
 from django.db.models import Q
 from i18naddress import get_validation_rules
 
 from ...account import models
-from ...core.utils import get_client_ip, get_country_by_ip
 from ...payment.utils import (
     fetch_customer_id,
     list_enabled_gateways,
@@ -47,17 +47,17 @@ def resolve_staff_users(info, query):
     return gql_optimizer.query(qs, info)
 
 
-def resolve_address_validator(info, country_code, country_area, city_area):
-    if not country_code:
-        client_ip = get_client_ip(info.context)
-        country = get_country_by_ip(client_ip)
-        if country:
-            country_code = country.code
-        else:
-            return None
+def resolve_address_validator(
+    info,
+    country_code: str,
+    country_area: Optional[str],
+    city: Optional[str],
+    city_area: Optional[str],
+):
     params = {
         "country_code": country_code,
         "country_area": country_area,
+        "city": city,
         "city_area": city_area,
     }
     rules = get_validation_rules(params)

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -13,6 +13,7 @@ from ...payment.utils import (
 )
 from ..utils import filter_by_query_param
 from .types import AddressValidationData, ChoiceValue
+from .utils import get_allowed_fields_camel_case, get_required_fields_camel_case
 
 USER_SEARCH_FIELDS = (
     "email",
@@ -66,8 +67,8 @@ def resolve_address_validator(
         country_name=rules.country_name,
         address_format=rules.address_format,
         address_latin_format=rules.address_latin_format,
-        allowed_fields=rules.allowed_fields,
-        required_fields=rules.required_fields,
+        allowed_fields=get_allowed_fields_camel_case(rules.allowed_fields),
+        required_fields=get_required_fields_camel_case(rules.required_fields),
         upper_fields=rules.upper_fields,
         country_area_type=rules.country_area_type,
         country_area_choices=[

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -65,9 +65,10 @@ class StaffUserInput(FilterInputObjectType):
 class AccountQueries(graphene.ObjectType):
     address_validation_rules = graphene.Field(
         AddressValidationData,
-        country_code=graphene.Argument(CountryCodeEnum, required=False),
-        country_area=graphene.String(required=False),
-        city_area=graphene.String(required=False),
+        country_code=graphene.Argument(CountryCodeEnum, required=True),
+        country_area=graphene.Argument(graphene.String),
+        city=graphene.Argument(graphene.String),
+        city_area=graphene.Argument(graphene.String),
     )
     customers = FilterInputConnectionField(
         User,
@@ -89,12 +90,13 @@ class AccountQueries(graphene.ObjectType):
     )
 
     def resolve_address_validation_rules(
-        self, info, country_code=None, country_area=None, city_area=None
+        self, info, country_code, country_area=None, city=None, city_area=None
     ):
         return resolve_address_validator(
             info,
-            country_code=country_code,
+            country_code,
             country_area=country_area,
+            city=city,
             city_area=city_area,
         )
 

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -48,7 +48,11 @@ from .mutations.staff import (
     UserClearStoredPrivateMeta,
     UserUpdatePrivateMeta,
 )
-from .resolvers import resolve_address_validator, resolve_customers, resolve_staff_users
+from .resolvers import (
+    resolve_address_validation_rules,
+    resolve_customers,
+    resolve_staff_users,
+)
 from .types import AddressValidationData, User
 
 
@@ -92,7 +96,7 @@ class AccountQueries(graphene.ObjectType):
     def resolve_address_validation_rules(
         self, info, country_code, country_area=None, city=None, city_area=None
     ):
-        return resolve_address_validator(
+        return resolve_address_validation_rules(
             info,
             country_code,
             country_area=country_area,

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -1,4 +1,5 @@
 from django.core.exceptions import ValidationError
+from graphene.utils.str_converters import to_camel_case
 
 from ...account import events as account_events
 
@@ -42,3 +43,24 @@ class StaffDeleteMixin(UserDeleteMixin):
         super().clean_instance(info, instance)
         if not instance.is_staff:
             raise ValidationError({"id": "Cannot delete a non-staff user."})
+
+
+def get_required_fields_camel_case(required_fields: set) -> set:
+    """Return set of AddressValidationRules required fields in camel case."""
+    return {validation_field_to_camel_case(field) for field in required_fields}
+
+
+def validation_field_to_camel_case(name: str) -> str:
+    """Convert name of the field from snake case to camel case."""
+    name = to_camel_case(name)
+    if name == "streetAddress":
+        return "streetAddress1"
+    return name
+
+
+def get_allowed_fields_camel_case(allowed_fields: set) -> set:
+    """Return set of AddressValidationRules allowed fields in camel case."""
+    fields = {validation_field_to_camel_case(field) for field in allowed_fields}
+    if "streetAddress1" in fields:
+        fields.add("streetAddress2")
+    return fields

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2974,7 +2974,7 @@ type Query {
   checkouts(before: String, after: String, first: Int, last: Int): CheckoutCountableConnection
   checkoutLine(id: ID): CheckoutLine
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
-  addressValidationRules(countryCode: CountryCode, countryArea: String, cityArea: String): AddressValidationData
+  addressValidationRules(countryCode: CountryCode!, countryArea: String, city: String, cityArea: String): AddressValidationData
   customers(filter: CustomerFilterInput, query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
   me: User
   staffUsers(filter: StaffUserInput, query: String, before: String, after: String, first: Int, last: Int): UserCountableConnection

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1793,7 +1793,7 @@ def test_set_default_address(
     assert data["user"]["defaultShippingAddress"]["id"] == address_id
 
 
-def test_address_validator(user_api_client):
+def test_address_validation_rules(user_api_client):
     query = """
     query getValidator(
         $country_code: CountryCode!, $country_area: String, $city_area: String) {
@@ -1822,7 +1822,7 @@ def test_address_validator(user_api_client):
     assert matcher.match("00-123")
 
 
-def test_address_validator_with_country_area(user_api_client):
+def test_address_validation_rules_with_country_area(user_api_client):
     query = """
     query getValidator(
         $country_code: CountryCode!, $country_area: String, $city_area: String) {
@@ -1868,7 +1868,7 @@ def test_address_validator_with_country_area(user_api_client):
     assert not data["cityAreaChoices"]
 
 
-def test_address_validator_fields_in_camel_case(user_api_client):
+def test_address_validation_rules_fields_in_camel_case(user_api_client):
     query = """
     query getValidator(
         $country_code: CountryCode!) {

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1868,6 +1868,28 @@ def test_address_validator_with_country_area(user_api_client):
     assert not data["cityAreaChoices"]
 
 
+def test_address_validator_fields_in_camel_case(user_api_client):
+    query = """
+    query getValidator(
+        $country_code: CountryCode!) {
+        addressValidationRules(countryCode: $country_code) {
+            requiredFields
+            allowedFields
+        }
+    }
+    """
+    variables = {"country_code": "PL"}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["addressValidationRules"]
+    required_fields = data["requiredFields"]
+    allowed_fields = data["allowedFields"]
+    assert "streetAddress1" in required_fields
+    assert "streetAddress2" not in required_fields
+    assert "streetAddress1" in allowed_fields
+    assert "streetAddress2" in allowed_fields
+
+
 CUSTOMER_PASSWORD_RESET_MUTATION = """
     mutation CustomerPasswordReset($email: String!) {
         customerPasswordReset(input: {email: $email}) {

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1796,7 +1796,7 @@ def test_set_default_address(
 def test_address_validator(user_api_client):
     query = """
     query getValidator(
-        $country_code: CountryCode, $country_area: String, $city_area: String) {
+        $country_code: CountryCode!, $country_area: String, $city_area: String) {
         addressValidationRules(
                 countryCode: $country_code,
                 countryArea: $country_area,
@@ -1822,42 +1822,10 @@ def test_address_validator(user_api_client):
     assert matcher.match("00-123")
 
 
-def test_address_validator_uses_geip_when_country_code_missing(
-    user_api_client, monkeypatch
-):
-    query = """
-    query getValidator(
-        $country_code: CountryCode, $country_area: String, $city_area: String) {
-        addressValidationRules(
-                countryCode: $country_code,
-                countryArea: $country_area,
-                cityArea: $city_area) {
-            countryCode,
-            countryName
-        }
-    }
-    """
-    variables = {"country_code": None, "country_area": None, "city_area": None}
-    mock_country_by_ip = Mock(return_value=Mock(code="US"))
-    monkeypatch.setattr(
-        "saleor.graphql.account.resolvers.get_client_ip",
-        lambda request: Mock(return_value="127.0.0.1"),
-    )
-    monkeypatch.setattr(
-        "saleor.graphql.account.resolvers.get_country_by_ip", mock_country_by_ip
-    )
-    response = user_api_client.post_graphql(query, variables)
-    content = get_graphql_content(response)
-    assert mock_country_by_ip.called
-    data = content["data"]["addressValidationRules"]
-    assert data["countryCode"] == "US"
-    assert data["countryName"] == "UNITED STATES"
-
-
 def test_address_validator_with_country_area(user_api_client):
     query = """
     query getValidator(
-        $country_code: CountryCode, $country_area: String, $city_area: String) {
+        $country_code: CountryCode!, $country_area: String, $city_area: String) {
         addressValidationRules(
                 countryCode: $country_code,
                 countryArea: $country_area,


### PR DESCRIPTION
I want to merge this change because it brings several minor changes to the `AddressValidationRules` endpoint.
First of all, it changes query's signature to take country code of type `CountryCode!`, adds `city` to the parameters, it drops support for country guessing based on GeoIP.
The second thing is returning allowed and required field names in camel case to be consistent with `AddressInput` field names.

<!-- Please mention all relevant issue numbers. -->

It fixes #4514 and it fixes #4541.

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.