### PR TITLE
Enabled opentracing segmentation of spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add slug to Warehouse, Product, ProductType and update slug in models which already using it - #5196 by @IKarbowiak
 - Add mutation for assigning, unassigning shipping zones to warehouse - #5217 by @kswiatek92
 - Fix passing addresses to `PaymentData` objects - #5223 by @maarcingebala
-- Return `null` when querying `me` as an anonymous user - #5231 as @maarcingebala
+- Return `null` when querying `me` as an anonymous user - #5231 by @maarcingebala
+- Added `PLAYGROUND_ENABLED` environment variable/setting to allow to enable the GraphQL playground when `DEBUG` is disabled - #5254 by @NyanKiyoshi
 
 ## 2.9.0
 

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import opentracing as ot
-import opentracing.tags
+import opentracing.tags as ot_tags
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.functional import SimpleLazyObject
@@ -51,7 +51,7 @@ class OpentracingGrapheneMiddleware:
             operation_name=info.operation.operation
         ) as scope:
             span = scope.span
-            span.set_tag(ot.tags.COMPONENT, "graphql")
+            span.set_tag(ot_tags.COMPONENT, "graphql")
             span.set_tag("graphql.parent_type", info.parent_type.name)
             span.set_tag("graphql.field_name", info.field_name)
             return next(root, info, **kwargs)

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -47,9 +47,10 @@ def should_trace(info):
 class OpentracingGrapheneMiddleware:
     @staticmethod
     def resolve(next, root, info, **kwargs):
-        with ot.global_tracer().start_active_span(
-            operation_name=info.operation.operation
-        ) as scope:
+        operation = (
+            f"{info.operation.operation}.{info.parent_type.name}.{info.field_name}"
+        )
+        with ot.global_tracer().start_active_span(operation_name=operation) as scope:
             span = scope.span
             span.set_tag(ot_tags.COMPONENT, "graphql")
             span.set_tag("graphql.parent_type", info.parent_type.name)

--- a/saleor/graphql/middleware.py
+++ b/saleor/graphql/middleware.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
-import opentracing
+import opentracing as ot
+import opentracing.tags
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.utils.functional import SimpleLazyObject
@@ -46,10 +47,11 @@ def should_trace(info):
 class OpentracingGrapheneMiddleware:
     @staticmethod
     def resolve(next, root, info, **kwargs):
-        with opentracing.global_tracer().start_span(
+        with ot.global_tracer().start_active_span(
             operation_name=info.operation.operation
-        ) as span:
-            span.set_tag("component", "graphql")
+        ) as scope:
+            span = scope.span
+            span.set_tag(ot.tags.COMPONENT, "graphql")
             span.set_tag("graphql.parent_type", info.parent_type.name)
             span.set_tag("graphql.field_name", info.field_name)
             return next(root, info, **kwargs)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -80,7 +80,7 @@ class GraphQLView(View):
     def dispatch(self, request, *args, **kwargs):
         # Handle options method the GraphQlView restricts it.
         if request.method == "GET":
-            if settings.DEBUG:
+            if settings.PLAYGROUND_ENABLED:
                 return render_to_response("graphql/playground.html")
             return HttpResponseNotAllowed(["OPTIONS", "POST"])
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -4,8 +4,7 @@ import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import opentracing as ot
-import opentracing.logs
-import opentracing.tags
+import opentracing.tags as ot_tags
 from django.conf import settings
 from django.db import connection
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
@@ -33,8 +32,8 @@ handled_errors_logger = logging.getLogger("saleor.graphql.errors.handled")
 def tracing_wrapper(execute, sql, params, many, context):
     with ot.global_tracer().start_active_span(operation_name="query") as scope:
         span = scope.span
-        span.set_tag(ot.tags.COMPONENT, "db")
-        span.set_tag(ot.tags.DATABASE_STATEMENT, sql)
+        span.set_tag(ot_tags.COMPONENT, "db")
+        span.set_tag(ot_tags.DATABASE_STATEMENT, sql)
         return execute(sql, params, many, context)
 
 
@@ -117,9 +116,9 @@ class GraphQLView(View):
     ) -> Tuple[Optional[Dict[str, List[Any]]], int]:
         with ot.global_tracer().start_active_span(operation_name="request") as scope:
             span = scope.span
-            span.set_tag(ot.tags.COMPONENT, "http")
-            span.set_tag(ot.tags.HTTP_METHOD, request.method)
-            span.set_tag(ot.tags.HTTP_URL, request.get_full_path())
+            span.set_tag(ot_tags.COMPONENT, "http")
+            span.set_tag(ot_tags.HTTP_METHOD, request.method)
+            span.set_tag(ot_tags.HTTP_URL, request.get_full_path())
 
             execution_result = self.execute_graphql_request(request, data)
             status_code = 200
@@ -137,7 +136,7 @@ class GraphQLView(View):
             else:
                 result = None
 
-            span.set_tag(ot.tags.HTTP_STATUS_CODE, status_code)
+            span.set_tag(ot_tags.HTTP_STATUS_CODE, status_code)
             return result, status_code
 
     def get_root_value(self):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -3,7 +3,9 @@ import logging
 import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-import opentracing
+import opentracing as ot
+import opentracing.logs
+import opentracing.tags
 from django.conf import settings
 from django.db import connection
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
@@ -29,18 +31,11 @@ handled_errors_logger = logging.getLogger("saleor.graphql.errors.handled")
 
 
 def tracing_wrapper(execute, sql, params, many, context):
-    with opentracing.global_tracer().start_span(operation_name="query") as span:
-        span.set_tag("component", "db")
-        span.set_tag("db.statement", sql)
-        try:
-            result = execute(sql, params, many, context)
-        except Exception as e:
-            span.set_tag("error", True)
-            span.set_tag("error.object", e)
-            raise
-        else:
-            span.set_tag("error", False)
-            return result
+    with ot.global_tracer().start_active_span(operation_name="query") as scope:
+        span = scope.span
+        span.set_tag(ot.tags.COMPONENT, "db")
+        span.set_tag(ot.tags.DATABASE_STATEMENT, sql)
+        return execute(sql, params, many, context)
 
 
 class GraphQLView(View):
@@ -120,10 +115,12 @@ class GraphQLView(View):
     def get_response(
         self, request: HttpRequest, data: dict
     ) -> Tuple[Optional[Dict[str, List[Any]]], int]:
-        with opentracing.global_tracer().start_span(operation_name="request") as span:
-            span.set_tag("component", "http")
-            span.set_tag("http.method", request.method)
-            span.set_tag("http.path", request.path)
+        with ot.global_tracer().start_active_span(operation_name="request") as scope:
+            span = scope.span
+            span.set_tag(ot.tags.COMPONENT, "http")
+            span.set_tag(ot.tags.HTTP_METHOD, request.method)
+            span.set_tag(ot.tags.HTTP_URL, request.get_full_path())
+
             execution_result = self.execute_graphql_request(request, data)
             status_code = 200
             if execution_result:
@@ -139,7 +136,8 @@ class GraphQLView(View):
                 result: Optional[Dict[str, List[Any]]] = response
             else:
                 result = None
-            span.set_tag("http.status_code", status_code)
+
+            span.set_tag(ot.tags.HTTP_STATUS_CODE, status_code)
             return result, status_code
 
     def get_root_value(self):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -346,9 +346,7 @@ DEFAULT_MAX_EMAIL_DISPLAY_NAME_LENGTH = 78
 # note: having multiple currencies is not supported yet
 AVAILABLE_CURRENCIES = [DEFAULT_CURRENCY]
 
-COUNTRIES_OVERRIDE = {
-    "EU": "European Union",
-}
+COUNTRIES_OVERRIDE = {"EU": "European Union"}
 
 OPENEXCHANGERATES_API_KEY = os.environ.get("OPENEXCHANGERATES_API_KEY")
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -389,7 +389,7 @@ MAX_CHECKOUT_LINE_QUANTITY = int(os.environ.get("MAX_CHECKOUT_LINE_QUANTITY", 50
 
 TEST_RUNNER = "tests.runner.PytestTestRunner"
 
-PLAYGROUND_ENABLED = get_bool_from_env("PLAYGROUND_ENABLED", DEBUG)
+PLAYGROUND_ENABLED = get_bool_from_env("PLAYGROUND_ENABLED", True)
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1"))
 ALLOWED_GRAPHQL_ORIGINS = os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -391,6 +391,8 @@ MAX_CHECKOUT_LINE_QUANTITY = int(os.environ.get("MAX_CHECKOUT_LINE_QUANTITY", 50
 
 TEST_RUNNER = "tests.runner.PytestTestRunner"
 
+PLAYGROUND_ENABLED = get_bool_from_env("PLAYGROUND_ENABLED", DEBUG)
+
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1"))
 ALLOWED_GRAPHQL_ORIGINS = os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*")
 

--- a/tests/api/test_view.py
+++ b/tests/api/test_view.py
@@ -52,14 +52,11 @@ def test_batch_queries(category, product, api_client):
     assert data["category"]["name"] == category.name
 
 
-def test_graphql_view_get_enabled_or_disabled(client, settings):
-    settings.PLAYGROUND_ENABLED = False
+@pytest.mark.parametrize("playground_on, status", [(True, 200), (False, 405)])
+def test_graphql_view_get_enabled_or_disabled(client, settings, playground_on, status):
+    settings.PLAYGROUND_ENABLED = playground_on
     response = client.get(API_PATH)
-    assert response.status_code == 405
-
-    settings.PLAYGROUND_ENABLED = True
-    response = client.get(API_PATH)
-    assert response.status_code == 200
+    assert response.status_code == status
 
 
 def test_graphql_view_options(client):

--- a/tests/api/test_view.py
+++ b/tests/api/test_view.py
@@ -52,16 +52,14 @@ def test_batch_queries(category, product, api_client):
     assert data["category"]["name"] == category.name
 
 
-def test_graphql_view_get_in_non_debug_mode(client):
+def test_graphql_view_get_enabled_or_disabled(client, settings):
+    settings.PLAYGROUND_ENABLED = False
     response = client.get(API_PATH)
     assert response.status_code == 405
 
-
-@override_settings(DEBUG=True)
-def test_graphql_view_get_in_debug_mode(client):
+    settings.PLAYGROUND_ENABLED = True
     response = client.get(API_PATH)
     assert response.status_code == 200
-    assert response.templates[0].name == "graphql/playground.html"
 
 
 def test_graphql_view_options(client):


### PR DESCRIPTION
This adds segmentation to the OpenTracing spans, so each child span has its parent correctly associated to it.

On top, I added a change that was in my logs: `PLAYGROUND_ENABLED` setting key, which was discussed some time ago that it would be nice to be able to use the playground in production mode.

Closes #5249.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [ ] ~~Changes are mentioned in the changelog.~~ feature not released yet
