### PR TITLE
Delete checkout lines by setting the quantity to zero

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -92,7 +92,7 @@ def update_checkout_shipping_method_if_invalid(checkout: models.Checkout, discou
 def check_lines_quantity(variants, quantities):
     """Check if stock is sufficient for each line in the list of dicts."""
     for variant, quantity in zip(variants, quantities):
-        if quantity < 1:
+        if quantity < 0:
             raise ValidationError(
                 {
                     "quantity": ValidationError(


### PR DESCRIPTION
This PR allows removing checkout lines by setting the quantity to zero:

```graphql
mutation {
  checkoutLinesUpdate(
    checkoutId: "abc"
    lines: [{ variantId: "xyz", quantity: 0 }]
  ) {
    ...
  }
}

```

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
