### PR TITLE
Fix nondeterministic category test

### DIFF
--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -402,9 +402,12 @@ def test_category_delete_mutation_for_categories_tree(
     with pytest.raises(parent._meta.model.DoesNotExist):
         parent.refresh_from_db()
 
-    mock_update_products_minimal_variant_prices_task.delay.assert_called_once_with(
-        product_ids=[p.pk for p in product_list]
-    )
+    mock_update_products_minimal_variant_prices_task.delay.assert_called_once()
+    (
+        _call_args,
+        call_kwargs,
+    ) = mock_update_products_minimal_variant_prices_task.delay.call_args
+    assert set(call_kwargs["product_ids"]) == set(p.pk for p in product_list)
 
     for product in product_list:
         product.refresh_from_db()


### PR DESCRIPTION
`test_category_delete_mutation_for_categories_tree` failed randomly. 
The same situation as that resolved in #5058 