### PR TITLE
Fix for overwriting hidden secret fields

### DIFF
--- a/saleor/extensions/base_plugin.py
+++ b/saleor/extensions/base_plugin.py
@@ -27,6 +27,7 @@ class BasePlugin:
 
     PLUGIN_NAME = ""
     CONFIG_STRUCTURE = None
+    REDACTED_FORM = "*" * 10
 
     def __init__(self, *args, **kwargs):
         self._cached_config = None
@@ -324,6 +325,11 @@ class BasePlugin:
             for config_item_to_update in configuration_to_update:
                 if config_item["name"] == config_item_to_update.get("name"):
                     new_value = config_item_to_update.get("value")
+                    # The frontend can send all configuration fields with
+                    # all secrets as **...**, we have to omit all secrets which
+                    # weren't modified
+                    if new_value == cls.REDACTED_FORM:
+                        continue
                     config_item.update([("value", new_value)])
 
     @classmethod

--- a/saleor/extensions/plugins/avatax/plugin.py
+++ b/saleor/extensions/plugins/avatax/plugin.py
@@ -447,7 +447,7 @@ class AvataxPlugin(BasePlugin):
         for field in configuration:
             if field.get("name") == "Password or license" and field.get("value"):
                 # We don't want to share our secret data
-                field["value"] = "*" * 6
+                field["value"] = cls.REDACTED_FORM
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -137,7 +137,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         for field in configuration:
             # We don't want to share our secret data
             if field.get("name") in secret_fields and field.get("value"):
-                field["value"] = "*" * 10
+                field["value"] = cls.REDACTED_FORM
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -94,7 +94,7 @@ class RazorpayGatewayPlugin(BasePlugin):
         for field in configuration:
             # We don't want to share our secret data
             if field.get("name") in secret_fields and field.get("value"):
-                field["value"] = "*" * 10
+                field["value"] = cls.REDACTED_FORM
 
     @classmethod
     def _get_default_configuration(cls):

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -96,7 +96,7 @@ class StripeGatewayPlugin(BasePlugin):
         for field in configuration:
             # We don't want to share our secret data
             if field.get("name") in secret_fields and field.get("value"):
-                field["value"] = "*" * 10
+                field["value"] = cls.REDACTED_FORM
 
     @classmethod
     def _get_default_configuration(cls):


### PR DESCRIPTION
Dashboard sends all configuration fields to update, we added logic to hide the value of all secrets fields. Plugin has to check if value is  '**...**'. This is quick fix. As a expected solution I would like to have different type of field for configuration, like `SecretField`