### PR TITLE
Fix for necessity of requires_confirmation field on AccountRegister

### DIFF
--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -44,8 +44,7 @@ class AccountRegister(ModelMutation):
         )
 
     requires_confirmation = graphene.Boolean(
-        required=True,
-        description="Informs whether users need to confirm their email address.",
+        description="Informs whether users need to confirm their email address."
     )
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -66,7 +66,7 @@ input AccountInput {
 
 type AccountRegister {
   errors: [Error!]
-  requiresConfirmation: Boolean!
+  requiresConfirmation: Boolean
   accountErrors: [AccountError!]
   user: User
 }


### PR DESCRIPTION
I want to merge this change because it fixes a minor bug in #1527
When for ex. user already existed and we tried to register same email again, mutation would crash because requiresConfirmation field was mandatory (in which case it would be null in response so it shouldn't be a required field).

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
