### PR TITLE
Return null instead of a placeholder when image is missing

### DIFF
--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -228,13 +228,11 @@ class OrderLine(CountableDjangoObjectType):
     @gql_optimizer.resolver_hints(
         prefetch_related=["variant__images", "variant__product__images"]
     )
-    def resolve_thumbnail(root: models.OrderLine, info, *, size=None):
+    def resolve_thumbnail(root: models.OrderLine, info, *, size=255):
         if not root.variant_id:
             return None
         image = root.variant.get_first_image()
         if image:
-            if not size:
-                size = 255
             url = get_product_image_thumbnail(image, size, method="thumbnail")
             alt = image.alt
             return Image(alt=alt, url=info.context.build_absolute_uri(url))

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -231,12 +231,14 @@ class OrderLine(CountableDjangoObjectType):
     def resolve_thumbnail(root: models.OrderLine, info, *, size=None):
         if not root.variant_id:
             return None
-        if not size:
-            size = 255
         image = root.variant.get_first_image()
-        url = get_product_image_thumbnail(image, size, method="thumbnail")
-        alt = image.alt if image else None
-        return Image(alt=alt, url=info.context.build_absolute_uri(url))
+        if image:
+            if not size:
+                size = 255
+            url = get_product_image_thumbnail(image, size, method="thumbnail")
+            alt = image.alt
+            return Image(alt=alt, url=info.context.build_absolute_uri(url))
+        return None
 
     @staticmethod
     def resolve_unit_price(root: models.OrderLine, _info):

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -512,11 +512,9 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
 
     @staticmethod
     @gql_optimizer.resolver_hints(prefetch_related="images")
-    def resolve_thumbnail(root: models.Product, info, *, size=None):
+    def resolve_thumbnail(root: models.Product, info, *, size=255):
         image = root.get_first_image()
         if image:
-            if not size:
-                size = 255
             url = get_product_image_thumbnail(image, size, method="thumbnail")
             alt = image.alt
             return Image(alt=alt, url=info.context.build_absolute_uri(url))

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -514,12 +514,13 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
     @gql_optimizer.resolver_hints(prefetch_related="images")
     def resolve_thumbnail(root: models.Product, info, *, size=None):
         image = root.get_first_image()
-        if not size:
-            size = 255
-        url = get_product_image_thumbnail(image, size, method="thumbnail")
-        url = info.context.build_absolute_uri(url)
-        alt = image.alt if image else None
-        return Image(alt=alt, url=url)
+        if image:
+            if not size:
+                size = 255
+            url = get_product_image_thumbnail(image, size, method="thumbnail")
+            alt = image.alt
+            return Image(alt=alt, url=info.context.build_absolute_uri(url))
+        return None
 
     @staticmethod
     def resolve_url(root: models.Product, *_args):

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -109,10 +109,7 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
-    assert (
-        "/static/images/placeholder540x540.png"
-        in order_data["lines"][0]["thumbnail"]["url"]
-    )
+    assert order_data["lines"][0]["thumbnail"] is None
     variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
     assert order_data["lines"][0]["variant"]["id"] == variant_id
 


### PR DESCRIPTION
I want to merge this change because it fixes the issue #4733.

**Note:** I have not removed the [choose_placeholder](https://github.com/mirumee/saleor/blob/d54fd99d20c833321d5ce02154d3f15881b14222/saleor/product/templatetags/product_images.py#L25) method, [the default value](https://github.com/mirumee/saleor/blob/d54fd99d20c833321d5ce02154d3f15881b14222/saleor/settings.py#L496) or the [tests](https://github.com/mirumee/saleor/blob/d54fd99d20c833321d5ce02154d3f15881b14222/tests/test_product_tags.py#L109) for that method; either have not [changed the thumbnail method](https://github.com/mirumee/saleor/blob/d54fd99d20c833321d5ce02154d3f15881b14222/saleor/product/templatetags/product_images.py#L97) as the issue only asks for returning null for the Graph API, I hope that I got everything correctly, and sorry if I am wrong.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
