### PR TITLE
Add storefront queries to benchmarks

### DIFF
--- a/tests/api/benchmark/conftest.py
+++ b/tests/api/benchmark/conftest.py
@@ -1,0 +1,93 @@
+import pytest
+
+from saleor.discount.models import Sale
+from saleor.menu.utils import update_menu
+from saleor.product.models import Category
+
+
+@pytest.fixture
+def site_with_top_menu(site_settings):
+    menu = site_settings.top_menu
+    menu.items.create(name="Link 1", url="http://example.com/")
+    menu.items.create(name="Link 2", url="http://example.com/")
+    menu.items.create(name="Link 3", url="http://example.com/")
+    update_menu(menu)
+    return site_settings
+
+
+@pytest.fixture
+def site_with_bottom_menu(site_settings):
+    menu = site_settings.bottom_menu
+    menu.items.create(name="Link 1", url="http://example.com/")
+    menu.items.create(name="Link 2", url="http://example.com/")
+    menu.items.create(name="Link 3", url="http://example.com/")
+    update_menu(menu)
+    return site_settings
+
+
+@pytest.fixture
+def sales_list():
+    return list(
+        Sale.objects.bulk_create(
+            [Sale(name="Sale1", value=15), Sale(name="Sale2", value=5)]
+        )
+    )
+
+
+@pytest.fixture
+def homepage_collection(
+    site_settings,
+    collection,
+    product_list_published,
+    product_with_image,
+    product_with_variant_with_two_attributes,
+    product_with_multiple_values_attributes,
+    product_without_shipping,
+    non_default_category,
+    sales_list,
+):
+    product_with_image.category = non_default_category
+    product_with_image.save()
+
+    collection.products.set(product_list_published)
+
+    collection.products.add(product_with_image)
+    collection.products.add(product_with_variant_with_two_attributes)
+    collection.products.add(product_with_multiple_values_attributes)
+    collection.products.add(product_without_shipping)
+
+    site_settings.homepage_collection = collection
+    site_settings.save(update_fields=["homepage_collection"])
+    return collection
+
+
+@pytest.fixture
+def category_with_products(
+    product_with_image,
+    product_list_published,
+    product_with_variant_with_two_attributes,
+    product_with_multiple_values_attributes,
+    product_without_shipping,
+    sales_list,
+):
+    category = Category.objects.create(name="Category", slug="cat")
+
+    product_list_published.update(category=category)
+
+    product_with_image.category = category
+    product_with_image.save()
+    product_with_variant_with_two_attributes.category = category
+    product_with_variant_with_two_attributes.save()
+    product_with_multiple_values_attributes.category = category
+    product_with_multiple_values_attributes.save()
+    product_without_shipping.category = category
+    product_without_shipping.save()
+
+    return category
+
+
+@pytest.fixture
+def customer_checkout(customer_user, checkout_with_voucher_percentage_and_shipping):
+    checkout_with_voucher_percentage_and_shipping.user = customer_user
+    checkout_with_voucher_percentage_and_shipping.save()
+    return checkout_with_voucher_percentage_and_shipping

--- a/tests/api/benchmark/test_category.py
+++ b/tests/api/benchmark/test_category.py
@@ -1,0 +1,113 @@
+import graphene
+import pytest
+
+from tests.api.utils import get_graphql_content
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_category_view(api_client, category_with_products, count_queries):
+    query = """
+        fragment BasicProductFields on Product {
+          id
+          name
+          thumbnail {
+            url
+            alt
+          }
+          thumbnail2x: thumbnail(size: 510) {
+            url
+          }
+        }
+
+        fragment Price on TaxedMoney {
+          gross {
+            amount
+            currency
+          }
+          net {
+            amount
+            currency
+          }
+        }
+
+        fragment ProductPricingField on Product {
+          pricing {
+            onSale
+            priceRangeUndiscounted {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+            priceRange {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+          }
+        }
+
+        query Category($id: ID!, $pageSize: Int) {
+          products(first: $pageSize, filter: {categories: [$id]}) {
+            totalCount
+            edges {
+              node {
+                ...BasicProductFields
+                ...ProductPricingField
+                category {
+                  id
+                  name
+                }
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+              hasPreviousPage
+              startCursor
+            }
+          }
+          category(id: $id) {
+            seoDescription
+            seoTitle
+            id
+            name
+            backgroundImage {
+              url
+            }
+            ancestors(last: 5) {
+              edges {
+                node {
+                  id
+                  name
+                }
+              }
+            }
+          }
+          attributes(filter: {inCategory: $id}, first: 100) {
+            edges {
+              node {
+                id
+                name
+                slug
+                values {
+                  id
+                  name
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """
+    variables = {
+        "pageSize": 100,
+        "id": graphene.Node.to_global_id("Category", category_with_products.pk),
+    }
+    get_graphql_content(api_client.post_graphql(query, variables))

--- a/tests/api/benchmark/test_collection.py
+++ b/tests/api/benchmark/test_collection.py
@@ -1,0 +1,106 @@
+import graphene
+import pytest
+
+from tests.api.utils import get_graphql_content
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_collection_view(api_client, homepage_collection, count_queries):
+    query = """
+        fragment BasicProductFields on Product {
+          id
+          name
+          thumbnail {
+            url
+            alt
+          }
+          thumbnail2x: thumbnail(size: 510) {
+            url
+          }
+        }
+
+        fragment Price on TaxedMoney {
+          gross {
+            amount
+            currency
+          }
+          net {
+            amount
+            currency
+          }
+        }
+
+        fragment ProductPricingField on Product {
+          pricing {
+            onSale
+            priceRangeUndiscounted {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+            priceRange {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+          }
+        }
+
+        query Collection($id: ID!, $pageSize: Int) {
+          collection(id: $id) {
+            id
+            slug
+            name
+            seoDescription
+            seoTitle
+            backgroundImage {
+              url
+            }
+          }
+          products(first: $pageSize, filter: {collections: [$id]}) {
+            totalCount
+            edges {
+              node {
+                ...BasicProductFields
+                ...ProductPricingField
+                category {
+                  id
+                  name
+                }
+              }
+            }
+            pageInfo {
+              endCursor
+              hasNextPage
+              hasPreviousPage
+              startCursor
+            }
+          }
+          attributes(filter: {inCollection: $id}, first: 100) {
+            edges {
+              node {
+                id
+                name
+                slug
+                values {
+                  id
+                  name
+                  slug
+                }
+              }
+            }
+          }
+        }
+    """
+    variables = {
+        "pageSize": 100,
+        "id": graphene.Node.to_global_id("Collection", homepage_collection.pk),
+    }
+    get_graphql_content(api_client.post_graphql(query, variables))

--- a/tests/api/benchmark/test_homepage.py
+++ b/tests/api/benchmark/test_homepage.py
@@ -5,7 +5,7 @@ from tests.api.utils import get_graphql_content
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_retrieve_main_menu(api_client, count_queries):
+def test_retrieve_main_menu(api_client, site_with_top_menu, count_queries):
     query = """
         fragment MainMenuSubItem on MenuItem {
           id
@@ -52,7 +52,7 @@ def test_retrieve_main_menu(api_client, count_queries):
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_retrieve_secondary_menu(api_client, count_queries):
+def test_retrieve_secondary_menu(api_client, site_with_bottom_menu, count_queries):
     query = """
         fragment SecondaryMenuSubItem on MenuItem {
           id
@@ -118,7 +118,9 @@ def test_retrieve_shop(api_client, count_queries):
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_retrieve_product_list(api_client, count_queries):
+def test_retrieve_product_list(
+    api_client, homepage_collection, category, categories_tree, count_queries,
+):
     query = """
         query ProductsList {
           shop {
@@ -146,3 +148,213 @@ def test_retrieve_product_list(api_client, count_queries):
         }
     """
     get_graphql_content(api_client.post_graphql(query))
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_featured_products_list(api_client, homepage_collection, count_queries):
+    query = """
+        fragment BasicProductFields on Product {
+          id
+          name
+          thumbnail {
+            url
+            alt
+          }
+          thumbnail2x: thumbnail(size: 510) {
+            url
+          }
+        }
+
+        fragment Price on TaxedMoney {
+          gross {
+            amount
+            currency
+          }
+          net {
+            amount
+            currency
+          }
+        }
+
+        fragment ProductPricingField on Product {
+          pricing {
+            onSale
+            priceRangeUndiscounted {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+            priceRange {
+              start {
+                ...Price
+              }
+              stop {
+                ...Price
+              }
+            }
+          }
+        }
+
+        query FeaturedProducts {
+          shop {
+            homepageCollection {
+              id
+              products(first: 20) {
+                edges {
+                  node {
+                    ...BasicProductFields
+                    ...ProductPricingField
+                    category {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    get_graphql_content(api_client.post_graphql(query))
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_user_checkout_details(user_api_client, customer_checkout, count_queries):
+    query = """
+        fragment Price on TaxedMoney {
+          gross {
+            amount
+            currency
+          }
+          net {
+            amount
+            currency
+          }
+        }
+
+        fragment ProductVariant on ProductVariant {
+          id
+          name
+          pricing {
+            onSale
+            priceUndiscounted {
+              ...Price
+            }
+            price {
+              ...Price
+            }
+          }
+          product {
+            id
+            name
+            thumbnail {
+              url
+              alt
+            }
+            thumbnail2x: thumbnail(size: 510) {
+              url
+            }
+          }
+        }
+
+        fragment CheckoutLine on CheckoutLine {
+          id
+          quantity
+          totalPrice {
+            ...Price
+          }
+          variant {
+            stockQuantity
+            ...ProductVariant
+          }
+          quantity
+        }
+
+        fragment Address on Address {
+          id
+          firstName
+          lastName
+          companyName
+          streetAddress1
+          streetAddress2
+          city
+          postalCode
+          country {
+            code
+            country
+          }
+          countryArea
+          phone
+          isDefaultBillingAddress
+          isDefaultShippingAddress
+        }
+
+        fragment ShippingMethod on ShippingMethod {
+          id
+          name
+          price {
+            currency
+            amount
+          }
+        }
+
+        fragment Checkout on Checkout {
+          availablePaymentGateways {
+            name
+            config {
+              field
+              value
+            }
+          }
+          token
+          id
+          totalPrice {
+            ...Price
+          }
+          subtotalPrice {
+            ...Price
+          }
+          billingAddress {
+            ...Address
+          }
+          shippingAddress {
+            ...Address
+          }
+          email
+          availableShippingMethods {
+            ...ShippingMethod
+          }
+          shippingMethod {
+            ...ShippingMethod
+          }
+          shippingPrice {
+            ...Price
+          }
+          lines {
+            ...CheckoutLine
+          }
+          isShippingRequired
+          discount {
+            currency
+            amount
+          }
+          discountName
+          translatedDiscountName
+          voucherCode
+        }
+
+        query UserCheckoutDetails {
+          me {
+            id
+            checkout {
+              ...Checkout
+            }
+          }
+        }
+    """
+    get_graphql_content(user_api_client.post_graphql(query))


### PR DESCRIPTION
I want to merge this change because added storefront queries to benchmarks.

<!-- Please mention all relevant issue numbers. -->

### Screenshots

<!-- If your changes affect the UI, providing "before" and "after" screenshots will
greatly reduce the amount of work needed to review your work. -->

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
