### PR TITLE
Add method to BasePlugin to hide secret content

### DIFF
--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -169,12 +169,17 @@ class BasePlugin:
         if plugin_configuration.configuration:
             # Let's add a translated descriptions and labels
             cls._append_config_structure(plugin_configuration.configuration)
+            cls._hide_secret_configuration_fields(plugin_configuration.configuration)
         return plugin_configuration
 
     @classmethod
     def _get_default_configuration(cls):
         defaults = None
         return defaults
+
+    @classmethod
+    def _hide_secret_configuration_fields(cls, configuration: List[dict]):
+        return
 
     @classmethod
     def _append_config_structure(cls, configuration):
@@ -195,4 +200,5 @@ class BasePlugin:
         if configuration.configuration:
             # Let's add a translated descriptions and labels
             cls._append_config_structure(configuration.configuration)
+            cls._hide_secret_configuration_fields(configuration.configuration)
         return configuration

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -439,6 +439,13 @@ class AvataxPlugin(BasePlugin):
             raise ValidationError(error_msg + ", ".join(missing_fields))
 
     @classmethod
+    def _hide_secret_configuration_fields(cls, configuration):
+        for field in configuration:
+            if field.get("name") == "Password or license" and field.get("value"):
+                # We don't want to share our secret data
+                field["value"] = "*" * 6
+
+    @classmethod
     def _get_default_configuration(cls):
         defaults = {
             "name": cls.PLUGIN_NAME,


### PR DESCRIPTION
Some fields shouldn't be visible. Each plugin needs to handle it.
This PR adds a method to `BasePlugin` which will be used to hide secret content.