### PR TITLE
Update create permission group restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add --force flag to cleardb command - #5302 by @maarcingebala
 - Require non-empty message in orderAddNote mutation - #5316 by @maarcingebala
 - Stock management refactor - #5323 by @IKarbowiak
+- Update create permission group restriction - #5355 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/account/error_codes.py
+++ b/saleor/account/error_codes.py
@@ -15,6 +15,7 @@ class AccountErrorCode(Enum):
     INVALID = "invalid"
     INVALID_PASSWORD = "invalid_password"
     NOT_FOUND = "not_found"
+    NO_PERMISSION = "no_permission"
     PASSWORD_ENTIRELY_NUMERIC = "password_entirely_numeric"
     PASSWORD_TOO_COMMON = "password_too_common"
     PASSWORD_TOO_SHORT = "password_too_short"

--- a/saleor/account/models.py
+++ b/saleor/account/models.py
@@ -1,4 +1,4 @@
-from typing import Set
+from typing import Set, Union
 
 from django.conf import settings
 from django.contrib.auth.models import (
@@ -174,9 +174,10 @@ class User(PermissionsMixin, ModelWithMetadata, AbstractBaseUser):
     def get_short_name(self):
         return self.email
 
-    def has_perm(self, perm: BasePermissionEnum, obj=None):  # type: ignore
+    def has_perm(self, perm: Union[BasePermissionEnum, str], obj=None):  # type: ignore
         # This method is overridden to accept perm as BasePermissionEnum
-        return super().has_perm(perm.value, obj)
+        perm_value = perm.value if hasattr(perm, "value") else perm  # type: ignore
+        return super().has_perm(perm_value, obj)
 
 
 class ServiceAccount(ModelWithMetadata):

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -1,8 +1,13 @@
+from typing import TYPE_CHECKING, List
+
 from django.core.exceptions import ValidationError
 from graphene.utils.str_converters import to_camel_case
 
 from ...account import events as account_events
 from ...account.error_codes import AccountErrorCode
+
+if TYPE_CHECKING:
+    from ...account.models import User
 
 
 class UserDeleteMixin:
@@ -93,3 +98,12 @@ def get_allowed_fields_camel_case(allowed_fields: set) -> set:
     if "streetAddress1" in fields:
         fields.add("streetAddress2")
     return fields
+
+
+def get_permissions_user_has_not(user: "User", permissions: List[str]):
+    """Return indexes of permissions that the user hasn't got."""
+    indexes = []
+    for index, perm in enumerate(permissions):
+        if not user.has_perm(perm):
+            indexes.append(index)
+    return indexes

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -48,6 +48,12 @@ class AccountError(Error):
     code = AccountErrorCode(description="The error code.", required=True)
 
 
+class BulkAccountError(AccountError):
+    index = graphene.Int(
+        description="Index of an input list item that caused the error."
+    )
+
+
 class CheckoutError(Error):
     code = CheckoutErrorCode(description="The error code.", required=True)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -50,6 +50,7 @@ enum AccountErrorCode {
   INVALID
   INVALID_PASSWORD
   NOT_FOUND
+  NO_PERMISSION
   PASSWORD_ENTIRELY_NUMERIC
   PASSWORD_TOO_COMMON
   PASSWORD_TOO_SHORT
@@ -484,6 +485,13 @@ input AuthorizationKeyInput {
 enum AuthorizationKeyType {
   FACEBOOK
   GOOGLE_OAUTH2
+}
+
+type BulkAccountError {
+  field: String
+  message: String
+  code: AccountErrorCode!
+  index: Int
 }
 
 type BulkProductError {
@@ -2403,7 +2411,7 @@ type Mutation {
   serviceAccountTokenCreate(input: ServiceAccountTokenInput!): ServiceAccountTokenCreate
   serviceAccountTokenDelete(id: ID!): ServiceAccountTokenDelete
   permissionGroupCreate(input: PermissionGroupCreateInput!): PermissionGroupCreate
-  permissionGroupUpdate(id: ID!, input: PermissionGroupInput!): PermissionGroupUpdate
+  permissionGroupUpdate(id: ID!, input: PermissionGroupUpdateInput!): PermissionGroupUpdate
   permissionGroupDelete(id: ID!): PermissionGroupDelete
   permissionGroupAssignUsers(id: ID!, users: [ID!]!): PermissionGroupAssignUsers
   permissionGroupUnassignUsers(id: ID!, users: [ID!]!): PermissionGroupUnassignUsers
@@ -3034,7 +3042,7 @@ type PermissionGroupAssignUsers {
 type PermissionGroupCreate {
   errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]!
+  bulkAccountErrors: [BulkAccountError!]!
 }
 
 input PermissionGroupCreateInput {
@@ -3050,11 +3058,6 @@ type PermissionGroupDelete {
 
 input PermissionGroupFilterInput {
   search: String
-}
-
-input PermissionGroupInput {
-  name: String
-  permissions: [PermissionEnum!]
 }
 
 enum PermissionGroupSortField {
@@ -3075,7 +3078,12 @@ type PermissionGroupUnassignUsers {
 type PermissionGroupUpdate {
   errors: [Error!]!
   group: Group
-  accountErrors: [AccountError!]!
+  bulkAccountErrors: [BulkAccountError!]!
+}
+
+input PermissionGroupUpdateInput {
+  name: String
+  permissions: [PermissionEnum!]
 }
 
 type Plugin implements Node {

--- a/tests/api/benchmark/test_permission_group.py
+++ b/tests/api/benchmark/test_permission_group.py
@@ -1,0 +1,128 @@
+import graphene
+import pytest
+from django.contrib.auth.models import Group
+
+from saleor.core.permissions import AccountPermissions
+from tests.api.utils import get_graphql_content
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_permission_group_create(
+    staff_user,
+    permission_manage_staff,
+    staff_api_client,
+    permission_manage_users,
+    permission_manage_service_accounts,
+    count_queries,
+):
+    staff_user.user_permissions.add(
+        permission_manage_users, permission_manage_service_accounts
+    )
+    query = """
+        mutation PermissionGroupCreate(
+        $input: PermissionGroupCreateInput!) {
+        permissionGroupCreate(
+            input: $input)
+        {
+            group{
+                id
+                name
+                permissions {
+                    name
+                    code
+                }
+            }
+            bulkAccountErrors{
+                field
+                code
+                index
+                message
+            }
+        }
+    }
+    """
+
+    group_count = Group.objects.count()
+
+    variables = {
+        "input": {
+            "name": "New permission group",
+            "permissions": [
+                AccountPermissions.MANAGE_USERS.name,
+                AccountPermissions.MANAGE_SERVICE_ACCOUNTS.name,
+            ],
+        }
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_staff,)
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["permissionGroupCreate"]
+
+    groups = Group.objects.all()
+    assert data["bulkAccountErrors"] == []
+    assert len(groups) == group_count + 1
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_permission_group_update(
+    permission_group_manage_users,
+    staff_user,
+    permission_manage_staff,
+    staff_api_client,
+    permission_manage_service_accounts,
+    permission_manage_users,
+    count_queries,
+):
+    staff_user.user_permissions.add(
+        permission_manage_users, permission_manage_service_accounts
+    )
+    query = """
+    mutation PermissionGroupUpdate(
+        $id: ID!, $input: PermissionGroupUpdateInput!) {
+        permissionGroupUpdate(
+            id: $id, input: $input)
+        {
+            group{
+                id
+                name
+                permissions {
+                    name
+                    code
+                }
+            }
+            bulkAccountErrors{
+                field
+                code
+                index
+                message
+            }
+        }
+    }
+    """
+
+    group_count = Group.objects.count()
+
+    staff_user.user_permissions.add(
+        permission_manage_service_accounts, permission_manage_users
+    )
+    group = permission_group_manage_users
+
+    variables = {
+        "id": graphene.Node.to_global_id("Group", group.id),
+        "input": {
+            "name": "New permission group",
+            "permissions": [AccountPermissions.MANAGE_SERVICE_ACCOUNTS.name],
+        },
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_staff,)
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["permissionGroupUpdate"]
+
+    groups = Group.objects.all()
+    assert data["bulkAccountErrors"] == []
+    assert len(groups) == group_count


### PR DESCRIPTION
Add restriction to `PermissionGroupCreate` mutation:
- don't allow to create the group with permissions that user (creator) doesn't have

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [x] Database queries are optimized and the number of queries is constant.
1. [x] Database migration files are up to date.
1. [x] The changes are tested.
1. [x] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
