### PR TITLE
Generate matching postal codes for US addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed JSON encoding error on Google Analytics reporting - #5004 by @NyanKiyoshi
 - Create custom field to translation, use new translation types in translations query - #5007 by @fowczarek
 - Take allocated stock in account in `StockAvailability` filter - #5019 by @simonbru
+- Generate matching postal codes for US addresses - #5033 by @maarcingebala
 
 ## 2.9.0
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -344,14 +344,22 @@ def create_product_image(product, placeholder_dir, image_name):
 
 
 def create_address():
-    address = Address.objects.create(
+    address = Address(
         first_name=fake.first_name(),
         last_name=fake.last_name(),
         street_address_1=fake.street_address(),
         city=fake.city(),
-        postal_code=fake.postcode(),
         country=settings.DEFAULT_COUNTRY,
     )
+
+    if address.country == "US":
+        state = fake.state_abbr()
+        address.country_area = state
+        address.postal_code = fake.postalcode_in_state(state)
+    else:
+        address.postal_code = fake.postalcode()
+
+    address.save()
     return address
 
 


### PR DESCRIPTION
US addresses generated by `populatedb` were failing in our address validation checks. This PR fixes it by creating addresses with matching postal codes and states.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
