### PR TITLE
Fix faulty form selection mechanism of site settings company address

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -201,7 +201,7 @@ class CountryAwareAddressForm(AddressForm):
 
 
 def get_address_form_class(country_code):
-    return COUNTRY_FORMS[country_code]
+    return COUNTRY_FORMS.get(country_code, AddressForm)
 
 
 def get_form_i18n_lines(form_instance):

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -32,6 +32,7 @@ from saleor.account.utils import (
 )
 from saleor.account.validators import validate_possible_number
 from saleor.core.utils import build_absolute_uri
+from saleor.account.i18n import AddressForm
 
 
 @pytest.mark.parametrize("country", ["CN", "PL", "US", "IE"])
@@ -138,6 +139,11 @@ def test_get_address_form(form_data, form_valid, expected_preview, expected_coun
     assert preview is expected_preview
     assert form.is_valid() is form_valid
     assert form.i18n_country_code == expected_country
+
+
+def test_get_address_form_no_country_code():
+    form, _ = forms.get_address_form(data={}, country_code=None)
+    assert isinstance(form, AddressForm)
 
 
 def test_country_aware_form_has_only_supported_countries():


### PR DESCRIPTION
I want to merge this change because it fixes https://github.com/mirumee/saleor-dashboard/issues/282
Should be merged along with frontend fix available here:
https://github.com/mirumee/saleor-dashboard/pull/287

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
