### PR TITLE
Added more field for client requests information inside OpenTracing

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -24,6 +24,8 @@ from graphql.error import (
 from graphql.execution import ExecutionResult
 from graphql_jwt.exceptions import PermissionDenied
 
+from ..core.utils import is_valid_ipv4, is_valid_ipv6
+
 API_PATH = SimpleLazyObject(lambda: reverse("api"))
 
 unhandled_errors_logger = logging.getLogger("saleor.graphql.errors.unhandled")
@@ -96,7 +98,7 @@ class GraphQLView(View):
         ] = "Origin, Content-Type, Accept, Authorization"
         return response
 
-    def handle_query(self, request: HttpRequest):
+    def _handle_query(self, request: HttpRequest) -> JsonResponse:
         try:
             data = self.parse_body(request)
         except ValueError:
@@ -115,10 +117,8 @@ class GraphQLView(View):
             result, status_code = self.get_response(request, data)
         return JsonResponse(data=result, status=status_code, safe=False)
 
-    def get_response(
-        self, request: HttpRequest, data: dict
-    ) -> Tuple[Optional[Dict[str, List[Any]]], int]:
-        with ot.global_tracer().start_active_span(operation_name="request") as scope:
+    def handle_query(self, request: HttpRequest) -> JsonResponse:
+        with ot.global_tracer().start_active_span(operation_name="http") as scope:
             span = scope.span
             span.set_tag(ot_tags.COMPONENT, "http")
             span.set_tag(ot_tags.HTTP_METHOD, request.method)
@@ -126,24 +126,46 @@ class GraphQLView(View):
                 ot_tags.HTTP_URL, request.build_absolute_uri(request.get_full_path())
             )
 
-            execution_result = self.execute_graphql_request(request, data)
-            status_code = 200
-            if execution_result:
-                response = {}
-                if execution_result.errors:
-                    response["errors"] = [
-                        self.format_error(e) for e in execution_result.errors
-                    ]
-                if execution_result.invalid:
-                    status_code = 400
+            request_ips = request.META.get(settings.REAL_IP_ENVIRON, "")
+            for ip in request_ips.split(","):
+                if is_valid_ipv4(ip):
+                    span.set_tag(ot_tags.PEER_HOST_IPV4, ip)
+                elif is_valid_ipv6(ip):
+                    span.set_tag(ot_tags.PEER_HOST_IPV6, ip)
                 else:
-                    response["data"] = execution_result.data
-                result: Optional[Dict[str, List[Any]]] = response
-            else:
-                result = None
+                    continue
+                break
 
-            span.set_tag(ot_tags.HTTP_STATUS_CODE, status_code)
-            return result, status_code
+            response = self._handle_query(request)
+            span.set_tag(ot_tags.HTTP_STATUS_CODE, response.status_code)
+
+            # RFC2616: Content-Length is defined in bytes,
+            # we can calculate the RAW UTF-8 size using the length of
+            # response.content of type 'bytes'
+            span.set_tag("http.content_length", len(response.content))
+
+            return response
+
+    def get_response(
+        self, request: HttpRequest, data: dict
+    ) -> Tuple[Optional[Dict[str, List[Any]]], int]:
+        execution_result = self.execute_graphql_request(request, data)
+        status_code = 200
+        if execution_result:
+            response = {}
+            if execution_result.errors:
+                response["errors"] = [
+                    self.format_error(e) for e in execution_result.errors
+                ]
+            if execution_result.invalid:
+                status_code = 400
+            else:
+                response["data"] = execution_result.data
+            result: Optional[Dict[str, List[Any]]] = response
+        else:
+            result = None
+
+        return result, status_code
 
     def get_root_value(self):
         return self.root_value
@@ -177,29 +199,38 @@ class GraphQLView(View):
             return None, ExecutionResult(errors=[e], invalid=True)
 
     def execute_graphql_request(self, request: HttpRequest, data: dict):
-        query, variables, operation_name = self.get_graphql_params(request, data)
+        with ot.global_tracer().start_active_span(
+            operation_name="graphql_query"
+        ) as scope:
+            span = scope.span
+            span.set_tag(ot_tags.COMPONENT, "graphql_query")
 
-        document, error = self.parse_query(query)
-        if error:
-            return error
+            query, variables, operation_name = self.get_graphql_params(request, data)
 
-        extra_options: Dict[str, Optional[Any]] = {}
-        if self.executor:
-            # We only include it optionally since
-            # executor is not a valid argument in all backends
-            extra_options["executor"] = self.executor
-        try:
-            with connection.execute_wrapper(tracing_wrapper):
-                return document.execute(  # type: ignore
-                    root=self.get_root_value(),
-                    variables=variables,
-                    operation_name=operation_name,
-                    context=request,
-                    middleware=self.middleware,
-                    **extra_options,
-                )
-        except Exception as e:
-            return ExecutionResult(errors=[e], invalid=True)
+            document, error = self.parse_query(query)
+            if error:
+                return error
+
+            span.log_kv({"query": document.document_string[:2000]})
+            extra_options: Dict[str, Optional[Any]] = {}
+
+            if self.executor:
+                # We only include it optionally since
+                # executor is not a valid argument in all backends
+                extra_options["executor"] = self.executor
+            try:
+                with connection.execute_wrapper(tracing_wrapper):
+                    return document.execute(  # type: ignore
+                        root=self.get_root_value(),
+                        variables=variables,
+                        operation_name=operation_name,
+                        context=request,
+                        middleware=self.middleware,
+                        **extra_options,
+                    )
+            except Exception as e:
+                span.set_tag(ot_tags.ERROR, True)
+                return ExecutionResult(errors=[e], invalid=True)
 
     @staticmethod
     def parse_body(request: HttpRequest):

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -215,7 +215,9 @@ class GraphQLView(View):
             if error:
                 return error
 
-            span.log_kv({"query": document.document_string[:2000]})
+            if document is not None:
+                span.log_kv({"query": document.document_string[:2000]})
+
             extra_options: Dict[str, Optional[Any]] = {}
 
             if self.executor:

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -216,7 +216,13 @@ class GraphQLView(View):
                 return error
 
             if document is not None:
-                span.log_kv({"query": document.document_string[:2000]})
+                span.log_kv(
+                    {
+                        "query": document.document_string[
+                            : settings.OPENTRACING_MAX_QUERY_LENGTH_LOG
+                        ]
+                    }
+                )
 
             extra_options: Dict[str, Optional[Any]] = {}
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -134,6 +134,10 @@ class GraphQLView(View):
                     span.set_tag(ot_tags.PEER_HOST_IPV6, ip)
                 else:
                     continue
+                span.set_tag("http.client_ip", ip)
+                span.log_kv(
+                    {"http.client_ip_originated_from": settings.REAL_IP_ENVIRON}
+                )
                 break
 
             response = self._handle_query(request)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -483,6 +483,10 @@ CELERY_TASK_SERIALIZER = "json"
 CELERY_RESULT_SERIALIZER = "json"
 CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", None)
 
+# Change this value if your application is running behind a proxy,
+# e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR
+REAL_IP_ENVIRON = os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR")
+
 # Rich-text editor
 ALLOWED_TAGS = [
     "a",

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -487,6 +487,9 @@ CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", None)
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR
 REAL_IP_ENVIRON = os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR")
 
+# The maximum length of a graphql query to log in tracings
+OPENTRACING_MAX_QUERY_LENGTH_LOG = 2000
+
 # Rich-text editor
 ALLOWED_TAGS = [
     "a",


### PR DESCRIPTION
- Client IP
- Query Executed
- Response Content Length (bytes)

Note: the segments are now splited by query. For example a bulk query will generate two  segments descendant of http for clearer analysis and comprehension of bulk queries.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.
