### PR TITLE
Made middleware path resolving lazy and refactored middleware names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Generate matching postal codes for US addresses - #5033 by @maarcingebala
 - Update debug toolbar - #5032 by @IKarbowiak
 - Allow staff member to receive notification about customers orders - #4993 by @kswiatek92
+- Made middleware path resolving lazy and refactored middleware names - #5041 by @NyanKiyoshi
 
 ## 2.9.0
 

--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -7,7 +7,6 @@ from django.contrib.sites.models import Site
 from django.core.exceptions import MiddlewareNotUsed
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
-from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import SimpleLazyObject
 from django.utils.translation import get_language, ugettext_lazy as _
@@ -15,7 +14,7 @@ from django_countries.fields import Country
 
 from ..discount.utils import fetch_discounts
 from ..extensions.manager import get_extensions_manager
-from ..graphql.views import GraphQLView
+from ..graphql.views import API_PATH, GraphQLView
 from . import analytics
 from .exceptions import ReadOnlyException
 from .utils import get_client_ip, get_country_by_ip, get_currency_for_country
@@ -152,7 +151,7 @@ class ReadOnlyMiddleware:
         return self.get_response(request)
 
     def process_view(self, request, *_args, **_kwargs):
-        if request.path == reverse("api"):
+        if request.path == API_PATH:
             if not self._is_graphql_request_blocked(request):
                 return None
             error = GraphQLView.format_error(

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -2,13 +2,12 @@ from typing import Optional
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
-from django.shortcuts import reverse
 from django.utils.functional import SimpleLazyObject
 from graphene_django.settings import graphene_settings
 from graphql_jwt.middleware import JSONWebTokenMiddleware
 
 from ..account.models import ServiceAccount
-from .views import GraphQLView
+from .views import API_PATH, GraphQLView
 
 
 def jwt_middleware(get_response):
@@ -24,7 +23,7 @@ def jwt_middleware(get_response):
     graphene_settings.MIDDLEWARE.remove(JSONWebTokenMiddleware)
 
     def middleware(request):
-        if request.path == reverse("api"):
+        if request.path == API_PATH:
             # clear user authenticated by AuthenticationMiddleware
             request._cached_user = AnonymousUser()
             request.user = AnonymousUser()
@@ -47,7 +46,7 @@ def service_account_middleware(get_response):
     prefix = "bearer"
 
     def middleware(request):
-        if request.path == reverse("api"):
+        if request.path == API_PATH:
             request.service_account = None
             auth = request.META.get(service_account_auth_header, "").split()
             if len(auth) == 2:

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -22,7 +22,7 @@ def jwt_middleware(get_response):
     jwt_middleware_inst = JSONWebTokenMiddleware(get_response=get_response)
     graphene_settings.MIDDLEWARE.remove(JSONWebTokenMiddleware)
 
-    def middleware(request):
+    def _jwt_middleware(request):
         if request.path == API_PATH:
             # clear user authenticated by AuthenticationMiddleware
             request._cached_user = AnonymousUser()
@@ -32,7 +32,7 @@ def jwt_middleware(get_response):
             jwt_middleware_inst.process_request(request)
         return get_response(request)
 
-    return middleware
+    return _jwt_middleware
 
 
 def get_service_account(auth_token) -> Optional[ServiceAccount]:
@@ -45,7 +45,7 @@ def service_account_middleware(get_response):
     service_account_auth_header = "HTTP_AUTHORIZATION"
     prefix = "bearer"
 
-    def middleware(request):
+    def _service_account_middleware(request):
         if request.path == API_PATH:
             request.service_account = None
             auth = request.META.get(service_account_auth_header, "").split()
@@ -57,7 +57,7 @@ def service_account_middleware(get_response):
                     )
         return get_response(request)
 
-    return middleware
+    return _service_account_middleware
 
 
 def process_view(self, request, view_func, *args):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -5,6 +5,8 @@ import traceback
 from django.conf import settings
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
 from django.shortcuts import render_to_response
+from django.urls import reverse
+from django.utils.functional import SimpleLazyObject
 from django.views.generic import View
 from graphene_django.settings import graphene_settings
 from graphene_django.views import instantiate_middleware
@@ -16,6 +18,8 @@ from graphql.error import (
 )
 from graphql.execution import ExecutionResult
 from graphql_jwt.exceptions import PermissionDenied
+
+API_PATH = SimpleLazyObject(lambda: reverse("api"))
 
 unhandled_errors_logger = logging.getLogger("saleor.graphql.errors.unhandled")
 handled_errors_logger = logging.getLogger("saleor.graphql.errors.handled")


### PR DESCRIPTION
## Changes
- Made graphql api path' resolving lazy in middlewares:
  When profiling, it was noticed that most of the CPU time is actually wasted in the middlewares when calling and resolving `reverse("api")`. For example, when querying the `me` object, 28 ms of CPU time were used by the `reverse("api")` and 5 ms were actually being the rest of the request being processed.

 - Renamed middleware functions to meaningful names for easier profiling:
  In the profiling trace we see "middleware" everywhere, making it impossible to know what middleware was being executed without having to lookup the path and line number that was provided by the trace.
  middleware -> middleware -> middleware -> middleware. Who is who?


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
