### PR TITLE
Append description to fields returned from update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change AddressValidationRules API - #4655 by @Kwaidan00
 - Refactor account deletion mutations - #4668 by @fowczarek
 - Upgraded django-prices from v1 to v2.1. Currency codes are now locked at 3 characters max by default for consistency. - #4639 by @NyanKiyoshi
+- Fix - dynamic settings - Append description to fields returned from pluginConfigurationUpdate mutation - #4692 by @korycins
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change AddressValidationRules API - #4655 by @Kwaidan00
 - Refactor account deletion mutations - #4668 by @fowczarek
 - Upgraded django-prices from v1 to v2.1. Currency codes are now locked at 3 characters max by default for consistency. - #4639 by @NyanKiyoshi
-- Fix - dynamic settings - Append description to fields returned from pluginConfigurationUpdate mutation - #4692 by @korycins
 
 ## 2.8.0
 

--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -157,6 +157,9 @@ class BasePlugin:
         if "active" in cleaned_data:
             plugin_configuration.active = cleaned_data["active"]
         plugin_configuration.save()
+        if plugin_configuration.configuration:
+            # Let's add a translated descriptions and labels
+            cls._append_config_structure(plugin_configuration.configuration)
         return plugin_configuration
 
     @classmethod
@@ -166,7 +169,7 @@ class BasePlugin:
 
     @classmethod
     def _append_config_structure(cls, configuration):
-        config_structure = getattr(cls, "CONFIG_STRUCTURE", {})
+        config_structure = getattr(cls, "CONFIG_STRUCTURE") or {}
         for coniguration_field in configuration:
 
             structure_to_add = config_structure.get(coniguration_field.get("name"))


### PR DESCRIPTION
`pluginConfigurationUpdate` returns empty values for fields - "type", "helpText", "label". 
This PR fixes that