### PR TITLE
Fix to prevent saving attributes from clearing selected product type with 1.0 Dashboard

### DIFF
--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -527,7 +527,7 @@ class VariantImagesSelectForm(forms.Form):
 class AttributeForm(forms.ModelForm):
     class Meta:
         model = Attribute
-        exclude = ["input_type"]
+        exclude = ["input_type", "product_types", "product_variant_types"]
         labels = {
             "name": pgettext_lazy("Product display name", "Display name"),
             "slug": pgettext_lazy("Product internal name", "Internal name"),


### PR DESCRIPTION
I want to merge this change because...

Currently if you save an attribute using the 1.0 Dashboard it will clear out that attributes product type with blank data.

This PR will exclude any product type related fields ("product_types", "product_variant_types") from the AttributeForm to ensure that this information is not overridden and the selected product types are retained.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
