### PR TITLE
Add command createaccount

### DIFF
--- a/saleor/account/management/commands/createserviceaccount.py
+++ b/saleor/account/management/commands/createserviceaccount.py
@@ -71,8 +71,6 @@ class Command(BaseCommand):
         token_obj = service_account.tokens.create()
         data = {
             "auth_token": token_obj.auth_token,
-            "name": name,
-            "permissions": permissions,
         }
         if target_url:
             self.send_service_account_data(target_url, data)

--- a/saleor/account/management/commands/createserviceaccount.py
+++ b/saleor/account/management/commands/createserviceaccount.py
@@ -1,0 +1,79 @@
+import json
+from typing import Any, Dict, List, Optional
+
+import requests
+from django.contrib.auth.models import Permission
+from django.contrib.sites.models import Site
+from django.core.management import BaseCommand, CommandError
+from django.core.management.base import CommandParser
+from requests.exceptions import RequestException
+
+from ....core.permissions import get_permissions, get_permissions_enum_list
+from ...models import ServiceAccount
+
+
+class Command(BaseCommand):
+    help = "Used to create service account"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        parser.add_argument("name", type=str)
+        parser.add_argument(
+            "--permission",
+            action="append",
+            default=[],
+            dest="permissions",
+            help="Assign new permission to Service Account. "
+            "Argument can be specified multiple times.",
+        )
+        parser.add_argument("--is_active", default=True, dest="is_active")
+        parser.add_argument(
+            "--target_url",
+            dest="target_url",
+            help="Url which will receive newly created data of service account object.",
+        )
+
+    def validate_permissions(self, required_permissions: List[str]):
+        permissions = list(map(lambda x: x[1], get_permissions_enum_list()))
+        for perm in required_permissions:
+            if perm not in permissions:
+                raise CommandError(
+                    f"Permisssion: {perm} doesn't exist in Saleor."
+                    f" Avaiable permissions: {permissions}"
+                )
+
+    def clean_permissions(self, required_permissions: List[str]) -> List[Permission]:
+        permissions = get_permissions(required_permissions)
+        return permissions
+
+    def send_service_account_data(self, target_url, data: Dict[str, Any]):
+        domain = Site.objects.get_current().domain
+        headers = {"x-saleor-domain": domain}
+        try:
+            response = requests.post(target_url, json=data, headers=headers, timeout=15)
+        except RequestException as e:
+            raise CommandError(f"Request failed. Exception: {e}")
+        if response.status_code != 200:
+            raise CommandError(
+                f"Failed to send service account data to {target_url}. "  # type: ignore
+                f"Status code: {response.status_code}, content: {response.content}"
+            )
+
+    def handle(self, *args: Any, **options: Any) -> Optional[str]:
+        name = options["name"]
+        is_active = options["is_active"]
+        target_url = options["target_url"]
+        permissions = list(set(options["permissions"]))
+        self.validate_permissions(permissions)
+
+        service_account = ServiceAccount.objects.create(name=name, is_active=is_active)
+        permissions_qs = self.clean_permissions(permissions)
+        service_account.permissions.add(*permissions_qs)
+        token_obj = service_account.tokens.create()
+        data = {
+            "auth_token": token_obj.auth_token,
+            "name": name,
+            "permissions": permissions,
+        }
+        if target_url:
+            self.send_service_account_data(target_url, data)
+        return json.dumps(data)

--- a/saleor/account/management/commands/createserviceaccount.py
+++ b/saleor/account/management/commands/createserviceaccount.py
@@ -33,7 +33,7 @@ class Command(BaseCommand):
         )
 
     def validate_permissions(self, required_permissions: List[str]):
-        permissions = list(map(lambda x: x[1], get_permissions_enum_list()))
+        permissions = [perm[1] for perm in get_permissions_enum_list()]
         for perm in required_permissions:
             if perm not in permissions:
                 raise CommandError(

--- a/saleor/account/management/commands/createserviceaccount.py
+++ b/saleor/account/management/commands/createserviceaccount.py
@@ -74,4 +74,5 @@ class Command(BaseCommand):
         }
         if target_url:
             self.send_service_account_data(target_url, data)
-        return json.dumps(data)
+
+        return json.dumps(data) if not target_url else ""

--- a/saleor/account/management/commands/createserviceaccount.py
+++ b/saleor/account/management/commands/createserviceaccount.py
@@ -13,7 +13,7 @@ from ...models import ServiceAccount
 
 
 class Command(BaseCommand):
-    help = "Used to create service account"
+    help = "Used to create service account."
 
     def add_arguments(self, parser: CommandParser) -> None:
         parser.add_argument("name", type=str)
@@ -29,7 +29,9 @@ class Command(BaseCommand):
         parser.add_argument(
             "--target_url",
             dest="target_url",
-            help="Url which will receive newly created data of service account object.",
+            help="Url which will receive newly created data of service account object. "
+            "Command doesn't return service account data to stdout when this "
+            "argument is provided.",
         )
 
     def validate_permissions(self, required_permissions: List[str]):

--- a/tests/test_account_service_account.py
+++ b/tests/test_account_service_account.py
@@ -1,0 +1,63 @@
+from unittest.mock import ANY, Mock
+
+import requests
+from django.core.management import call_command
+
+from saleor.account.models import ServiceAccount
+from saleor.core.permissions import get_permissions
+
+
+def test_createaccount_command_creates_service_account():
+    name = "SA name"
+    permissions = ["account.manage_users", "order.manage_orders"]
+    call_command("createserviceaccount", name, permission=permissions)
+
+    sa_accounts = ServiceAccount.objects.filter(name=name)
+    assert len(sa_accounts) == 1
+
+    sa_account = sa_accounts[0]
+    tokens = sa_account.tokens.all()
+    assert len(tokens) == 1
+
+
+def test_createaccount_command_service_account_has_all_required_permissions():
+    name = "SA name"
+    permission_list = ["account.manage_users", "order.manage_orders"]
+    expected_permission = get_permissions(permission_list)
+    call_command("createserviceaccount", name, permission=permission_list)
+
+    sa_accounts = ServiceAccount.objects.filter(name=name)
+    assert len(sa_accounts) == 1
+    sa_account = sa_accounts[0]
+    assert set(sa_account.permissions.all()) == set(expected_permission)
+
+
+def test_createaccount_command_sends_data_to_target_url(monkeypatch):
+    mocked_response = Mock()
+    mocked_response.status_code = 200
+    mocked_post = Mock(return_value=mocked_response)
+
+    monkeypatch.setattr(requests, "post", mocked_post)
+
+    name = "SA name"
+    target_url = "https://ss.shop.com/register"
+    permissions = [
+        "account.manage_users",
+    ]
+
+    call_command(
+        "createserviceaccount", name, permission=permissions, target_url=target_url
+    )
+
+    service_account = ServiceAccount.objects.filter(name=name)[0]
+    token = service_account.tokens.all()[0].auth_token
+    mocked_post.assert_called_once_with(
+        target_url,
+        headers={"x-saleor-domain": "mirumee.com"},
+        json={
+            "auth_token": token,
+            "name": "SA name",
+            "permissions": ["account.manage_users"],
+        },
+        timeout=ANY,
+    )

--- a/tests/test_account_service_account.py
+++ b/tests/test_account_service_account.py
@@ -54,10 +54,6 @@ def test_createaccount_command_sends_data_to_target_url(monkeypatch):
     mocked_post.assert_called_once_with(
         target_url,
         headers={"x-saleor-domain": "mirumee.com"},
-        json={
-            "auth_token": token,
-            "name": "SA name",
-            "permissions": ["account.manage_users"],
-        },
+        json={"auth_token": token},
         timeout=ANY,
     )


### PR DESCRIPTION
Django command for creating service account instance.
```
./manage.py createserviceaccount service_name --permission account.manage_users --target_url http://127.0.0.1:8080/webhooks/register
```
`target_url` is optional argument. If provided, the command will send service_account data to given URL