### PR TITLE
Add default value to custom errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - availablePaymentGateways extended with configuration data in GraphQL schema - #4774 by @salwator
 - Add metadata to Order model - #4513 by @szewczykmira
 - Fixed display of the products tax rate in the details page of dashboard 1.0, users can now update the tax rate of products in dashboard 1.0. The tax fields will no longer be shown if no tax support is enabled. - #4780 by @NyanKiyoshi
+- Add default value to custom errors - #4797 by @fowczarek
 
 ## 2.8.0
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -49,7 +49,8 @@ def get_error_fields(error_type_class, error_type_field):
             graphene.List(
                 graphene.NonNull(error_type_class),
                 description="List of errors that occurred executing the mutation.",
-            )
+            ),
+            default_value=[],
         )
     }
 

--- a/tests/api/test_base_mutation.py
+++ b/tests/api/test_base_mutation.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from unittest.mock import Mock
 
 import graphene
@@ -5,6 +6,7 @@ import pytest
 from django.core.exceptions import ImproperlyConfigured
 
 from saleor.graphql.core.mutations import BaseMutation
+from saleor.graphql.core.types.common import Error
 from saleor.graphql.product import types as product_types
 
 
@@ -25,8 +27,27 @@ class Mutation(BaseMutation):
         return Mutation(name=product.name)
 
 
+class TestErrorCode(Enum):
+    INVALID = "invalid"
+
+
+TestErrorCode = graphene.Enum.from_enum(TestErrorCode)
+
+
+class TestError(Error):
+    code = TestErrorCode()
+
+
+class MutationWithCustomErrors(Mutation):
+    class Meta:
+        description = "Base mutation with custom errors"
+        error_type_class = Error
+        error_type_field = "custom_errors"
+
+
 class Mutations(graphene.ObjectType):
     test = Mutation.Field()
+    test_with_custom_errors = MutationWithCustomErrors.Field()
 
 
 schema = graphene.Schema(
@@ -82,6 +103,29 @@ def test_user_error_nonexistent_id(schema_context):
     assert user_errors
     assert user_errors[0]["field"] == "productId"
     assert user_errors[0]["message"] == "Couldn't resolve to a node: not-really"
+
+
+def test_mutation_custom_errors_default_value(product, schema_context):
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    query = """
+        mutation testMutation($productId: ID!) {
+            testWithCustomErrors(productId: $productId) {
+                name
+                errors {
+                    field
+                    message
+                }
+                customErrors {
+                    field
+                    message
+                }
+            }
+        }
+    """
+    variables = {"productId": product_id}
+    result = schema.execute(query, variables=variables, context_value=schema_context)
+    assert result.data["testWithCustomErrors"]["errors"] == []
+    assert result.data["testWithCustomErrors"]["customErrors"] == []
 
 
 def test_user_error_id_of_different_type(product, schema_context):


### PR DESCRIPTION
I want to merge this change because mutation should return empty errors as empty list(`[]`) instead of `null`.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
