### PR TITLE
Fix permission for checkoutCustomerAttach mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop gettext occurrences - #5189 by @IKarbowiak
 - Fix `product_created` webhook - #5187 by @dzkb
 - Drop unused resolver `resolve_availability` - #5190 by @maarcingebala
+- Fix permission for `checkoutCustomerAttach` mutation - #5192 by @maarcingebala
 
 ## 2.9.0
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -36,7 +36,7 @@ from ...payment.utils import store_customer_id
 from ...product import models as product_models
 from ...warehouse.availability import check_stock_quantity, get_available_quantity
 from ..account.i18n import I18nMixin
-from ..account.types import AddressInput, User
+from ..account.types import AddressInput
 from ..core.mutations import (
     BaseMutation,
     ClearMetaBaseMutation,
@@ -408,8 +408,9 @@ class CheckoutCustomerAttach(BaseMutation):
         customer_id = graphene.ID(
             required=False,
             description=(
-                "The ID of the customer. DEPRECATED: This field is deprecated. "
-                "To identify a customer you should authenticate with JWT token."
+                "The ID of the customer. DEPRECATED: This field is deprecated and will "
+                "be removed in Saleor 2.11. To identify a customer you should "
+                "authenticate with JWT token."
             ),
         )
 
@@ -434,10 +435,8 @@ class CheckoutCustomerAttach(BaseMutation):
         # error if it doesn't. This part can be removed when `customer_id` field is
         # removed.
         if customer_id:
-            customer = cls.get_node_or_error(
-                info, customer_id, only_type=User, field="customer_id"
-            )
-            if customer and customer != info.context.user:
+            current_user_id = graphene.Node.to_global_id("User", info.context.user.id)
+            if current_user_id != customer_id:
                 raise PermissionDenied()
 
         checkout.user = info.context.user
@@ -461,10 +460,16 @@ class CheckoutCustomerDetach(BaseMutation):
         return context.user.is_authenticated
 
     @classmethod
-    def perform_mutation(cls, _root, info, checkout_id):
+    def perform_mutation(cls, _root, info, **data):
+        checkout_id = data.get("checkout_id")
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
+
+        # Raise error if the current user doesn't own the checkout of the given ID.
+        if checkout.user and checkout.user != info.context.user:
+            raise PermissionDenied()
+
         checkout.user = None
         checkout.save(update_fields=["user", "last_change"])
         return CheckoutCustomerDetach(checkout=checkout)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -424,9 +424,7 @@ class CheckoutCustomerAttach(BaseMutation):
         return context.user.is_authenticated
 
     @classmethod
-    def perform_mutation(cls, _root, info, **data):
-        checkout_id = data.get("checkout_id")
-        customer_id = data.get("customer_id")
+    def perform_mutation(cls, _root, info, checkout_id, customer_id=None):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
@@ -460,8 +458,7 @@ class CheckoutCustomerDetach(BaseMutation):
         return context.user.is_authenticated
 
     @classmethod
-    def perform_mutation(cls, _root, info, **data):
-        checkout_id = data.get("checkout_id")
+    def perform_mutation(cls, _root, info, checkout_id):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2288,7 +2288,7 @@ type Mutation {
   checkoutBillingAddressUpdate(billingAddress: AddressInput!, checkoutId: ID!): CheckoutBillingAddressUpdate
   checkoutComplete(checkoutId: ID!, redirectUrl: String, storeSource: Boolean = false): CheckoutComplete
   checkoutCreate(input: CheckoutCreateInput!): CheckoutCreate
-  checkoutCustomerAttach(checkoutId: ID!, customerId: ID!): CheckoutCustomerAttach
+  checkoutCustomerAttach(checkoutId: ID!, customerId: ID): CheckoutCustomerAttach
   checkoutCustomerDetach(checkoutId: ID!): CheckoutCustomerDetach
   checkoutEmailUpdate(checkoutId: ID, email: String!): CheckoutEmailUpdate
   checkoutLineDelete(checkoutId: ID!, lineId: ID): CheckoutLineDelete

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -8,6 +8,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from prices import Money, TaxedMoney
 
+from saleor.account.models import User
 from saleor.checkout import calculations
 from saleor.checkout.error_codes import CheckoutErrorCode
 from saleor.checkout.models import Checkout
@@ -25,7 +26,7 @@ from saleor.payment.interface import GatewayResponse
 from saleor.shipping import ShippingMethodType
 from saleor.shipping.models import ShippingMethod
 from saleor.warehouse.models import Stock
-from tests.api.utils import get_graphql_content
+from tests.api.utils import assert_no_permission, get_graphql_content
 
 
 @pytest.fixture
@@ -851,7 +852,9 @@ def test_checkout_line_delete_by_zero_quantity(
     mocked_update_shipping_method.assert_called_once_with(checkout, mock.ANY)
 
 
-def test_checkout_customer_attach(user_api_client, checkout_with_item, customer_user):
+def test_checkout_customer_attach(
+    api_client, user_api_client, checkout_with_item, customer_user
+):
     checkout = checkout_with_item
     assert checkout.user is None
 
@@ -871,15 +874,25 @@ def test_checkout_customer_attach(user_api_client, checkout_with_item, customer_
     """
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     customer_id = graphene.Node.to_global_id("User", customer_user.pk)
-
     variables = {"checkoutId": checkout_id, "customerId": customer_id}
+
+    # Mutation should fail for unauthenticated customers
+    response = api_client.post_graphql(query, variables)
+    assert_no_permission(response)
+
+    # Mutation should succeed for authenticated customer
     response = user_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
-
     data = content["data"]["checkoutCustomerAttach"]
     assert not data["errors"]
     checkout.refresh_from_db()
     assert checkout.user == customer_user
+
+    # Mutation with ID of a different user should fail as well
+    other_customer = User.objects.create_user("othercustomer@example.com", "password")
+    variables["customerId"] = graphene.Node.to_global_id("User", other_customer.pk)
+    response = user_api_client.post_graphql(query, variables)
+    assert_no_permission(response)
 
 
 MUTATION_CHECKOUT_CUSTOMER_DETACH = """


### PR DESCRIPTION
There is a vulnerability in the `checkoutCustomerAttach` mutation that allows assigning arbitrary customers to checkout without checking if the customer owns this checkout instance. This PR changes this behavior to only attach a checkout to the currently authenticated customer. 

Also `checkoutCustomerDetach` was changed to require authentication.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
