### PR TITLE
Restrict access to user field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `product_created` webhook - #5187 by @dzkb
 - Drop unused resolver `resolve_availability` - #5190 by @maarcingebala
 - Fix permission for `checkoutCustomerAttach` mutation - #5192 by @maarcingebala
+- Restrict access to user field - #5194 by @maarcingebala
 
 ## 2.9.0
 

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -591,7 +591,7 @@ def create_staff_users(how_many=2, superuser=False):
         first_name = fake.first_name()
         last_name = fake.last_name()
         email = get_email(first_name, last_name)
-        staff_user = User.objects.create(
+        staff_user = User.objects.create_user(
             first_name=first_name,
             last_name=last_name,
             email=email,

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -3,7 +3,6 @@ import graphene_django_optimizer as gql_optimizer
 from django.contrib.auth import get_user_model, models as auth_models
 from graphene import relay
 from graphene_federation import key
-from graphql_jwt.decorators import permission_required
 from graphql_jwt.exceptions import PermissionDenied
 
 from ...account import models
@@ -16,7 +15,7 @@ from ..core.fields import PrefetchingConnectionField
 from ..core.resolvers import resolve_meta, resolve_private_meta
 from ..core.types import CountryDisplay, Image, MetadataObjectType, PermissionDisplay
 from ..core.utils import get_node_optimized
-from ..decorators import one_of_permissions_required
+from ..decorators import one_of_permissions_required, permission_required
 from ..utils import format_permissions_for_display
 from ..wishlist.resolvers import resolve_wishlist_items_from_user
 from ..wishlist.types import WishlistItem

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -142,8 +142,10 @@ class CustomerEvent(CountableDjangoObjectType):
     @staticmethod
     def resolve_user(root: models.CustomerEvent, info):
         user = info.context.user
-        if user == root.user or user.has_perms(
-            [AccountPermissions.MANAGE_USERS, AccountPermissions.MANAGE_STAFF]
+        if (
+            user == root.user
+            or user.has_perm(AccountPermissions.MANAGE_USERS)
+            or user.has_perm(AccountPermissions.MANAGE_STAFF)
         ):
             return root.user
         raise PermissionDenied()

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -1,6 +1,6 @@
 import graphene
 
-from ...core.permissions import OrderPermissions
+from ...core.permissions import CheckoutPermissions
 from ..core.fields import BaseDjangoConnectionField, PrefetchingConnectionField
 from ..decorators import permission_required
 from ..payment.mutations import CheckoutPaymentCreate
@@ -47,14 +47,14 @@ class CheckoutQueries(graphene.ObjectType):
     def resolve_checkout(self, *_args, token):
         return resolve_checkout(token)
 
-    @permission_required(OrderPermissions.MANAGE_ORDERS)
+    @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
     def resolve_checkouts(self, *_args, **_kwargs):
         resolve_checkouts()
 
     def resolve_checkout_line(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, CheckoutLine)
 
-    @permission_required(OrderPermissions.MANAGE_ORDERS)
+    @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
     def resolve_checkout_lines(self, *_args, **_kwargs):
         return resolve_checkout_lines()
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -68,8 +68,10 @@ class OrderEvent(CountableDjangoObjectType):
     @staticmethod
     def resolve_user(root: models.OrderEvent, info):
         user = info.context.user
-        if user == root.user or user.has_perms(
-            [AccountPermissions.MANAGE_USERS, AccountPermissions.MANAGE_STAFF]
+        if (
+            user == root.user
+            or user.has_perm(AccountPermissions.MANAGE_USERS)
+            or user.has_perm(AccountPermissions.MANAGE_STAFF)
         ):
             return root.user
         raise PermissionDenied()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1338,7 +1338,7 @@ type CustomerEvent implements Node {
   id: ID!
   date: DateTime
   type: CustomerEventsEnum
-  user(id: ID): User
+  user: User
   message: String
   count: Int
   order: Order
@@ -2512,7 +2512,7 @@ type OrderEvent implements Node {
   id: ID!
   date: DateTime
   type: OrderEventsEnum
-  user(id: ID): User
+  user: User
   message: String
   email: String
   emailType: OrderEventsEmailsEnum

--- a/tests/api/benchmark/test_checkout.py
+++ b/tests/api/benchmark/test_checkout.py
@@ -481,9 +481,6 @@ def test_add_billing_address_to_checkout(
         fragment Checkout on Checkout {
           token
           id
-          user {
-            email
-          }
           totalPrice {
             ...Price
           }

--- a/tests/api/test_checkout.py
+++ b/tests/api/test_checkout.py
@@ -1678,7 +1678,7 @@ def test_query_checkout_line(checkout_with_item, user_api_client):
 
 
 def test_query_checkouts(
-    checkout_with_item, staff_api_client, permission_manage_orders
+    checkout_with_item, staff_api_client, permission_manage_checkouts
 ):
     query = """
     {
@@ -1693,7 +1693,7 @@ def test_query_checkouts(
     """
     checkout = checkout_with_item
     response = staff_api_client.post_graphql(
-        query, {}, permissions=[permission_manage_orders]
+        query, {}, permissions=[permission_manage_checkouts]
     )
     content = get_graphql_content(response)
     received_checkout = content["data"]["checkouts"]["edges"][0]["node"]
@@ -1701,7 +1701,7 @@ def test_query_checkouts(
 
 
 def test_query_checkout_lines(
-    checkout_with_item, staff_api_client, permission_manage_orders
+    checkout_with_item, staff_api_client, permission_manage_checkouts
 ):
     query = """
     {
@@ -1716,7 +1716,7 @@ def test_query_checkout_lines(
     """
     checkout = checkout_with_item
     response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_orders]
+        query, permissions=[permission_manage_checkouts]
     )
     content = get_graphql_content(response)
     lines = content["data"]["checkoutLines"]["edges"]

--- a/tests/api/test_gift_card.py
+++ b/tests/api/test_gift_card.py
@@ -8,8 +8,8 @@ from tests.api.utils import get_graphql_content
 from .utils import assert_no_permission
 
 
-def test_query_gift_card_with_premissions(
-    staff_api_client, gift_card, permission_manage_gift_card
+def test_query_gift_card_with_permissions(
+    staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
 ):
     query = """
     query giftCard($id: ID!) {
@@ -24,8 +24,19 @@ def test_query_gift_card_with_premissions(
     """
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
-    staff_api_client.user.user_permissions.add(permission_manage_gift_card)
-    response = staff_api_client.post_graphql(query, variables)
+
+    # Query should fail without manage_users permission.
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_gift_card]
+    )
+    assert_no_permission(response)
+
+    # Query should succeed with manage_users and manage_gift_card permissions.
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
+    )
     content = get_graphql_content(response)
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
@@ -34,7 +45,10 @@ def test_query_gift_card_with_premissions(
 
 
 def test_query_gift_card_code_without_user(
-    staff_api_client, gift_card_created_by_staff, permission_manage_gift_card
+    staff_api_client,
+    gift_card_created_by_staff,
+    permission_manage_gift_card,
+    permission_manage_users,
 ):
     query = """
     query giftCard($id: ID!) {
@@ -51,8 +65,11 @@ def test_query_gift_card_code_without_user(
     gift_card = gift_card_created_by_staff
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
-    staff_api_client.user.user_permissions.add(permission_manage_gift_card)
-    response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
+    )
     content = get_graphql_content(response)
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
@@ -62,7 +79,7 @@ def test_query_gift_card_code_without_user(
 
 
 def test_query_gift_card_code_with_user(
-    staff_api_client, gift_card, permission_manage_gift_card
+    staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
 ):
     query = """
     query giftCard($id: ID!) {
@@ -78,8 +95,11 @@ def test_query_gift_card_code_with_user(
     """
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
-    staff_api_client.user.user_permissions.add(permission_manage_gift_card)
-    response = staff_api_client.post_graphql(query, variables)
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
+    )
     content = get_graphql_content(response)
     data = content["data"]["giftCard"]
     assert data["id"] == gift_card_id
@@ -200,7 +220,12 @@ mutation giftCardCreate(
 """
 
 
-def test_create_gift_card(staff_api_client, customer_user, permission_manage_gift_card):
+def test_create_gift_card(
+    staff_api_client,
+    customer_user,
+    permission_manage_gift_card,
+    permission_manage_users,
+):
     code = "mirumee"
     start_date = date(day=1, month=1, year=2018)
     end_date = date(day=1, month=1, year=2019)
@@ -213,7 +238,9 @@ def test_create_gift_card(staff_api_client, customer_user, permission_manage_gif
         "userEmail": customer_user.email,
     }
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     errors = content["data"]["giftCardCreate"]["errors"]
@@ -231,7 +258,7 @@ def test_create_gift_card(staff_api_client, customer_user, permission_manage_gif
 
 
 def test_create_gift_card_with_empty_code(
-    staff_api_client, permission_manage_gift_card
+    staff_api_client, permission_manage_gift_card, permission_manage_users
 ):
     start_date = date(day=1, month=1, year=2018)
     end_date = date(day=1, month=1, year=2019)
@@ -244,7 +271,9 @@ def test_create_gift_card_with_empty_code(
         "userEmail": staff_api_client.user.email,
     }
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     errors = content["data"]["giftCardCreate"]["errors"]
@@ -254,7 +283,9 @@ def test_create_gift_card_with_empty_code(
     assert len(data["displayCode"]) > 4
 
 
-def test_create_gift_card_without_code(staff_api_client, permission_manage_gift_card):
+def test_create_gift_card_without_code(
+    staff_api_client, permission_manage_gift_card, permission_manage_users
+):
     start_date = date(day=1, month=1, year=2018)
     end_date = date(day=1, month=1, year=2019)
     initial_balance = 123
@@ -265,7 +296,9 @@ def test_create_gift_card_without_code(staff_api_client, permission_manage_gift_
         "userEmail": staff_api_client.user.email,
     }
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     errors = content["data"]["giftCardCreate"]["errors"]
@@ -276,12 +309,14 @@ def test_create_gift_card_without_code(staff_api_client, permission_manage_gift_
 
 
 def test_create_gift_card_with_existing_voucher_code(
-    staff_api_client, voucher, permission_manage_gift_card
+    staff_api_client, voucher, permission_manage_gift_card, permission_manage_users
 ):
     initial_balance = 123
     variables = {"code": voucher.code, "balance": initial_balance}
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     assert content["data"]["giftCardCreate"]["errors"]
@@ -294,12 +329,14 @@ def test_create_gift_card_with_existing_voucher_code(
 
 
 def test_create_gift_card_with_existing_gift_card_code(
-    staff_api_client, gift_card, permission_manage_gift_card
+    staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
 ):
     initial_balance = 123
     variables = {"code": gift_card.code, "balance": initial_balance}
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     assert content["data"]["giftCardCreate"]["errors"]
@@ -311,7 +348,9 @@ def test_create_gift_card_with_existing_gift_card_code(
     assert gift_card_errors[0]["code"] == GiftCardErrorCode.ALREADY_EXISTS.name
 
 
-def test_create_gift_card_without_user(staff_api_client, permission_manage_gift_card):
+def test_create_gift_card_without_user(
+    staff_api_client, permission_manage_gift_card, permission_manage_users
+):
     code = "mirumee1"
     start_date = date(day=1, month=1, year=2018)
     end_date = date(day=1, month=1, year=2019)
@@ -324,7 +363,9 @@ def test_create_gift_card_without_user(staff_api_client, permission_manage_gift_
         "userEmail": "",
     }
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     errors = content["data"]["giftCardCreate"]["errors"]
@@ -337,7 +378,7 @@ def test_create_gift_card_without_user(staff_api_client, permission_manage_gift_
 
 
 def test_create_gift_card_with_incorrect_user_email(
-    staff_api_client, permission_manage_gift_card
+    staff_api_client, permission_manage_gift_card, permission_manage_users
 ):
     code = "mirumee1"
     start_date = date(day=1, month=1, year=2018)
@@ -351,7 +392,9 @@ def test_create_gift_card_with_incorrect_user_email(
         "userEmail": "incorrect@email.com",
     }
     response = staff_api_client.post_graphql(
-        CREATE_GIFT_CARD_MUTATION, variables, permissions=[permission_manage_gift_card]
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
     )
     content = get_graphql_content(response)
     errors = content["data"]["giftCardCreate"]["errors"]

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -1936,6 +1936,60 @@ def test_order_by_token_query(api_client, order):
     assert content["data"]["orderByToken"]["id"] == order_id
 
 
+def test_order_by_token_user_restriction(api_client, order):
+    query = """
+    query OrderByToken($token: UUID!) {
+        orderByToken(token: $token) {
+            user {
+                id
+            }
+        }
+    }
+    """
+    response = api_client.post_graphql(query, {"token": order.token})
+    assert_no_permission(response)
+
+
+def test_order_by_token_events_restriction(api_client, order):
+    query = """
+    query OrderByToken($token: UUID!) {
+        orderByToken(token: $token) {
+            events {
+                id
+            }
+        }
+    }
+    """
+    response = api_client.post_graphql(query, {"token": order.token})
+    assert_no_permission(response)
+
+
+def test_authorized_access_to_order_by_token(
+    user_api_client, staff_api_client, customer_user, order, permission_manage_users
+):
+    query = """
+    query OrderByToken($token: UUID!) {
+        orderByToken(token: $token) {
+            user {
+                id
+            }
+        }
+    }
+    """
+    variables = {"token": order.token}
+    customer_user_id = graphene.Node.to_global_id("User", customer_user.id)
+
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["orderByToken"]["user"]["id"] == customer_user_id
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["orderByToken"]["user"]["id"] == customer_user_id
+
+
 MUTATION_CANCEL_ORDERS = """
     mutation CancelManyOrders($ids: [ID]!, $restock: Boolean!) {
         orderBulkCancel(ids: $ids, restock: $restock) {
@@ -1950,7 +2004,7 @@ MUTATION_CANCEL_ORDERS = """
 
 
 def test_order_bulk_cancel_with_restock(
-    staff_api_client, orders, order_with_lines, permission_manage_orders, address,
+    staff_api_client, orders, order_with_lines, permission_manage_orders, address
 ):
     assert order_with_lines.can_cancel()
     orders.append(order_with_lines)
@@ -1960,7 +2014,7 @@ def test_order_bulk_cancel_with_restock(
         "restock": True,
     }
     response = staff_api_client.post_graphql(
-        MUTATION_CANCEL_ORDERS, variables, permissions=[permission_manage_orders],
+        MUTATION_CANCEL_ORDERS, variables, permissions=[permission_manage_orders]
     )
     order_with_lines.refresh_from_db()
     content = get_graphql_content(response)

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -971,14 +971,14 @@ def test_staff_notification_create_mutation_with_customer_user(
 
 
 def test_staff_notification_create_mutation_with_email(
-    staff_api_client, permission_manage_settings
+    staff_api_client, permission_manage_settings, permission_manage_staff
 ):
     staff_email = "test_email@example.com"
     variables = {"input": {"email": staff_email}}
     response = staff_api_client.post_graphql(
         MUTATION_STAFF_NOTIFICATION_RECIPIENT_CREATE,
         variables,
-        permissions=[permission_manage_settings],
+        permissions=[permission_manage_settings, permission_manage_staff],
     )
     content = get_graphql_content(response)
 


### PR DESCRIPTION
This PR adds permission checks to all `User` fields to make sure that we return it only for staff users with proper permissions or for authenticated users fetching their own data.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
