### PR TITLE
Consider products with all their stock allocated as out of stock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed serialization error on weight fields when running `loaddata` and `dumpdb` - #5005 by @NyanKiyoshi
 - Fixed JSON encoding error on Google Analytics reporting - #5004 by @NyanKiyoshi
 - Create custom field to translation, use new translation types in translations query - #5007 by @fowczarek
+- Take allocated stock in account in `StockAvailability` filter - #5019 by @simonbru
 
 ## 2.9.0
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -99,11 +99,13 @@ def sort_qs(qs, sort_by):
 
 
 def filter_products_by_stock_availability(qs, stock_availability):
-    qs = qs.annotate(total_quantity=Sum("variants__quantity"))
+    qs = qs.annotate(
+        total_available=Sum("variants__quantity") - Sum("variants__quantity_allocated")
+    )
     if stock_availability == StockAvailability.IN_STOCK:
-        qs = qs.filter(total_quantity__gt=0)
+        qs = qs.filter(total_available__gt=0)
     elif stock_availability == StockAvailability.OUT_OF_STOCK:
-        qs = qs.filter(total_quantity=0)
+        qs = qs.filter(total_available__lte=0)
     return qs
 
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -216,7 +216,8 @@ def test_product_query(staff_api_client, product, permission_manage_products):
     [
         ("IN_STOCK", 5, 1),
         ("OUT_OF_STOCK", 0, 1),
-        ("OUT_OF_STOCK", 1, 0),
+        ("OUT_OF_STOCK", 1, 1),
+        ("OUT_OF_STOCK", 2, 0),
         ("IN_STOCK", 0, 0),
     ],
 )


### PR DESCRIPTION
Currently, the `stockAvailability` filter on product connections does not take allocated stock in account. In practice, it makes it difficult to retrieve the list of products that can actually be ordered.

This behavior is inconsistent with the `isAvailable` attribute on `Product` and `ProductVariant`, which consider items with all their stock allocated as *not available*.

### Pull Request Checklist

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
