### PR TITLE
lock django-elasticsearch-dsl to 0.5.0

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -31,7 +31,7 @@ django-storages = {extras = ["google"],version = "*"}
 django-templated-email = ">=2.2.0"
 django-versatileimagefield = ">=1.10"
 django-webpack-loader = ">=0.3.0"
-django-elasticsearch-dsl = ">=0.5.0,<0.6.0"
+django-elasticsearch-dsl = "==0.5.0"
 django-recaptcha = "<2.0.0"
 django-silk = "==2.0.0"
 elasticsearch = "==6.3.1"


### PR DESCRIPTION
I kept getting sub-dependency conflicts with `pipenv lock`. I researched and found that the 0.5.1 release bumped their elasticsearch-dsl dependency to mismatch Saleor's. So I did this locally and pipenv locked.

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
