### PR TITLE
Reworked the JWT middleware tests so they actually execute the chain

### DIFF
--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -1,16 +1,13 @@
+from functools import partial
 from unittest.mock import Mock, patch
 
 import graphene
 import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Q
-from django.http import HttpResponse
 from django.shortcuts import reverse
-from django.test import RequestFactory
-from graphql_jwt.shortcuts import get_token
 from graphql_relay import to_global_id
 
-from saleor.graphql.middleware import jwt_middleware
 from saleor.graphql.product.types import Product
 from saleor.graphql.utils import (
     filter_by_query_param,
@@ -34,25 +31,51 @@ def test_middleware_dont_generate_sql_requests(
         assert response.status_code == 200
 
 
-def test_jwt_middleware(admin_user):
-    def get_response(request):
-        return HttpResponse()
+def test_jwt_middleware(client, admin_user):
+    user_details_query = """
+        {
+          me {
+            email
+          }
+        }
+    """
 
-    rf = RequestFactory()
-    middleware = jwt_middleware(get_response)
+    create_token_query = """
+        mutation {
+          tokenCreate(email: "admin@example.com", password: "password") {
+            token
+          }
+        }
+    """
+
+    api_url = reverse("api")
+    api_client_post = partial(client.post, api_url, content_type="application/json")
 
     # test setting AnonymousUser on unauthorized request to API
-    request = rf.get(reverse("api"))
-    assert not hasattr(request, "user")
-    middleware(request)
-    assert isinstance(request.user, AnonymousUser)
+    response = api_client_post(data={"query": user_details_query})
+    repl_data = response.json()
+    assert response.status_code == 200
+    assert isinstance(response.wsgi_request.user, AnonymousUser)
+    assert "errors" in repl_data
+    assert repl_data["data"]["me"] is None
+
+    # test creating a token for admin user
+    response = api_client_post(data={"query": create_token_query})
+    repl_data = response.json()
+    assert response.status_code == 200
+    assert response.wsgi_request.user == admin_user
+    token = repl_data["data"]["tokenCreate"]["token"]
+    assert token is not None
 
     # test request with proper JWT token authorizes the request to API
-    token = get_token(admin_user)
-    request = rf.get(reverse("api"), **{"HTTP_AUTHORIZATION": "JWT %s" % token})
-    assert not hasattr(request, "user")
-    middleware(request)
-    assert request.user == admin_user
+    response = api_client_post(
+        data={"query": user_details_query}, HTTP_AUTHORIZATION=f"JWT {token}"
+    )
+    repl_data = response.json()
+    assert response.status_code == 200
+    assert response.wsgi_request.user == admin_user
+    assert "errors" not in repl_data
+    assert repl_data["data"]["me"] == {"email": admin_user.email}
 
 
 def test_real_query(user_api_client, product):


### PR DESCRIPTION
When we have some critical logic over some middleware, those tests were an issue as they don't execute the middleware chain nor the whole request chain; resulting in unwanted results and failures.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
