### PR TITLE
Plugins config should always keep Boolean as Boolean

### DIFF
--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -322,17 +322,20 @@ class BasePlugin:
     def _update_config_items(
         cls, configuration_to_update: List[dict], current_config: List[dict]
     ):
-    
+        config_structure = (
+            cls.CONFIG_STRUCTURE if cls.CONFIG_STRUCTURE is not None else {}
+        )
         for config_item in current_config:
             for config_item_to_update in configuration_to_update:
-                if config_item["name"] == config_item_to_update.get("name"):
+                config_item_name = config_item_to_update.get("name")
+                if config_item["name"] == config_item_name:
                     new_value = config_item_to_update.get("value")
                     # The frontend can send all configuration fields with
                     # all secrets as **...**, we have to omit all secrets which
                     # weren't modified
                     if new_value == cls.REDACTED_FORM:
                         continue
-                    item_type = config_item.get("type")
+                    item_type = config_structure.get(config_item_name, {}).get("type")
                     if item_type == ConfigurationTypeField.BOOLEAN and not isinstance(
                         new_value, bool
                     ):

--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -6,6 +6,7 @@ from django.db.models import QuerySet
 from django_countries.fields import Country
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
+from . import ConfigurationTypeField
 from .models import PluginConfiguration
 
 if TYPE_CHECKING:
@@ -321,6 +322,7 @@ class BasePlugin:
     def _update_config_items(
         cls, configuration_to_update: List[dict], current_config: List[dict]
     ):
+    
         for config_item in current_config:
             for config_item_to_update in configuration_to_update:
                 if config_item["name"] == config_item_to_update.get("name"):
@@ -330,6 +332,11 @@ class BasePlugin:
                     # weren't modified
                     if new_value == cls.REDACTED_FORM:
                         continue
+                    item_type = config_item.get("type")
+                    if item_type == ConfigurationTypeField.BOOLEAN and not isinstance(
+                        new_value, bool
+                    ):
+                        new_value = new_value.lower() == "true"
                     config_item.update([("value", new_value)])
 
     @classmethod

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -99,9 +99,9 @@ class AvataxPlugin(BasePlugin):
             self.config = AvataxConfiguration(
                 username_or_account=configuration["Username or account"],
                 password_or_license=configuration["Password or license"],
-                use_sandbox=configuration["Use sandbox"] == "true",
+                use_sandbox=configuration["Use sandbox"],
                 company_name=configuration["Company name"],
-                autocommit=configuration["Autocommit"] == "true",
+                autocommit=configuration["Autocommit"],
             )
         else:
             # This should be removed after we drop an Avatax's settings from Django

--- a/tests/api/test_extensions.py
+++ b/tests/api/test_extensions.py
@@ -10,6 +10,23 @@ from tests.api.utils import get_graphql_content
 
 class PluginSample(BasePlugin):
     PLUGIN_NAME = "PluginSample"
+    CONFIG_STRUCTURE = {
+        "Username": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Username input field",
+            "label": "Username",
+        },
+        "Password": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Password input field",
+            "label": "Password",
+        },
+        "Use sandbox": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": "Use sandbox",
+            "label": "Use sandbox",
+        },
+    }
 
     @classmethod
     def get_plugin_configuration(cls, queryset) -> "PluginConfiguration":

--- a/tests/dashboard/test_payment.py
+++ b/tests/dashboard/test_payment.py
@@ -189,6 +189,12 @@ def test_gateway_configuration_form_json_field_set_to_false(field_name, form_dat
     assert cleaned_data[field_name]["value"] is False
 
 
+def get_config_value(field_name, configuration):
+    for elem in configuration:
+        if elem["name"] == field_name:
+            return elem["value"]
+
+
 def test_form_properly_save_plugin_config(form_data, plugin_configuration):
     assert plugin_configuration.active
     form = GatewayConfigurationForm(BraintreeGatewayPlugin, form_data)
@@ -196,6 +202,9 @@ def test_form_properly_save_plugin_config(form_data, plugin_configuration):
     form.save()
     plugin_configuration.refresh_from_db()
     assert plugin_configuration.active is False
+    assert isinstance(
+        get_config_value("Use sandbox", plugin_configuration.configuration), bool
+    )
 
 
 def test_configure_payment_gateway_properly_handle_form(

--- a/tests/extensions/plugins/test_avatax.py
+++ b/tests/extensions/plugins/test_avatax.py
@@ -19,9 +19,11 @@ from saleor.extensions.plugins.avatax.plugin import AvataxPlugin
 
 @pytest.fixture
 def plugin_configuration(db):
-    plugin_configuration = PluginConfiguration.objects.create(
-        **AvataxPlugin._get_default_configuration()
-    )
+    default_configuration = AvataxPlugin._get_default_configuration()
+    for elem in default_configuration["configuration"]:
+        if elem["name"] == "Use sandbox":
+            elem["value"] = False
+    plugin_configuration = PluginConfiguration.objects.create(**default_configuration)
     config = [
         {"name": "Username or account", "value": "2000134479"},
         {"name": "Password or license", "value": "697932CFCBDE505B"},

--- a/tests/extensions/plugins/test_plugins.py
+++ b/tests/extensions/plugins/test_plugins.py
@@ -1,0 +1,83 @@
+import pytest
+
+from saleor.extensions import ConfigurationTypeField
+from saleor.extensions.base_plugin import BasePlugin
+from saleor.extensions.models import PluginConfiguration
+
+
+class PluginSample(BasePlugin):
+    PLUGIN_NAME = "PluginSample"
+    CONFIG_STRUCTURE = {
+        "Username": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Username of Sample account",
+            "label": "Username",
+        },
+        "Use sandbox": {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": "Select if you want to test this integration",
+            "label": "Use sandbox",
+        },
+    }
+
+    @classmethod
+    def _get_default_configuration(cls):
+        defaults = {
+            "name": cls.PLUGIN_NAME,
+            "description": "",
+            "active": True,
+            "configuration": [
+                {"name": "Username", "value": "admin@example.com"},
+                {"name": "Use sandbox", "value": True},
+            ],
+        }
+        return defaults
+
+
+@pytest.fixture(autouse=True)
+def settings_plugins(settings):
+    settings.PLUGINS = [
+        "saleor.extensions.plugins.avatax.plugin.AvataxPlugin",
+        "saleor.extensions.plugins.vatlayer.plugin.VatlayerPlugin",
+        "saleor.extensions.plugins.webhook.plugin.WebhookPlugin",
+        "saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin",
+        "saleor.payment.gateways.stripe.plugin.StripeGatewayPlugin",
+        "saleor.payment.gateways.braintree.plugin.BraintreeGatewayPlugin",
+        "saleor.payment.gateways.razorpay.plugin.RazorpayGatewayPlugin",
+    ]
+
+
+def get_config_value(field_name, configuration):
+    for elem in configuration:
+        if elem["name"] == field_name:
+            return elem["value"]
+
+
+def test_update_config_items_keeps_bool_value():
+    data_to_update = [
+        {"name": "Username", "value": "new_admin@example.com"},
+        {"name": "Use sandbox", "value": False},
+    ]
+    plugin_sample = PluginSample()
+    plugin_sample._initialize_plugin_configuration()
+    qs = PluginConfiguration.objects.all()
+    configuration = PluginSample.get_plugin_configuration(qs)
+    plugin_sample._update_config_items(data_to_update, configuration.configuration)
+    configuration.save()
+    configuration.refresh_from_db()
+    assert get_config_value("Use sandbox", configuration.configuration) is False
+
+
+def test_update_config_items_convert_to_bool_value():
+    data_to_update = [
+        {"name": "Username", "value": "new_admin@example.com"},
+        {"name": "Use sandbox", "value": "false"},
+    ]
+    plugin_sample = PluginSample()
+    plugin_sample._initialize_plugin_configuration()
+    qs = PluginConfiguration.objects.all()
+    configuration = PluginSample.get_plugin_configuration(qs)
+    plugin_sample._update_config_items(data_to_update, configuration.configuration)
+    configuration.save()
+    configuration.refresh_from_db()
+    assert get_config_value("Use sandbox", configuration.configuration) is False


### PR DESCRIPTION
I want to merge this change because currently, requests from graphQL are saving boolean values as strings in the plugin configuration and this has caused us already some issues.

I would suggest creating a separate issue for adding tests and checks that will make sure that similar error will not happen again.

<!-- Please mention all relevant issue numbers. -->
Closes #4879

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
