### PR TITLE
Require fields in schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `fulfillment created` webhook - @szewczykmira
 - Unify saleor metadata - #5178 by @fowczarek
 - Add compiled versions of emails to the repository - #5260 by @tomaszszymanski129
+- Add required prop to fields where applicable - #5293 by @dominik-zeglen
 
 
 ## 2.9.0

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -51,6 +51,7 @@ def get_error_fields(error_type_class, error_type_field):
                 description="List of errors that occurred executing the mutation.",
             ),
             default_value=[],
+            required=True,
         )
     }
 
@@ -93,6 +94,7 @@ class BaseMutation(graphene.Mutation):
     errors = graphene.List(
         graphene.NonNull(Error),
         description="List of errors that occurred executing the mutation.",
+        required=True,
     )
 
     class Meta:

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -57,7 +57,7 @@ class MenuError(Error):
 
 
 class MetadataError(Error):
-    code = MetadataErrorCode(description="The error code.")
+    code = MetadataErrorCode(description="The error code.", required=True)
 
 
 class OrderError(Error):

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -45,15 +45,15 @@ class Error(graphene.ObjectType):
 
 
 class AccountError(Error):
-    code = AccountErrorCode(description="The error code.")
+    code = AccountErrorCode(description="The error code.", required=True)
 
 
 class CheckoutError(Error):
-    code = CheckoutErrorCode(description="The error code.")
+    code = CheckoutErrorCode(description="The error code.", required=True)
 
 
 class MenuError(Error):
-    code = MenuErrorCode(description="The error code.")
+    code = MenuErrorCode(description="The error code.", required=True)
 
 
 class MetadataError(Error):
@@ -61,11 +61,11 @@ class MetadataError(Error):
 
 
 class OrderError(Error):
-    code = OrderErrorCode(description="The error code.")
+    code = OrderErrorCode(description="The error code.", required=True)
 
 
 class ProductError(Error):
-    code = ProductErrorCode(description="The error code.")
+    code = ProductErrorCode(description="The error code.", required=True)
 
 
 class BulkProductError(ProductError):
@@ -75,43 +75,43 @@ class BulkProductError(ProductError):
 
 
 class ShopError(Error):
-    code = ShopErrorCode(description="The error code.")
+    code = ShopErrorCode(description="The error code.", required=True)
 
 
 class ShippingError(Error):
-    code = ShippingErrorCode(description="The error code.")
+    code = ShippingErrorCode(description="The error code.", required=True)
 
 
 class PageError(Error):
-    code = PageErrorCode(description="The error code.")
+    code = PageErrorCode(description="The error code.", required=True)
 
 
 class PaymentError(Error):
-    code = PaymentErrorCode(description="The error code.")
+    code = PaymentErrorCode(description="The error code.", required=True)
 
 
 class GiftCardError(Error):
-    code = GiftCardErrorCode(description="The error code.")
+    code = GiftCardErrorCode(description="The error code.", required=True)
 
 
 class ExtensionsError(Error):
-    code = ExtensionsErrorCode(description="The error code.")
+    code = ExtensionsErrorCode(description="The error code.", required=True)
 
 
 class StockError(Error):
-    code = StockErrorCode(description="The error code.")
+    code = StockErrorCode(description="The error code.", required=True)
 
 
 class WarehouseError(Error):
-    code = WarehouseErrorCode(description="The error code.")
+    code = WarehouseErrorCode(description="The error code.", required=True)
 
 
 class WebhookError(Error):
-    code = WebhookErrorCode(description="The error code.")
+    code = WebhookErrorCode(description="The error code.", required=True)
 
 
 class WishlistError(Error):
-    code = WishlistErrorCode(description="The error code.")
+    code = WishlistErrorCode(description="The error code.", required=True)
 
 
 class LanguageDisplay(graphene.ObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3678,7 +3678,7 @@ type Query {
   translation(id: ID!, kind: TranslatableKinds!): TranslatableItem
   stock(id: ID!): Stock
   stocks(filter: StockFilterInput, before: String, after: String, first: Int, last: Int): StockCountableConnection
-  shop: Shop
+  shop: Shop!
   shippingZone(id: ID!): ShippingZone
   shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
   digitalContent(id: ID!): DigitalContent
@@ -4911,13 +4911,13 @@ input WarehouseUpdateInput {
 }
 
 type Webhook implements Node {
-  name: String
+  name: String!
   serviceAccount: ServiceAccount!
   targetUrl: String!
   isActive: Boolean!
   secretKey: String
   id: ID!
-  events: [WebhookEvent]
+  events: [WebhookEvent!]!
 }
 
 type WebhookCountableConnection {
@@ -4967,8 +4967,8 @@ enum WebhookErrorCode {
 }
 
 type WebhookEvent {
-  eventType: WebhookEventTypeEnum
-  name: String
+  eventType: WebhookEventTypeEnum!
+  name: String!
 }
 
 enum WebhookEventTypeEnum {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2110,7 +2110,7 @@ type MetaStore {
 type MetadataError {
   field: String
   message: String
-  code: MetadataErrorCode
+  code: MetadataErrorCode!
 }
 
 enum MetadataErrorCode {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4,36 +4,36 @@ schema {
 }
 
 type AccountAddressCreate {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
 type AccountError {
   field: String
   message: String
-  code: AccountErrorCode
+  code: AccountErrorCode!
 }
 
 enum AccountErrorCode {
@@ -66,9 +66,9 @@ input AccountInput {
 }
 
 type AccountRegister {
-  errors: [Error!]
+  errors: [Error!]!
   requiresConfirmation: Boolean
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -79,25 +79,25 @@ input AccountRegisterInput {
 }
 
 type AccountRequestDeletion {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type AccountUpdate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
 type AccountUpdateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -119,16 +119,16 @@ type Address implements Node {
 }
 
 type AddressCreate {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
@@ -147,9 +147,9 @@ input AddressInput {
 }
 
 type AddressSetDefault {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 enum AddressTypeEnum {
@@ -158,9 +158,9 @@ enum AddressTypeEnum {
 }
 
 type AddressUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   address: Address
 }
 
@@ -185,9 +185,9 @@ type AddressValidationData {
 }
 
 type AssignNavigation {
-  errors: [Error!]
+  errors: [Error!]!
   menu: Menu
-  menuErrors: [MenuError!]
+  menuErrors: [MenuError!]!
 }
 
 type Attribute implements Node, ObjectWithMetadata {
@@ -212,9 +212,9 @@ type Attribute implements Node, ObjectWithMetadata {
 }
 
 type AttributeAssign {
-  errors: [Error!]
+  errors: [Error!]!
   productType: ProductType
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input AttributeAssignInput {
@@ -223,20 +223,20 @@ input AttributeAssignInput {
 }
 
 type AttributeBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type AttributeClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   attribute: Attribute
 }
 
 type AttributeClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   attribute: Attribute
 }
 
@@ -252,9 +252,9 @@ type AttributeCountableEdge {
 }
 
 type AttributeCreate {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input AttributeCreateInput {
@@ -272,8 +272,8 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   attribute: Attribute
 }
 
@@ -302,9 +302,9 @@ enum AttributeInputTypeEnum {
 }
 
 type AttributeReorderValues {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 enum AttributeSortField {
@@ -334,7 +334,7 @@ type AttributeTranslatableContent implements Node {
 }
 
 type AttributeTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
 }
 
@@ -350,15 +350,15 @@ enum AttributeTypeEnum {
 }
 
 type AttributeUnassign {
-  errors: [Error!]
+  errors: [Error!]!
   productType: ProductType
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type AttributeUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input AttributeUpdateInput {
@@ -376,14 +376,14 @@ input AttributeUpdateInput {
 }
 
 type AttributeUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   attribute: Attribute
 }
 
 type AttributeUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   attribute: Attribute
 }
 
@@ -397,15 +397,15 @@ type AttributeValue implements Node {
 }
 
 type AttributeValueBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type AttributeValueCreate {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
   attributeValue: AttributeValue
 }
 
@@ -414,9 +414,9 @@ input AttributeValueCreateInput {
 }
 
 type AttributeValueDelete {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
   attributeValue: AttributeValue
 }
 
@@ -433,7 +433,7 @@ type AttributeValueTranslatableContent implements Node {
 }
 
 type AttributeValueTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   attributeValue: AttributeValue
 }
 
@@ -451,9 +451,9 @@ enum AttributeValueType {
 }
 
 type AttributeValueUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   attribute: Attribute
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
   attributeValue: AttributeValue
 }
 
@@ -463,17 +463,17 @@ type AuthorizationKey {
 }
 
 type AuthorizationKeyAdd {
-  errors: [Error!]
+  errors: [Error!]!
   authorizationKey: AuthorizationKey
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 type AuthorizationKeyDelete {
-  errors: [Error!]
+  errors: [Error!]!
   authorizationKey: AuthorizationKey
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 input AuthorizationKeyInput {
@@ -489,7 +489,7 @@ enum AuthorizationKeyType {
 type BulkProductError {
   field: String
   message: String
-  code: ProductErrorCode
+  code: ProductErrorCode!
   index: Int
 }
 
@@ -522,20 +522,20 @@ type Category implements Node, ObjectWithMetadata {
 }
 
 type CategoryBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type CategoryClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
@@ -551,14 +551,14 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
@@ -600,7 +600,7 @@ type CategoryTranslatableContent implements Node {
 }
 
 type CategoryTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   category: Category
 }
 
@@ -615,20 +615,20 @@ type CategoryTranslation implements Node {
 }
 
 type CategoryUpdate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
 type CategoryUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   category: Category
 }
 
@@ -663,34 +663,34 @@ type Checkout implements Node, ObjectWithMetadata {
 }
 
 type CheckoutAddPromoCode {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutClearMeta {
-  errors: [Error!]
-  checkoutErrors: [CheckoutError!]
+  errors: [Error!]!
+  checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutClearPrivateMeta {
-  errors: [Error!]
-  checkoutErrors: [CheckoutError!]
+  errors: [Error!]!
+  checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutComplete {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
   confirmationNeeded: Boolean!
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutCountableConnection {
@@ -705,9 +705,9 @@ type CheckoutCountableEdge {
 }
 
 type CheckoutCreate {
-  errors: [Error!]
+  errors: [Error!]!
   created: Boolean
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
@@ -719,27 +719,27 @@ input CheckoutCreateInput {
 }
 
 type CheckoutCustomerAttach {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutError {
   field: String
   message: String
-  code: CheckoutErrorCode
+  code: CheckoutErrorCode!
 }
 
 enum CheckoutErrorCode {
@@ -783,9 +783,9 @@ type CheckoutLineCountableEdge {
 }
 
 type CheckoutLineDelete {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 input CheckoutLineInput {
@@ -794,51 +794,51 @@ input CheckoutLineInput {
 }
 
 type CheckoutLinesAdd {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
   payment: Payment
-  paymentErrors: [PaymentError!]
+  paymentErrors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]
+  checkoutErrors: [CheckoutError!]!
 }
 
 type CheckoutUpdateMeta {
-  errors: [Error!]
-  checkoutErrors: [CheckoutError!]
+  errors: [Error!]!
+  checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
 type CheckoutUpdatePrivateMeta {
-  errors: [Error!]
-  checkoutErrors: [CheckoutError!]
+  errors: [Error!]!
+  checkoutErrors: [CheckoutError!]!
   checkout: Checkout
 }
 
@@ -867,32 +867,32 @@ type Collection implements Node, ObjectWithMetadata {
 }
 
 type CollectionAddProducts {
-  errors: [Error!]
+  errors: [Error!]!
   collection: Collection
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type CollectionBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type CollectionBulkPublish {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type CollectionClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
@@ -908,8 +908,8 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
@@ -927,8 +927,8 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
@@ -956,15 +956,15 @@ enum CollectionPublished {
 }
 
 type CollectionRemoveProducts {
-  errors: [Error!]
+  errors: [Error!]!
   collection: Collection
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type CollectionReorderProducts {
-  errors: [Error!]
+  errors: [Error!]!
   collection: Collection
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 enum CollectionSortField {
@@ -990,7 +990,7 @@ type CollectionTranslatableContent implements Node {
 }
 
 type CollectionTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   collection: Collection
 }
 
@@ -1005,20 +1005,20 @@ type CollectionTranslation implements Node {
 }
 
 type CollectionUpdate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
 type CollectionUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   collection: Collection
 }
 
@@ -1043,13 +1043,13 @@ enum ConfigurationTypeFieldEnum {
 }
 
 type ConfirmAccount {
-  errors: [Error!]
+  errors: [Error!]!
 }
 
 type ConfirmEmailChange {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 enum CountryCode {
@@ -1326,20 +1326,20 @@ type CreditCard {
 }
 
 type CustomerBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type CustomerCreate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -1389,8 +1389,8 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -1411,14 +1411,14 @@ input DateTimeRangeInput {
 scalar Decimal
 
 type DeleteMetadata {
-  errors: [Error!]
-  metadataErrors: [MetadataError!]
+  errors: [Error!]!
+  metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  errors: [Error!]
-  metadataErrors: [MetadataError!]
+  errors: [Error!]!
+  metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
@@ -1449,16 +1449,16 @@ type DigitalContentCountableEdge {
 }
 
 type DigitalContentCreate {
-  errors: [Error!]
+  errors: [Error!]!
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type DigitalContentDelete {
-  errors: [Error!]
+  errors: [Error!]!
   variant: ProductVariant
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input DigitalContentInput {
@@ -1469,10 +1469,10 @@ input DigitalContentInput {
 }
 
 type DigitalContentUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input DigitalContentUploadInput {
@@ -1493,8 +1493,8 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
 
@@ -1520,20 +1520,20 @@ type Domain {
 }
 
 type DraftOrderBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type DraftOrderComplete {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  errors: [Error!]
-  orderErrors: [OrderError!]
+  errors: [Error!]!
+  orderErrors: [OrderError!]!
   order: Order
 }
 
@@ -1550,8 +1550,8 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  errors: [Error!]
-  orderErrors: [OrderError!]
+  errors: [Error!]!
+  orderErrors: [OrderError!]!
   order: Order
 }
 
@@ -1567,35 +1567,35 @@ input DraftOrderInput {
 }
 
 type DraftOrderLineDelete {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
   orderLine: OrderLine
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type DraftOrderLineUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
   orderLine: OrderLine
 }
 
 type DraftOrderLinesBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type DraftOrderLinesCreate {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
   orderLines: [OrderLine!]
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  errors: [Error!]
-  orderErrors: [OrderError!]
+  errors: [Error!]!
+  orderErrors: [OrderError!]!
   order: Order
 }
 
@@ -1607,7 +1607,7 @@ type Error {
 type ExtensionsError {
   field: String
   message: String
-  code: ExtensionsErrorCode
+  code: ExtensionsErrorCode!
 }
 
 enum ExtensionsErrorCode {
@@ -1634,10 +1634,10 @@ type Fulfillment implements Node, ObjectWithMetadata {
 }
 
 type FulfillmentCancel {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 input FulfillmentCancelInput {
@@ -1645,20 +1645,20 @@ input FulfillmentCancelInput {
 }
 
 type FulfillmentClearMeta {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
 }
 
 type FulfillmentClearPrivateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
 }
 
 type FulfillmentCreate {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 input FulfillmentCreateInput {
@@ -1684,20 +1684,20 @@ enum FulfillmentStatus {
 }
 
 type FulfillmentUpdateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
 }
 
 type FulfillmentUpdatePrivateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
 }
 
 type FulfillmentUpdateTracking {
-  errors: [Error!]
+  errors: [Error!]!
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 input FulfillmentUpdateTrackingInput {
@@ -1731,9 +1731,9 @@ type GiftCard implements Node {
 }
 
 type GiftCardActivate {
-  errors: [Error!]
+  errors: [Error!]!
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]
+  giftCardErrors: [GiftCardError!]!
 }
 
 type GiftCardCountableConnection {
@@ -1748,8 +1748,8 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  errors: [Error!]
-  giftCardErrors: [GiftCardError!]
+  errors: [Error!]!
+  giftCardErrors: [GiftCardError!]!
   giftCard: GiftCard
 }
 
@@ -1762,15 +1762,15 @@ input GiftCardCreateInput {
 }
 
 type GiftCardDeactivate {
-  errors: [Error!]
+  errors: [Error!]!
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]
+  giftCardErrors: [GiftCardError!]!
 }
 
 type GiftCardError {
   field: String
   message: String
-  code: GiftCardErrorCode
+  code: GiftCardErrorCode!
 }
 
 enum GiftCardErrorCode {
@@ -1783,8 +1783,8 @@ enum GiftCardErrorCode {
 }
 
 type GiftCardUpdate {
-  errors: [Error!]
-  giftCardErrors: [GiftCardError!]
+  errors: [Error!]!
+  giftCardErrors: [GiftCardError!]!
   giftCard: GiftCard
 }
 
@@ -1814,9 +1814,9 @@ type GroupCountableEdge {
 }
 
 type HomepageCollectionUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 type Image {
@@ -1894,9 +1894,9 @@ type Menu implements Node {
 }
 
 type MenuBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  menuErrors: [MenuError!]
+  menuErrors: [MenuError!]!
 }
 
 type MenuCountableConnection {
@@ -1911,8 +1911,8 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menu: Menu
 }
 
@@ -1922,15 +1922,15 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menu: Menu
 }
 
 type MenuError {
   field: String
   message: String
-  code: MenuErrorCode
+  code: MenuErrorCode!
 }
 
 enum MenuErrorCode {
@@ -1968,9 +1968,9 @@ type MenuItem implements Node {
 }
 
 type MenuItemBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  menuErrors: [MenuError!]
+  menuErrors: [MenuError!]!
 }
 
 type MenuItemCountableConnection {
@@ -1985,8 +1985,8 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2001,8 +2001,8 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2019,9 +2019,9 @@ input MenuItemInput {
 }
 
 type MenuItemMove {
-  errors: [Error!]
+  errors: [Error!]!
   menu: Menu
-  menuErrors: [MenuError!]
+  menuErrors: [MenuError!]!
 }
 
 input MenuItemMoveInput {
@@ -2043,7 +2043,7 @@ type MenuItemTranslatableContent implements Node {
 }
 
 type MenuItemTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   menuItem: MenuItem
 }
 
@@ -2054,8 +2054,8 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menuItem: MenuItem
 }
 
@@ -2074,8 +2074,8 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  errors: [Error!]
-  menuErrors: [MenuError!]
+  errors: [Error!]!
+  menuErrors: [MenuError!]!
   menu: Menu
 }
 
@@ -2482,10 +2482,10 @@ enum OrderAction {
 }
 
 type OrderAddNote {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
   event: OrderEvent
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 input OrderAddNoteInput {
@@ -2493,30 +2493,30 @@ input OrderAddNoteInput {
 }
 
 type OrderBulkCancel {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type OrderCancel {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type OrderCapture {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type OrderClearMeta {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
 }
 
 type OrderClearPrivateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
 }
 
@@ -2545,7 +2545,7 @@ input OrderDraftFilterInput {
 type OrderError {
   field: String
   message: String
-  code: OrderErrorCode
+  code: OrderErrorCode!
 }
 
 enum OrderErrorCode {
@@ -2675,15 +2675,15 @@ input OrderLineInput {
 }
 
 type OrderMarkAsPaid {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type OrderRefund {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 enum OrderSortField {
@@ -2718,8 +2718,8 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  errors: [Error!]
-  orderErrors: [OrderError!]
+  errors: [Error!]!
+  orderErrors: [OrderError!]!
   order: Order
 }
 
@@ -2730,19 +2730,19 @@ input OrderUpdateInput {
 }
 
 type OrderUpdateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
 }
 
 type OrderUpdatePrivateMeta {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
 }
 
 type OrderUpdateShipping {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 input OrderUpdateShippingInput {
@@ -2750,9 +2750,9 @@ input OrderUpdateShippingInput {
 }
 
 type OrderVoid {
-  errors: [Error!]
+  errors: [Error!]!
   order: Order
-  orderErrors: [OrderError!]
+  orderErrors: [OrderError!]!
 }
 
 type Page implements Node {
@@ -2770,12 +2770,12 @@ type Page implements Node {
 }
 
 type PageBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
 }
 
 type PageBulkPublish {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
 }
 
@@ -2791,21 +2791,21 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  errors: [Error!]
-  pageErrors: [PageError!]
+  errors: [Error!]!
+  pageErrors: [PageError!]!
   page: Page
 }
 
 type PageDelete {
-  errors: [Error!]
-  pageErrors: [PageError!]
+  errors: [Error!]!
+  pageErrors: [PageError!]!
   page: Page
 }
 
 type PageError {
   field: String
   message: String
-  code: PageErrorCode
+  code: PageErrorCode!
 }
 
 enum PageErrorCode {
@@ -2862,7 +2862,7 @@ type PageTranslatableContent implements Node {
 }
 
 type PageTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   page: PageTranslatableContent
 }
 
@@ -2885,15 +2885,15 @@ input PageTranslationInput {
 }
 
 type PageUpdate {
-  errors: [Error!]
-  pageErrors: [PageError!]
+  errors: [Error!]!
+  pageErrors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type Payment implements Node {
@@ -2920,9 +2920,9 @@ type Payment implements Node {
 }
 
 type PaymentCapture {
-  errors: [Error!]
+  errors: [Error!]!
   payment: Payment
-  paymentErrors: [PaymentError!]
+  paymentErrors: [PaymentError!]!
 }
 
 enum PaymentChargeStatusEnum {
@@ -2947,7 +2947,7 @@ type PaymentCountableEdge {
 type PaymentError {
   field: String
   message: String
-  code: PaymentErrorCode
+  code: PaymentErrorCode!
 }
 
 enum PaymentErrorCode {
@@ -2974,15 +2974,15 @@ input PaymentInput {
 }
 
 type PaymentRefund {
-  errors: [Error!]
+  errors: [Error!]!
   payment: Payment
-  paymentErrors: [PaymentError!]
+  paymentErrors: [PaymentError!]!
 }
 
 type PaymentSecureConfirm {
-  errors: [Error!]
+  errors: [Error!]!
   payment: Payment
-  paymentErrors: [PaymentError!]
+  paymentErrors: [PaymentError!]!
 }
 
 type PaymentSource {
@@ -2991,9 +2991,9 @@ type PaymentSource {
 }
 
 type PaymentVoid {
-  errors: [Error!]
+  errors: [Error!]!
   payment: Payment
-  paymentErrors: [PaymentError!]
+  paymentErrors: [PaymentError!]!
 }
 
 type PermissionDisplay {
@@ -3020,15 +3020,15 @@ enum PermissionEnum {
 }
 
 type PermissionGroupAssignUsers {
-  errors: [Error!]
+  errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type PermissionGroupCreate {
-  errors: [Error!]
+  errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 input PermissionGroupCreateInput {
@@ -3037,8 +3037,8 @@ input PermissionGroupCreateInput {
 }
 
 type PermissionGroupDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   group: Group
 }
 
@@ -3061,15 +3061,15 @@ input PermissionGroupSortingInput {
 }
 
 type PermissionGroupUnassignUsers {
-  errors: [Error!]
+  errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type PermissionGroupUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type Plugin implements Node {
@@ -3107,9 +3107,9 @@ input PluginSortingInput {
 }
 
 type PluginUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   plugin: Plugin
-  extensionsErrors: [ExtensionsError!]
+  extensionsErrors: [ExtensionsError!]!
 }
 
 input PluginUpdateInput {
@@ -3159,26 +3159,26 @@ type Product implements Node, ObjectWithMetadata {
 }
 
 type ProductBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductBulkPublish {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
@@ -3194,8 +3194,8 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
@@ -3221,15 +3221,15 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductError {
   field: String
   message: String
-  code: ProductErrorCode
+  code: ProductErrorCode!
 }
 
 enum ProductErrorCode {
@@ -3268,16 +3268,16 @@ type ProductImage implements Node {
 }
 
 type ProductImageBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductImageCreate {
-  errors: [Error!]
+  errors: [Error!]!
   product: Product
   image: ProductImage
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input ProductImageCreateInput {
@@ -3287,24 +3287,24 @@ input ProductImageCreateInput {
 }
 
 type ProductImageDelete {
-  errors: [Error!]
+  errors: [Error!]!
   product: Product
   image: ProductImage
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductImageReorder {
-  errors: [Error!]
+  errors: [Error!]!
   product: Product
   images: [ProductImage]
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductImageUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   product: Product
   image: ProductImage
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 input ProductImageUpdateInput {
@@ -3367,7 +3367,7 @@ type ProductTranslatableContent implements Node {
 }
 
 type ProductTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   product: Product
 }
 
@@ -3402,20 +3402,20 @@ type ProductType implements Node, ObjectWithMetadata {
 }
 
 type ProductTypeBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductTypeClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
@@ -3436,14 +3436,14 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
@@ -3472,9 +3472,9 @@ input ProductTypeInput {
 }
 
 type ProductTypeReorderAttributes {
-  errors: [Error!]
+  errors: [Error!]!
   productType: ProductType
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 enum ProductTypeSortField {
@@ -3489,38 +3489,38 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
 type ProductUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   product: Product
 }
 
@@ -3553,10 +3553,10 @@ type ProductVariant implements Node, ObjectWithMetadata {
 }
 
 type ProductVariantBulkCreate {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
   productVariants: [ProductVariant!]!
-  bulkProductErrors: [BulkProductError!]
+  bulkProductErrors: [BulkProductError!]!
 }
 
 input ProductVariantBulkCreateInput {
@@ -3570,20 +3570,20 @@ input ProductVariantBulkCreateInput {
 }
 
 type ProductVariantBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type ProductVariantClearMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantClearPrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -3599,8 +3599,8 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -3616,8 +3616,8 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -3639,7 +3639,7 @@ type ProductVariantTranslatableContent implements Node {
 }
 
 type ProductVariantTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   productVariant: ProductVariant
 }
 
@@ -3650,20 +3650,20 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantUpdateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
 type ProductVariantUpdatePrivateMeta {
-  errors: [Error!]
-  productErrors: [ProductError!]
+  errors: [Error!]!
+  productErrors: [ProductError!]!
   productVariant: ProductVariant
 }
 
@@ -3758,14 +3758,14 @@ enum ReportingPeriod {
 }
 
 type RequestEmailChange {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
 }
 
 type Sale implements Node {
@@ -3782,12 +3782,12 @@ type Sale implements Node {
 }
 
 type SaleAddCatalogues {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
 type SaleBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
 }
 
@@ -3803,12 +3803,12 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
 type SaleDelete {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
@@ -3831,7 +3831,7 @@ input SaleInput {
 }
 
 type SaleRemoveCatalogues {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
@@ -3856,7 +3856,7 @@ type SaleTranslatableContent implements Node {
 }
 
 type SaleTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
@@ -3872,7 +3872,7 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   sale: Sale
 }
 
@@ -3900,8 +3900,8 @@ type ServiceAccount implements Node, ObjectWithMetadata {
 }
 
 type ServiceAccountClearPrivateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
@@ -3917,15 +3917,15 @@ type ServiceAccountCountableEdge {
 }
 
 type ServiceAccountCreate {
-  errors: [Error!]
+  errors: [Error!]!
   authToken: String
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
 type ServiceAccountDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
@@ -3957,15 +3957,15 @@ type ServiceAccountToken implements Node {
 }
 
 type ServiceAccountTokenCreate {
-  errors: [Error!]
+  errors: [Error!]!
   authToken: String
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
   serviceAccountToken: ServiceAccountToken
 }
 
 type ServiceAccountTokenDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   serviceAccountToken: ServiceAccountToken
 }
 
@@ -3975,14 +3975,14 @@ input ServiceAccountTokenInput {
 }
 
 type ServiceAccountUpdate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
 type ServiceAccountUpdatePrivateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   serviceAccount: ServiceAccount
 }
 
@@ -3996,7 +3996,7 @@ type SetPassword {
 type ShippingError {
   field: String
   message: String
-  code: ShippingErrorCode
+  code: ShippingErrorCode!
 }
 
 enum ShippingErrorCode {
@@ -4040,23 +4040,23 @@ enum ShippingMethodTypeEnum {
 }
 
 type ShippingPriceBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
-  errors: [Error!]
+  errors: [Error!]!
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
   shippingMethod: ShippingMethod
 }
 
 type ShippingPriceDelete {
-  errors: [Error!]
+  errors: [Error!]!
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
 }
 
 input ShippingPriceInput {
@@ -4071,14 +4071,14 @@ input ShippingPriceInput {
 }
 
 type ShippingPriceTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   shippingMethod: ShippingMethod
 }
 
 type ShippingPriceUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
   shippingMethod: ShippingMethod
 }
 
@@ -4093,9 +4093,9 @@ type ShippingZone implements Node {
 }
 
 type ShippingZoneBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
 }
 
 type ShippingZoneCountableConnection {
@@ -4110,14 +4110,14 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  errors: [Error!]
+  errors: [Error!]!
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
 }
 
 type ShippingZoneDelete {
-  errors: [Error!]
-  shippingErrors: [ShippingError!]
+  errors: [Error!]!
+  shippingErrors: [ShippingError!]!
   shippingZone: ShippingZone
 }
 
@@ -4128,9 +4128,9 @@ input ShippingZoneInput {
 }
 
 type ShippingZoneUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]
+  shippingErrors: [ShippingError!]!
 }
 
 type Shop {
@@ -4166,21 +4166,21 @@ type Shop {
 }
 
 type ShopAddressUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 type ShopError {
   field: String
   message: String
-  code: ShopErrorCode
+  code: ShopErrorCode!
 }
 
 enum ShopErrorCode {
@@ -4194,9 +4194,9 @@ enum ShopErrorCode {
 }
 
 type ShopFetchTaxRates {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 input ShopSettingsInput {
@@ -4216,7 +4216,7 @@ input ShopSettingsInput {
 }
 
 type ShopSettingsTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
 }
 
@@ -4226,9 +4226,9 @@ input ShopSettingsTranslationInput {
 }
 
 type ShopSettingsUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   shop: Shop
-  shopErrors: [ShopError!]
+  shopErrors: [ShopError!]!
 }
 
 type ShopTranslation implements Node {
@@ -4244,14 +4244,14 @@ input SiteDomainInput {
 }
 
 type StaffBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type StaffCreate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -4266,8 +4266,8 @@ input StaffCreateInput {
 }
 
 type StaffDelete {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -4293,14 +4293,14 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  errors: [Error!]
-  shopErrors: [ShopError!]
+  errors: [Error!]!
+  shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  errors: [Error!]
-  shopErrors: [ShopError!]
+  errors: [Error!]!
+  shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
@@ -4311,14 +4311,14 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  errors: [Error!]
-  shopErrors: [ShopError!]
+  errors: [Error!]!
+  shopErrors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -4342,9 +4342,9 @@ enum StockAvailability {
 }
 
 type StockBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  stockError: [StockError!]
+  stockError: [StockError!]!
 }
 
 type StockCountableConnection {
@@ -4359,13 +4359,13 @@ type StockCountableEdge {
 }
 
 type StockCreate {
-  errors: [Error!]
-  stockErrors: [StockError!]
+  errors: [Error!]!
+  stockErrors: [StockError!]!
   stock: Stock
 }
 
 type StockDelete {
-  errors: [Error!]
+  errors: [Error!]!
   stock: Stock
 }
 
@@ -4381,7 +4381,7 @@ enum StockErorrCode {
 type StockError {
   field: String
   message: String
-  code: StockErorrCode
+  code: StockErorrCode!
 }
 
 input StockFilterInput {
@@ -4397,8 +4397,8 @@ input StockInput {
 }
 
 type StockUpdate {
-  errors: [Error!]
-  stockError: [StockError!]
+  errors: [Error!]!
+  stockError: [StockError!]!
   stock: Stock
 }
 
@@ -4518,14 +4518,14 @@ input TranslationInput {
 scalar UUID
 
 type UpdateMetadata {
-  errors: [Error!]
-  metadataErrors: [MetadataError!]
+  errors: [Error!]!
+  metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  errors: [Error!]
-  metadataErrors: [MetadataError!]
+  errors: [Error!]!
+  metadataErrors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
@@ -4559,32 +4559,32 @@ type User implements Node, ObjectWithMetadata {
 }
 
 type UserAvatarDelete {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   user: User
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type UserBulkSetActive {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
-  accountErrors: [AccountError!]
+  accountErrors: [AccountError!]!
 }
 
 type UserClearMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
 type UserClearPrivateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -4623,14 +4623,14 @@ input UserSortingInput {
 }
 
 type UserUpdateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
 type UserUpdatePrivateMeta {
-  errors: [Error!]
-  accountErrors: [AccountError!]
+  errors: [Error!]!
+  accountErrors: [AccountError!]!
   user: User
 }
 
@@ -4641,17 +4641,17 @@ type VAT {
 }
 
 type VariantImageAssign {
-  errors: [Error!]
+  errors: [Error!]!
   productVariant: ProductVariant
   image: ProductImage
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type VariantImageUnassign {
-  errors: [Error!]
+  errors: [Error!]!
   productVariant: ProductVariant
   image: ProductImage
-  productErrors: [ProductError!]
+  productErrors: [ProductError!]!
 }
 
 type VariantPricingInfo {
@@ -4691,12 +4691,12 @@ type Voucher implements Node {
 }
 
 type VoucherAddCatalogues {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
 type VoucherBulkDelete {
-  errors: [Error!]
+  errors: [Error!]!
   count: Int!
 }
 
@@ -4712,12 +4712,12 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
@@ -4755,7 +4755,7 @@ input VoucherInput {
 }
 
 type VoucherRemoveCatalogues {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
@@ -4782,7 +4782,7 @@ type VoucherTranslatableContent implements Node {
 }
 
 type VoucherTranslate {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
@@ -4799,7 +4799,7 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   voucher: Voucher
 }
 
@@ -4836,8 +4836,8 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  errors: [Error!]
-  warehouseErrors: [WarehouseError!]
+  errors: [Error!]!
+  warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -4851,15 +4851,15 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  errors: [Error!]
-  warehouseErrors: [WarehouseError!]
+  errors: [Error!]!
+  warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
 type WarehouseError {
   field: String
   message: String
-  code: WarehouseErrorCode
+  code: WarehouseErrorCode!
 }
 
 enum WarehouseErrorCode {
@@ -4876,15 +4876,15 @@ input WarehouseFilterInput {
 }
 
 type WarehouseShippingZoneAssign {
-  errors: [Error!]
+  errors: [Error!]!
   warehouse: Warehouse
-  warehouseErrors: [WarehouseError!]
+  warehouseErrors: [WarehouseError!]!
 }
 
 type WarehouseShippingZoneUnassign {
-  errors: [Error!]
+  errors: [Error!]!
   warehouse: Warehouse
-  warehouseErrors: [WarehouseError!]
+  warehouseErrors: [WarehouseError!]!
 }
 
 enum WarehouseSortField {
@@ -4897,8 +4897,8 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  errors: [Error!]
-  warehouseErrors: [WarehouseError!]
+  errors: [Error!]!
+  warehouseErrors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
@@ -4932,8 +4932,8 @@ type WebhookCountableEdge {
 }
 
 type WebhookCreate {
-  errors: [Error!]
-  webhookErrors: [WebhookError!]
+  errors: [Error!]!
+  webhookErrors: [WebhookError!]!
   webhook: Webhook
 }
 
@@ -4947,15 +4947,15 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  errors: [Error!]
+  errors: [Error!]!
   webhook: Webhook
-  webhookErrors: [WebhookError!]
+  webhookErrors: [WebhookError!]!
 }
 
 type WebhookError {
   field: String
   message: String
-  code: WebhookErrorCode
+  code: WebhookErrorCode!
 }
 
 enum WebhookErrorCode {
@@ -5013,9 +5013,9 @@ input WebhookSortingInput {
 }
 
 type WebhookUpdate {
-  errors: [Error!]
+  errors: [Error!]!
   webhook: Webhook
-  webhookErrors: [WebhookError!]
+  webhookErrors: [WebhookError!]!
 }
 
 input WebhookUpdateInput {
@@ -5048,21 +5048,21 @@ type Wishlist implements Node {
 }
 
 type WishlistAddProductMutation {
-  errors: [Error!]
+  errors: [Error!]!
   wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]
+  wishlistErrors: [WishlistError!]!
 }
 
 type WishlistAddProductVariantMutation {
-  errors: [Error!]
+  errors: [Error!]!
   wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]
+  wishlistErrors: [WishlistError!]!
 }
 
 type WishlistError {
   field: String
   message: String
-  code: WishlistErrorCode
+  code: WishlistErrorCode!
 }
 
 enum WishlistErrorCode {
@@ -5092,15 +5092,15 @@ type WishlistItemCountableEdge {
 }
 
 type WishlistRemoveProductMutation {
-  errors: [Error!]
+  errors: [Error!]!
   wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]
+  wishlistErrors: [WishlistError!]!
 }
 
 type WishlistRemoveProductVariantMutation {
-  errors: [Error!]
+  errors: [Error!]!
   wishlist: [WishlistItem]
-  wishlistErrors: [WishlistError!]
+  wishlistErrors: [WishlistError!]!
 }
 
 scalar _Any

--- a/saleor/graphql/shop/schema.py
+++ b/saleor/graphql/shop/schema.py
@@ -17,7 +17,9 @@ from .types import Shop
 
 
 class ShopQueries(graphene.ObjectType):
-    shop = graphene.Field(Shop, description="Return information about the shop.")
+    shop = graphene.Field(
+        Shop, description="Return information about the shop.", required=True
+    )
 
     def resolve_shop(self, _info):
         return Shop()

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -8,8 +8,10 @@ from .enums import WebhookEventTypeEnum
 
 
 class WebhookEvent(CountableDjangoObjectType):
-    name = graphene.String(description="Display name of the event.")
-    event_type = WebhookEventTypeEnum(description="Internal name of the event type.")
+    name = graphene.String(description="Display name of the event.", required=True)
+    event_type = WebhookEventTypeEnum(
+        description="Internal name of the event type.", required=True
+    )
 
     class Meta:
         model = models.WebhookEvent
@@ -22,8 +24,13 @@ class WebhookEvent(CountableDjangoObjectType):
 
 
 class Webhook(CountableDjangoObjectType):
+    name = graphene.String(required=True)
     events = gql_optimizer.field(
-        graphene.List(WebhookEvent, description="List of webhook events."),
+        graphene.List(
+            graphene.NonNull(WebhookEvent),
+            description="List of webhook events.",
+            required=True,
+        ),
         model_field="events",
     )
 


### PR DESCRIPTION
I want to merge this change because it ensures API consumer that these fields are always returned and non-nullable.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [x] Privileged views and APIs are guarded by proper permission checks.
1. [x] All visible strings are translated with proper context.
1. [x] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
