### PR TITLE
Remove mutations from validate_address

### DIFF
--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -3,7 +3,6 @@ from django_countries import countries
 
 from ...account.error_codes import AccountErrorCode
 from ...account.forms import get_address_form
-from ...account.models import Address
 from ...account.validators import validate_possible_number
 
 

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -14,7 +14,7 @@ class I18nMixin:
     """
 
     @classmethod
-    def validate_address(cls, address_data: dict, instance=None):
+    def validate_address(cls, address_data: dict):
         phone = address_data.get("phone", None)
         if phone:
             try:
@@ -43,9 +43,4 @@ class I18nMixin:
         if not address_form.is_valid():
             raise ValidationError(address_form.errors.as_data())
 
-        if not instance:
-            instance = Address()
-
-        cls.construct_instance(instance, address_form.cleaned_data)
-        cls.clean_instance(instance)
-        return instance
+        return address_form.cleaned_data

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.utils import timezone
 
+from ...account.models import Address
 from ...checkout import models
 from ...checkout.error_codes import CheckoutErrorCode
 from ...checkout.utils import (
@@ -34,7 +35,6 @@ from ...payment.interface import AddressData
 from ...payment.utils import store_customer_id
 from ...product import models as product_models
 from ..account.i18n import I18nMixin
-from ..account.models import Address
 from ..account.types import AddressInput, User
 from ..core.mutations import (
     BaseMutation,

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -480,17 +480,17 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
 
         cleaned_address_data = cls.validate_address(shipping_address)
 
-        checkout.shipping_address = cls.construct_instance(
-            checkout.shipping_address or Address(),
+        shipping_address = cls.construct_instance(
+            shipping_address,
             cleaned_address_data
         )
-        cls.clean_instance(checkout.shipping_address)
-
-        update_checkout_shipping_method_if_invalid(checkout, info.context.discounts)
+        cls.clean_instance(shipping_address)
 
         with transaction.atomic():
             shipping_address.save()
             change_shipping_address_in_checkout(checkout, shipping_address)
+
+        update_checkout_shipping_method_if_invalid(checkout, info.context.discounts)
         recalculate_checkout_discount(checkout, info.context.discounts)
 
         return CheckoutShippingAddressUpdate(checkout=checkout)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -34,6 +34,7 @@ from ...payment.interface import AddressData
 from ...payment.utils import store_customer_id
 from ...product import models as product_models
 from ..account.i18n import I18nMixin
+from ..account.models import Address
 from ..account.types import AddressInput, User
 from ..core.mutations import (
     BaseMutation,
@@ -477,9 +478,13 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
                 }
             )
 
-        shipping_address = cls.validate_address(
-            shipping_address, instance=checkout.shipping_address
+        cleaned_address_data = cls.validate_address(shipping_address)
+
+        checkout.shipping_address = cls.construct_instance(
+            checkout.shipping_address or Address(),
+            cleaned_address_data
         )
+        cls.clean_instance(checkout.shipping_address)
 
         update_checkout_shipping_method_if_invalid(checkout, info.context.discounts)
 


### PR DESCRIPTION
I want to merge this change because it fixes #4493 .

### Pull Request Checklist

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [ ] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
