### PR TITLE
Force django to load the wsgi on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Ensure that a GraphQL query is a string - #4836 by @nix010
 - Add ability to configure the password reset link - #4863 by @fowczarek
 - Fixed a performance issue where Saleor would sometimes run huge, unneeded prefetches when resolving categories or collections - #5291 by @NyanKiyoshi
+- uWSGI now forces the django application to directly load on startup instead of being lazy - #5357 by @NyanKiyoshi
 
 ### Core
 

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -12,6 +12,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 """
 import os
+import sys
 
 from django.core.wsgi import get_wsgi_application
 
@@ -27,3 +28,16 @@ application = get_wsgi_application()
 # from helloworld.wsgi import HelloWorldApplication
 # application = HelloWorldApplication(application)
 application = health_check(application, "/health/")
+
+# Warm-up the django application instead of letting it lazy-load
+application(
+    {
+        "REQUEST_METHOD": "GET",
+        "SERVER_NAME": "127.0.0.1",
+        "REMOTE_ADDR": "127.0.0.1",
+        "SERVER_PORT": 80,
+        "PATH_INFO": "/graphql/",
+        "wsgi.input": sys.stdin,
+    },
+    lambda x, y: None,
+)

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -12,11 +12,18 @@ middleware here, or combine a Django application with an application of another
 framework.
 """
 import os
-import sys
 
 from django.core.wsgi import get_wsgi_application
+from django.utils.functional import SimpleLazyObject
 
 from saleor.wsgi.health_check import health_check
+
+
+def get_allowed_host_lazy():
+    from django.conf import settings
+
+    return settings.ALLOWED_HOSTS[0]
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
 
@@ -33,11 +40,11 @@ application = health_check(application, "/health/")
 application(
     {
         "REQUEST_METHOD": "GET",
-        "SERVER_NAME": "127.0.0.1",
+        "SERVER_NAME": SimpleLazyObject(get_allowed_host_lazy),
         "REMOTE_ADDR": "127.0.0.1",
         "SERVER_PORT": 80,
         "PATH_INFO": "/graphql/",
-        "wsgi.input": sys.stdin,
+        "wsgi.input": b"",
     },
     lambda x, y: None,
 )


### PR DESCRIPTION
This avoids latencies when the workers are serving their first request coming from Django lazy-loading the application.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [x] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [x] Changes are mentioned in the changelog.
