### PR TITLE
Add validation of plugin's configuration before .save()

### DIFF
--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -147,6 +147,14 @@ class BasePlugin:
                     config_item.update([("value", new_value)])
 
     @classmethod
+    def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
+        """Validate if provided configuration is correct.
+
+        Raise django.core.exceptions.ValidationError in the other cases
+        """
+        return
+
+    @classmethod
     def save_plugin_configuration(
         cls, plugin_configuration: "PluginConfiguration", cleaned_data
     ):
@@ -156,6 +164,7 @@ class BasePlugin:
             cls._update_config_items(configuration_to_update, current_config)
         if "active" in cleaned_data:
             plugin_configuration.active = cleaned_data["active"]
+        cls.validate_plugin_configuration(plugin_configuration)
         plugin_configuration.save()
         return plugin_configuration
 

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -436,7 +436,7 @@ class AvataxPlugin(BasePlugin):
                 "To enable a plugin, you need to provide values for the "
                 "following fields: "
             )
-            raise ValidationError({"Avatax": error_msg + ", ".join(missing_fields)})
+            raise ValidationError(error_msg + ", ".join(missing_fields))
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -433,9 +433,10 @@ class AvataxPlugin(BasePlugin):
 
         if plugin_configuration.active and missing_fields:
             error_msg = (
-                "To enable a plugin, you need to provide values for the following fields: "
+                "To enable a plugin, you need to provide values for the "
+                "following fields: "
             )
-            raise ValidationError({"active": error_msg + ", ".join(missing_fields)})
+            raise ValidationError({"Avatax": error_msg + ", ".join(missing_fields)})
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -433,7 +433,7 @@ class AvataxPlugin(BasePlugin):
 
         if plugin_configuration.active and missing_fields:
             error_msg = (
-                "To enable a plugin you need to provide missing value for the fields: "
+                "To enable a plugin, you need to provide values for the following fields: "
             )
             raise ValidationError({"active": error_msg + ", ".join(missing_fields)})
 

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Union
 from urllib.parse import urljoin
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.utils.translation import pgettext_lazy
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
@@ -30,6 +31,7 @@ from .tasks import api_post_request_task
 if TYPE_CHECKING:
     from ....checkout.models import Checkout, CheckoutLine
     from ....order.models import Order, OrderLine
+    from ...models import PluginConfiguration
 
 logger = logging.getLogger(__name__)
 
@@ -417,6 +419,23 @@ class AvataxPlugin(BasePlugin):
         if not self.active:
             return previous_value
         return True
+
+    @classmethod
+    def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
+        """Validate if provided configuration is correct."""
+        missing_fields = []
+        configuration = plugin_configuration.configuration
+        configuration = {item["name"]: item["value"] for item in configuration}
+        if not configuration["Username or account"]:
+            missing_fields.append("Username or account")
+        if not configuration["Password or license"]:
+            missing_fields.append("Password or license")
+
+        if plugin_configuration.active and missing_fields:
+            error_msg = (
+                "To enable a plugin you need to provide missing value for the fields: "
+            )
+            raise ValidationError({"active": error_msg + ", ".join(missing_fields)})
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/extensions/plugins/vatlayer/plugin.py
+++ b/saleor/extensions/plugins/vatlayer/plugin.py
@@ -327,7 +327,7 @@ class VatlayerPlugin(BasePlugin):
         """Validate if provided configuration is correct."""
         if not settings.VATLAYER_ACCESS_KEY and plugin_configuration.active:
             raise ValidationError(
-                "Cannot be enabled without provided " "'settings.VATLAYER_ACCESS_KEY'"
+                "Cannot be enabled without provided 'settings.VATLAYER_ACCESS_KEY'"
             )
 
     @classmethod

--- a/saleor/extensions/plugins/vatlayer/plugin.py
+++ b/saleor/extensions/plugins/vatlayer/plugin.py
@@ -328,7 +328,7 @@ class VatlayerPlugin(BasePlugin):
         if not settings.VATLAYER_ACCESS_KEY and plugin_configuration.active:
             raise ValidationError(
                 {
-                    "active": "Cannot be enabled without provided "
+                    "Vatlayer": "Cannot be enabled without provided "
                     "'settings.VATLAYER_ACCESS_KEY'"
                 }
             )

--- a/saleor/extensions/plugins/vatlayer/plugin.py
+++ b/saleor/extensions/plugins/vatlayer/plugin.py
@@ -327,10 +327,7 @@ class VatlayerPlugin(BasePlugin):
         """Validate if provided configuration is correct."""
         if not settings.VATLAYER_ACCESS_KEY and plugin_configuration.active:
             raise ValidationError(
-                {
-                    "Vatlayer": "Cannot be enabled without provided "
-                    "'settings.VATLAYER_ACCESS_KEY'"
-                }
+                "Cannot be enabled without provided " "'settings.VATLAYER_ACCESS_KEY'"
             )
 
     @classmethod

--- a/saleor/extensions/plugins/vatlayer/plugin.py
+++ b/saleor/extensions/plugins/vatlayer/plugin.py
@@ -2,6 +2,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, List, Union
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django_countries.fields import Country
 from django_prices_vatlayer.utils import get_tax_rate_types
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
     from ....product.models import Product
     from ....account.models import Address
     from ....order.models import OrderLine, Order
+    from ...models import PluginConfiguration
 
 
 class VatlayerPlugin(BasePlugin):
@@ -319,6 +321,17 @@ class VatlayerPlugin(BasePlugin):
         rate_name = self.__get_tax_code_from_object_meta(obj).code
         tax = taxes.get(rate_name) or taxes.get(DEFAULT_TAX_RATE_NAME)
         return Decimal(tax["value"])
+
+    @classmethod
+    def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
+        """Validate if provided configuration is correct."""
+        if not settings.VATLAYER_ACCESS_KEY and plugin_configuration.active:
+            raise ValidationError(
+                {
+                    "active": "Cannot be enabled without provided "
+                    "'settings.VATLAYER_ACCESS_KEY'"
+                }
+            )
 
     @classmethod
     def _get_default_configuration(cls):

--- a/tests/extensions/plugins/test_vatlayer.py
+++ b/tests/extensions/plugins/test_vatlayer.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock
 from urllib.parse import urlparse
 
 import pytest
-from django.core.exceptions import ImproperlyConfigured
+from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.urls import reverse
 from django_countries.fields import Country
 from django_prices_vatlayer.models import VAT
@@ -531,6 +531,14 @@ def test_save_plugin_configuration(vatlayer, settings):
 
     configuration.refresh_from_db()
     assert not configuration.active
+
+
+def test_save_plugin_configuration_cannot_be_enabled_without_config(settings):
+    settings.PLUGINS = ["saleor.extensions.plugins.vatlayer.plugin.VatlayerPlugin"]
+    manager = get_extensions_manager()
+    manager.get_plugin_configuration("Vatlayer")
+    with pytest.raises(ValidationError):
+        manager.save_plugin_configuration("Vatlayer", {"active": True})
 
 
 def test_show_taxes_on_storefront(vatlayer, settings):


### PR DESCRIPTION
Add new method to `BasePlugin` - `validate_plugin_configuration`. Manager will run it before saving new changes. If validation fails, it will raise `ValidationError` and will return error_msg over API.