### PR TITLE
Bulk variant create in graphql API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed the inability of filtering attributes using `inCategory` and `inCollection` and deprecated those fields to use `filter { inCollection: ..., inCategory: ... }` instead - #4700 by @NyanKiyoshi & @khalibloo
 - Fixed internal error when updating or creating a sale with missing required values - #4778 by @NyanKiyoshi
 - Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
+- Added product variant bulk create mutation - #4735 by @fowczarek
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed internal error when updating or creating a sale with missing required values - #4778 by @NyanKiyoshi
 - Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
 - Added product variant bulk create mutation - #4735 by @fowczarek
+- Added product variant bulk create mutation - #4749 by @fowczarek
 
 ## 2.8.0
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -100,7 +100,7 @@ class SetPassword(CreateToken):
     def handle_typed_errors(cls, errors: list):
         account_errors = [
             AccountError(field=e.field, message=e.message, code=code)
-            for e, code, _ in errors
+            for e, code, _params in errors
         ]
         return cls(errors=[e[0] for e in errors], account_errors=account_errors)
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -100,7 +100,7 @@ class SetPassword(CreateToken):
     def handle_typed_errors(cls, errors: list):
         account_errors = [
             AccountError(field=e.field, message=e.message, code=code)
-            for e, code in errors
+            for e, code, _ in errors
         ]
         return cls(errors=[e[0] for e in errors], account_errors=account_errors)
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -66,13 +66,18 @@ def validation_error_to_error_type(validation_error: ValidationError) -> list:
                     (
                         Error(field=field, message=err.messages[0]),
                         get_error_code_from_error(err),
+                        err.params,
                     )
                 )
     else:
         # convert non-field errors
         for err in validation_error.error_list:
             err_list.append(
-                (Error(message=err.messages[0]), get_error_code_from_error(err))
+                (
+                    Error(message=err.messages[0]),
+                    get_error_code_from_error(err),
+                    err.params,
+                )
             )
     return err_list
 
@@ -295,7 +300,7 @@ class BaseMutation(graphene.Mutation):
         ):
             typed_errors = [
                 cls._meta.error_type_class(field=e.field, message=e.message, code=code)
-                for e, code in errors
+                for e, code, _ in errors
             ]
             extra.update({cls._meta.error_type_field: typed_errors})
         return cls(errors=[e[0] for e in errors], **extra)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -300,7 +300,7 @@ class BaseMutation(graphene.Mutation):
         ):
             typed_errors = [
                 cls._meta.error_type_class(field=e.field, message=e.message, code=code)
-                for e, code, _ in errors
+                for e, code, _params in errors
             ]
             extra.update({cls._meta.error_type_field: typed_errors})
         return cls(errors=[e[0] for e in errors], **extra)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -336,7 +336,7 @@ class ModelMutation(BaseMutation):
         cls._update_mutation_arguments_and_fields(arguments=arguments, fields=fields)
 
     @classmethod
-    def clean_input(cls, info, instance, data):
+    def clean_input(cls, info, instance, data, input_cls=None):
         """Clean input data received from mutation arguments.
 
         Fields containing IDs or lists of IDs are automatically resolved into
@@ -366,7 +366,8 @@ class ModelMutation(BaseMutation):
                 return field.type.of_type == Upload
             return field.type == Upload
 
-        input_cls = getattr(cls.Arguments, "input")
+        if not input_cls:
+            input_cls = getattr(cls.Arguments, "input")
         cleaned_input = {}
 
         for field_name, field_item in input_cls._meta.fields.items():

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -60,7 +60,7 @@ class ProductError(Error):
 
 class BulkProductError(ProductError):
     index = graphene.Int(
-        description="Index of an input list item that caused the error"
+        description="Index of an input list item that caused the error."
     )
 
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -59,7 +59,9 @@ class ProductError(Error):
 
 
 class BulkProductError(ProductError):
-    index = graphene.Int(description="Input list index with error")
+    index = graphene.Int(
+        description="Index of an input list item that caused the error"
+    )
 
 
 class ShopError(Error):

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -58,6 +58,10 @@ class ProductError(Error):
     code = ProductErrorCode(description="The error code.")
 
 
+class BulkProductError(ProductError):
+    index = graphene.Int(description="Input list index with error")
+
+
 class ShopError(Error):
     code = ShopErrorCode(description="The error code.")
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -119,7 +119,7 @@ class ProductVariantBulkCreate(BaseMutation):
             description="Input list of product variants to create.",
         )
         product_id = graphene.ID(
-            description="ID of the product to create the variants for",
+            description="ID of the product to create the variants for.",
             name="product",
             required=True,
         )

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -125,9 +125,7 @@ class ProductVariantBulkCreate(ModelMutation):
         return attributes
 
     @classmethod
-    def clean_input(
-        cls, info, instance: models.ProductVariant, data: dict, product_type
-    ):
+    def clean_input(cls, info, instance: models.ProductVariant, data: dict):
         cleaned_input = super().clean_input(
             info, instance, data, ProductVariantBulkCreateInput
         )
@@ -148,7 +146,7 @@ class ProductVariantBulkCreate(ModelMutation):
         if attributes:
             try:
                 cleaned_input["attributes"] = cls.clean_attributes(
-                    attributes, product_type
+                    attributes, data["product_type"]
                 )
             except ValidationError as exc:
                 raise ValidationError({"attributes": exc})
@@ -185,9 +183,8 @@ class ProductVariantBulkCreate(ModelMutation):
         for variant_data in data.get("input"):
             try:
                 instance = cls.get_instance(info, **variant_data)
-                cleaned_input = cls.clean_input(
-                    info, instance, variant_data, product_type
-                )
+                variant_data["product_type"] = product_type
+                cleaned_input = cls.clean_input(info, instance, variant_data)
                 cleaned_input["product"] = product
                 instance = cls.construct_instance(instance, cleaned_input)
                 cls.clean_instance(instance)

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -93,7 +93,11 @@ class ProductVariantBulkCreateInput(ProductVariantInput):
 
 
 class ProductVariantBulkCreate(ModelMutation):
-    count = graphene.Int(description="Returns how many objects were affected.")
+    count = graphene.Int(
+        required=True,
+        default_value=0,
+        description="Returns how many objects were affected.",
+    )
 
     class Arguments:
         input = graphene.List(

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -109,7 +109,7 @@ class ProductVariantBulkCreate(BaseMutation):
     )
 
     class Arguments:
-        input = graphene.List(
+        variants = graphene.List(
             ProductVariantBulkCreateInput,
             required=True,
             description="Fields required to create a product variants.",
@@ -191,7 +191,7 @@ class ProductVariantBulkCreate(BaseMutation):
         cleaned_inputs = []
         sku_list = []
         product_type = product.product_type
-        for variant_data in data.get("input"):
+        for variant_data in data.get("variants"):
             try:
                 instance = models.ProductVariant()
                 variant_data["product_type"] = product_type
@@ -210,9 +210,7 @@ class ProductVariantBulkCreate(BaseMutation):
                     sku_list.append(sku)
                 else:
                     errors["sku"].append(
-                        ValidationError(
-                            "Duplicated SKU.", ProductErrorCode.ALREADY_EXISTS
-                        )
+                        ValidationError("Duplicated SKU.", ProductErrorCode.UNIQUE)
                     )
         if not errors:
             cls.save_instances(info, instances, cleaned_inputs)

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -21,6 +21,7 @@ from .bulk_mutations.products import (
     ProductBulkPublish,
     ProductImageBulkDelete,
     ProductTypeBulkDelete,
+    ProductVariantBulkCreate,
     ProductVariantBulkDelete,
 )
 from .enums import StockAvailability
@@ -400,6 +401,7 @@ class ProductMutations(graphene.ObjectType):
 
     product_variant_create = ProductVariantCreate.Field()
     product_variant_delete = ProductVariantDelete.Field()
+    product_variant_bulk_create = ProductVariantBulkCreate.Field()
     product_variant_bulk_delete = ProductVariantBulkDelete.Field()
     product_variant_update = ProductVariantUpdate.Field()
     product_variant_translate = ProductVariantTranslate.Field()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3184,7 +3184,7 @@ type ProductVariant implements Node {
 type ProductVariantBulkCreate {
   errors: [Error!]
   count: Int!
-  productVariants: [ProductVariant]!
+  productVariants: [ProductVariant!]!
   bulkProductErrors: [BulkProductError!]
 }
 
@@ -3192,7 +3192,7 @@ input ProductVariantBulkCreateInput {
   attributes: [AttributeValueInput]!
   costPrice: Decimal
   priceOverride: Decimal
-  sku: String
+  sku: String!
   quantity: Int
   trackInventory: Boolean
   weight: WeightScalar

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -463,6 +463,13 @@ enum AuthorizationKeyType {
   GOOGLE_OAUTH2
 }
 
+type BulkProductError {
+  field: String
+  message: String
+  code: ProductErrorCode
+  index: Int
+}
+
 input CatalogueInput {
   products: [ID]
   categories: [ID]
@@ -2068,6 +2075,7 @@ type Mutations {
   digitalContentUrlCreate(input: DigitalContentUrlCreateInput!): DigitalContentUrlCreate
   productVariantCreate(input: ProductVariantCreateInput!): ProductVariantCreate
   productVariantDelete(id: ID!): ProductVariantDelete
+  productVariantBulkCreate(product: ID!, variants: [ProductVariantBulkCreateInput]!): ProductVariantBulkCreate
   productVariantBulkDelete(ids: [ID]!): ProductVariantBulkDelete
   productVariantUpdate(id: ID!, input: ProductVariantInput!): ProductVariantUpdate
   productVariantTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): ProductVariantTranslate
@@ -3171,6 +3179,23 @@ type ProductVariant implements Node {
   images: [ProductImage]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
+}
+
+type ProductVariantBulkCreate {
+  errors: [Error!]
+  count: Int!
+  productVariants: [ProductVariant]!
+  bulkProductErrors: [BulkProductError!]
+}
+
+input ProductVariantBulkCreateInput {
+  attributes: [AttributeValueInput]!
+  costPrice: Decimal
+  priceOverride: Decimal
+  sku: String
+  quantity: Int
+  trackInventory: Boolean
+  weight: WeightScalar
 }
 
 type ProductVariantBulkDelete {


### PR DESCRIPTION
I want to merge this change because we need to add a mutation that will create multiple variants in one batch. Specs for the mutation:

```
productVariantBulkCreate(productId: ID!, variants: [ProductVariantCreateInput!]): ProductVariantBulkCreate

type ProductVariantBulkCreate {
  count: Int!
  errors: [Error!]
}
```


<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
