### PR TITLE
Extend payment gateway GraphQL type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
 - Fixed the inability of filtering attributes using `inCategory` and `inCollection` and deprecated those fields to use `filter { inCollection: ..., inCategory: ... }` instead - #4700 by @NyanKiyoshi & @khalibloo
 - Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
+- Fixed internal error when updating or creating a sale with missing required values - #4778 by @NyanKiyoshi
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added product variant bulk create mutation - #4735 by @fowczarek
 - Added product variant bulk create mutation - #4749 by @fowczarek
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
-- Fixed the inability of filtering attributes using `inCategory` and `inCollection` and deprecated those fields to use `filter { inCollection: ..., inCategory: ... }` instead - #4700 by @NyanKiyoshi & @khalibloo
-- Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
-- Fixed internal error when updating or creating a sale with missing required values - #4778 by @NyanKiyoshi
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added product variant bulk create mutation - #4749 by @fowczarek
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
 - Fixed the inability of filtering attributes using `inCategory` and `inCollection` and deprecated those fields to use `filter { inCollection: ..., inCategory: ... }` instead - #4700 by @NyanKiyoshi & @khalibloo
+- Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed the internal error filtering pages by URL in the dashboard 1.0 - #4776 by @NyanKiyoshi
 - Added product variant bulk create mutation - #4735 by @fowczarek
 - Added product variant bulk create mutation - #4749 by @fowczarek
+- availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
 
 ## 2.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added product variant bulk create mutation - #4735 by @fowczarek
 - Added product variant bulk create mutation - #4749 by @fowczarek
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
+- Fixed the inability of filtering attributes using `inCategory` and `inCollection` and deprecated those fields to use `filter { inCollection: ..., inCategory: ... }` instead - #4700 by @NyanKiyoshi & @khalibloo
 
 ## 2.8.0
 

--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -195,6 +195,9 @@ class BasePlugin:
     def get_payment_template(self, previous_value):
         return NotImplemented
 
+    def get_payment_config(self, previous_value):
+        return NotImplemented
+
     @classmethod
     def _update_config_items(
         cls, configuration_to_update: List[dict], current_config: List[dict]

--- a/saleor/extensions/manager.py
+++ b/saleor/extensions/manager.py
@@ -263,10 +263,13 @@ class ExtensionsManager(PaymentInterface):
             )
         raise Exception(f"Payment plugin {gateway} is inaccessible!")
 
-    def list_payment_gateways(self) -> List[str]:
+    def list_payment_gateways(self) -> List[dict]:
         payment_method = "process_payment"
         return [
-            plugin.PLUGIN_NAME
+            {
+                "name": plugin.PLUGIN_NAME,
+                "config": self.__get_payment_config(plugin.PLUGIN_NAME),
+            }
             for plugin in self.plugins
             if payment_method in type(plugin).__dict__
             and self.get_plugin_configuration(plugin.PLUGIN_NAME).active
@@ -275,6 +278,12 @@ class ExtensionsManager(PaymentInterface):
     def get_payment_template(self, gateway: str) -> str:
         method_name = "get_payment_template"
         default_value = None
+        gtw = self.get_plugin(gateway)
+        return self.__run_method_on_single_plugin(gtw, method_name, default_value)
+
+    def __get_payment_config(self, gateway: str) -> List[dict]:
+        method_name = "get_payment_config"
+        default_value = []
         gtw = self.get_plugin(gateway)
         return self.__run_method_on_single_plugin(gtw, method_name, default_value)
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -15,12 +15,12 @@ from ..shipping.types import ShippingMethod
 
 
 class GatewayConfigLine(graphene.ObjectType):
-    field = graphene.String(required=True, description="Gateway config key")
-    value = graphene.String(description="Gateway config value for key")
+    field = graphene.String(required=True, description="Gateway config key.")
+    value = graphene.String(description="Gateway config value for key.")
 
 
 class PaymentGateway(graphene.ObjectType):
-    name = graphene.String(required=True, description="Payment gateway name")
+    name = graphene.String(required=True, description="Payment gateway name.")
     config = graphene.List(graphene.NonNull(GatewayConfigLine), required=True)
 
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -18,10 +18,23 @@ class GatewayConfigLine(graphene.ObjectType):
     field = graphene.String(required=True, description="Gateway config key.")
     value = graphene.String(description="Gateway config value for key.")
 
+    class Meta:
+        description = "Payment gateway client configuration key and value pair."
+
 
 class PaymentGateway(graphene.ObjectType):
     name = graphene.String(required=True, description="Payment gateway name.")
-    config = graphene.List(graphene.NonNull(GatewayConfigLine), required=True)
+    config = graphene.List(
+        graphene.NonNull(GatewayConfigLine),
+        required=True,
+        description="Payment gateway client configuration.",
+    )
+
+    class Meta:
+        description = (
+            "Available payment gateway backend with configuration "
+            "necessary to setup client."
+        )
 
 
 class CheckoutLine(CountableDjangoObjectType):

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -167,10 +167,7 @@ class Checkout(MetadataObjectType, CountableDjangoObjectType):
 
     @staticmethod
     def resolve_available_payment_gateways(_: models.Checkout, _info):
-        return [
-            {"name": gtw, "config": []}
-            for gtw in get_extensions_manager().list_payment_gateways()
-        ]
+        return [gtw for gtw in get_extensions_manager().list_payment_gateways()]
 
     @staticmethod
     def resolve_gift_cards(root: models.Checkout, _info):

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -19,6 +19,10 @@ class PaymentQueries(graphene.ObjectType):
     payment_client_token = graphene.Field(
         graphene.String,
         gateway=graphene.String(required=True, description="A payment gateway."),
+        deprecation_reason=(
+            "DEPRECATED: Will be removed in Saleor 2.10, "
+            "use payment gateway config instead in availablePaymentGateways."
+        ),
     )
 
     @permission_required("order.manage_orders")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -604,7 +604,7 @@ type Checkout implements Node {
   privateMeta: [MetaStore]!
   meta: [MetaStore]!
   availableShippingMethods: [ShippingMethod]!
-  availablePaymentGateways: [String]!
+  availablePaymentGateways: [PaymentGateway]!
   email: String!
   isShippingRequired: Boolean!
   lines: [CheckoutLine]
@@ -1608,6 +1608,11 @@ type FulfillmentUpdateTracking {
 input FulfillmentUpdateTrackingInput {
   trackingNumber: String
   notifyCustomer: Boolean
+}
+
+type GatewayConfigLine {
+  field: String!
+  value: String
 }
 
 scalar GenericScalar
@@ -2687,6 +2692,11 @@ enum PaymentErrorCode {
   PAYMENT_ERROR
   REQUIRED
   UNIQUE
+}
+
+type PaymentGateway {
+  name: String!
+  config: [GatewayConfigLine!]!
 }
 
 input PaymentInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3323,7 +3323,7 @@ type Query {
   reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment
   payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection
-  paymentClientToken(gateway: String!): String
+  paymentClientToken(gateway: String!): String @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.10, use payment gateway config instead in availablePaymentGateways.")
   page(id: ID, slug: String): Page
   pages(query: String, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection

--- a/saleor/order/forms.py
+++ b/saleor/order/forms.py
@@ -10,7 +10,10 @@ from .models import Order
 
 
 def get_gateways():
-    gateways = [(gtw, gtw.capitalize() + " gateway") for gtw in gateway.list_gateways()]
+    gateways = [
+        (gtw["name"], gtw["name"].capitalize() + " gateway")
+        for gtw in gateway.list_gateways()
+    ]
     return gateways
 
 

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -204,7 +204,7 @@ def get_client_token(gateway: str, customer_id: str = None) -> str:
     return plugin_manager.get_client_token(gateway, token_config)
 
 
-def list_gateways() -> List[str]:
+def list_gateways() -> List[dict]:
     return get_extensions_manager().list_payment_gateways()
 
 

--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import braintree as braintree_sdk
 from django.core.exceptions import ImproperlyConfigured
@@ -111,7 +111,9 @@ def get_braintree_gateway(sandbox_mode, merchant_id, public_key, private_key):
     return gateway
 
 
-def get_client_token(config: GatewayConfig, token_config: TokenConfig = None) -> str:
+def get_client_token(
+    config: GatewayConfig, token_config: Optional[TokenConfig] = None
+) -> str:
     gateway = get_braintree_gateway(**config.connection_params)
     if not token_config:
         return gateway.client_token.generate()

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -103,7 +103,12 @@ class BraintreeGatewayPlugin(BasePlugin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.config = None
+        self.config = GatewayConfig(
+            gateway_name=GATEWAY_NAME,
+            auto_capture=True,
+            template_path="",
+            connection_params={},
+        )
 
     def _initialize_plugin_configuration(self):
         super()._initialize_plugin_configuration()
@@ -145,7 +150,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         }
         return defaults
 
-    def _get_gateway_config(self):
+    def _get_gateway_config(self) -> GatewayConfig:
         return self.config
 
     @require_active_plugin
@@ -199,3 +204,11 @@ class BraintreeGatewayPlugin(BasePlugin):
     @require_active_plugin
     def get_payment_template(self, previous_value) -> str:
         return self._get_gateway_config().template_path
+
+    @require_active_plugin
+    def get_payment_config(self, previous_value):
+        config = self._get_gateway_config()
+        return [
+            {"field": "store_customer_card", "value": config.store_customer},
+            {"field": "client_token", "value": get_client_token(config=config)},
+        ]

--- a/saleor/payment/gateways/dummy/plugin.py
+++ b/saleor/payment/gateways/dummy/plugin.py
@@ -154,3 +154,8 @@ class DummyGatewayPlugin(BasePlugin):
     @require_active_plugin
     def get_payment_template(self, previous_value) -> str:
         return self._get_gateway_config().template_path
+
+    @require_active_plugin
+    def get_payment_config(self, previous_value):
+        config = self._get_gateway_config()
+        return [{"field": "store_customer_card", "value": config.store_customer}]

--- a/saleor/payment/gateways/stripe/__init__.py
+++ b/saleor/payment/gateways/stripe/__init__.py
@@ -181,7 +181,7 @@ def process_payment(
 
 
 def _get_client(**connection_params):
-    stripe.api_key = connection_params.get("secret_key")
+    stripe.api_key = connection_params.get("private_key")
     return stripe
 
 

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -138,9 +138,18 @@ class StripeGatewayPlugin(BasePlugin):
     ) -> "GatewayResponse":
         return process_payment(payment_information, self._get_gateway_config())
 
+    @require_active_plugin
     def list_payment_sources(
         self, customer_id: str, previous_value
     ) -> List["CustomerSource"]:
         sources = list_client_sources(self._get_gateway_config(), customer_id)
         previous_value.extend(sources)
         return previous_value
+
+    @require_active_plugin
+    def get_payment_config(self, previous_value):
+        config = self._get_gateway_config()
+        return [
+            {"field": "api_key", "value": config.connection_params["public_key"]},
+            {"field": "store_customer_card", "value": config.store_customer},
+        ]

--- a/tests/api/benchmark/test_checkout.py
+++ b/tests/api/benchmark/test_checkout.py
@@ -134,7 +134,6 @@ def test_create_checkout(api_client, graphql_address_data, variant, count_querie
         }
 
         fragment Checkout on Checkout {
-          availablePaymentGateways
           token
           id
           user {
@@ -275,7 +274,6 @@ def test_add_shipping_to_checkout(
         }
 
         fragment Checkout on Checkout {
-          availablePaymentGateways
           token
           id
           user {
@@ -409,7 +407,6 @@ def test_add_billing_address_to_checkout(
         }
 
         fragment Checkout on Checkout {
-          availablePaymentGateways
           token
           id
           user {

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -379,11 +379,27 @@ def test_checkout_create_check_lines_quantity(
     assert data["errors"][0]["field"] == "quantity"
 
 
-def test_checkout_available_payment_gateways(api_client, checkout_with_item):
+@pytest.fixture
+def expected_dummy_gateway():
+    return {
+        "name": "Dummy",
+        "config": [{"field": "store_customer_card", "value": False}],
+    }
+
+
+def test_checkout_available_payment_gateways(
+    api_client, checkout_with_item, expected_dummy_gateway
+):
     query = """
     query getCheckout($token: UUID!) {
         checkout(token: $token) {
-           availablePaymentGateways
+           availablePaymentGateways {
+               name
+               config {
+                   field
+                   value
+               }
+           }
         }
     }
     """
@@ -391,7 +407,7 @@ def test_checkout_available_payment_gateways(api_client, checkout_with_item):
     response = api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
-    assert data["availablePaymentGateways"] == ["Dummy"]
+    assert data["availablePaymentGateways"] == [expected_dummy_gateway]
 
 
 def test_checkout_available_shipping_methods(

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -383,7 +383,7 @@ def test_checkout_create_check_lines_quantity(
 def expected_dummy_gateway():
     return {
         "name": "Dummy",
-        "config": [{"field": "store_customer_card", "value": False}],
+        "config": [{"field": "store_customer_card", "value": "false"}],
     }
 
 

--- a/tests/extensions/test_manager.py
+++ b/tests/extensions/test_manager.py
@@ -373,6 +373,7 @@ def test_plugin_add_new_configuration(
 
 
 class ActivePaymentGateway(BasePlugin):
+    CLIENT_CONFIG = [{"field": "foo", "value": "bar"}]
     PLUGIN_NAME = "braintree"
 
     @classmethod
@@ -387,6 +388,9 @@ class ActivePaymentGateway(BasePlugin):
 
     def process_payment(self, payment_information, previous_value):
         pass
+
+    def get_payment_config(self, previous_value):
+        return self.CLIENT_CONFIG
 
 
 class InactivePaymentGateway(BasePlugin):
@@ -407,10 +411,14 @@ class InactivePaymentGateway(BasePlugin):
 
 
 def test_manager_serve_list_of_payment_gateways():
+    expected_gateway = {
+        "name": ActivePaymentGateway.PLUGIN_NAME,
+        "config": ActivePaymentGateway.CLIENT_CONFIG,
+    }
     plugins = [
         "tests.extensions.test_manager.SamplePlugin",
         "tests.extensions.test_manager.ActivePaymentGateway",
         "tests.extensions.test_manager.InactivePaymentGateway",
     ]
     manager = ExtensionsManager(plugins=plugins)
-    assert manager.list_payment_gateways() == [ActivePaymentGateway.PLUGIN_NAME]
+    assert manager.list_payment_gateways() == [expected_gateway]

--- a/tests/gateway/stripe/test_stripe.py
+++ b/tests/gateway/stripe/test_stripe.py
@@ -40,7 +40,7 @@ def gateway_config():
         template_path="template.html",
         connection_params={
             "public_key": "public",
-            "secret_key": "secret",
+            "private_key": "secret",
             "store_name": "Saleor",
             "store_image": "image.gif",
             "prefill": True,
@@ -57,7 +57,7 @@ def sandbox_gateway_config(gateway_config):
     if RECORD:
         connection_params = {
             "public_key": os.environ.get("STRIPE_PUBLIC_KEY"),
-            "secret_key": os.environ.get("STRIPE_SECRET_KEY"),
+            "private_key": os.environ.get("STRIPE_SECRET_KEY"),
         }
         gateway_config.connection_params.update(connection_params)
     return gateway_config


### PR DESCRIPTION
Fixes #4772 

Roadmap:
- [x] Extend GraphQL schema
- [x] Add new plugin method
- [x] Serve config from gateways:
   - [x] Dummy (sample _store_customer_)
   - [x] Stripe (_api_key_, _store_customer_)
   - [x] Braintree (_client_token_, _store_customer_)
- [x] Align tests and types

### Checklist
1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
