### PR TITLE
Drop manage_users permission from permissions query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed crash when placing an order when a customer happens to have the same address more than once - #4823 by @NyanKiyoshi
 - Fix fetching staff user without manage_users permission - #4835 by @fowczarek
 - Add form to configure payments in dashboard - #4807 by @szewczykmira
+- Drop `manage_users` permission from the `permissions` query - #4854 by @maarcingebala
 
 ## 2.8.0
 

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -224,7 +224,6 @@ class Shop(graphene.ObjectType):
         return Navigation(main=top_menu, secondary=bottom_menu)
 
     @staticmethod
-    @permission_required("account.manage_users")
     def resolve_permissions(_, _info):
         permissions = get_permissions()
         return format_permissions_for_display(permissions)

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -164,7 +164,7 @@ def test_query_languages(settings, user_api_client):
     assert len(data["languages"]) == len(settings.LANGUAGES)
 
 
-def test_query_permissions(staff_api_client, permission_manage_users):
+def test_query_permissions(staff_api_client):
     query = """
     query {
         shop {
@@ -175,9 +175,7 @@ def test_query_permissions(staff_api_client, permission_manage_users):
         }
     }
     """
-    response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_users]
-    )
+    response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["shop"]
     permissions = data["permissions"]


### PR DESCRIPTION
Enum with names of permission in Saleor should be publicly available.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
