### PR TITLE
Add multitenant routing and endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ tqdm = "^4.36"
 uwsgi = {version = "^2.0.8", platform = "!=win32"}
 weasyprint = ">=48"
 oauthlib = "^3.0"
+django-threadlocals = "^0.10"
 
 [tool.poetry.dev-dependencies]
 black = "19.10b0"
@@ -70,6 +71,7 @@ codecov = "^2.0.15"
 coverage = "^4.5.4"
 django-debug-toolbar = "^2.0"
 django-debug-toolbar-request-history = "^0"
+django-threadlocals = "^0.10"
 django-graphiql-debug-toolbar = "^0.1.4"
 django-extensions = "^2.2.1"
 flake8 = "^3.7.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,7 @@ django-render-block==0.6
 django-silk==2.0.0
 django-storages==1.9.1
 django-templated-email==2.3.0
+django-threadlocals==0.10
 django-versatileimagefield==1.11
 docutils==0.15.2
 draftjs-sanitizer==1.0.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -54,6 +54,7 @@ django-silk==2.0.0
 django-storages==1.9.1
 django-stubs==1.2.0
 django-templated-email==2.3.0
+django-threadlocals==0.10
 django-versatileimagefield==1.11
 docutils==0.15.2
 draftjs-sanitizer==1.0.0

--- a/saleor/core/management/commands/populatedb.py
+++ b/saleor/core/management/commands/populatedb.py
@@ -36,6 +36,13 @@ class Command(BaseCommand):
             help="Create admin account",
         )
         parser.add_argument(
+            "--onlysuperuser",
+            action="store_true",
+            dest="onlysuperuser",
+            default=False,
+            help="Only create admin account",
+        )
+        parser.add_argument(
             "--withoutimages",
             action="store_true",
             dest="withoutimages",
@@ -55,6 +62,11 @@ class Command(BaseCommand):
             dest="skipsequencereset",
             default=False,
             help="Don't reset SQL sequences that are out of sync.",
+        )
+        parser.add_argument(
+            "--database",
+            default=False,
+            help="Name of the database to populate data to",
         )
 
     def make_database_faster(self):
@@ -86,6 +98,14 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.make_database_faster()
+
+        if options["onlysuperuser"]:
+            credentials = {"email": "admin@example.com", "password": "admin"}
+            msg = create_superuser(credentials)
+            self.stdout.write(msg)
+            add_address_to_admin(credentials["email"])
+            return
+
         create_images = not options["withoutimages"]
         for msg in create_shipping_zones():
             self.stdout.write(msg)

--- a/saleor/migrate/views.py
+++ b/saleor/migrate/views.py
@@ -1,0 +1,31 @@
+import dj_database_url
+from django.conf import settings
+from django.http import HttpResponse
+from django.core.management import execute_from_command_line
+from ..utils import fetch_credentials
+
+def migrate(request):
+    domain = request.headers["X-Domain-ID"]
+    credentials = fetch_credentials(domain)
+
+    client = credentials.get('client')
+    connection = credentials.get('connection')
+
+    host = connection.get('host')
+    port = connection.get('port')
+    user = connection.get('user')
+    password = connection.get('password')
+    database = connection.get('database')
+
+    connection_string = f"{client}://{user}:{password}@{host}:{port}/{database}"
+    settings.DATABASES["dynamic-database"] = dj_database_url.parse(connection_string)
+
+    execute_from_command_line([
+        '../../manage.py',
+        'migrate',
+        '--database',
+        'dynamic-database'
+    ])
+
+    response = HttpResponse(status=204)
+    return response

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -9,8 +9,10 @@ from .data_feeds.urls import urlpatterns as feed_urls
 from .graphql.api import schema
 from .graphql.views import GraphQLView
 from .product.views import digital_product
+from .migrate.views import migrate
 
 urlpatterns = [
+    url(r"^migrate/", migrate, name="migrate"),
     url(r"^graphql/", csrf_exempt(GraphQLView.as_view(schema=schema)), name="api"),
     url(r"^feeds/", include((feed_urls, "data_feeds"), namespace="data_feeds")),
     url(

--- a/saleor/utils.py
+++ b/saleor/utils.py
@@ -1,0 +1,15 @@
+import os
+import json
+import urllib
+import contextlib
+
+def fetch_credentials(domain=None):
+    try:
+        api = os.environ.get('DOMAIN_DATABASE_HOST')
+        url = f"{api}/{domain}/database"
+
+        with contextlib.closing(urllib.request.urlopen(url)) as response:
+            credentials = response.read().decode('utf-8')
+            return json.loads(credentials)
+    except Exception as e:
+        raise e


### PR DESCRIPTION
This PR adds `DatabaseRouter` to handle incoming requests and set them to their appropriate `domainId`.
A new endpoint `GET /migrate` is added as well to be able to remotely run migrations to specific databases at a time.