### PR TITLE
move extracting requester to utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `checkout_quantity_changed` webhook - #5042 by @derenio
 - Remove unnecessary manage_orders permission - #5142 by @kswiatek92
 - Mutation to change user email - #5076 by @kswiatek92
+- Move extracting user or service_account from context to utils - #5152 by @kswiatek92
 
 ## 2.9.0
 

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -11,7 +11,11 @@ from ...account import models
 from ...core.permissions import AccountPermissions
 from ...payment import gateway
 from ...payment.utils import fetch_customer_id
-from ..utils import filter_by_query_param, sort_queryset
+from ..utils import (
+    filter_by_query_param,
+    get_user_or_service_account_from_context,
+    sort_queryset,
+)
 from .sorters import ServiceAccountSortField, UserSortField, UserSortingInput
 from .types import AddressValidationData, ChoiceValue
 from .utils import get_allowed_fields_camel_case, get_required_fields_camel_case
@@ -54,7 +58,7 @@ def resolve_staff_users(info, query, sort_by=None, **_kwargs):
 
 
 def resolve_user(info, id):
-    requester = info.context.user or info.context.service_account
+    requester = get_user_or_service_account_from_context(info.context)
     if requester:
         _model, user_pk = graphene.Node.from_global_id(id)
         if requester.has_perms(

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -11,6 +11,7 @@ from ..utils import (
     filter_by_period,
     filter_by_query_param,
     get_database_id,
+    get_user_or_service_account_from_context,
     get_nodes,
     sort_queryset,
 )
@@ -141,9 +142,7 @@ def resolve_products(
     **_kwargs,
 ):
 
-    user = info.context.user
-    if user.is_anonymous and info.context.service_account:
-        user = info.context.service_account
+    user = get_user_or_service_account_from_context(info.context)
     qs = models.Product.objects.visible_to_user(user)
     qs = sort_products(qs, sort_by)
 

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -183,3 +183,9 @@ def create_jwt_payload(user, context=None):
     payload["is_staff"] = user.is_staff
     payload["is_superuser"] = user.is_superuser
     return payload
+
+
+def get_user_or_service_account_from_context(context):
+    # order is important
+    # service_account can be None but user if None then is passed as anonymous
+    return context.service_account or context.user

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -304,6 +304,18 @@ def test_user_query_permission_manage_users_get_customer(
     assert customer_user.email == data["email"]
 
 
+def test_user_query_as_service_account(
+    service_account_api_client, customer_user, permission_manage_users, service_account
+):
+    service_account.permissions.add(permission_manage_users)
+    customer_id = graphene.Node.to_global_id("User", customer_user.pk)
+    variables = {"id": customer_id}
+    response = service_account_api_client.post_graphql(USER_QUERY, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["user"]
+    assert customer_user.email == data["email"]
+
+
 def test_user_query_permission_manage_users_get_staff(
     staff_api_client, staff_user, permission_manage_users
 ):


### PR DESCRIPTION
service account can be None
but user will always be set (user or anonymous)
previous `info.context.user or info.context.service_account` always returned user

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
