### PR TITLE
Fixed crash when no stock info is available to know if the product is in stock

### DIFF
--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -7,7 +7,7 @@ from ..core.exceptions import InsufficientStock
 from .models import Stock
 
 if TYPE_CHECKING:
-    from ...product.models import Product, ProductVariant
+    from ..product.models import Product, ProductVariant
 
 
 def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity: int):
@@ -44,8 +44,8 @@ def get_quantity_allocated(variant: "ProductVariant", country_code: str) -> int:
 
 def is_variant_in_stock(variant: "ProductVariant", country_code: str) -> bool:
     """Check if variant is available in given country."""
-    stock = Stock.objects.get_variant_stock_for_country(country_code, variant)
-    return stock.is_available
+    quantity_available = get_available_quantity(variant, country_code)
+    return quantity_available > 0
 
 
 def stocks_for_product(product: "Product", country_code: str):

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -68,6 +68,10 @@ class StockQuerySet(models.QuerySet):
     def get_variant_stock_for_country(
         self, country_code: str, product_variant: ProductVariant
     ):
+        """Return the stock information about the a stock for a given country.
+
+        Note it will raise a 'Stock.DoesNotExist' exception if no such stock is found.
+        """
         return self.for_country(country_code).get(product_variant=product_variant)
 
     def get_or_create_for_country(
@@ -99,10 +103,6 @@ class Stock(models.Model):
     @property
     def quantity_available(self) -> int:
         return max(self.quantity - self.quantity_allocated, 0)
-
-    @property
-    def is_available(self):
-        return self.quantity_available > 0
 
     def check_quantity(self, quantity: int):
         if quantity > self.quantity_available:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -770,7 +770,7 @@ def product_with_default_variant(product_type_without_variant, category, warehou
 
 
 @pytest.fixture
-def variant(product):
+def variant(product) -> ProductVariant:
     product_variant = ProductVariant.objects.create(
         product=product, sku="SKU_A", cost_price=Money(1, "USD")
     )

--- a/tests/test_data_feeds.py
+++ b/tests/test_data_feeds.py
@@ -7,6 +7,7 @@ from django.utils.encoding import smart_text
 from saleor.data_feeds.google_merchant import (
     get_feed_items,
     item_attributes,
+    item_availability,
     item_google_product_category,
     write_feed,
 )
@@ -36,6 +37,11 @@ def test_saleor_feed_items(product, site_settings):
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
+
+
+def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):
+    variant.stock.all().delete()
+    assert item_availability(variant) == "out of stock"
 
 
 def test_category_formatter(db):


### PR DESCRIPTION
When querying `isAvailable`, or using google merchant, or other parts it might raise `saleor.warehouse.models.Stock.DoesNotExist: Stock matching query does not exist.` depending on the data available. This pull request fixes this.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Not released yet - Changes are mentioned in the changelog.
