### PR TITLE
Push version tag to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,9 +33,10 @@ jobs:
           name: Push Docker image
           command: |
             docker login -u $DOCKERCLOUD_USER -p $DOCKERCLOUD_PASS
-            docker tag mirumee/saleor:latest mirumee/saleor:$CIRCLE_SHA1
+            docker tag mirumee/saleor:latest mirumee/saleor:$CIRCLE_SHA1 mirumee/saleor:$SALEOR_VERSION
             docker push mirumee/saleor:$CIRCLE_SHA1
             docker push mirumee/saleor:latest
+            docker push mirumee/saleor:$SALEOR_VERSION
       - run:
           name: Deploy saleor-demo
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,4 +57,6 @@ workflows:
             branches:
               only: master
             tags:
-              only: /demo.*/
+              only:
+                - /demo.*/
+                - /^\d+\.\d+\.\d+$/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Stock management refactor - #5323 by @IKarbowiak
 - Add discount error codes - #5348 by @IKarbowiak
 - Add benchmarks to checkout mutations - #5339 by @fowczarek
+- Push version tag to Docker Hub - #5394 by @machadovilaca
 
 ## 2.9.0
 


### PR DESCRIPTION
I want to merge this change because currently only `latest` and `COMMIT_SHA1` are being pushed to Docker Hub and for anyone who wants to run saleor on his own using Docker, without a need to build own image, it's harder to keep track of released versions without the version tag.

In this PR I enable circleci on tag releases, and push, on every deploy, the `SALEOR_VERSION` tag to Docker Hub.

# Impact

* [ ] New migrations
* [ ] New API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
