### PR TITLE
Query object translation with only manage_translation permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add sub-categories to random data - #4949 by @IKarbowiak
 - Deprecate `localized` field in Money type - #4952 by @IKarbowiak
 - Fix for shipping api doesn't apply taxes - #4913 by @kswiatek92
+- Query object translation with only manage_translation permission - #4914 by @fowczarek
 
 ## 2.9.0
 

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -6,14 +6,14 @@ from ..utils import filter_by_query_param
 PAGE_SEARCH_FIELDS = ("content", "slug", "title")
 
 
-def resolve_page(info, page_global_id=None, slug=None):
-    assert page_global_id or slug, "No page ID or slug provided."
+def resolve_page(info, global_page_id=None, slug=None):
+    assert global_page_id or slug, "No page ID or slug provided."
     user = info.context.user
 
     if slug is not None:
         page = models.Page.objects.visible_to_user(user).filter(slug=slug).first()
     else:
-        _type, page_pk = graphene.Node.from_global_id(page_global_id)
+        _type, page_pk = graphene.Node.from_global_id(global_page_id)
         page = models.Page.objects.visible_to_user(user).filter(pk=page_pk).first()
     return page
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -322,6 +322,13 @@ input AttributeSortingInput {
   direction: OrderDirection!
 }
 
+type AttributeStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): AttributeTranslation
+  attribute: Attribute
+}
+
 type AttributeTranslate {
   errors: [Error!]
   attribute: Attribute
@@ -414,6 +421,13 @@ input AttributeValueInput {
   values: [String]!
 }
 
+type AttributeValueStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
+  attributeValue: AttributeValue
+}
+
 type AttributeValueTranslate {
   errors: [Error!]
   attributeValue: AttributeValue
@@ -486,9 +500,9 @@ type Category implements Node {
   seoDescription: String
   id: ID!
   name: String!
-  slug: String!
   description: String!
   descriptionJson: JSONString!
+  slug: String!
   parent: Category
   level: Int!
   privateMeta: [MetaStore]!
@@ -554,6 +568,17 @@ input CategoryInput {
   seo: SeoInput
   backgroundImage: Upload
   backgroundImageAlt: String
+}
+
+type CategoryStrings implements Node {
+  seoTitle: String
+  seoDescription: String
+  id: ID!
+  name: String!
+  description: String!
+  descriptionJson: JSONString!
+  translation(languageCode: LanguageCodeEnum!): CategoryTranslation
+  category: Category
 }
 
 type CategoryTranslate {
@@ -809,15 +834,15 @@ type ChoiceValue {
 }
 
 type Collection implements Node {
-  publicationDate: Date
-  isPublished: Boolean!
   seoTitle: String
   seoDescription: String
   id: ID!
   name: String!
-  slug: String!
   description: String!
   descriptionJson: JSONString!
+  publicationDate: Date
+  isPublished: Boolean!
+  slug: String!
   privateMeta: [MetaStore]!
   meta: [MetaStore]!
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
@@ -923,6 +948,17 @@ type CollectionReorderProducts {
   errors: [Error!]
   collection: Collection
   productErrors: [ProductError!]
+}
+
+type CollectionStrings implements Node {
+  seoTitle: String
+  seoDescription: String
+  id: ID!
+  name: String!
+  description: String!
+  descriptionJson: JSONString!
+  translation(languageCode: LanguageCodeEnum!): CollectionTranslation
+  collection: Collection
 }
 
 type CollectionTranslate {
@@ -1361,6 +1397,8 @@ input DateTimeRangeInput {
 }
 
 scalar Decimal
+
+union DefaultTranslationItem = ProductStrings | CollectionStrings | CategoryStrings | AttributeStrings | AttributeValueStrings | ProductVariantStrings | PageStrings | ShippingMethodStrings | SaleStrings | VoucherStrings | MenuItemStrings
 
 type DigitalContent implements Node {
   useDefaultSettings: Boolean!
@@ -1876,9 +1914,9 @@ input MenuInput {
 
 type MenuItem implements Node {
   id: ID!
+  name: String!
   sortOrder: Int @deprecated(reason: "Will be dropped in 2.10 and is deprecated since 2.9: use the position in list instead and relative calculus to determine shift position.")
   menu: Menu!
-  name: String!
   parent: MenuItem
   category: Category
   collection: Collection
@@ -1950,6 +1988,13 @@ input MenuItemMoveInput {
   itemId: ID!
   parentId: ID
   sortOrder: Int
+}
+
+type MenuItemStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
+  menuItem: MenuItem
 }
 
 type MenuItemTranslate {
@@ -2586,15 +2631,15 @@ type OrderVoid {
 }
 
 type Page implements Node {
-  publicationDate: Date
-  isPublished: Boolean!
   seoTitle: String
   seoDescription: String
   id: ID!
-  slug: String!
   title: String!
   content: String!
   contentJson: JSONString!
+  publicationDate: Date
+  isPublished: Boolean!
+  slug: String!
   created: DateTime!
   translation(languageCode: LanguageCodeEnum!): PageTranslation
 }
@@ -2651,9 +2696,20 @@ input PageInput {
   seo: SeoInput
 }
 
+type PageStrings implements Node {
+  seoTitle: String
+  seoDescription: String
+  id: ID!
+  title: String!
+  content: String!
+  contentJson: JSONString!
+  translation(languageCode: LanguageCodeEnum!): PageTranslation
+  page: Page
+}
+
 type PageTranslate {
   errors: [Error!]
-  page: Page
+  page: PageStrings
 }
 
 type PageTranslation implements Node {
@@ -2854,14 +2910,14 @@ input PriceRangeInput {
 
 type Product implements Node {
   id: ID!
-  publicationDate: Date
-  isPublished: Boolean!
   seoTitle: String
   seoDescription: String
-  productType: ProductType!
   name: String!
   description: String!
   descriptionJson: JSONString!
+  publicationDate: Date
+  isPublished: Boolean!
+  productType: ProductType!
   category: Category!
   updatedAt: DateTime
   chargeTaxes: Boolean!
@@ -3082,6 +3138,17 @@ type ProductPricingInfo {
   priceRangeLocalCurrency: TaxedMoneyRange
 }
 
+type ProductStrings implements Node {
+  id: ID!
+  seoTitle: String
+  seoDescription: String
+  name: String!
+  description: String!
+  descriptionJson: JSONString!
+  translation(languageCode: LanguageCodeEnum!): ProductTranslation
+  product: Product
+}
+
 type ProductTranslate {
   errors: [Error!]
   product: Product
@@ -3226,8 +3293,8 @@ type ProductUpdatePrivateMeta {
 
 type ProductVariant implements Node {
   id: ID!
-  sku: String!
   name: String!
+  sku: String!
   product: Product!
   trackInventory: Boolean!
   quantityAllocated: Int!
@@ -3330,6 +3397,13 @@ input ProductVariantInput {
   weight: WeightScalar
 }
 
+type ProductVariantStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
+  productVariant: ProductVariant
+}
+
 type ProductVariantTranslate {
   errors: [Error!]
   productVariant: ProductVariant
@@ -3365,6 +3439,7 @@ type Query {
   webhookEvents: [WebhookEvent]
   webhookSamplePayload(eventType: WebhookEventTypeEnum!): JSONString
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
+  translation(id: ID!, kind: TranslatableKinds!): DefaultTranslationItem
   shop: Shop
   shippingZone(id: ID!): ShippingZone
   shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
@@ -3512,6 +3587,13 @@ input SaleInput {
 
 type SaleRemoveCatalogues {
   errors: [Error!]
+  sale: Sale
+}
+
+type SaleStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): SaleTranslation
   sale: Sale
 }
 
@@ -3668,6 +3750,13 @@ type ShippingMethod implements Node {
   maximumOrderWeight: Weight
   type: ShippingMethodTypeEnum
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
+}
+
+type ShippingMethodStrings implements Node {
+  id: ID!
+  name: String!
+  translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
+  shippingMethod: ShippingMethod
 }
 
 type ShippingMethodTranslation implements Node {
@@ -4190,8 +4279,8 @@ type VerifyToken {
 
 type Voucher implements Node {
   id: ID!
-  type: VoucherTypeEnum!
   name: String
+  type: VoucherTypeEnum!
   code: String!
   usageLimit: Int
   used: Int!
@@ -4277,6 +4366,13 @@ input VoucherInput {
 
 type VoucherRemoveCatalogues {
   errors: [Error!]
+  voucher: Voucher
+}
+
+type VoucherStrings implements Node {
+  id: ID!
+  name: String
+  translation(languageCode: LanguageCodeEnum!): VoucherTranslation
   voucher: Voucher
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -322,7 +322,7 @@ input AttributeSortingInput {
   direction: OrderDirection!
 }
 
-type AttributeStrings implements Node {
+type AttributeTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
@@ -421,7 +421,7 @@ input AttributeValueInput {
   values: [String]!
 }
 
-type AttributeValueStrings implements Node {
+type AttributeValueTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
@@ -570,7 +570,7 @@ input CategoryInput {
   backgroundImageAlt: String
 }
 
-type CategoryStrings implements Node {
+type CategoryTranslatableContent implements Node {
   seoTitle: String
   seoDescription: String
   id: ID!
@@ -950,7 +950,7 @@ type CollectionReorderProducts {
   productErrors: [ProductError!]
 }
 
-type CollectionStrings implements Node {
+type CollectionTranslatableContent implements Node {
   seoTitle: String
   seoDescription: String
   id: ID!
@@ -1398,7 +1398,7 @@ input DateTimeRangeInput {
 
 scalar Decimal
 
-union DefaultTranslationItem = ProductStrings | CollectionStrings | CategoryStrings | AttributeStrings | AttributeValueStrings | ProductVariantStrings | PageStrings | ShippingMethodStrings | SaleStrings | VoucherStrings | MenuItemStrings
+union DefaultTranslationItem = ProductTranslatableContent | CollectionTranslatableContent | CategoryTranslatableContent | AttributeTranslatableContent | AttributeValueTranslatableContent | ProductVariantTranslatableContent | PageTranslatableContent | ShippingMethodTranslatableContent | SaleTranslatableContent | VoucherTranslatableContent | MenuItemTranslatableContent
 
 type DigitalContent implements Node {
   useDefaultSettings: Boolean!
@@ -1990,7 +1990,7 @@ input MenuItemMoveInput {
   sortOrder: Int
 }
 
-type MenuItemStrings implements Node {
+type MenuItemTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
@@ -2696,7 +2696,7 @@ input PageInput {
   seo: SeoInput
 }
 
-type PageStrings implements Node {
+type PageTranslatableContent implements Node {
   seoTitle: String
   seoDescription: String
   id: ID!
@@ -2709,7 +2709,7 @@ type PageStrings implements Node {
 
 type PageTranslate {
   errors: [Error!]
-  page: PageStrings
+  page: PageTranslatableContent
 }
 
 type PageTranslation implements Node {
@@ -3138,7 +3138,7 @@ type ProductPricingInfo {
   priceRangeLocalCurrency: TaxedMoneyRange
 }
 
-type ProductStrings implements Node {
+type ProductTranslatableContent implements Node {
   id: ID!
   seoTitle: String
   seoDescription: String
@@ -3397,7 +3397,7 @@ input ProductVariantInput {
   weight: WeightScalar
 }
 
-type ProductVariantStrings implements Node {
+type ProductVariantTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
@@ -3590,7 +3590,7 @@ type SaleRemoveCatalogues {
   sale: Sale
 }
 
-type SaleStrings implements Node {
+type SaleTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
@@ -3752,7 +3752,7 @@ type ShippingMethod implements Node {
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
 }
 
-type ShippingMethodStrings implements Node {
+type ShippingMethodTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
@@ -4369,7 +4369,7 @@ type VoucherRemoveCatalogues {
   voucher: Voucher
 }
 
-type VoucherStrings implements Node {
+type VoucherTranslatableContent implements Node {
   id: ID!
   name: String
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...discount.models import Sale
+from ...discount.models import Sale, Voucher
 from ...page.models import Page
 from ...product.models import (
     Attribute,
@@ -63,6 +63,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.PageStrings,
             translation_types.ShippingMethodStrings,
             translation_types.SaleStrings,
+            translation_types.VoucherStrings,
         )
 
 
@@ -161,3 +162,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.SALE:
             _type, sale_id = graphene.Node.from_global_id(id)
             return Sale.objects.filter(pk=sale_id).first()
+        elif kind == TranslatableKinds.VOUCHER:
+            _type, voucher_id = graphene.Node.from_global_id(id)
+            return Voucher.objects.filter(pk=voucher_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...discount.models import Sale, Voucher
+from ...menu.models import MenuItem
 from ...page.models import Page
 from ...product.models import (
     Attribute,
@@ -64,6 +65,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.ShippingMethodStrings,
             translation_types.SaleStrings,
             translation_types.VoucherStrings,
+            translation_types.MenuItemStrings,
         )
 
 
@@ -159,9 +161,15 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.SHIPPING_METHOD:
             _type, shipping_method_id = graphene.Node.from_global_id(id)
             return ShippingMethod.objects.filter(pk=shipping_method_id).first()
+            # TODO test data not visible without perms
         elif kind == TranslatableKinds.SALE:
             _type, sale_id = graphene.Node.from_global_id(id)
             return Sale.objects.filter(pk=sale_id).first()
+            # TODO test data not visible without perms
         elif kind == TranslatableKinds.VOUCHER:
             _type, voucher_id = graphene.Node.from_global_id(id)
             return Voucher.objects.filter(pk=voucher_id).first()
+            # TODO No dashbord options to create translation create issue
+        elif kind == TranslatableKinds.MENU_ITEM:
+            _type, menu_item_id = graphene.Node.from_global_id(id)
+            return MenuItem.objects.filter(pk=menu_item_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...product.models import Attribute, Category, Collection, Product
+from ...product.models import Attribute, AttributeValue, Category, Collection, Product
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -48,6 +48,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.CollectionStrings,
             translation_types.CategoryStrings,
             translation_types.AttributeStrings,
+            translation_types.AttributeValueStrings,
         )
 
 
@@ -129,3 +130,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.ATTRIBUTE:
             _type, attribute_id = graphene.Node.from_global_id(id)
             return Attribute.objects.filter(pk=attribute_id).first()
+        elif kind == TranslatableKinds.ATTRIBUTE_VALUE:
+            _type, attribute_value_id = graphene.Node.from_global_id(id)
+            return AttributeValue.objects.filter(pk=attribute_value_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...product.models import Collection, Product
+from ...product.models import Category, Collection, Product
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -43,7 +43,11 @@ class TranslatableItem(graphene.Union):
 # TODO Consider name of this class
 class DefaultTranslationItem(graphene.Union):
     class Meta:
-        types = (translation_types.ProductStrings, translation_types.CollectionStrings)
+        types = (
+            translation_types.ProductStrings,
+            translation_types.CollectionStrings,
+            translation_types.CategoryStrings,
+        )
 
 
 class TranslatableItemConnection(CountableConnection):
@@ -74,6 +78,7 @@ class TranslationQueries(graphene.ObjectType):
             TranslatableKinds, required=True, description="Kind of objects to retrieve."
         ),
     )
+    # TODO Add test for this query
     translation = graphene.Field(
         DefaultTranslationItem,
         id=graphene.Argument(
@@ -117,3 +122,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.COLLECTION:
             _type, collection_id = graphene.Node.from_global_id(id)
             return Collection.objects.filter(pk=collection_id).first()
+        elif kind == TranslatableKinds.CATEGORY:
+            _type, category_id = graphene.Node.from_global_id(id)
+            return Category.objects.filter(pk=category_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ...discount.models import Sale
 from ...page.models import Page
 from ...product.models import (
     Attribute,
@@ -61,6 +62,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.ProductVariantStrings,
             translation_types.PageStrings,
             translation_types.ShippingMethodStrings,
+            translation_types.SaleStrings,
         )
 
 
@@ -156,3 +158,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.SHIPPING_METHOD:
             _type, shipping_method_id = graphene.Node.from_global_id(id)
             return ShippingMethod.objects.filter(pk=shipping_method_id).first()
+        elif kind == TranslatableKinds.SALE:
+            _type, sale_id = graphene.Node.from_global_id(id)
+            return Sale.objects.filter(pk=sale_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...product.models import Category, Collection, Product
+from ...product.models import Attribute, Category, Collection, Product
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -47,6 +47,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.ProductStrings,
             translation_types.CollectionStrings,
             translation_types.CategoryStrings,
+            translation_types.AttributeStrings,
         )
 
 
@@ -125,3 +126,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.CATEGORY:
             _type, category_id = graphene.Node.from_global_id(id)
             return Category.objects.filter(pk=category_id).first()
+        elif kind == TranslatableKinds.ATTRIBUTE:
+            _type, attribute_id = graphene.Node.from_global_id(id)
+            return Attribute.objects.filter(pk=attribute_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -146,7 +146,7 @@ class TranslationQueries(graphene.ObjectType):
             return Attribute.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.ATTRIBUTE_VALUE:
             return AttributeValue.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.VARIANT:  # TODO test hidden data
+        elif kind == TranslatableKinds.VARIANT:
             return ProductVariant.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.PAGE:  # TODO test hidden data
             return Page.objects.filter(pk=kind_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -138,7 +138,7 @@ class TranslationQueries(graphene.ObjectType):
         _type, kind_id = graphene.Node.from_global_id(id)
         if kind == TranslatableKinds.PRODUCT:
             return Product.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.COLLECTION:  # TODO test hidden data
+        elif kind == TranslatableKinds.COLLECTION:
             return Collection.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.CATEGORY:
             return Category.objects.filter(pk=kind_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -76,15 +76,15 @@ class TranslatableItemConnection(CountableConnection):
 
 class TranslatableKinds(graphene.Enum):
     ATTRIBUTE = "Attribute"
-    ATTRIBUTE_VALUE = "Attribute value"
+    ATTRIBUTE_VALUE = "AttributeValue"
     CATEGORY = "Category"
     COLLECTION = "Collection"
-    MENU_ITEM = "Menu item"
+    MENU_ITEM = "MenuItem"
     PAGE = "Page"
     PRODUCT = "Product"
     SALE = "Sale"
-    SHIPPING_METHOD = "Shipping method"
-    VARIANT = "Variant"
+    SHIPPING_METHOD = "ShippingMethod"
+    VARIANT = "ProductVariant"
     VOUCHER = "Voucher"
 
 
@@ -97,7 +97,6 @@ class TranslationQueries(graphene.ObjectType):
             TranslatableKinds, required=True, description="Kind of objects to retrieve."
         ),
     )
-    # TODO Add test for this query
     translation = graphene.Field(
         DefaultTranslationItem,
         id=graphene.Argument(
@@ -134,8 +133,9 @@ class TranslationQueries(graphene.ObjectType):
 
     @permission_required("site.manage_translations")
     def resolve_translation(self, info, id, kind, **_kwargs):
-        # TODO add kind validation
         _type, kind_id = graphene.Node.from_global_id(id)
+        if not _type == kind:
+            return None
         if kind == TranslatableKinds.PRODUCT:
             return Product.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.COLLECTION:

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -155,7 +155,6 @@ class TranslationQueries(graphene.ObjectType):
             return ShippingMethod.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.SALE:
             return Sale.objects.filter(pk=kind_id).first()
-            # TODO test data not visible without perms
         elif kind == TranslatableKinds.VOUCHER:
             return Voucher.objects.filter(pk=kind_id).first()
             # TODO No dashbord options to create translation create issue

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -148,7 +148,7 @@ class TranslationQueries(graphene.ObjectType):
             return AttributeValue.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.VARIANT:
             return ProductVariant.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.PAGE:  # TODO test hidden data
+        elif kind == TranslatableKinds.PAGE:
             return Page.objects.filter(pk=kind_id).first()
             # TODO test data not visible without perms
             # TODO No dashbord options to create translation create issue

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -9,6 +9,7 @@ from ...product.models import (
     Product,
     ProductVariant,
 )
+from ...shipping.models import ShippingMethod
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -59,6 +60,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.AttributeValueStrings,
             translation_types.ProductVariantStrings,
             translation_types.PageStrings,
+            translation_types.ShippingMethodStrings,
         )
 
 
@@ -149,3 +151,8 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.PAGE:  # TODO test hidden data
             _type, page_id = graphene.Node.from_global_id(id)
             return Page.objects.filter(pk=page_id).first()
+            # TODO test data not visible without perms
+            # TODO No dashbord options to create translation create issue
+        elif kind == TranslatableKinds.SHIPPING_METHOD:
+            _type, shipping_method_id = graphene.Node.from_global_id(id)
+            return ShippingMethod.objects.filter(pk=shipping_method_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,5 +1,6 @@
 import graphene
 
+from ...page.models import Page
 from ...product.models import (
     Attribute,
     AttributeValue,
@@ -47,7 +48,7 @@ class TranslatableItem(graphene.Union):
         )
 
 
-# TODO Consider name of this class
+# TODO Consider name of this class, maby we should replace TranslatableItem
 class DefaultTranslationItem(graphene.Union):
     class Meta:
         types = (
@@ -57,6 +58,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.AttributeStrings,
             translation_types.AttributeValueStrings,
             translation_types.ProductVariantStrings,
+            translation_types.PageStrings,
         )
 
 
@@ -144,3 +146,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.VARIANT:  # TODO test hidden data
             _type, product_variant_id = graphene.Node.from_global_id(id)
             return ProductVariant.objects.filter(pk=product_variant_id).first()
+        elif kind == TranslatableKinds.PAGE:  # TODO test hidden data
+            _type, page_id = graphene.Node.from_global_id(id)
+            return Page.objects.filter(pk=page_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,13 @@
 import graphene
 
-from ...product.models import Attribute, AttributeValue, Category, Collection, Product
+from ...product.models import (
+    Attribute,
+    AttributeValue,
+    Category,
+    Collection,
+    Product,
+    ProductVariant,
+)
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -49,6 +56,7 @@ class DefaultTranslationItem(graphene.Union):
             translation_types.CategoryStrings,
             translation_types.AttributeStrings,
             translation_types.AttributeValueStrings,
+            translation_types.ProductVariantStrings,
         )
 
 
@@ -118,10 +126,10 @@ class TranslationQueries(graphene.ObjectType):
     @permission_required("site.manage_translations")
     def resolve_translation(self, info, id, kind, **_kwargs):
         # TODO Add other translatable items
-        if kind == TranslatableKinds.PRODUCT:
+        if kind == TranslatableKinds.PRODUCT:  # TODO test hidden data
             _type, product_id = graphene.Node.from_global_id(id)
             return Product.objects.filter(pk=product_id).first()
-        elif kind == TranslatableKinds.COLLECTION:
+        elif kind == TranslatableKinds.COLLECTION:  # TODO test hidden data
             _type, collection_id = graphene.Node.from_global_id(id)
             return Collection.objects.filter(pk=collection_id).first()
         elif kind == TranslatableKinds.CATEGORY:
@@ -133,3 +141,6 @@ class TranslationQueries(graphene.ObjectType):
         elif kind == TranslatableKinds.ATTRIBUTE_VALUE:
             _type, attribute_value_id = graphene.Node.from_global_id(id)
             return AttributeValue.objects.filter(pk=attribute_value_id).first()
+        elif kind == TranslatableKinds.VARIANT:  # TODO test hidden data
+            _type, product_variant_id = graphene.Node.from_global_id(id)
+            return ProductVariant.objects.filter(pk=product_variant_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...product.models import Product
+from ...product.models import Collection, Product
 from ..core.connection import CountableConnection
 from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
@@ -43,7 +43,7 @@ class TranslatableItem(graphene.Union):
 # TODO Consider name of this class
 class DefaultTranslationItem(graphene.Union):
     class Meta:
-        types = (translation_types.ProductStrings,)
+        types = (translation_types.ProductStrings, translation_types.CollectionStrings)
 
 
 class TranslatableItemConnection(CountableConnection):
@@ -110,7 +110,10 @@ class TranslationQueries(graphene.ObjectType):
 
     @permission_required("site.manage_translations")
     def resolve_translation(self, info, id, kind, **_kwargs):
+        # TODO Add other translatable items
         if kind == TranslatableKinds.PRODUCT:
             _type, product_id = graphene.Node.from_global_id(id)
             return Product.objects.filter(pk=product_id).first()
-        # TODO Add other translatable items
+        elif kind == TranslatableKinds.COLLECTION:
+            _type, collection_id = graphene.Node.from_global_id(id)
+            return Collection.objects.filter(pk=collection_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -150,11 +150,9 @@ class TranslationQueries(graphene.ObjectType):
             return ProductVariant.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.PAGE:
             return Page.objects.filter(pk=kind_id).first()
-            # TODO test data not visible without perms
             # TODO No dashbord options to create translation create issue
         elif kind == TranslatableKinds.SHIPPING_METHOD:
             return ShippingMethod.objects.filter(pk=kind_id).first()
-            # TODO test data not visible without perms
         elif kind == TranslatableKinds.SALE:
             return Sale.objects.filter(pk=kind_id).first()
             # TODO test data not visible without perms

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -108,7 +108,6 @@ class TranslationQueries(graphene.ObjectType):
         ),
     )
 
-    # TODO Add tra
     def resolve_translations(self, info, kind, **_kwargs):
         if kind == TranslatableKinds.PRODUCT:
             return resolve_products(info)
@@ -137,7 +136,7 @@ class TranslationQueries(graphene.ObjectType):
     def resolve_translation(self, info, id, kind, **_kwargs):
         # TODO add kind validation
         _type, kind_id = graphene.Node.from_global_id(id)
-        if kind == TranslatableKinds.PRODUCT:  # TODO test hidden data
+        if kind == TranslatableKinds.PRODUCT:
             return Product.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.COLLECTION:  # TODO test hidden data
             return Collection.objects.filter(pk=kind_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -108,6 +108,7 @@ class TranslationQueries(graphene.ObjectType):
         ),
     )
 
+    # TODO Add tra
     def resolve_translations(self, info, kind, **_kwargs):
         if kind == TranslatableKinds.PRODUCT:
             return resolve_products(info)
@@ -134,42 +135,32 @@ class TranslationQueries(graphene.ObjectType):
 
     @permission_required("site.manage_translations")
     def resolve_translation(self, info, id, kind, **_kwargs):
-        # TODO Add other translatable items
+        # TODO add kind validation
+        _type, kind_id = graphene.Node.from_global_id(id)
         if kind == TranslatableKinds.PRODUCT:  # TODO test hidden data
-            _type, product_id = graphene.Node.from_global_id(id)
-            return Product.objects.filter(pk=product_id).first()
+            return Product.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.COLLECTION:  # TODO test hidden data
-            _type, collection_id = graphene.Node.from_global_id(id)
-            return Collection.objects.filter(pk=collection_id).first()
+            return Collection.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.CATEGORY:
-            _type, category_id = graphene.Node.from_global_id(id)
-            return Category.objects.filter(pk=category_id).first()
+            return Category.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.ATTRIBUTE:
-            _type, attribute_id = graphene.Node.from_global_id(id)
-            return Attribute.objects.filter(pk=attribute_id).first()
+            return Attribute.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.ATTRIBUTE_VALUE:
-            _type, attribute_value_id = graphene.Node.from_global_id(id)
-            return AttributeValue.objects.filter(pk=attribute_value_id).first()
+            return AttributeValue.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.VARIANT:  # TODO test hidden data
-            _type, product_variant_id = graphene.Node.from_global_id(id)
-            return ProductVariant.objects.filter(pk=product_variant_id).first()
+            return ProductVariant.objects.filter(pk=kind_id).first()
         elif kind == TranslatableKinds.PAGE:  # TODO test hidden data
-            _type, page_id = graphene.Node.from_global_id(id)
-            return Page.objects.filter(pk=page_id).first()
+            return Page.objects.filter(pk=kind_id).first()
             # TODO test data not visible without perms
             # TODO No dashbord options to create translation create issue
         elif kind == TranslatableKinds.SHIPPING_METHOD:
-            _type, shipping_method_id = graphene.Node.from_global_id(id)
-            return ShippingMethod.objects.filter(pk=shipping_method_id).first()
+            return ShippingMethod.objects.filter(pk=kind_id).first()
             # TODO test data not visible without perms
         elif kind == TranslatableKinds.SALE:
-            _type, sale_id = graphene.Node.from_global_id(id)
-            return Sale.objects.filter(pk=sale_id).first()
+            return Sale.objects.filter(pk=kind_id).first()
             # TODO test data not visible without perms
         elif kind == TranslatableKinds.VOUCHER:
-            _type, voucher_id = graphene.Node.from_global_id(id)
-            return Voucher.objects.filter(pk=voucher_id).first()
+            return Voucher.objects.filter(pk=kind_id).first()
             # TODO No dashbord options to create translation create issue
         elif kind == TranslatableKinds.MENU_ITEM:
-            _type, menu_item_id = graphene.Node.from_global_id(id)
-            return MenuItem.objects.filter(pk=menu_item_id).first()
+            return MenuItem.objects.filter(pk=kind_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -51,21 +51,22 @@ class TranslatableItem(graphene.Union):
         )
 
 
-# TODO Consider name of this class, maby we should replace TranslatableItem
+# TODO Consider name of this class, we should replace to TranslatableItem after
+# `translations` query refactor. Issue #4957
 class DefaultTranslationItem(graphene.Union):
     class Meta:
         types = (
-            translation_types.ProductStrings,
-            translation_types.CollectionStrings,
-            translation_types.CategoryStrings,
-            translation_types.AttributeStrings,
-            translation_types.AttributeValueStrings,
-            translation_types.ProductVariantStrings,
-            translation_types.PageStrings,
-            translation_types.ShippingMethodStrings,
-            translation_types.SaleStrings,
-            translation_types.VoucherStrings,
-            translation_types.MenuItemStrings,
+            translation_types.ProductTranslatableContent,
+            translation_types.CollectionTranslatableContent,
+            translation_types.CategoryTranslatableContent,
+            translation_types.AttributeTranslatableContent,
+            translation_types.AttributeValueTranslatableContent,
+            translation_types.ProductVariantTranslatableContent,
+            translation_types.PageTranslatableContent,
+            translation_types.ShippingMethodTranslatableContent,
+            translation_types.SaleTranslatableContent,
+            translation_types.VoucherTranslatableContent,
+            translation_types.MenuItemTranslatableContent,
         )
 
 
@@ -89,7 +90,7 @@ class TranslatableKinds(graphene.Enum):
 
 
 class TranslationQueries(graphene.ObjectType):
-    # TODO We nead to change output of this query to new types
+    # TODO We nead to change output of this query to new types. Issue #4957
     translations = BaseConnectionField(
         TranslatableItemConnection,
         description="Returns a list of all translatable items of a given kind.",
@@ -133,30 +134,22 @@ class TranslationQueries(graphene.ObjectType):
 
     @permission_required("site.manage_translations")
     def resolve_translation(self, info, id, kind, **_kwargs):
+        # Disable all the no-member violations in this function
+        # pylint: disable=no-member
         _type, kind_id = graphene.Node.from_global_id(id)
         if not _type == kind:
             return None
-        if kind == TranslatableKinds.PRODUCT:
-            return Product.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.COLLECTION:
-            return Collection.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.CATEGORY:
-            return Category.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.ATTRIBUTE:
-            return Attribute.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.ATTRIBUTE_VALUE:
-            return AttributeValue.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.VARIANT:
-            return ProductVariant.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.PAGE:
-            return Page.objects.filter(pk=kind_id).first()
-            # TODO No dashbord options to create translation create issue
-        elif kind == TranslatableKinds.SHIPPING_METHOD:
-            return ShippingMethod.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.SALE:
-            return Sale.objects.filter(pk=kind_id).first()
-        elif kind == TranslatableKinds.VOUCHER:
-            return Voucher.objects.filter(pk=kind_id).first()
-            # TODO No dashbord options to create translation create issue
-        elif kind == TranslatableKinds.MENU_ITEM:
-            return MenuItem.objects.filter(pk=kind_id).first()
+        models = {
+            TranslatableKinds.PRODUCT.value: Product,
+            TranslatableKinds.COLLECTION.value: Collection,
+            TranslatableKinds.CATEGORY.value: Category,
+            TranslatableKinds.ATTRIBUTE.value: Attribute,
+            TranslatableKinds.ATTRIBUTE_VALUE.value: AttributeValue,
+            TranslatableKinds.VARIANT.value: ProductVariant,
+            TranslatableKinds.PAGE.value: Page,
+            TranslatableKinds.SHIPPING_METHOD.value: ShippingMethod,
+            TranslatableKinds.SALE.value: Sale,
+            TranslatableKinds.VOUCHER.value: Voucher,
+            TranslatableKinds.MENU_ITEM.value: MenuItem,
+        }
+        return models[kind].objects.filter(pk=kind_id).first()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -101,7 +101,7 @@ class TranslationQueries(graphene.ObjectType):
     translation = graphene.Field(
         DefaultTranslationItem,
         id=graphene.Argument(
-            graphene.ID, description="ID of the objects to retrieve.", required=True
+            graphene.ID, description="ID of the object to retrieve.", required=True
         ),
         kind=graphene.Argument(
             TranslatableKinds, required=True, description="Kind of objects to retrieve."

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -104,7 +104,7 @@ class TranslationQueries(graphene.ObjectType):
             graphene.ID, description="ID of the object to retrieve.", required=True
         ),
         kind=graphene.Argument(
-            TranslatableKinds, required=True, description="Kind of objects to retrieve."
+            TranslatableKinds, required=True, description="Kind of the object to retrieve."
         ),
     )
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -308,6 +308,45 @@ class PageTranslation(BaseTranslationType):
         ]
 
 
+class PageStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        PageTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description="Returns translated Page fields for the given language code.",
+        resolver=resolve_translation,
+    )
+    page = graphene.Field(
+        "saleor.graphql.page.types.Page",
+        description=(
+            "A static page that can be manually added by a shop operator ",
+            "through the dashboard.",
+        ),
+    )
+
+    class Meta:
+        model = page_models.Page
+        interfaces = [graphene.relay.Node]
+        only_fields = [
+            "content",
+            "content_json",
+            "id",
+            "seo_description",
+            "seo_title",
+            "title",
+        ]
+
+    def resolve_page(self, info):
+        return (
+            page_models.Page.objects.visible_to_user(info.context.user)
+            .filter(pk=self.id)
+            .first()
+        )
+
+
 class VoucherTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.VoucherTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -112,6 +112,40 @@ class ProductVariantTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class ProductVariantStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        ProductVariantTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated Product Variant fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    product_variant = graphene.Field(
+        "saleor.graphql.product.types.products.ProductVariant",
+        description=(
+            "Represents a version of a product such as different size or color."
+        ),
+    )
+
+    class Meta:
+        model = product_models.ProductVariant
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    def resolve_product_variant(self, info):
+        visible_products = product_models.Product.objects.visible_to_user(
+            info.context.user
+        ).values_list("pk", flat=True)
+        return product_models.ProductVariant.objects.filter(
+            product__id__in=visible_products, pk=self.id
+        ).first()
+
+
 class ProductTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -122,6 +122,44 @@ class CollectionTranslation(BaseTranslationType):
         ]
 
 
+class CollectionStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        CollectionTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated Collection fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    collection = graphene.Field(
+        "saleor.graphql.product.types.products.Collection",
+        description="Represents a collection of products.",
+    )
+
+    class Meta:
+        model = product_models.Collection
+        interfaces = [graphene.relay.Node]
+        only_fields = [
+            "description",
+            "description_json",
+            "id",
+            "name",
+            "seo_title",
+            "seo_description",
+        ]
+
+    def resolve_collection(self, info):
+        return (
+            product_models.Collection.objects.visible_to_user(info.context.user)
+            .filter(pk=self.id)
+            .first()
+        )
+
+
 class CategoryTranslation(BaseTranslationType):
     class Meta:
         model = product_models.CategoryTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -10,6 +10,7 @@ from ...site import models as site_models
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import LanguageDisplay
 from ..core.utils import str_to_enum
+from ..decorators import permission_required
 from .enums import LanguageCodeEnum
 from .resolvers import resolve_translation
 
@@ -380,3 +381,34 @@ class ShippingMethodTranslation(BaseTranslationType):
         model = shipping_models.ShippingMethodTranslation
         interfaces = [graphene.relay.Node]
         only_fields = ["id", "name"]
+
+
+class ShippingMethodStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        ShippingMethodTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated shipping method fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    shipping_method = graphene.Field(
+        "saleor.graphql.shipping.types.ShippingMethod",
+        description=(
+            "Shipping method are the methods you'll use to get customer's orders "
+            " to them. They are directly exposed to the customers."
+        ),
+    )
+
+    class Meta:
+        model = shipping_models.ShippingMethod
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    @permission_required("shipping.manage_shipping")
+    def resolve_shipping_method(self, info):
+        return self

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -362,6 +362,35 @@ class SaleTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class SaleStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        SaleTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description="Returns translated sale fields for the given language code.",
+        resolver=resolve_translation,
+    )
+    sale = graphene.Field(
+        "saleor.graphql.discount.types.Sale",
+        description=(
+            "Sales allow creating discounts for categories, collections "
+            "or products and are visible to all the customers."
+        ),
+    )
+
+    class Meta:
+        model = discount_models.Sale
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    @permission_required("discount.manage_discounts")
+    def resolve_sale(self, info):
+        return self
+
+
 class ShopTranslation(BaseTranslationType):
     class Meta:
         model = site_models.SiteSettingsTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -174,6 +174,38 @@ class CategoryTranslation(BaseTranslationType):
         ]
 
 
+class CategoryStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        CategoryTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=("Returns translated Category fields for the given language code."),
+        resolver=resolve_translation,
+    )
+    category = graphene.Field(
+        "saleor.graphql.product.types.products.Category",
+        description="Represents a single category of products.",
+    )
+
+    class Meta:
+        model = product_models.Category
+        interfaces = [graphene.relay.Node]
+        only_fields = [
+            "description",
+            "description_json",
+            "id",
+            "name",
+            "seo_title",
+            "seo_description",
+        ]
+
+    def resolve_category(self, info):
+        return self
+
+
 class PageTranslation(BaseTranslationType):
     class Meta:
         model = page_models.PageTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -355,6 +355,37 @@ class VoucherTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class VoucherStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        VoucherTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description="Returns translated Voucher fields for the given language code.",
+        resolver=resolve_translation,
+    )
+    voucher = graphene.Field(
+        "saleor.graphql.discount.types.Voucher",
+        # TODO consider move description to variable.
+        description=(
+            "Vouchers allow giving discounts to particular customers on categories, "
+            "collections or specific products. They can be used during checkout by "
+            "providing valid voucher codes."
+        ),
+    )
+
+    class Meta:
+        model = discount_models.Voucher
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    @permission_required("discount.manage_discounts")
+    def resolve_voucher(self, info):
+        return self
+
+
 class SaleTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.SaleTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -54,7 +54,7 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated Attribute Value fields " "for the given language code."
+            "Returns translated Attribute Value fields for the given language code."
         ),
         resolver=resolve_translation,
     )
@@ -88,7 +88,7 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated Attribute fields " "for the given language code."
+            "Returns translated Attribute fields for the given language code."
         ),
         resolver=resolve_translation,
     )
@@ -122,7 +122,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated Product Variant fields " "for the given language code."
+            "Returns translated Product Variant fields for the given language code."
         ),
         resolver=resolve_translation,
     )
@@ -220,7 +220,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated Collection fields " "for the given language code."
+            "Returns translated Collection fields for the given language code."
         ),
         resolver=resolve_translation,
     )
@@ -482,7 +482,7 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated shipping method fields " "for the given language code."
+            "Returns translated shipping method fields for the given language code."
         ),
         resolver=resolve_translation,
     )

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -51,6 +51,33 @@ class AttributeTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class AttributeStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        AttributeTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated Attribute fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    attribute = graphene.Field(
+        "saleor.graphql.product.types.products.Attribute",
+        description="Custom attribute of a product.",
+    )
+
+    class Meta:
+        model = product_models.Attribute
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    def resolve_attribute(self, info):
+        return self
+
+
 class ProductVariantTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductVariantTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -45,7 +45,7 @@ class AttributeValueTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class AttributeValueStrings(CountableDjangoObjectType):
+class AttributeValueTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         AttributeValueTranslation,
         language_code=graphene.Argument(
@@ -79,7 +79,7 @@ class AttributeTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class AttributeStrings(CountableDjangoObjectType):
+class AttributeTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         AttributeTranslation,
         language_code=graphene.Argument(
@@ -113,7 +113,7 @@ class ProductVariantTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class ProductVariantStrings(CountableDjangoObjectType):
+class ProductVariantTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         ProductVariantTranslation,
         language_code=graphene.Argument(
@@ -161,7 +161,7 @@ class ProductTranslation(BaseTranslationType):
         ]
 
 
-class ProductStrings(CountableDjangoObjectType):
+class ProductTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         ProductTranslation,
         language_code=graphene.Argument(
@@ -211,7 +211,7 @@ class CollectionTranslation(BaseTranslationType):
         ]
 
 
-class CollectionStrings(CountableDjangoObjectType):
+class CollectionTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         CollectionTranslation,
         language_code=graphene.Argument(
@@ -263,7 +263,7 @@ class CategoryTranslation(BaseTranslationType):
         ]
 
 
-class CategoryStrings(CountableDjangoObjectType):
+class CategoryTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         CategoryTranslation,
         language_code=graphene.Argument(
@@ -309,7 +309,7 @@ class PageTranslation(BaseTranslationType):
         ]
 
 
-class PageStrings(CountableDjangoObjectType):
+class PageTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         PageTranslation,
         language_code=graphene.Argument(
@@ -355,7 +355,7 @@ class VoucherTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class VoucherStrings(CountableDjangoObjectType):
+class VoucherTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         VoucherTranslation,
         language_code=graphene.Argument(
@@ -368,7 +368,7 @@ class VoucherStrings(CountableDjangoObjectType):
     )
     voucher = graphene.Field(
         "saleor.graphql.discount.types.Voucher",
-        # TODO consider move description to variable.
+        # TODO consider move description to variable. Issue #4957
         description=(
             "Vouchers allow giving discounts to particular customers on categories, "
             "collections or specific products. They can be used during checkout by "
@@ -393,7 +393,7 @@ class SaleTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class SaleStrings(CountableDjangoObjectType):
+class SaleTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         SaleTranslation,
         language_code=graphene.Argument(
@@ -436,7 +436,7 @@ class MenuItemTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class MenuItemStrings(CountableDjangoObjectType):
+class MenuItemTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         MenuItemTranslation,
         language_code=graphene.Argument(
@@ -445,7 +445,7 @@ class MenuItemStrings(CountableDjangoObjectType):
             required=True,
         ),
         description=(
-            "Returns translated Menu item fields " "for the given language code."
+            "Returns translated Menu item fields for the given language code."
         ),
         resolver=resolve_translation,
     )
@@ -473,7 +473,7 @@ class ShippingMethodTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
-class ShippingMethodStrings(CountableDjangoObjectType):
+class ShippingMethodTranslatableContent(CountableDjangoObjectType):
     translation = graphene.Field(
         ShippingMethodTranslation,
         language_code=graphene.Argument(

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -44,6 +44,33 @@ class AttributeValueTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class AttributeValueStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        AttributeValueTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated Attribute Value fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    attribute_value = graphene.Field(
+        "saleor.graphql.product.types.attributes.AttributeValue",
+        description="Represents a value of an attribute.",
+    )
+
+    class Meta:
+        model = product_models.AttributeValue
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    def resolve_attribute_value(self, info):
+        return self
+
+
 class AttributeTranslation(BaseTranslationType):
     class Meta:
         model = product_models.AttributeTranslation
@@ -65,7 +92,7 @@ class AttributeStrings(CountableDjangoObjectType):
         resolver=resolve_translation,
     )
     attribute = graphene.Field(
-        "saleor.graphql.product.types.products.Attribute",
+        "saleor.graphql.product.types.attributes.Attribute",
         description="Custom attribute of a product.",
     )
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -436,6 +436,36 @@ class MenuItemTranslation(BaseTranslationType):
         only_fields = ["id", "name"]
 
 
+class MenuItemStrings(CountableDjangoObjectType):
+    translation = graphene.Field(
+        MenuItemTranslation,
+        language_code=graphene.Argument(
+            LanguageCodeEnum,
+            description="A language code to return the translation for.",
+            required=True,
+        ),
+        description=(
+            "Returns translated Menu item fields " "for the given language code."
+        ),
+        resolver=resolve_translation,
+    )
+    menu_item = graphene.Field(
+        "saleor.graphql.menu.types.MenuItem",
+        description=(
+            "Represents a single item of the related menu. Can store categories, "
+            "collection or pages."
+        ),
+    )
+
+    class Meta:
+        model = menu_models.MenuItem
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id", "name"]
+
+    def resolve_menu_item(self, info):
+        return self
+
+
 class ShippingMethodTranslation(BaseTranslationType):
     class Meta:
         model = shipping_models.ShippingMethodTranslation

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -78,8 +78,9 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
-    def resolve_attribute_value(self, info):
-        return self
+    @staticmethod
+    def resolve_attribute_value(root: product_models.AttributeValue, _info):
+        return root
 
 
 class AttributeTranslation(BaseTranslationType):
@@ -112,8 +113,9 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
-    def resolve_attribute(self, info):
-        return self
+    @staticmethod
+    def resolve_attribute(root: product_models.Attribute, _info):
+        return root
 
 
 class ProductVariantTranslation(BaseTranslationType):
@@ -148,12 +150,13 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
-    def resolve_product_variant(self, info):
+    @staticmethod
+    def resolve_product_variant(root: product_models.ProductVariant, info):
         visible_products = product_models.Product.objects.visible_to_user(
             info.context.user
         ).values_list("pk", flat=True)
         return product_models.ProductVariant.objects.filter(
-            product__id__in=visible_products, pk=self.id
+            product__id__in=visible_products, pk=root.id
         ).first()
 
 
@@ -185,10 +188,11 @@ class ProductTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
-    def resolve_product(self, info):
+    @staticmethod
+    def resolve_product(root: product_models.Product, info):
         return (
             product_models.Product.objects.visible_to_user(info.context.user)
-            .filter(pk=self.id)
+            .filter(pk=root.id)
             .first()
         )
 
@@ -223,10 +227,11 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
-    def resolve_collection(self, info):
+    @staticmethod
+    def resolve_collection(root: product_models.Collection, info):
         return (
             product_models.Collection.objects.visible_to_user(info.context.user)
-            .filter(pk=self.id)
+            .filter(pk=root.id)
             .first()
         )
 
@@ -259,8 +264,9 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
-    def resolve_category(self, info):
-        return self
+    @staticmethod
+    def resolve_category(root: product_models.Category, _info):
+        return root
 
 
 class PageTranslation(BaseTranslationType):
@@ -308,10 +314,11 @@ class PageTranslatableContent(CountableDjangoObjectType):
             "title",
         ]
 
-    def resolve_page(self, info):
+    @staticmethod
+    def resolve_page(root: page_models.Page, info):
         return (
             page_models.Page.objects.visible_to_user(info.context.user)
-            .filter(pk=self.id)
+            .filter(pk=root.id)
             .first()
         )
 
@@ -349,9 +356,10 @@ class VoucherTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
+    @staticmethod
     @permission_required("discount.manage_discounts")
-    def resolve_voucher(self, info):
-        return self
+    def resolve_voucher(root: discount_models.Voucher, _info):
+        return root
 
 
 class SaleTranslation(BaseTranslationType):
@@ -385,9 +393,10 @@ class SaleTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
+    @staticmethod
     @permission_required("discount.manage_discounts")
-    def resolve_sale(self, info):
-        return self
+    def resolve_sale(root: discount_models.Sale, _info):
+        return root
 
 
 class ShopTranslation(BaseTranslationType):
@@ -430,8 +439,9 @@ class MenuItemTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
-    def resolve_menu_item(self, info):
-        return self
+    @staticmethod
+    def resolve_menu_item(root: menu_models.MenuItem, _info):
+        return root
 
 
 class ShippingMethodTranslation(BaseTranslationType):
@@ -467,6 +477,7 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
         interfaces = [graphene.relay.Node]
         only_fields = BASIC_TRANSLATABLE_FIELDS
 
+    @staticmethod
     @permission_required("shipping.manage_shipping")
-    def resolve_shipping_method(self, info):
-        return self
+    def resolve_shipping_method(root: shipping_models.ShippingMethod, _info):
+        return root

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -14,6 +14,16 @@ from ..decorators import permission_required
 from .enums import LanguageCodeEnum
 from .resolvers import resolve_translation
 
+BASIC_TRANSLATABLE_FIELDS = ["id", "name"]
+EXTENDED_TRANSLATABLE_FIELDS = [
+    "id",
+    "name",
+    "description",
+    "description_json",
+    "seo_title",
+    "seo_description",
+]
+
 
 class BaseTranslationType(CountableDjangoObjectType):
     language = graphene.Field(
@@ -42,7 +52,7 @@ class AttributeValueTranslation(BaseTranslationType):
     class Meta:
         model = product_models.AttributeValueTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class AttributeValueTranslatableContent(CountableDjangoObjectType):
@@ -66,7 +76,7 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.AttributeValue
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     def resolve_attribute_value(self, info):
         return self
@@ -76,7 +86,7 @@ class AttributeTranslation(BaseTranslationType):
     class Meta:
         model = product_models.AttributeTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class AttributeTranslatableContent(CountableDjangoObjectType):
@@ -100,7 +110,7 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.Attribute
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     def resolve_attribute(self, info):
         return self
@@ -110,7 +120,7 @@ class ProductVariantTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductVariantTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class ProductVariantTranslatableContent(CountableDjangoObjectType):
@@ -136,7 +146,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.ProductVariant
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     def resolve_product_variant(self, info):
         visible_products = product_models.Product.objects.visible_to_user(
@@ -151,14 +161,7 @@ class ProductTranslation(BaseTranslationType):
     class Meta:
         model = product_models.ProductTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
 
 class ProductTranslatableContent(CountableDjangoObjectType):
@@ -180,14 +183,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.Product
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
     def resolve_product(self, info):
         return (
@@ -201,14 +197,7 @@ class CollectionTranslation(BaseTranslationType):
     class Meta:
         model = product_models.CollectionTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
 
 class CollectionTranslatableContent(CountableDjangoObjectType):
@@ -232,14 +221,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.Collection
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
     def resolve_collection(self, info):
         return (
@@ -253,14 +235,7 @@ class CategoryTranslation(BaseTranslationType):
     class Meta:
         model = product_models.CategoryTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
 
 class CategoryTranslatableContent(CountableDjangoObjectType):
@@ -282,14 +257,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = product_models.Category
         interfaces = [graphene.relay.Node]
-        only_fields = [
-            "description",
-            "description_json",
-            "id",
-            "name",
-            "seo_title",
-            "seo_description",
-        ]
+        only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
     def resolve_category(self, info):
         return self
@@ -352,7 +320,7 @@ class VoucherTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.VoucherTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class VoucherTranslatableContent(CountableDjangoObjectType):
@@ -379,7 +347,7 @@ class VoucherTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = discount_models.Voucher
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     @permission_required("discount.manage_discounts")
     def resolve_voucher(self, info):
@@ -390,7 +358,7 @@ class SaleTranslation(BaseTranslationType):
     class Meta:
         model = discount_models.SaleTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class SaleTranslatableContent(CountableDjangoObjectType):
@@ -415,7 +383,7 @@ class SaleTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = discount_models.Sale
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     @permission_required("discount.manage_discounts")
     def resolve_sale(self, info):
@@ -433,7 +401,7 @@ class MenuItemTranslation(BaseTranslationType):
     class Meta:
         model = menu_models.MenuItemTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class MenuItemTranslatableContent(CountableDjangoObjectType):
@@ -460,7 +428,7 @@ class MenuItemTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = menu_models.MenuItem
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     def resolve_menu_item(self, info):
         return self
@@ -470,7 +438,7 @@ class ShippingMethodTranslation(BaseTranslationType):
     class Meta:
         model = shipping_models.ShippingMethodTranslation
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
 
 class ShippingMethodTranslatableContent(CountableDjangoObjectType):
@@ -497,7 +465,7 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
     class Meta:
         model = shipping_models.ShippingMethod
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name"]
+        only_fields = BASIC_TRANSLATABLE_FIELDS
 
     @permission_required("shipping.manage_shipping")
     def resolve_shipping_method(self, info):

--- a/tests/api/test_translations.py
+++ b/tests/api/test_translations.py
@@ -1371,7 +1371,7 @@ QUERY_TRANSLATION_PRODUCT = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on ProductStrings{
+            ...on ProductTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1433,7 +1433,7 @@ QUERY_TRANSLATION_COLLECTION = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on CollectionStrings{
+            ...on CollectionTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1495,7 +1495,7 @@ QUERY_TRANSLATION_CATEGORY = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on CategoryStrings{
+            ...on CategoryTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1539,7 +1539,7 @@ QUERY_TRANSLATION_ATTRIBUTE = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on AttributeStrings{
+            ...on AttributeTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1584,7 +1584,7 @@ QUERY_TRANSLATION_ATTRIBUTE_VALUE = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on AttributeValueStrings{
+            ...on AttributeValueTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1633,7 +1633,7 @@ QUERY_TRANSLATION_VARIANT = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on ProductVariantStrings{
+            ...on ProductVariantTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1696,7 +1696,7 @@ QUERY_TRANSLATION_PAGE = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on PageStrings{
+            ...on PageTranslatableContent{
                 id
                 title
                 translation(languageCode: $languageCode){
@@ -1758,7 +1758,7 @@ QUERY_TRANSLATION_SHIPPING_METHOD = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on ShippingMethodStrings{
+            ...on ShippingMethodTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1817,7 +1817,7 @@ QUERY_TRANSLATION_SALE = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on SaleStrings{
+            ...on SaleTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1870,7 +1870,7 @@ QUERY_TRANSLATION_VOUCHER = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on VoucherStrings{
+            ...on VoucherTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){
@@ -1923,7 +1923,7 @@ QUERY_TRANSLATION_MENU_ITEM = """
     ){
         translation(kind: $kind, id: $id){
             __typename
-            ...on MenuItemStrings{
+            ...on MenuItemTranslatableContent{
                 id
                 name
                 translation(languageCode: $languageCode){

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ from saleor.product.models import (
     Attribute,
     AttributeTranslation,
     AttributeValue,
+    AttributeValueTranslation,
     Category,
     CategoryTranslation,
     Collection,
@@ -1268,7 +1269,16 @@ def translated_variant_fr(product):
 def translated_attribute(product):
     attribute = product.product_type.product_attributes.first()
     return AttributeTranslation.objects.create(
-        language_code="fr", attribute=attribute, name="Name tranlsated to french"
+        language_code="fr", attribute=attribute, name="French attribute name"
+    )
+
+
+@pytest.fixture
+def translated_attribute_value(pink_attribute_value):
+    return AttributeValueTranslation.objects.create(
+        language_code="fr",
+        attribute_value=pink_attribute_value,
+        name="French attribute value name",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ from saleor.product.models import (
     AttributeTranslation,
     AttributeValue,
     Category,
+    CategoryTranslation,
     Collection,
     CollectionTranslation,
     DigitalContent,
@@ -1295,6 +1296,16 @@ def collection_translation_fr(collection):
         collection=collection,
         name="French collection name",
         description="French description",
+    )
+
+
+@pytest.fixture
+def category_translation_fr(category):
+    return CategoryTranslation.objects.create(
+        language_code="fr",
+        category=category,
+        name="French category name",
+        description="French category description",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,7 +30,7 @@ from saleor.discount.models import (
     VoucherTranslation,
 )
 from saleor.giftcard.models import GiftCard
-from saleor.menu.models import Menu, MenuItem
+from saleor.menu.models import Menu, MenuItem, MenuItemTranslation
 from saleor.menu.utils import update_menu
 from saleor.order import OrderStatus
 from saleor.order.actions import fulfill_order_line
@@ -1361,6 +1361,13 @@ def shipping_method_translation_fr(shipping_method):
 def sale_translation_fr(sale):
     return SaleTranslation.objects.create(
         language_code="fr", sale=sale, name="French sale name"
+    )
+
+
+@pytest.fixture
+def menu_item_translation_fr(menu_item):
+    return MenuItemTranslation.objects.create(
+        language_code="fr", menu_item=menu_item, name="French manu item name"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,13 @@ from saleor.checkout.models import Checkout
 from saleor.checkout.utils import add_variant_to_checkout
 from saleor.core.payments import PaymentInterface
 from saleor.discount import DiscountInfo, DiscountValueType, VoucherType
-from saleor.discount.models import Sale, Voucher, VoucherCustomer, VoucherTranslation
+from saleor.discount.models import (
+    Sale,
+    SaleTranslation,
+    Voucher,
+    VoucherCustomer,
+    VoucherTranslation,
+)
 from saleor.giftcard.models import GiftCard
 from saleor.menu.models import Menu, MenuItem
 from saleor.menu.utils import update_menu
@@ -1348,6 +1354,13 @@ def shipping_method_translation_fr(shipping_method):
         language_code="fr",
         shipping_method=shipping_method,
         name="French shipping method name",
+    )
+
+
+@pytest.fixture
+def sale_translation_fr(sale):
+    return SaleTranslation.objects.create(
+        language_code="fr", sale=sale, name="French sale name"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,6 +41,7 @@ from saleor.product.models import (
     AttributeValue,
     Category,
     Collection,
+    CollectionTranslation,
     DigitalContent,
     DigitalContentUrl,
     Product,
@@ -1283,6 +1284,16 @@ def product_translation_fr(product):
         language_code="fr",
         product=product,
         name="French name",
+        description="French description",
+    )
+
+
+@pytest.fixture
+def collection_translation_fr(collection):
+    return CollectionTranslation.objects.create(
+        language_code="fr",
+        collection=collection,
+        name="French collection name",
         description="French description",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,7 @@ from saleor.product.models import (
     ProductTranslation,
     ProductType,
     ProductVariant,
+    ProductVariantTranslation,
 )
 from saleor.product.utils.attributes import associate_attribute_values_to_instance
 from saleor.shipping.models import ShippingMethod, ShippingMethodType, ShippingZone
@@ -1296,6 +1297,13 @@ def product_translation_fr(product):
         product=product,
         name="French name",
         description="French description",
+    )
+
+
+@pytest.fixture
+def variant_translation_fr(variant):
+    return ProductVariantTranslation.objects.create(
+        language_code="fr", product_variant=variant, name="French product variant name"
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,12 @@ from saleor.product.models import (
     ProductVariantTranslation,
 )
 from saleor.product.utils.attributes import associate_attribute_values_to_instance
-from saleor.shipping.models import ShippingMethod, ShippingMethodType, ShippingZone
+from saleor.shipping.models import (
+    ShippingMethod,
+    ShippingMethodTranslation,
+    ShippingMethodType,
+    ShippingZone,
+)
 from saleor.site import AuthenticationBackends
 from saleor.site.models import AuthorizationKey, SiteSettings
 from saleor.webhook import WebhookEventType
@@ -1334,6 +1339,15 @@ def page_translation_fr(page):
         page=page,
         title="French page title",
         content="French page content",
+    )
+
+
+@pytest.fixture
+def shipping_method_translation_fr(shipping_method):
+    return ShippingMethodTranslation.objects.create(
+        language_code="fr",
+        shipping_method=shipping_method,
+        name="French shipping method name",
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -31,7 +31,7 @@ from saleor.order.actions import fulfill_order_line
 from saleor.order.events import OrderEvents
 from saleor.order.models import FulfillmentStatus, Order, OrderEvent
 from saleor.order.utils import recalculate_order
-from saleor.page.models import Page
+from saleor.page.models import Page, PageTranslation
 from saleor.payment import ChargeStatus, TransactionKind
 from saleor.payment.models import Payment
 from saleor.product import AttributeInputType
@@ -1324,6 +1324,16 @@ def category_translation_fr(category):
         category=category,
         name="French category name",
         description="French category description",
+    )
+
+
+@pytest.fixture
+def page_translation_fr(page):
+    return PageTranslation.objects.create(
+        language_code="fr",
+        page=page,
+        title="French page title",
+        content="French page content",
     )
 
 


### PR DESCRIPTION
I want to merge this change because resolve #4834 

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
