### PR TITLE
Fix "assert_called_once_with" depending on list's order

### DIFF
--- a/tests/api/test_product_minimal_variant_price.py
+++ b/tests/api/test_product_minimal_variant_price.py
@@ -295,9 +295,12 @@ def test_category_delete_updates_minimal_variant_price(
     data = content["data"]["categoryDelete"]
     assert data["errors"] == []
 
-    mock_update_products_minimal_variant_prices_task.delay.assert_called_once_with(
-        product_ids=[p.pk for p in product_list]
-    )
+    mock_update_products_minimal_variant_prices_task.delay.assert_called_once()
+    (
+        call_args,
+        call_kwargs,
+    ) = mock_update_products_minimal_variant_prices_task.delay.call_args
+    assert set(call_kwargs["product_ids"]) == set(p.pk for p in product_list)
 
     for product in product_list:
         product.refresh_from_db()

--- a/tests/api/test_product_minimal_variant_price.py
+++ b/tests/api/test_product_minimal_variant_price.py
@@ -297,7 +297,7 @@ def test_category_delete_updates_minimal_variant_price(
 
     mock_update_products_minimal_variant_prices_task.delay.assert_called_once()
     (
-        call_args,
+        _call_args,
         call_kwargs,
     ) = mock_update_products_minimal_variant_prices_task.delay.call_args
     assert set(call_kwargs["product_ids"]) == set(p.pk for p in product_list)


### PR DESCRIPTION
One of the `minimal product variant` tests randomly failed while I was working on unrelated features:

> https://travis-ci.com/mirumee/saleor/jobs/265209511

The reason for it is that the mock of `update_products_minimal_variant_prices_task` checks if it was called with a `product_ids` list which order depends on db's query and may vary.

I fixed it by retrieving the list and changing it into a _set_ which overcomes the ordering issue.