### PR TITLE
Hide OSError uwsgi errors from log and sentry

### DIFF
--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -11,3 +11,4 @@ static-map = /static=/app/static
 mimefile = /etc/mime.types
 ignore-sigpipe = true
 ignore-write-errors = true
+disable-write-exception=true


### PR DESCRIPTION
Standard changes to hide OSError errors that appears in log file or sentry events