### PR TITLE
Fix subcategory update redirection

### DIFF
--- a/saleor/dashboard/category/views.py
+++ b/saleor/dashboard/category/views.py
@@ -73,8 +73,8 @@ def category_edit(request, root_pk=None):
             request,
             pgettext_lazy("Dashboard message", "Updated category %s") % category,
         )
-        if root_pk:
-            return redirect("dashboard:category-details", pk=root_pk)
+        if root and root.parent:
+            return redirect("dashboard:category-details", pk=root.parent.pk)
         return redirect("dashboard:category-list")
     elif form.errors:
         status = 400
@@ -88,6 +88,7 @@ def category_edit(request, root_pk=None):
 def category_details(request, pk):
     root = get_object_or_404(Category, pk=pk)
     path = root.get_ancestors(include_self=True) if root else []
+    is_child = True if root.parent else False
     categories = root.get_children().order_by("name")
     category_filter = CategoryFilter(request.GET, queryset=categories)
     categories = get_paginator_items(
@@ -99,6 +100,7 @@ def category_details(request, pk):
         "root": root,
         "filter_set": category_filter,
         "is_empty": not category_filter.queryset.exists(),
+        "is_child": is_child,
     }
     return TemplateResponse(request, "dashboard/category/detail.html", ctx)
 

--- a/templates/dashboard/category/detail.html
+++ b/templates/dashboard/category/detail.html
@@ -98,6 +98,7 @@
             </a>
           </div>
         </div>
+        {% if not is_child %}
         <div class="card">
           <div class="card-content">
             <span class="card-title">
@@ -153,6 +154,7 @@
             </table>
           </div>
         </div>
+        {% endif %}
         {% paginate categories %}
       </div>
       <div class="col s12 l3" id="filters">


### PR DESCRIPTION
I want to merge this change because it fixes #4798 
With this fix, form into subcategory page is been removed and subcategory's update redirects to the parent category page.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

**BEFORE**
![66124019-30eae180-e598-11e9-92ae-a522974c4fda](https://user-images.githubusercontent.com/15129491/66298165-75a4ae80-e8f1-11e9-9f1a-b4448a2ba450.jpg)

**AFTER**
<img width="1987" alt="Schermata 2019-10-07 alle 11 02 42" src="https://user-images.githubusercontent.com/15129491/66298427-03809980-e8f2-11e9-9869-6b88fb3c0329.png">



### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.