### PR TITLE
chore(ci): add mypy step in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,8 @@ matrix:
       python: "3.6"
     - env: TOXENV=flake8
       python: "3.6"
+    - env: TOXENV=mypy
+      python: "3.6"
     - env: TOXENV=check_gql_schema
       python: "3.6"
     - env: TOXENV=check_migrations

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -108,6 +108,7 @@ measurement==3.0.0
 more-itertools==7.2.0
 mpmath==1.1.0
 multidict==4.5.2; python_version >= "3.5"
+mypy==0.740
 nodeenv==1.3.3
 oauthlib==3.1.0
 packaging==19.2

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,13 @@ deps =
 commands =
     flake8 saleor tests
 
+[testenv:mypy]
+basepython = python3.6
+deps =
+    mypy>=0.740
+commands =
+    mypy saleor
+
 [testenv:pydocstyle]
 basepython = python3.6
 whitelist_externals = sh


### PR DESCRIPTION
I want to merge this change because it was requested at #4720

I decided to go with `mypy` because it was available in pypi. `pyright` needs to be installed from npm, which would have added a nodejs stack to the project.

<!-- Please mention all relevant issue numbers. -->
Fixes #4720 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] The changes are tested.
1. [ ] Changes are mentioned in the changelog.
