### PR TITLE
Drop django-silk

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -93,17 +93,6 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 
 [[package]]
 category = "main"
-description = "A tool that automatically formats Python code to conform to the PEP 8 style guide"
-name = "autopep8"
-optional = false
-python-versions = "*"
-version = "1.5"
-
-[package.dependencies]
-pycodestyle = ">=2.5.0"
-
-[[package]]
-category = "main"
 description = "Internationalization utilities"
 name = "babel"
 optional = false
@@ -638,25 +627,6 @@ django = ">=1.11"
 
 [[package]]
 category = "main"
-description = "Silky smooth profiling for the Django Framework"
-name = "django-silk"
-optional = false
-python-versions = "*"
-version = "2.0.0"
-
-[package.dependencies]
-Django = "*"
-Jinja2 = "*"
-Pygments = "*"
-autopep8 = "*"
-gprof2dot = "<2017.09.19"
-python-dateutil = "*"
-pytz = "*"
-requests = "*"
-sqlparse = "*"
-
-[[package]]
-category = "main"
 description = "Support for many storage backends in Django"
 name = "django-storages"
 optional = false
@@ -936,14 +906,6 @@ grpc = ["grpcio (>=1.0.0)"]
 
 [[package]]
 category = "main"
-description = "Generate a dot graph from the output of several profilers."
-name = "gprof2dot"
-optional = false
-python-versions = "*"
-version = "2016.10.13"
-
-[[package]]
-category = "main"
 description = "GraphQL Framework for Python"
 name = "graphene"
 optional = false
@@ -1116,7 +1078,7 @@ tornado = ">=4.3"
 tests = ["mock (1.0.1)", "pycurl (>=7.43,<8)", "pytest (>=3.7.0,<3.8.0)", "pytest-cov (2.5.1)", "coverage (<4.4)", "pytest-timeout (1.3.1)", "pytest-tornado", "pytest-benchmark (>=3.0.0rc1,<3.2)", "pytest-localserver", "flake8", "flake8-quotes", "codecov", "opentracing_instrumentation (>=3,<4)", "prometheus_client (0.3.1)", "tchannel (>=0.27)"]
 
 [[package]]
-category = "main"
+category = "dev"
 description = "A very fast and expressive template engine."
 name = "jinja2"
 optional = false
@@ -1212,7 +1174,7 @@ setuptools = ">=36"
 testing = ["coverage", "pyyaml"]
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Safely add untrusted strings to HTML/XML markup."
 name = "markupsafe"
 optional = false
@@ -1488,7 +1450,7 @@ version = "0.2.8"
 pyasn1 = ">=0.4.6,<0.5.0"
 
 [[package]]
-category = "main"
+category = "dev"
 description = "Python style guide checker"
 name = "pycodestyle"
 optional = false
@@ -1521,14 +1483,6 @@ name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "2.1.1"
-
-[[package]]
-category = "main"
-description = "Pygments is a syntax highlighting package written in Python."
-name = "pygments"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.5.2"
 
 [[package]]
 category = "main"
@@ -2238,7 +2192,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "fa1b17ea41f9d339469ca6576d69ddf6f9838f8da831338ee0c64b9f57602bb2"
+content-hash = "cdce0d4430a22368f965fe9b03ccf8cfb5bf0c1e03fb4d32e0c33963c8673632"
 python-versions = "~3.8"
 
 [metadata.files]
@@ -2277,9 +2231,6 @@ atomicwrites = [
 attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
-]
-autopep8 = [
-    {file = "autopep8-1.5.tar.gz", hash = "sha256:0f592a0447acea0c2b0a9602be1e4e3d86db52badd2e3c84f0193bfd89fd3a43"},
 ]
 babel = [
     {file = "Babel-2.7.0-py2.py3-none-any.whl", hash = "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab"},
@@ -2499,10 +2450,6 @@ django-prices-vatlayer = [
 django-render-block = [
     {file = "django_render_block-0.6-py2.py3-none-any.whl", hash = "sha256:95c7dc9610378a10e0c4a10d8364ec7307210889afccd6a67a6aaa0fd599bd4d"},
 ]
-django-silk = [
-    {file = "django-silk-2.0.0.tar.gz", hash = "sha256:22b69762eee91138a3a58f960b35f18467d685c0db87ae42dca8bd4abef11a21"},
-    {file = "django_silk-2.0.0-py2.py3-none-any.whl", hash = "sha256:76a4240654642692eb9990f7bd0e4212483e5a58e2fc7ac315860a5544bc5e7d"},
-]
 django-storages = [
     {file = "django-storages-1.9.1.tar.gz", hash = "sha256:a59e9923cbce7068792f75344ed7727021ee4ac20f227cf17297d0d03d141e91"},
     {file = "django_storages-1.9.1-py2.py3-none-any.whl", hash = "sha256:3103991c2ee8cef8a2ff096709973ffe7106183d211a79f22cf855f33533d924"},
@@ -2583,9 +2530,6 @@ google-resumable-media = [
 ]
 googleapis-common-protos = [
     {file = "googleapis-common-protos-1.51.0.tar.gz", hash = "sha256:013c91704279119150e44ef770086fdbba158c1f978a6402167d47d5409e226e"},
-]
-gprof2dot = [
-    {file = "gprof2dot-2016.10.13.tar.gz", hash = "sha256:48c1e168c28b8a8eb23bf30fda78fe2ef218269a41505341ec27c27083e47cf4"},
 ]
 graphene = [
     {file = "graphene-2.1.8-py2.py3-none-any.whl", hash = "sha256:09165f03e1591b76bf57b133482db9be6dac72c74b0a628d3c93182af9c5a896"},
@@ -2959,10 +2903,6 @@ pydocstyle = [
 pyflakes = [
     {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
-]
-pygments = [
-    {file = "Pygments-2.5.2-py2.py3-none-any.whl", hash = "sha256:2a3fe295e54a20164a9df49c75fa58526d3be48e14aceba6d6b1e8ac0bfd6f1b"},
-    {file = "Pygments-2.5.2.tar.gz", hash = "sha256:98c8aa5a9f778fcd1026a17361ddaf7330d1b7c62ae97c3bb0ae73e0b9b6b0fe"},
 ]
 pyjwt = [
     {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ django-phonenumber-field = "^2.4"
 django-prices = "^2.1"
 django-prices-openexchangerates = "^1.0.1"
 django-prices-vatlayer = "^1.0.2"
-django-silk = "~2.0"
 django-storages = { version = "^1.7.1", extras = [ "google" ] }
 django-templated-email = "^2.3.0"
 django-versatileimagefield = "^2.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 amqp==2.5.2
 aniso8601==7.0.0
 asgiref==3.2.3
-autopep8==1.5
 babel==2.7.0
 beautifulsoup4==4.7.1
 billiard==3.6.3.0
@@ -32,7 +31,6 @@ django-prices==2.2.0
 django-prices-openexchangerates==1.1.0
 django-prices-vatlayer==1.0.2
 django-render-block==0.6
-django-silk==2.0.0
 django-storages==1.9.1
 django-templated-email==2.3.0
 django-versatileimagefield==2.0
@@ -49,7 +47,6 @@ google-i18n-address==2.3.5
 google-measurement-protocol==1.0.0
 google-resumable-media==0.5.0
 googleapis-common-protos==1.51.0
-gprof2dot==2016.10.13
 graphene==2.1.8
 graphene-django==2.8.2
 graphene-django-optimizer==0.6.1
@@ -60,13 +57,11 @@ html-to-draftjs==1.0.1
 html5lib==1.0.1
 idna==2.9
 jaeger-client==4.3.0
-jinja2==2.11.1
 jmespath==0.9.4
 jsonfield==3.0.0
 kombu==4.6.8
 lxml==4.5.0
 markdown==3.2.1
-markupsafe==1.1.1
 maxminddb==1.5.2
 maxminddb-geolite2==2018.703
 measurement==3.2.0
@@ -82,9 +77,7 @@ psycopg2-binary==2.8.4
 purl==1.5
 pyasn1==0.4.8
 pyasn1-modules==0.2.8
-pycodestyle==2.5.0
 pycparser==2.19
-pygments==2.5.2
 pyjwt==1.7.1
 pyphen==0.9.5
 python-dateutil==2.8.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,6 @@ aspy.yaml==1.3.0
 astroid==2.3.3
 atomicwrites==1.3.0; sys_platform == "win32"
 attrs==19.3.0
-autopep8==1.5
 babel==2.7.0
 beautifulsoup4==4.7.1
 beautifultable==0.7.0
@@ -50,7 +49,6 @@ django-prices==2.2.0
 django-prices-openexchangerates==1.1.0
 django-prices-vatlayer==1.0.2
 django-render-block==0.6
-django-silk==2.0.0
 django-storages==1.9.1
 django-stubs==1.2.0
 django-templated-email==2.3.0
@@ -72,7 +70,6 @@ google-i18n-address==2.3.5
 google-measurement-protocol==1.0.0
 google-resumable-media==0.5.0
 googleapis-common-protos==1.51.0
-gprof2dot==2016.10.13
 graphene==2.1.8
 graphene-django==2.8.2
 graphene-django-optimizer==0.6.1
@@ -123,7 +120,6 @@ pycodestyle==2.5.0
 pycparser==2.19
 pydocstyle==4.0.1
 pyflakes==2.1.1
-pygments==2.5.2
 pyjwt==1.7.1
 pylint==2.4.4
 pylint-celery==0.3

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -264,11 +264,6 @@ if ENABLE_DEBUG_TOOLBAR:
         ]
         DEBUG_TOOLBAR_CONFIG = {"RESULTS_CACHE_SIZE": 100}
 
-ENABLE_SILK = get_bool_from_env("ENABLE_SILK", False)
-if ENABLE_SILK:
-    MIDDLEWARE.insert(0, "silk.middleware.SilkyMiddleware")
-    INSTALLED_APPS.append("silk")
-
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -37,6 +37,3 @@ if settings.DEBUG:
         url(r"^static/(?P<path>.*)$", serve),
         url(r"^", RedirectView.as_view(url="/graphql/")),
     ]
-
-if settings.ENABLE_SILK:
-    urlpatterns += [url(r"^silk/", include("silk.urls", namespace="silk"))]


### PR DESCRIPTION
OpenTracing with a local Jaeger server seems to be doing a better job, especially now that all requests target the same view.

### Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

1. [ ] Privileged views and APIs are guarded by proper permission checks.
1. [ ] All visible strings are translated with proper context.
1. [ ] All data-formatting is locale-aware (dates, numbers, and so on).
1. [ ] Database queries are optimized and the number of queries is constant.
1. [ ] Database migration files are up to date.
1. [ ] The changes are tested.
1. [ ] GraphQL schema and type definitions are up to date.
1. [ ] Changes are mentioned in the changelog.