### PR TITLE
Add user_permissions on user type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow specifying users in groups mutations - #5362 by @IKarbowiak
 - Add user can manage field to group type - #5376 by @IKarbowiak
 - Prevent users from modifying a group with permissions they don't hold - #5380 by @IKarbowiak
+- Add user_permissions on user type - #5390 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -258,8 +258,9 @@ class UserPermission(Permission):
 
     def resolve_source_permission_groups(root: Permission, _info, user_id, **_kwargs):
         user_id = from_global_id_strict_type(user_id, only_type="User", field="pk")
-        user = models.User.objects.get(pk=user_id)  # type: ignore
-        groups = user.groups.filter(permissions__name=root.name)
+        groups = auth_models.Group.objects.filter(
+            user__pk=user_id, permissions__name=root.name
+        )
         return groups
 
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -12,7 +12,7 @@ from ...order import models as order_models
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
 from ..core.fields import PrefetchingConnectionField
-from ..core.types import CountryDisplay, Image, PermissionDisplay
+from ..core.types import CountryDisplay, Image, Permission
 from ..core.utils import get_node_optimized
 from ..decorators import one_of_permissions_required, permission_required
 from ..meta.deprecated.resolvers import resolve_meta, resolve_private_meta
@@ -190,7 +190,7 @@ class ServiceAccountToken(CountableDjangoObjectType):
 @key(fields="id")
 class ServiceAccount(CountableDjangoObjectType):
     permissions = graphene.List(
-        PermissionDisplay, description="List of the service's permissions."
+        Permission, description="List of the service's permissions."
     )
     created = graphene.DateTime(
         description="The date and time when the service account was created."
@@ -269,7 +269,7 @@ class User(CountableDjangoObjectType):
         model_field="orders",
     )
     permissions = gql_optimizer.field(
-        graphene.List(PermissionDisplay, description="List of user's permissions."),
+        graphene.List(Permission, description="List of user's permissions."),
         model_field="user_permissions",
     )
     permission_groups = gql_optimizer.field(
@@ -463,9 +463,7 @@ class StaffNotificationRecipient(CountableDjangoObjectType):
 @key(fields="id")
 class Group(CountableDjangoObjectType):
     users = graphene.List(User, description="List of group users")
-    permissions = graphene.List(
-        PermissionDisplay, description="List of group permissions"
-    )
+    permissions = graphene.List(Permission, description="List of group permissions")
     user_can_manage = graphene.Boolean(
         required=True,
         description=(

--- a/saleor/graphql/core/types/__init__.py
+++ b/saleor/graphql/core/types/__init__.py
@@ -4,7 +4,7 @@ from .common import (
     Error,
     Image,
     LanguageDisplay,
-    PermissionDisplay,
+    Permission,
     SeoInput,
     TaxType,
     Weight,

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -38,7 +38,7 @@ class LanguageDisplay(graphene.ObjectType):
     language = graphene.String(description="Full name of the language.", required=True)
 
 
-class PermissionDisplay(graphene.ObjectType):
+class Permission(graphene.ObjectType):
     code = PermissionEnum(description="Internal code for permission.", required=True)
     name = graphene.String(
         description="Describe action(s) allowed to do by permission.", required=True

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4566,7 +4566,8 @@ type User implements Node & ObjectWithMetadata {
   checkout: Checkout
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  permissions: [Permission]
+  permissions: [Permission] @deprecated(reason: "Will be removed in Saleor 2.11.Use the `userPermissions` instead.")
+  userPermissions: [UserPermission]
   permissionGroups: [Group]
   avatar(size: Int): Image
   events: [CustomerEvent]
@@ -4624,6 +4625,12 @@ input UserCreateInput {
   isActive: Boolean
   note: String
   redirectUrl: String
+}
+
+type UserPermission {
+  code: PermissionEnum!
+  name: String!
+  sourcePermissionGroups(userId: ID!): [Group!]
 }
 
 enum UserSortField {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1804,7 +1804,7 @@ input GiftCardUpdateInput {
 type Group implements Node {
   id: ID!
   name: String!
-  permissions: [PermissionDisplay]
+  permissions: [Permission]
   users: [User]
   userCanManage: Boolean!
 }
@@ -3000,7 +3000,7 @@ type PaymentVoid {
   paymentErrors: [PaymentError!]!
 }
 
-type PermissionDisplay {
+type Permission {
   code: PermissionEnum!
   name: String!
 }
@@ -3930,7 +3930,7 @@ type ServiceAccount implements Node & ObjectWithMetadata {
   name: String
   created: DateTime
   isActive: Boolean
-  permissions: [PermissionDisplay]
+  permissions: [Permission]
   tokens: [ServiceAccountToken]
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
@@ -4187,7 +4187,7 @@ type Shop {
   languages: [LanguageDisplay]!
   name: String!
   navigation: Navigation
-  permissions: [PermissionDisplay]!
+  permissions: [Permission]!
   phonePrefixes: [String]!
   headerText: String
   includeTaxesInPrices: Boolean!
@@ -4566,7 +4566,7 @@ type User implements Node & ObjectWithMetadata {
   checkout: Checkout
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  permissions: [PermissionDisplay]
+  permissions: [Permission]
   permissionGroups: [Group]
   avatar(size: Int): Image
   events: [CustomerEvent]

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -13,7 +13,7 @@ from ...product import models as product_models
 from ...site import models as site_models
 from ..account.types import Address, StaffNotificationRecipient
 from ..core.enums import WeightUnitsEnum
-from ..core.types.common import CountryDisplay, LanguageDisplay, PermissionDisplay
+from ..core.types.common import CountryDisplay, LanguageDisplay, Permission
 from ..core.utils import get_node_optimized, str_to_enum
 from ..decorators import permission_required
 from ..menu.types import Menu
@@ -110,7 +110,7 @@ class Shop(graphene.ObjectType):
     name = graphene.String(description="Shop's name.", required=True)
     navigation = graphene.Field(Navigation, description="Shop's navigation.")
     permissions = graphene.List(
-        PermissionDisplay, description="List of available permissions.", required=True
+        Permission, description="List of available permissions.", required=True
     )
     phone_prefixes = graphene.List(
         graphene.String, description="List of possible phone prefixes.", required=True

--- a/saleor/graphql/utils.py
+++ b/saleor/graphql/utils.py
@@ -10,7 +10,7 @@ from graphql_jwt.utils import jwt_payload
 from graphql_relay import from_global_id
 
 from .core.enums import PermissionEnum, ReportingPeriod
-from .core.types import PermissionDisplay, SortInputObjectType
+from .core.types import Permission, SortInputObjectType
 
 ERROR_COULD_NO_RESOLVE_GLOBAL_ID = (
     "Could not resolve to a node with the global id list of '%s'."
@@ -163,7 +163,7 @@ def filter_by_period(queryset, period, field_name):
 
 
 def format_permissions_for_display(permissions):
-    """Transform permissions queryset into PermissionDisplay list.
+    """Transform permissions queryset into Permission list.
 
     Keyword Arguments:
         permissions - queryset with permissions
@@ -174,7 +174,7 @@ def format_permissions_for_display(permissions):
     ).values("name", "formated_codename")
 
     formatted_permissions = [
-        PermissionDisplay(
+        Permission(
             code=PermissionEnum.get(data["formated_codename"]), name=data["name"]
         )
         for data in permissions_data

--- a/tests/api/benchmark/test_account.py
+++ b/tests/api/benchmark/test_account.py
@@ -32,6 +32,7 @@ def test_query_staff_user(
     staff_user.avatar = avatar_mock
     staff_user.save()
 
+    # update query in #5389 (deprecated 'permissions' field)
     query = """
         query User($id: ID!) {
             user(id: $id) {
@@ -89,6 +90,11 @@ def test_query_staff_user(
                 }
                 permissions {
                     code
+                    name
+                }
+                userPermissions {
+                    code
+                    name
                 }
                 permissionGroups {
                     name


### PR DESCRIPTION
Update `User` type. Add `UserPermission` type with `source_permission_groups` field for user source groups of given permission.

# Impact

* [ ] New migrations
* [x] New API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
