### PR TITLE
Return null when querying "me" as an anonymous user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add slug to Warehouse, Product, ProductType and update slug in models which already using it - #5196 by @IKarbowiak
 - Add mutation for assigning, unassigning shipping zones to warehouse - #5217 by @kswiatek92
 - Fix passing addresses to `PaymentData` objects - #5223 by @maarcingebala
+- Return `null` when querying `me` as an anonymous user - #5231 as @maarcingebala
 
 ## 2.9.0
 

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -1,5 +1,4 @@
 import graphene
-from graphql_jwt.decorators import login_required
 
 from ...core.permissions import AccountPermissions
 from ..core.fields import FilterInputConnectionField
@@ -208,9 +207,9 @@ class AccountQueries(graphene.ObjectType):
     def resolve_permission_group(self, info, id):
         return graphene.Node.get_node_from_global_id(info, id, Group)
 
-    @login_required
     def resolve_me(self, info):
-        return info.context.user
+        user = info.context.user
+        return user if user.is_authenticated else None
 
     @permission_required(AccountPermissions.MANAGE_STAFF)
     def resolve_staff_users(self, info, query=None, **kwargs):

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -466,7 +466,8 @@ def test_me_query(user_api_client):
 
 def test_me_query_anonymous_client(api_client):
     response = api_client.post_graphql(ME_QUERY)
-    assert_no_permission(response)
+    content = get_graphql_content(response)
+    assert content["data"]["me"] is None
 
 
 def test_me_query_customer_can_not_see_note(

--- a/tests/api/test_graphql.py
+++ b/tests/api/test_graphql.py
@@ -50,7 +50,6 @@ def test_jwt_middleware(client, admin_user):
     repl_data = response.json()
     assert response.status_code == 200
     assert isinstance(response.wsgi_request.user, AnonymousUser)
-    assert "errors" in repl_data
     assert repl_data["data"]["me"] is None
 
     # test creating a token for admin user

--- a/tests/api/test_wishlist.py
+++ b/tests/api/test_wishlist.py
@@ -195,7 +195,8 @@ def test_wishlist_get_items_from_anonymous_user(api_client):
     }
     """
     response = api_client.post_graphql(query)
-    assert_no_permission(response)
+    content = get_graphql_content(response)
+    assert content["data"]["me"] is None
 
 
 def test_wishlist_get_items_from_logged_user(user_api_client, customer_wishlist_item):


### PR DESCRIPTION
It's enough to just return `null` when an anonymous user queries the `me` field.

Fixes #5113

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
