### PR TITLE
Fixed 'Add to cart' malfunction in product/details.html

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -1,0 +1,1 @@
+Joel Varma Dirisam

--- a/Contributors.md
+++ b/Contributors.md
@@ -1,1 +1,0 @@
-Joel Varma Dirisam

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -161,7 +161,7 @@
           </h2>
         {% endif %}
       {% endif %}
-      {% if is_visible and product.is_in_stock %}
+      {% if is_visible and product.is_in_stock and availability.available %}
         {% block orderform %}
           {% if show_variant_picker %}
             {% csrf_token %}

--- a/templates/product/details.html
+++ b/templates/product/details.html
@@ -161,7 +161,7 @@
           </h2>
         {% endif %}
       {% endif %}
-      {% if is_visible and product.is_in_stock and availability.available %}
+      {% if availability.available %}
         {% block orderform %}
           {% if show_variant_picker %}
             {% csrf_token %}


### PR DESCRIPTION
### What I'm trying to achieve
After unpublishing a product, disable the add to cart button.

### Steps to reproduce the problem
Unpublish a product in the admin dashboard
Open the same product's detail page.
The product can still be added to cart.

### What I expected to happen
Display message : This product is currently unavailable.

### System information
Operating system: Mac
Browser: Google Chrome