### PR TITLE
Change required black version from >=19.3b0 to ==19.3b0 in tox file

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ commands =
 [testenv:black]
 basepython = python3.6
 deps =
-    black>=19.3b0
+    black==19.3b0
 commands =
     black --check saleor tests
 


### PR DESCRIPTION
CI is failing because of differences in tox requirements and requirements_dev.txt.