### PR TITLE
Drop unused resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,11 +48,12 @@ All notable, unreleased changes to this project will be documented in this file.
 - Move extracting user or service_account from context to utils - #5152 by @kswiatek92
 - Add deprecate description to order status/created arguments - #5076 by @kswiatek92
 - Fix getting title field in page mutations #5160 by @maarcingebala
-- Copy public and private metadata from the checkout to the order upon creation -  #5165 by @dankolbman
+- Copy public and private metadata from the checkout to the order upon creation - #5165 by @dankolbman
 - Add warehouses and stocks- #4986 by @szewczykmira
 - Add permission groups - #5176 by @IKarbowiak
 - Drop gettext occurrences - #5189 by @IKarbowiak
 - Fix `product_created` webhook - #5187 by @dzkb
+- Drop unused resolver `resolve_availability` - #5190 by @maarcingebala
 
 ## 2.9.0
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -347,8 +347,6 @@ class ProductVariant(CountableDjangoObjectType, MetadataObjectType):
         )
         return VariantPricingInfo(**asdict(availability))
 
-    resolve_availability = resolve_pricing
-
     @staticmethod
     def resolve_is_available(root: models.ProductVariant, info):
         country = info.context.country
@@ -522,8 +520,6 @@ class Product(CountableDjangoObjectType, MetadataObjectType):
             context.extensions,
         )
         return ProductPricingInfo(**asdict(availability))
-
-    resolve_availability = resolve_pricing
 
     @staticmethod
     @gql_optimizer.resolver_hints(prefetch_related=("variants"))


### PR DESCRIPTION
`availability` fields were dropped from Product and ProductVariant type in #5107 but resolvers that were shared with the `pricing` field stayed. This PR removes the unused resolvers.

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [ ] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
