### PR TITLE
Product.availability and ProductVariant.availability have incorrect deprecation message #4320

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -125,7 +125,7 @@ class BasePricingInfo(graphene.ObjectType):
         description="Whether it is in stock and visible or not.",
         deprecation_reason=(
             "DEPRECATED: Will be removed in Saleor 2.10, "
-            "this has been moved to the parent type as 'is_available'."
+            "this has been moved to the parent type as 'isAvailable'."
         ),
     )
     on_sale = graphene.Boolean(description="Whether it is in sale or not.")
@@ -192,7 +192,7 @@ class ProductVariant(CountableDjangoObjectType, MetadataObjectType):
         description="Price of the product variant.",
         deprecation_reason=(
             "DEPRECATED: Will be removed in Saleor 2.10, "
-            "has been replaced by 'pricing.price_undiscounted'"
+            "has been replaced by 'pricing.priceUndiscounted'"
         ),
     )
     availability = graphene.Field(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2664,7 +2664,7 @@ enum ProductOrderField {
 }
 
 type ProductPricingInfo {
-  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'is_available'.")
+  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney
@@ -2816,7 +2816,7 @@ type ProductVariant implements Node {
   meta: [MetaStore]!
   stockQuantity: Int!
   priceOverride: Money
-  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'pricing.price_undiscounted'")
+  price: Money @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been replaced by 'pricing.priceUndiscounted'")
   availability: VariantPricingInfo @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, has been renamed to 'pricing'.")
   pricing: VariantPricingInfo
   isAvailable: Boolean
@@ -3565,7 +3565,7 @@ type VariantImageUnassign {
 }
 
 type VariantPricingInfo {
-  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'is_available'.")
+  available: Boolean @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, this has been moved to the parent type as 'isAvailable'.")
   onSale: Boolean
   discount: TaxedMoney
   discountLocalCurrency: TaxedMoney


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->
Product.availability and ProductVariant.availability have incorrect deprecation message #4320

Update products.py #4601
Previous attempt at pulling failed. Since last previous pull attempt I have updated the schema and used black to format code-style on changed files.
### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
