### PR TITLE
Add user id to jwt payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Generate matching postal codes for US addresses - #5033 by @maarcingebala
 - Update debug toolbar - #5032 by @IKarbowiak
 - Allow staff member to receive notification about customers orders - #4993 by @kswiatek92
+- JWT payload now contains user global id - #5039 by @salwator
 
 ## 2.9.0
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -228,7 +228,8 @@ class ServiceAccount(MetadataObjectType, CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
 
-@key(fields="id")
+@key("id")
+@key("email")
 class User(MetadataObjectType, CountableDjangoObjectType):
     addresses = gql_optimizer.field(
         graphene.List(Address, description="List of all user's addresses."),
@@ -353,7 +354,9 @@ class User(MetadataObjectType, CountableDjangoObjectType):
 
     @staticmethod
     def __resolve_reference(root, _info, **_kwargs):
-        return graphene.Node.get_node_from_global_id(_info, root.id)
+        if root.id is not None:
+            return graphene.Node.get_node_from_global_id(_info, root.id)
+        return get_user_model().objects.get(email=root.email)
 
 
 class ChoiceValue(graphene.ObjectType):

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -167,6 +167,7 @@ def format_permissions_for_display(permissions):
 
 def create_jwt_payload(user, context=None):
     payload = jwt_payload(user, context)
+    payload["user_id"] = graphene.Node.to_global_id("User", user.id)
     payload["is_staff"] = user.is_staff
     payload["is_superuser"] = user.is_superuser
     return payload

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -4,6 +4,7 @@ import uuid
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import graphene
+import jwt
 import pytest
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
@@ -76,7 +77,7 @@ def query_staff_users_with_filter():
     return query
 
 
-def test_create_token_mutation(admin_client, staff_user):
+def test_create_token_mutation(admin_client, staff_user, settings):
     query = """
     mutation TokenCreate($email: String!, $password: String!) {
         tokenCreate(email: $email, password: $password) {
@@ -96,7 +97,10 @@ def test_create_token_mutation(admin_client, staff_user):
     )
     content = get_graphql_content(response)
     token_data = content["data"]["tokenCreate"]
-    assert token_data["token"]
+    token = jwt.decode(token_data["token"], settings.SECRET_KEY)
+    assert token["email"] == staff_user.email
+    assert token["user_id"] == graphene.Node.to_global_id("User", staff_user.id)
+
     assert token_data["errors"] == []
 
     incorrect_variables = {"email": staff_user.email, "password": "incorrect"}

--- a/tests/api/test_federation.py
+++ b/tests/api/test_federation.py
@@ -1,0 +1,50 @@
+import graphene
+import pytest
+
+from .utils import get_graphql_content
+
+
+@pytest.fixture
+def user_representation_by_id(staff_user):
+    user_id = graphene.Node.to_global_id("User", staff_user.id)
+    return {"_representations": [{"id": user_id, "__typename": "User"}]}
+
+
+@pytest.fixture
+def user_representation_by_email(staff_user):
+    return {"_representations": [{"email": staff_user.email, "__typename": "User"}]}
+
+
+FEDERATED_QUERY = """
+query($_representations: [_Any!]!) {
+  _entities(representations: $_representations) {
+    ... on User {
+      id
+      email
+      isStaff
+    }
+  }
+}
+"""
+
+
+def test_get_user_data_through_federated_query_by_id(
+    staff_api_client, user_representation_by_id, staff_user
+):
+    response = staff_api_client.post_graphql(FEDERATED_QUERY, user_representation_by_id)
+    content = get_graphql_content(response)["data"]["_entities"]
+    assert len(content) == 1
+    assert content[0]["email"] == staff_user.email
+    assert content[0]["isStaff"] == staff_user.is_staff
+
+
+def test_get_user_data_through_federated_query_by_email(
+    staff_api_client, user_representation_by_email, staff_user
+):
+    response = staff_api_client.post_graphql(
+        FEDERATED_QUERY, user_representation_by_email
+    )
+    content = get_graphql_content(response)["data"]["_entities"]
+    assert len(content) == 1
+    assert content[0]["id"] == graphene.Node.to_global_id("User", staff_user.id)
+    assert content[0]["isStaff"] == staff_user.is_staff


### PR DESCRIPTION
This PR extends JWT payload with additional user global ID to make it easier to use the saleor with other services in a federation, token now contains graphql type key so nothing more is needed to get user data from saleor in a query.
Additionally, it adds email as key to User graphql type as it may be a more convenient identifier.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
