### PR TITLE
Update webhook mutation doesnt work for event list

### DIFF
--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -84,7 +84,7 @@ class WebhookCreate(ModelMutation):
     @classmethod
     def save(cls, info, instance, cleaned_input):
         instance.save()
-        events = cleaned_input.get("events", [])
+        events = set(cleaned_input.get("events", []))
         models.WebhookEvent.objects.bulk_create(
             [
                 models.WebhookEvent(webhook=instance, event_type=event)

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -131,6 +131,19 @@ class WebhookUpdate(ModelMutation):
         error_type_class = WebhookError
         error_type_field = "webhook_errors"
 
+    @classmethod
+    def save(cls, info, instance, cleaned_input):
+        instance.save()
+        events = set(cleaned_input.get("events", []))
+        if events:
+            instance.events.all().delete()
+            models.WebhookEvent.objects.bulk_create(
+                [
+                    models.WebhookEvent(webhook=instance, event_type=event)
+                    for event in events
+                ]
+            )
+
 
 class WebhookDelete(ModelDeleteMutation):
     webhook = graphene.Field(Webhook)

--- a/tests/api/test_webhook.py
+++ b/tests/api/test_webhook.py
@@ -30,7 +30,10 @@ def test_webhook_create_by_service_account(
     variables = {
         "name": "New integration",
         "target_url": "https://www.example.com",
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+        ],
     }
     response = service_account_api_client.post_graphql(query, variables=variables)
     get_graphql_content(response)
@@ -284,7 +287,10 @@ def test_webhook_update_by_staff(
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
     variables = {
         "id": webhook_id,
-        "events": [WebhookEventTypeEnum.CUSTOMER_CREATED.name],
+        "events": [
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+        ],
         "is_active": False,
     }
     staff_api_client.user.user_permissions.add(permission_manage_webhooks)

--- a/tests/api/test_webhook.py
+++ b/tests/api/test_webhook.py
@@ -284,7 +284,7 @@ def test_webhook_update_by_staff(
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
     variables = {
         "id": webhook_id,
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [WebhookEventTypeEnum.CUSTOMER_CREATED.name],
         "is_active": False,
     }
     staff_api_client.user.user_permissions.add(permission_manage_webhooks)
@@ -294,7 +294,7 @@ def test_webhook_update_by_staff(
     assert webhook.is_active is False
     events = webhook.events.all()
     assert len(events) == 1
-    assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
+    assert events[0].event_type == WebhookEventTypeEnum.CUSTOMER_CREATED.value
 
 
 def test_webhook_update_by_staff_without_permission(
@@ -304,7 +304,10 @@ def test_webhook_update_by_staff_without_permission(
     webhook_id = graphene.Node.to_global_id("Webhook", webhook.pk)
     variables = {
         "id": webhook_id,
-        "events": [WebhookEventTypeEnum.ORDER_CREATED.name],
+        "events": [
+            WebhookEventTypeEnum.ORDER_CREATED.name,
+            WebhookEventTypeEnum.CUSTOMER_CREATED.name,
+        ],
         "is_active": False,
     }
     response = staff_api_client.post_graphql(query, variables=variables)


### PR DESCRIPTION
This PR fixes a `WebhookUpdate` mutation. It didn't work for updating an events list.