### PR TITLE
Add validation if user is not anonymous before saving an order events

### DIFF
--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -28,6 +28,10 @@ def _get_payment_data(amount: Optional[Decimal], payment: Payment) -> Dict:
     }
 
 
+def _user_is_valid(user: UserType) -> bool:
+    return user and not user.is_anonymous
+
+
 def email_sent_event(
     *,
     order: Order,
@@ -58,6 +62,8 @@ def email_resent_event(
 
 
 def draft_order_created_event(*, order: Order, user: UserType) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.DRAFT_CREATED, user=user
     )
@@ -66,7 +72,8 @@ def draft_order_created_event(*, order: Order, user: UserType) -> OrderEvent:
 def draft_order_added_products_event(
     *, order: Order, user: UserType, order_lines: List[Tuple[int, OrderLine]]
 ) -> OrderEvent:
-
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.DRAFT_ADDED_PRODUCTS,
@@ -78,7 +85,8 @@ def draft_order_added_products_event(
 def draft_order_removed_products_event(
     *, order: Order, user: UserType, order_lines: List[Tuple[int, OrderLine]]
 ) -> OrderEvent:
-
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.DRAFT_REMOVED_PRODUCTS,
@@ -96,16 +104,17 @@ def order_created_event(
         event_type = OrderEvents.PLACED
         account_events.customer_placed_order_event(user=user, order=order)
 
-    order_event_user = None if user.is_anonymous else user
+    if not _user_is_valid(user):
+        user = None
 
-    return OrderEvent.objects.create(
-        order=order, type=event_type, user=order_event_user
-    )
+    return OrderEvent.objects.create(order=order, type=event_type, user=user)
 
 
 def draft_order_oversold_items_event(
     *, order: Order, user: UserType, oversold_items: List[str]
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.OVERSOLD_ITEMS,
@@ -115,10 +124,14 @@ def draft_order_oversold_items_event(
 
 
 def order_canceled_event(*, order: Order, user: UserType) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(order=order, type=OrderEvents.CANCELED, user=user)
 
 
 def order_manually_marked_as_paid_event(*, order: Order, user: UserType) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order, type=OrderEvents.ORDER_MARKED_AS_PAID, user=user
     )
@@ -131,6 +144,8 @@ def order_fully_paid_event(*, order: Order) -> OrderEvent:
 def payment_captured_event(
     *, order: Order, user: UserType, amount: Decimal, payment: Payment
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_CAPTURED,
@@ -142,6 +157,8 @@ def payment_captured_event(
 def payment_refunded_event(
     *, order: Order, user: UserType, amount: Decimal, payment: Payment
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_REFUNDED,
@@ -153,6 +170,8 @@ def payment_refunded_event(
 def payment_voided_event(
     *, order: Order, user: UserType, payment: Payment
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.PAYMENT_VOIDED,
@@ -165,6 +184,8 @@ def payment_failed_event(
     *, order: Order, user: UserType, message: str, payment: Payment
 ) -> OrderEvent:
 
+    if not _user_is_valid(user):
+        user = None
     parameters = {"message": message}
 
     if payment:
@@ -178,6 +199,8 @@ def payment_failed_event(
 def fulfillment_canceled_event(
     *, order: Order, user: UserType, fulfillment: Fulfillment
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_CANCELED,
@@ -189,6 +212,8 @@ def fulfillment_canceled_event(
 def fulfillment_restocked_items_event(
     *, order: Order, user: UserType, fulfillment: Union[Order, Fulfillment]
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_RESTOCKED_ITEMS,
@@ -200,6 +225,8 @@ def fulfillment_restocked_items_event(
 def fulfillment_fulfilled_items_event(
     *, order: Order, user: UserType, fulfillment_lines: List[FulfillmentLine]
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.FULFILLMENT_FULFILLED_ITEMS,
@@ -211,6 +238,8 @@ def fulfillment_fulfilled_items_event(
 def fulfillment_tracking_updated_event(
     *, order: Order, user: UserType, tracking_number: str, fulfillment: Fulfillment
 ) -> OrderEvent:
+    if not _user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.TRACKING_UPDATED,

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -8,7 +8,7 @@ from ..payment.models import Payment
 from . import OrderEvents, OrderEventsEmails
 from .models import OrderEvent
 
-UserType = User
+UserType = Optional[User]
 
 
 def _lines_per_quantity_to_line_object_list(quantities_per_order_line):
@@ -29,7 +29,7 @@ def _get_payment_data(amount: Optional[Decimal], payment: Payment) -> Dict:
 
 
 def _user_is_valid(user: UserType) -> bool:
-    return user and not user.is_anonymous
+    return bool(user and not user.is_anonymous)
 
 
 def email_sent_event(
@@ -102,7 +102,10 @@ def order_created_event(
         event_type = OrderEvents.PLACED_FROM_DRAFT
     else:
         event_type = OrderEvents.PLACED
-        account_events.customer_placed_order_event(user=user, order=order)
+        account_events.customer_placed_order_event(
+            user=user,  # type: ignore
+            order=order,
+        )
 
     if not _user_is_valid(user):
         user = None


### PR DESCRIPTION
There is an issue with the `OrderEvents`. They don't take into consideration that an event can be created by ServiceAccount, they expect `User` object and they don't check if the user is a real object. 
This PR adds only validation to check if the provided user is not anonymous.