### PR TITLE
Force pytest to ignore DJANGO_SETTINGS_MODULE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Remove thumbnail generation from migration - #3494 by @kswiatek92
 - Rename 'shipping_date' field in fulfillment model to 'created' - #2433 by @kswiatek92
 - Reduce number of queries for 'completeCheckout' mutation - #4989 by @IKarbowiak
+- Now force pytest to ignore the environment variable containing the django settings module - #4992 by @NyanKiyoshi
 
 ## 2.9.0
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,12 +14,11 @@ exclude_lines =
     return NotImplemented
 
 [tool:pytest]
-addopts = -n auto --vcr-record-mode=none
+addopts = -n auto --vcr-record-mode=none --ds=tests.settings
 testpaths = tests saleor
 filterwarnings =
     ignore::DeprecationWarning
     ignore::PendingDeprecationWarning
-DJANGO_SETTINGS_MODULE = tests.settings
 markers =
     integration
 


### PR DESCRIPTION
If you need to set a custom `DJANGO_SETTINGS_MODULE` for the tests,
use `export PYTEST_ADDOPTS='--ds pkg.your_test_settings'`.

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
