### PR TITLE
Unify permission for service account api client in test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop unused resolver `resolve_availability` - #5190 by @maarcingebala
 - Fix permission for `checkoutCustomerAttach` mutation - #5192 by @maarcingebala
 - Restrict access to user field - #5194 by @maarcingebala
+- Unify permission for service account api client in test - #5197 by @fowczarek
 
 ## 2.9.0
 

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -25,6 +25,7 @@ class ApiClient(Client):
         self.token = None
         self.user = user
         self.service_token = None
+        self.service_account = service_account
         if not user.is_anonymous:
             self.token = get_token(user)
         elif service_account:
@@ -86,7 +87,10 @@ class ApiClient(Client):
             if check_no_permissions:
                 response = super().post(API_PATH, data, **kwargs)
                 assert_no_permission(response)
-            self.user.user_permissions.add(*permissions)
+            if self.service_account:
+                self.service_account.permissions.add(*permissions)
+            else:
+                self.user.user_permissions.add(*permissions)
         return super().post(API_PATH, data, **kwargs)
 
     def post_multipart(self, *args, permissions=None, **kwargs):

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -306,12 +306,13 @@ def test_user_query_permission_manage_users_get_customer(
 
 
 def test_user_query_as_service_account(
-    service_account_api_client, customer_user, permission_manage_users, service_account
+    service_account_api_client, customer_user, permission_manage_users
 ):
-    service_account.permissions.add(permission_manage_users)
     customer_id = graphene.Node.to_global_id("User", customer_user.pk)
     variables = {"id": customer_id}
-    response = service_account_api_client.post_graphql(USER_QUERY, variables)
+    response = service_account_api_client.post_graphql(
+        USER_QUERY, variables, permissions=[permission_manage_users]
+    )
     content = get_graphql_content(response)
     data = content["data"]["user"]
     assert customer_user.email == data["email"]
@@ -3128,14 +3129,12 @@ def test_address_query_as_not_owner(
 
 
 def test_address_query_as_service_account_with_permission(
-    service_account_api_client,
-    service_account,
-    address_other_country,
-    permission_manage_users,
+    service_account_api_client, address_other_country, permission_manage_users,
 ):
-    service_account.permissions.add(permission_manage_users)
     variables = {"id": graphene.Node.to_global_id("Address", address_other_country.pk)}
-    response = service_account_api_client.post_graphql(ADDRESS_QUERY, variables)
+    response = service_account_api_client.post_graphql(
+        ADDRESS_QUERY, variables, permissions=[permission_manage_users]
+    )
     content = get_graphql_content(response)
     data = content["data"]["address"]
     assert data["country"]["code"] == address_other_country.country.code

--- a/tests/api/test_account_service_account.py
+++ b/tests/api/test_account_service_account.py
@@ -356,8 +356,9 @@ def test_service_account_with_access_to_resources(
     """
     response = service_account_api_client.post_graphql(query)
     assert_no_permission(response)
-    service_account.permissions.add(permission_manage_orders)
-    response = service_account_api_client.post_graphql(query)
+    response = service_account_api_client.post_graphql(
+        query, permissions=[permission_manage_orders]
+    )
     get_graphql_content(response)
 
 

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -110,13 +110,13 @@ def test_fetch_all_products(user_api_client, product):
 
 
 def test_fetch_all_products_service_account(
-    service_account_api_client,
-    service_account,
-    unavailable_product,
-    permission_manage_products,
+    service_account_api_client, unavailable_product, permission_manage_products,
 ):
-    service_account.permissions.add(permission_manage_products)
-    response = service_account_api_client.post_graphql(QUERY_FETCH_ALL_PRODUCTS)
+    response = service_account_api_client.post_graphql(
+        QUERY_FETCH_ALL_PRODUCTS,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
     content = get_graphql_content(response)
     product_data = content["data"]["products"]["edges"][0]["node"]
     assert product_data["name"] == unavailable_product.name

--- a/tests/api/test_webhook.py
+++ b/tests/api/test_webhook.py
@@ -27,9 +27,8 @@ WEBHOOK_CREATE_BY_SERVICE_ACCOUNT = """
 
 
 def test_webhook_create_by_service_account(
-    service_account_api_client, service_account, permission_manage_orders
+    service_account_api_client, permission_manage_orders
 ):
-    service_account.permissions.add(permission_manage_orders)
     query = WEBHOOK_CREATE_BY_SERVICE_ACCOUNT
     variables = {
         "name": "New integration",
@@ -39,7 +38,12 @@ def test_webhook_create_by_service_account(
             WebhookEventTypeEnum.ORDER_CREATED.name,
         ],
     }
-    response = service_account_api_client.post_graphql(query, variables=variables)
+    response = service_account_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_orders],
+        check_no_permissions=False,
+    )
     get_graphql_content(response)
     new_webhook = Webhook.objects.get()
     assert new_webhook.name == "New integration"
@@ -52,7 +56,6 @@ def test_webhook_create_by_service_account(
 def test_webhook_create_inactive_service_account(
     service_account_api_client, service_account, permission_manage_orders
 ):
-    service_account.permissions.add(permission_manage_orders)
     service_account.is_active = False
     service_account.save()
     query = WEBHOOK_CREATE_BY_SERVICE_ACCOUNT
@@ -62,7 +65,9 @@ def test_webhook_create_inactive_service_account(
         "name": "",
     }
 
-    response = service_account_api_client.post_graphql(query, variables=variables)
+    response = service_account_api_client.post_graphql(
+        query, variables=variables, permissions=[permission_manage_orders]
+    )
     assert_no_permission(response)
 
 
@@ -631,14 +636,14 @@ def test_sample_payload_query_by_service_account(
     has_access,
     service_account_api_client,
     permission_manage_orders,
-    service_account,
 ):
 
     mock_generate_sample_payload.return_value = {"mocked_response": ""}
     query = SAMPLE_PAYLOAD_QUERY
-    service_account.permissions.add(permission_manage_orders)
     variables = {"event_type": event_type.name}
-    response = service_account_api_client.post_graphql(query, variables=variables)
+    response = service_account_api_client.post_graphql(
+        query, variables=variables, permissions=[permission_manage_orders]
+    )
     if not has_access:
         assert_no_permission(response)
         mock_generate_sample_payload.assert_not_called()


### PR DESCRIPTION
Unify permission for service account api client in test. 
After this PR we are allowed to use permissions as parameter of `post_graphql` in tests.
 
<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
