### PR TITLE
Fix problem with free shipping voucher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-..
+- Fix problem with free shipping voucher - #4942 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -784,7 +784,11 @@ def recalculate_checkout_discount(checkout, discounts):
         else:
             manager = get_extensions_manager()
             subtotal = manager.calculate_checkout_subtotal(checkout, discounts).gross
-            checkout.discount = min(discount, subtotal)
+            checkout.discount = (
+                min(discount, subtotal)
+                if voucher.type != VoucherType.SHIPPING
+                else discount
+            )
             checkout.discount_name = str(voucher)
             checkout.translated_discount_name = (
                 voucher.translated.name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,17 @@ def checkout_with_gift_card(checkout_with_item, gift_card):
 
 
 @pytest.fixture
+def checkout_with_voucher_percentage_and_shipping(
+    checkout_with_voucher_percentage, shipping_method, address
+):
+    checkout = checkout_with_voucher_percentage
+    checkout.shipping_method = shipping_method
+    checkout.shipping_address = address
+    checkout.save()
+    return checkout
+
+
+@pytest.fixture
 def address(db):  # pylint: disable=W0613
     return Address.objects.create(
         first_name="John",
@@ -785,6 +796,14 @@ def voucher_shipping_type():
     return Voucher.objects.create(
         code="mirumee", discount_value=10, type=VoucherType.SHIPPING, countries="IS"
     )
+
+
+@pytest.fixture
+def voucher_free_shipping(voucher_percentage):
+    voucher_percentage.type = VoucherType.SHIPPING
+    voucher_percentage.discount_value = 100
+    voucher_percentage.save()
+    return voucher_percentage
 
 
 @pytest.fixture


### PR DESCRIPTION
Fix problem with free shipping method - now free shipping voucher slash off the shipment price instead of the lower amount

Fixes #4925 

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/40886528/68286436-65632900-0081-11ea-94b6-c9006d565967.png)

After:
![image](https://user-images.githubusercontent.com/40886528/68286535-8a579c00-0081-11ea-959f-a915f7288708.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
