### PR TITLE
Copy metadata to order upon checkout completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Move extracting user or service_account from context to utils - #5152 by @kswiatek92
 - Add deprecate description to order status/created arguments - #5076 by @kswiatek92
 - Fix getting title field in page mutations #5160 by @maarcingebala
+- Copy public and private metadata from the checkout to the order upon creation -  #5165 by @dankolbman
 
 ## 2.9.0
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -754,6 +754,11 @@ def create_order(
     # assign checkout payments to the order
     checkout.payments.update(order=order)
 
+    # copy metadata from the checkout into the new order
+    order.meta = checkout.meta
+    order.private_meta = checkout.private_meta
+    order.save()
+
     order_created(order=order, user=user)
 
     # Send the order confirmation email

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -1162,6 +1162,10 @@ def test_checkout_complete(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.billing_address = address
+    checkout.store_meta(namespace="PUBLIC", client="PLUGIN", item={"accepted": "true"})
+    checkout.store_private_meta(
+        namespace="PRIVATE", client="PLUGIN", item={"accepted": "true"},
+    )
     checkout.save()
 
     checkout_line = checkout.lines.first()
@@ -1193,6 +1197,8 @@ def test_checkout_complete(
     order = Order.objects.first()
     assert order.token == order_token
     assert order.total.gross == total.gross - gift_current_balance
+    assert order.meta == checkout.meta
+    assert order.private_meta == checkout.private_meta
 
     order_line = order.lines.first()
     assert checkout_line_quantity == order_line.quantity


### PR DESCRIPTION
Metadata that has been added to a checkout may be needed post-completion. Currently, all metadata is lost on the checkout once it is completed as the checkout object is deleted during order creation.

This PR copies both the meta and private_meta from the checkout object to the new order when it is created.

Addresses #5162 

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
