### PR TITLE
Disable email account confirmation on Heroku

### DIFF
--- a/app.json
+++ b/app.json
@@ -38,7 +38,8 @@
       "description": "",
       "value": "",
       "required": false
-    }
+    },
+    "ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL": false
   },
   "scripts": {
     "postdeploy": "python manage.py migrate && python manage.py populatedb --createsuperuser --withoutimages"


### PR DESCRIPTION
The Heroku build fails because `ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL` is true by default which in turn requires configuring a storefront domain. We cannot assume where the storefront is deployed so this has to be configured manually. This PR disables email account confirmation which I think is fine for test Heroku builds.