### PR TITLE
Add 3D secure require flag to braintree plugin dynamic configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Refactored the backend side of `checkoutCreate` to improve performances and prevent side effects over the user's checkout if the checkout creation was to fail. - #4367 by @NyanKiyoshi
 - Refactored the logic of cleaning the checkout shipping method over the API, so users do not lose the shipping method when updating their checkout. If the shipping method becomes invalid, it will be replaced by the cheapest available. - #4367 by @NyanKiyoshi & @szewczykmira
 - Refactored process of getting available shipping methods to make it easier to understand and prevent human-made errors. - #4367 by @NyanKiyoshi
+- Moved 3D secure option to Braintree plugin configuration and update config structure mechanism - #4751 by @salwator
 
 ## 2.7.0
 

--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -245,6 +245,7 @@ class BasePlugin:
         update_values = [copy(k) for k in default_config if k["name"] in missing_keys]
         config.extend(update_values)
 
+        configuration.configuration = config
         configuration.save(update_fields=["configuration"])
 
     @classmethod

--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -241,8 +241,15 @@ class BasePlugin:
         if not missing_keys:
             return
 
-        default_config = cls._get_default_configuration()["configuration"]
-        update_values = [copy(k) for k in default_config if k["name"] in missing_keys]
+        default_config = cls._get_default_configuration()
+        if not default_config:
+            return
+
+        update_values = [
+            copy(k)
+            for k in default_config["configuration"]
+            if k["name"] in missing_keys
+        ]
         config.extend(update_values)
 
         configuration.configuration = config

--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -16,9 +16,6 @@ from ...interface import (
 from .errors import DEFAULT_ERROR_MESSAGE, BraintreeException
 from .forms import BraintreePaymentForm
 
-# FIXME: Move to SiteSettings
-THREE_D_SECURE_REQUIRED = False
-
 # Error codes whitelist should be a dict of code: error_msg_override
 # if no error_msg_override is provided,
 # then error message returned by the gateway will be used
@@ -170,7 +167,7 @@ def transaction_for_new_customer(
             "options": {
                 "submit_for_settlement": config.auto_capture,
                 "store_in_vault_on_success": payment_information.reuse_source,
-                "three_d_secure": {"required": THREE_D_SECURE_REQUIRED},
+                "three_d_secure": {"required": config.require_3d_secure},
             },
             **get_customer_data(payment_information),
         }

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -84,6 +84,14 @@ class BraintreeGatewayPlugin(BasePlugin):
             ),
             "label": pgettext_lazy("Plugin label", "Automatic payment capture"),
         },
+        "Require 3D secure": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": pgettext_lazy(
+                "Plugin help text",
+                "Determines if Saleor should enforce 3D secure during payment.",
+            ),
+            "label": pgettext_lazy("Plugin label", "Require 3D secure"),
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -108,6 +116,7 @@ class BraintreeGatewayPlugin(BasePlugin):
                 },
                 template_path="",
                 store_customer=configuration["Store customers card"],
+                require_3d_secure=configuration["Require 3D secure"],
             )
 
     @classmethod
@@ -123,6 +132,7 @@ class BraintreeGatewayPlugin(BasePlugin):
                 {"name": "Merchant ID", "value": ""},
                 {"name": "Store customers card", "value": False},
                 {"name": "Automatic payment capture", "value": True},
+                {"name": "Require 3D secure", "value": False},
             ],
         }
         return defaults

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -91,6 +91,7 @@ class GatewayConfig:
     # a unified structure
     connection_params: Dict[str, Any]
     store_customer: bool = False
+    require_3d_secure: bool = False
 
 
 @dataclass


### PR DESCRIPTION
Flag to force 3D secure on payments in braintree payment gateway implementation is hard-coded.
This PR moves this setting to plugin dynamic configuration.

Additionally, since there was no mechanism for updating plugin config after config structure is changed, I've added additional update function to _BasePlugin_.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
