### PR TITLE
Optimize discounted price calculation

### DIFF
--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -46,19 +46,12 @@ def remove_voucher_usage_by_customer(voucher, customer_email):
         voucher_customer.delete()
 
 
-def are_product_collections_on_sale(product, discount: DiscountInfo):
-    """Check if any collection is on sale."""
-    discounted_collections = discount.collection_ids
-    product_collections = set(c.id for c in product.collections.all())
-    return product_collections.intersection(discounted_collections)
-
-
-def get_product_discount_on_sale(product, discount: DiscountInfo):
+def get_product_discount_on_sale(product, product_collections, discount:DiscountInfo):
     """Return discount value if product is on sale or raise NotApplicable."""
     is_product_on_sale = (
-        product.id in discount.product_ids
-        or product.category_id in discount.category_ids
-        or are_product_collections_on_sale(product, discount)
+        product.id in discount.product_ids or
+        product.category_id in discount.category_ids or
+        product_collections.intersection(discount.collection_ids)
     )
     if is_product_on_sale:
         return discount.sale.get_discount()
@@ -66,12 +59,13 @@ def get_product_discount_on_sale(product, discount: DiscountInfo):
         pgettext("Voucher not applicable", "Discount not applicable for this product")
     )
 
-
+    
 def get_product_discounts(product, discounts: Iterable[DiscountInfo]):
     """Return discount values for all discounts applicable to a product."""
+    product_collections = set(c.id for c in product.collections.all())
     for discount in discounts:
         try:
-            yield get_product_discount_on_sale(product, discount)
+            yield get_product_discount_on_sale( product, product_collections, discount)
         except NotApplicable:
             pass
 

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -49,9 +49,9 @@ def remove_voucher_usage_by_customer(voucher, customer_email):
 def get_product_discount_on_sale(product, product_collections, discount:DiscountInfo):
     """Return discount value if product is on sale or raise NotApplicable."""
     is_product_on_sale = (
-        product.id in discount.product_ids or
-        product.category_id in discount.category_ids or
-        product_collections.intersection(discount.collection_ids)
+        product.id in discount.product_ids 
+        or product.category_id in discount.category_ids 
+        or product_collections.intersection(discount.collection_ids)
     )
     if is_product_on_sale:
         return discount.sale.get_discount()
@@ -62,7 +62,7 @@ def get_product_discount_on_sale(product, product_collections, discount:Discount
     
 def get_product_discounts(product, discounts: Iterable[DiscountInfo]):
     """Return discount values for all discounts applicable to a product."""
-    product_collections = product.collections.all().values_list("pk", flat=True)
+    product_collections = set(product.collections.all().values_list("pk", flat=True))
     for discount in discounts:
         try:
             yield get_product_discount_on_sale( product, product_collections, discount)

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -62,7 +62,7 @@ def get_product_discount_on_sale(product, product_collections, discount:Discount
     
 def get_product_discounts(product, discounts: Iterable[DiscountInfo]):
     """Return discount values for all discounts applicable to a product."""
-    product_collections = set(c.id for c in product.collections.all())
+    product_collections = product.collections.all().values_list("pk", flat=True)
     for discount in discounts:
         try:
             yield get_product_discount_on_sale( product, product_collections, discount)

--- a/tests/test_discounts.py
+++ b/tests/test_discounts.py
@@ -141,11 +141,11 @@ def test_sale_applies_to_correct_products(product_type, category):
     discount = DiscountInfo(
         sale=sale, product_ids={product.id}, category_ids=set(), collection_ids=set()
     )
-    product_discount = get_product_discount_on_sale(variant.product, discount)
+    product_discount = get_product_discount_on_sale(variant.product, set(), discount)
     discounted_price = product_discount(product.price)
     assert discounted_price == Money(7, "USD")
     with pytest.raises(NotApplicable):
-        get_product_discount_on_sale(sec_variant.product, discount)
+        get_product_discount_on_sale(sec_variant.product, set(), discount)
 
 
 def test_increase_voucher_usage():


### PR DESCRIPTION
What about pull out query for product.collection from loop?
I saw looped sql for product collection in my local log and it's getting many as much as discounts is set.

I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
