### PR TITLE
change redirect to graphql/ to /graphql/ in urls to prevent server recursive …

### DIFF
--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -35,7 +35,7 @@ if settings.DEBUG:
 
     urlpatterns += static("/media/", document_root=settings.MEDIA_ROOT) + [
         url(r"^static/(?P<path>.*)$", serve),
-        url(r"^", RedirectView.as_view(url="graphql/")),
+        url(r"^", RedirectView.as_view(url="/graphql/")),
     ]
 
 if settings.ENABLE_SILK:


### PR DESCRIPTION
…redirect

I want to merge this change because...
The not found URL keeps redirecting to graphql/  and append to the URL with non-stop
e.g: http://localhost:8000/unknown/graphql/graphql/.../graphql

### Screenshots

![Screen Shot 2020-01-22 at 11 17 28 AM](https://user-images.githubusercontent.com/25222631/72881139-dde49800-3d08-11ea-84d3-78ce950b455d.png)


### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
