### PR TITLE
Create token for service account by default

### DIFF
--- a/saleor/graphql/account/mutations/service_account.py
+++ b/saleor/graphql/account/mutations/service_account.py
@@ -73,6 +73,10 @@ class ServiceAccountTokenDelete(ModelDeleteMutation):
 
 
 class ServiceAccountCreate(ModelMutation):
+    auth_token = graphene.types.String(
+        description="The newly created authentication token"
+    )
+
     class Arguments:
         input = ServiceAccountInput(
             required=True,
@@ -94,6 +98,17 @@ class ServiceAccountCreate(ModelMutation):
             permissions = cleaned_input.pop("permissions")
             cleaned_input["permissions"] = get_permissions(permissions)
         return cleaned_input
+
+    @classmethod
+    def save(cls, info, instance, cleaned_input):
+        instance.save()
+        instance.tokens.create(name="Default")
+
+    @classmethod
+    def success_response(cls, instance):
+        response = super().success_response(instance)
+        response.auth_token = instance.tokens.get().auth_token
+        return response
 
 
 class ServiceAccountUpdate(ModelMutation):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3478,6 +3478,7 @@ type ServiceAccountCountableEdge {
 
 type ServiceAccountCreate {
   errors: [Error!]
+  authToken: String
   accountErrors: [AccountError!]
   serviceAccount: ServiceAccount
 }

--- a/tests/api/test_account_service_account.py
+++ b/tests/api/test_account_service_account.py
@@ -12,6 +12,7 @@ SERVICE_ACCOUNT_CREATE_MUTATION = """
         serviceAccountCreate(input:
             {name: $name, isActive: $is_active, permissions: $permissions})
         {
+            authToken
             serviceAccount{
                 permissions{
                     code
@@ -50,10 +51,12 @@ def test_service_account_create_mutation(
     response = staff_api_client.post_graphql(query, variables=variables)
     content = get_graphql_content(response)
     service_account_data = content["data"]["serviceAccountCreate"]["serviceAccount"]
+    default_token = content["data"]["serviceAccountCreate"]["authToken"]
     service_account = ServiceAccount.objects.get()
     assert service_account_data["isActive"] == service_account.is_active
     assert service_account_data["name"] == service_account.name
     assert list(service_account.permissions.all()) == [permission_manage_products]
+    assert default_token == service_account.tokens.get().auth_token
 
 
 def test_service_account_create_mutation_no_permissions(


### PR DESCRIPTION
This pr introduces changes for Service Account create mutation. 
Mutation will create `auth_token` by default.