### PR TITLE
Fixed display of tax rate (forms & details) + update of product tax rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added product variant bulk create mutation - #4749 by @fowczarek
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
 - Add metadata to Order model - #4513 by @szewczykmira
+- Fixed display of the products tax rate in the details page of dashboard 1.0, users can now update the tax rate of products in dashboard 1.0. The tax fields will no longer be shown if no tax support is enabled. - #4780 by @NyanKiyoshi
 
 ## 2.8.0
 

--- a/saleor/dashboard/product/forms.py
+++ b/saleor/dashboard/product/forms.py
@@ -253,7 +253,15 @@ class AttributesMixin:
 
 class ProductForm(MoneyModelForm, AttributesMixin):
     tax_rate = forms.ChoiceField(
-        required=False, label=pgettext_lazy("Product tax rate type", "Tax rate")
+        required=False,
+        label=pgettext_lazy("Product tax rate type", "Tax rate"),
+        help_text=pgettext_lazy(
+            "Help text for the tax rate field over the product update/create form",
+            (
+                "Make sure you have enabled a VAT provider and fetched the rates if "
+                "needed by the plugin."
+            ),
+        ),
     )
     category = TreeNodeChoiceField(
         queryset=Category.objects.all(), label=pgettext_lazy("Category", "Category")
@@ -301,9 +309,9 @@ class ProductForm(MoneyModelForm, AttributesMixin):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.manager = manager = get_extensions_manager()
+        self.manager = get_extensions_manager()
         product_type = self.instance.product_type
-        self.initial["tax_rate"] = get_product_tax_rate(self.instance, manager)
+        self.initial["tax_rate"] = get_product_tax_rate(self.instance, self.manager)
         self.available_attributes = product_type.product_attributes.prefetch_related(
             "values"
         ).product_attributes_sorted()
@@ -320,9 +328,15 @@ class ProductForm(MoneyModelForm, AttributesMixin):
         self.fields["seo_title"] = SeoTitleField(
             extra_attrs={"data-bind": self["name"].auto_id}
         )
-        self.fields["tax_rate"].choices = [
-            (tax.code, tax.description) for tax in manager.get_tax_rate_type_choices()
+        tax_rate_field = self.fields["tax_rate"]
+        tax_rate_field.choices = [
+            (tax.code, tax.description)
+            for tax in self.manager.get_tax_rate_type_choices()
         ]
+
+        if not tax_rate_field.choices:
+            tax_rate_field.disabled = True
+
         if include_taxes_in_prices():
             self.fields["price"].label = pgettext_lazy(
                 "Currency gross amount", "Gross price"

--- a/saleor/dashboard/product/utils.py
+++ b/saleor/dashboard/product/utils.py
@@ -1,0 +1,11 @@
+from ...extensions.manager import ExtensionsManager, get_extensions_manager
+from ...product.models import Product
+
+
+def get_product_tax_rate(product: Product, manager: ExtensionsManager = None) -> str:
+    manager = manager or get_extensions_manager()
+    tax_rate = manager.get_tax_code_from_object_meta(product).code
+    tax_rate = (
+        tax_rate or manager.get_tax_code_from_object_meta(product.product_type).code
+    )
+    return tax_rate

--- a/saleor/dashboard/product/views.py
+++ b/saleor/dashboard/product/views.py
@@ -23,6 +23,7 @@ from ...product.utils.costs import get_margin_for_variant, get_product_costs_dat
 from ..views import staff_member_required
 from . import forms
 from .filters import AttributeFilter, ProductFilter, ProductTypeFilter
+from .utils import get_product_tax_rate
 
 
 @staff_member_required
@@ -69,6 +70,7 @@ def product_details(request, pk):
     only_variant = variants.first() if no_variants else None
     ctx = {
         "product": product,
+        "tax_rate_code": get_product_tax_rate(product),
         "sale_price": sale_price,
         "discounted_price": discounted_price,
         "variants": variants,

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -152,7 +152,7 @@
                   {% trans "Pricing" context "Product pricing card header" %}
                 </h5>
                 <h6>
-                  {% if product.charge_taxes %}
+                  {% if product.charge_taxes and tax_rate_code %}
                     {% blocktrans trimmed with tax_rate=tax_rate_code context "Product pricing card header subtitle" %}
                       Taxes are charged ({{ tax_rate }} tax rate)
                     {% endblocktrans %}

--- a/templates/dashboard/product/detail.html
+++ b/templates/dashboard/product/detail.html
@@ -153,7 +153,7 @@
                 </h5>
                 <h6>
                   {% if product.charge_taxes %}
-                    {% blocktrans trimmed with tax_rate=product.tax_rate context "Product pricing card header subtitle" %}
+                    {% blocktrans trimmed with tax_rate=tax_rate_code context "Product pricing card header subtitle" %}
                       Taxes are charged ({{ tax_rate }} tax rate)
                     {% endblocktrans %}
                   {% else %}

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -87,7 +87,9 @@
                   {{ product_form.price|materializecss }}
                 </div>
                 <div class="row">
-                  {{ product_form.tax_rate|materializecss }}
+                  {% if product_form.tax_rate.field.choices %}
+                    {{ product_form.tax_rate|materializecss }}
+                  {% endif %}
                   {{ product_form.charge_taxes|materializecss }}
                 </div>
                 {% if not product.product_type.has_variants %}

--- a/templates/dashboard/product/form.html
+++ b/templates/dashboard/product/form.html
@@ -87,9 +87,7 @@
                   {{ product_form.price|materializecss }}
                 </div>
                 <div class="row">
-                  {% if product_form.tax_rate.field.choices %}
-                    {{ product_form.tax_rate|materializecss }}
-                  {% endif %}
+                  {{ product_form.tax_rate|materializecss }}
                   {{ product_form.charge_taxes|materializecss }}
                 </div>
                 {% if not product.product_type.has_variants %}

--- a/templates/dashboard/product/product_type/form.html
+++ b/templates/dashboard/product/product_type/form.html
@@ -90,16 +90,18 @@
                 </div>
               </div>
             </div>
-            {% if form.tax_rate.field.choices %}
               <div class="row">
                 <div class="col s12">
                   <span class="card-title">{% trans "Taxes" %}</span>
                 </div>
                 <div class="col s12 m8">
-                  {{ form.tax_rate|materializecss }}
+                  {% if form.tax_rate.field.choices %}
+                    {{ form.tax_rate|materializecss }}
+                  {% else %}
+                    {% trans "Tax settings are disabled. Make sure you have enabled a VAT provider and fetched the rates if required by the plugin." context "Note message in product type form when no rates were found" %}
+                  {% endif %}
                 </div>
               </div>
-            {% endif %}
             <div class="row">
               <div class="col s12">
                 <span class="card-title">{% trans "Shipping" %}</span>

--- a/templates/dashboard/product/product_type/form.html
+++ b/templates/dashboard/product/product_type/form.html
@@ -90,14 +90,16 @@
                 </div>
               </div>
             </div>
-            <div class="row">
-              <div class="col s12">
-                <span class="card-title">{% trans "Taxes" %}</span>
+            {% if form.tax_rate.field.choices %}
+              <div class="row">
+                <div class="col s12">
+                  <span class="card-title">{% trans "Taxes" %}</span>
+                </div>
+                <div class="col s12 m8">
+                  {{ form.tax_rate|materializecss }}
+                </div>
               </div>
-              <div class="col s12 m8">
-                {{ form.tax_rate|materializecss }}
-              </div>
-            </div>
+            {% endif %}
             <div class="row">
               <div class="col s12">
                 <span class="card-title">{% trans "Shipping" %}</span>


### PR DESCRIPTION
Closes https://github.com/mirumee/saleor/issues/4635

- No longer display the tax rate field if there is no tax support
- User is now able to change a product's tax rate
- User is now able to see the tax rate of in the product details page

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
