### PR TITLE
Deprecate `localized` field in Money type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Fix problem with free shipping voucher - #4942 by @IKarbowiak
 - Add sub-categories to random data - #4949 by @IKarbowiak
+- Deprecate `localized` field in Money type - #4952 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -8,7 +8,11 @@ class Money(graphene.ObjectType):
     currency = graphene.String(description="Currency code.", required=True)
     amount = graphene.Float(description="Amount of money.", required=True)
     localized = graphene.String(
-        description="Money formatted according to the current locale.", required=True
+        description="Money formatted according to the current locale.",
+        required=True,
+        deprecation_reason="DEPRECATED: Will be removed in Saleor 2.11. "
+        "Price formatting according to the current locale will be "
+        "handled by the frontend client.",
     )
 
     class Meta:

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -11,7 +11,7 @@ class Money(graphene.ObjectType):
         description="Money formatted according to the current locale.",
         required=True,
         deprecation_reason="DEPRECATED: Will be removed in Saleor 2.11. "
-        "Price formatting according to the current locale will be "
+        "Price formatting according to the current locale should be "
         "handled by the frontend client.",
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2004,7 +2004,7 @@ type MetaStore {
 type Money {
   currency: String!
   amount: Float!
-  localized: String! @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.11. Price formatting according to the current locale will be handled by the frontend client.")
+  localized: String! @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.11. Price formatting according to the current locale should be handled by the frontend client.")
 }
 
 type MoneyRange {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2004,7 +2004,7 @@ type MetaStore {
 type Money {
   currency: String!
   amount: Float!
-  localized: String!
+  localized: String! @deprecated(reason: "DEPRECATED: Will be removed in Saleor 2.11. Price formatting according to the current locale will be handled by the frontend client.")
 }
 
 type MoneyRange {


### PR DESCRIPTION
Set 'localized' field in the Money type as deprecated - it's useless. Price formatting according to the current locale will be handled by the frontend client.

Closes #4934 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
