### PR TITLE
Use calculate methods from calculation wrapper method

### DIFF
--- a/saleor/extensions/plugins/vatlayer/plugin.py
+++ b/saleor/extensions/plugins/vatlayer/plugin.py
@@ -7,6 +7,8 @@ from django_countries.fields import Country
 from django_prices_vatlayer.utils import get_tax_rate_types
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
+
+from ....checkout import calculations
 from ....core.taxes import TaxType
 from ....graphql.core.utils.error_codes import ExtensionsErrorCode
 from ...base_plugin import BasePlugin
@@ -72,12 +74,9 @@ class VatlayerPlugin(BasePlugin):
         if self._skip_plugin(previous_value):
             return previous_value
 
-        zero_total = Money(0, currency=previous_value.currency)
-        taxed_zero = TaxedMoney(zero_total, zero_total)
-
         return (
-            self.calculate_checkout_subtotal(checkout, discounts, previous_value)
-            + self.calculate_checkout_shipping(checkout, discounts, taxed_zero)
+            calculations.checkout_subtotal(checkout, discounts)
+            + calculations.checkout_shipping_price(checkout, discounts)
             - checkout.discount
         )
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1,7 +1,7 @@
 import graphene
 import graphene_django_optimizer as gql_optimizer
 
-from ...checkout import models
+from ...checkout import calculations, models
 from ...checkout.utils import get_valid_shipping_methods_for_checkout
 from ...core.taxes import display_gross_prices, zero_taxed_money
 from ...extensions.manager import get_extensions_manager
@@ -146,22 +146,20 @@ class Checkout(MetadataObjectType, CountableDjangoObjectType):
     @staticmethod
     def resolve_total_price(root: models.Checkout, info):
         taxed_total = (
-            info.context.extensions.calculate_checkout_total(
-                checkout=root, discounts=info.context.discounts
-            )
+            calculations.checkout_total(checkout=root, discounts=info.context.discounts)
             - root.get_total_gift_cards_balance()
         )
         return max(taxed_total, zero_taxed_money())
 
     @staticmethod
     def resolve_subtotal_price(root: models.Checkout, info):
-        return info.context.extensions.calculate_checkout_subtotal(
+        return calculations.checkout_subtotal(
             checkout=root, discounts=info.context.discounts
         )
 
     @staticmethod
     def resolve_shipping_price(root: models.Checkout, info):
-        return info.context.extensions.calculate_checkout_shipping(
+        return calculations.checkout_shipping_price(
             checkout=root, discounts=info.context.discounts
         )
 

--- a/tests/extensions/plugins/test_vatlayer.py
+++ b/tests/extensions/plugins/test_vatlayer.py
@@ -8,6 +8,7 @@ from django.urls import reverse
 from django_countries.fields import Country
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
+from saleor.checkout import calculations
 from saleor.checkout.utils import add_variant_to_checkout
 from saleor.core.taxes import quantize_price
 from saleor.extensions.manager import get_extensions_manager
@@ -461,3 +462,33 @@ def test_apply_taxes_to_product(vatlayer, settings, variant, discount_info):
         variant.product, variant.get_price([discount_info]), country
     )
     assert price == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5.00", "USD"))
+
+
+def test_calculations_checkout_total_with_vatlayer(
+    vatlayer, settings, checkout_with_item
+):
+    settings.PLUGINS = ["saleor.extensions.plugins.vatlayer.plugin.VatlayerPlugin"]
+    checkout_subtotal = calculations.checkout_total(checkout_with_item)
+    assert checkout_subtotal == TaxedMoney(
+        net=Money("30", "USD"), gross=Money("30", "USD")
+    )
+
+
+def test_calculations_checkout_subtotal_with_vatlayer(
+    vatlayer, settings, checkout_with_item
+):
+    settings.PLUGINS = ["saleor.extensions.plugins.vatlayer.plugin.VatlayerPlugin"]
+    checkout_subtotal = calculations.checkout_subtotal(checkout_with_item)
+    assert checkout_subtotal == TaxedMoney(
+        net=Money("30", "USD"), gross=Money("30", "USD")
+    )
+
+
+def test_calculations_checkout_shipping_price_with_vatlayer(
+    vatlayer, settings, checkout_with_item
+):
+    settings.PLUGINS = ["saleor.extensions.plugins.vatlayer.plugin.VatlayerPlugin"]
+    checkout_shipping_price = calculations.checkout_shipping_price(checkout_with_item)
+    assert checkout_shipping_price == TaxedMoney(
+        net=Money("0", "USD"), gross=Money("0", "USD")
+    )


### PR DESCRIPTION
Vatlayer is missing calculate subtotal method
which raise an error
```
TypeError: unsupported operand type(s) for +: 'NotImplementedType' and 'TaxedMoney'
```
used `checkout_subtotal` method from calculation wrapper to fix this issue

### Pull Request 


1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
