### PR TITLE
Account address create mutation doesn't return user data.

### DIFF
--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -174,11 +174,11 @@ class AccountAddressCreate(ModelMutation):
     def perform_mutation(cls, root, info, **data):
         success_response = super().perform_mutation(root, info, **data)
         address_type = data.get("type", None)
+        user = info.context.user
+        success_response.user = user
         if address_type:
-            user = info.context.user
             instance = success_response.address
             utils.change_user_default_address(user, instance, address_type)
-            success_response.user = user
         return success_response
 
     @classmethod

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -2312,6 +2312,9 @@ mutation($addressInput: AddressInput!, $addressType: AddressTypeEnum) {
         id,
         city
     }
+    user {
+        email
+    }
   }
 }
 """
@@ -2339,6 +2342,15 @@ def test_customer_create_address(
 
     user.refresh_from_db()
     assert user.addresses.count() == nr_of_addresses + 1
+
+
+def test_account_address_create_return_user(user_api_client, graphql_address_data):
+    user = user_api_client.user
+    variables = {"addressInput": graphql_address_data}
+    response = user_api_client.post_graphql(ACCOUNT_ADDRESS_CREATE_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["accountAddressCreate"]["user"]
+    assert data["email"] == user.email
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because account address create mutation without type doesn't return user data.
 
<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
