### PR TITLE
Fix wrong calculation of total in checkout details

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -743,8 +743,7 @@ def get_checkout_context(checkout, discounts, currency=None, shipping_range=None
         start=checkout_subtotal, stop=checkout_subtotal
     )
     if shipping_required and shipping_range:
-        total_with_shipping = shipping_range + checkout_subtotal.net
-
+        total_with_shipping = shipping_range + checkout_subtotal
     context = {
         "checkout": checkout,
         "checkout_are_taxes_handled": manager.taxes_are_enabled(),

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -106,6 +106,9 @@ class AvataxPlugin(BasePlugin):
             self.config = AvataxConfiguration(
                 username_or_account=settings.AVATAX_USERNAME_OR_ACCOUNT,
                 password_or_license=settings.AVATAX_PASSWORD_OR_LICENSE,
+                use_sandbox=settings.AVATAX_USE_SANDBOX,
+                autocommit=settings.AVATAX_AUTOCOMMIT,
+                company_name=settings.AVATAX_COMPANY_NAME,
             )
             self.active = (
                 settings.AVATAX_USERNAME_OR_ACCOUNT

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -366,9 +366,9 @@ VATLAYER_USE_HTTPS = get_bool_from_env("VATLAYER_USE_HTTPS", False)
 # Avatax supports two ways of log in - username:password or account:license
 AVATAX_USERNAME_OR_ACCOUNT = os.environ.get("AVATAX_USERNAME_OR_ACCOUNT")
 AVATAX_PASSWORD_OR_LICENSE = os.environ.get("AVATAX_PASSWORD_OR_LICENSE")
-AVATAX_USE_SANDBOX = os.environ.get("AVATAX_USE_SANDBOX", DEBUG)
+AVATAX_USE_SANDBOX = get_bool_from_env("AVATAX_USE_SANDBOX", DEBUG)
 AVATAX_COMPANY_NAME = os.environ.get("AVATAX_COMPANY_NAME", "DEFAULT")
-AVATAX_AUTOCOMMIT = os.environ.get("AVATAX_AUTOCOMMIT", False)
+AVATAX_AUTOCOMMIT = get_bool_from_env("AVATAX_AUTOCOMMIT", False)
 
 ACCOUNT_ACTIVATION_DAYS = 3
 


### PR DESCRIPTION
- Fix for wrong calculation fo total value in checkout.
- Pass all mandatory variables to Avatax's plugin
- Convert Avatax's envs to bool if required.