### PR TITLE
Add ability to assign multiple warehouses in mutations to create/update a shipping zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add discount error codes - #5348 by @IKarbowiak
 - Add benchmarks to checkout mutations - #5339 by @fowczarek
 - Add pagination tests - #5363 by @fowczarek
+- Add ability to assign multiple warehouses in mutations to create/update a shipping zone - #5399 by @fowczarek
 
 
 ## 2.9.0

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -197,12 +197,6 @@ class BaseMutation(graphene.Mutation):
         return instances
 
     @classmethod
-    def get_duplicates_ids(cls, add_nodes, remove_nodes):
-        if add_nodes and remove_nodes:
-            return set(add_nodes) & set(remove_nodes)
-        return []
-
-    @classmethod
     def clean_instance(cls, info, instance):
         """Clean the instance that was created using the input data.
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -197,6 +197,12 @@ class BaseMutation(graphene.Mutation):
         return instances
 
     @classmethod
+    def check_for_duplicates_ids(cls, add_nodes, remove_nodes):
+        if add_nodes and remove_nodes:
+            return bool(set(add_nodes) & set(remove_nodes))
+        return False
+
+    @classmethod
     def clean_instance(cls, info, instance):
         """Clean the instance that was created using the input data.
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -197,10 +197,10 @@ class BaseMutation(graphene.Mutation):
         return instances
 
     @classmethod
-    def check_for_duplicates_ids(cls, add_nodes, remove_nodes):
+    def get_duplicates_ids(cls, add_nodes, remove_nodes):
         if add_nodes and remove_nodes:
-            return bool(set(add_nodes) & set(remove_nodes))
-        return False
+            return set(add_nodes) & set(remove_nodes)
+        return []
 
     @classmethod
     def clean_instance(cls, info, instance):

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -85,6 +85,11 @@ class ShopError(Error):
 
 class ShippingError(Error):
     code = ShippingErrorCode(description="The error code.", required=True)
+    warehouses = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of warehouse IDs which causes the error.",
+        required=False,
+    )
 
 
 class PageError(Error):

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -99,3 +99,10 @@ def validate_slug_value(cleaned_input, slug_field_name: str = "slug"):
             raise ValidationError(
                 f"{slug_field_name.capitalize()} value cannot be blank."
             )
+
+
+def get_duplicates_ids(first_list, second_list):
+    """Return items that appear on both provided lists."""
+    if first_list and second_list:
+        return set(first_list) & set(second_list)
+    return []

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4172,6 +4172,7 @@ input ShippingZoneInput {
   name: String
   countries: [String]
   default: Boolean
+  warehouses: [ID]
 }
 
 type ShippingZoneUpdate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2191,10 +2191,10 @@ type Mutation {
   shippingPriceBulkDelete(ids: [ID]!): ShippingPriceBulkDelete
   shippingPriceUpdate(id: ID!, input: ShippingPriceInput!): ShippingPriceUpdate
   shippingPriceTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): ShippingPriceTranslate
-  shippingZoneCreate(input: ShippingZoneInput!): ShippingZoneCreate
+  shippingZoneCreate(input: ShippingZoneCreateInput!): ShippingZoneCreate
   shippingZoneDelete(id: ID!): ShippingZoneDelete
   shippingZoneBulkDelete(ids: [ID]!): ShippingZoneBulkDelete
-  shippingZoneUpdate(id: ID!, input: ShippingZoneInput!): ShippingZoneUpdate
+  shippingZoneUpdate(id: ID!, input: ShippingZoneUpdateInput!): ShippingZoneUpdate
   attributeCreate(input: AttributeCreateInput!): AttributeCreate
   attributeDelete(id: ID!): AttributeDelete
   attributeBulkDelete(ids: [ID]!): AttributeBulkDelete
@@ -4054,6 +4054,7 @@ enum ShippingErrorCode {
   NOT_FOUND
   REQUIRED
   UNIQUE
+  CANNOT_ADD_AND_REMOVE
 }
 
 type ShippingMethod implements Node {
@@ -4162,23 +4163,31 @@ type ShippingZoneCreate {
   shippingErrors: [ShippingError!]!
 }
 
+input ShippingZoneCreateInput {
+  name: String
+  countries: [String]
+  default: Boolean
+  addWarehouses: [ID]
+}
+
 type ShippingZoneDelete {
   errors: [Error!]!
   shippingErrors: [ShippingError!]!
   shippingZone: ShippingZone
 }
 
-input ShippingZoneInput {
-  name: String
-  countries: [String]
-  default: Boolean
-  warehouses: [ID]
-}
-
 type ShippingZoneUpdate {
   errors: [Error!]!
   shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
+}
+
+input ShippingZoneUpdateInput {
+  name: String
+  countries: [String]
+  default: Boolean
+  addWarehouses: [ID]
+  removeWarehouses: [ID]
 }
 
 type Shop {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4044,6 +4044,7 @@ type ShippingError {
   field: String
   message: String
   code: ShippingErrorCode!
+  warehouses: [ID!]
 }
 
 enum ShippingErrorCode {

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -9,6 +9,7 @@ from ...shipping.utils import default_shipping_zone_exists
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import Decimal, WeightScalar
 from ..core.types.common import ShippingError
+from ..core.utils import get_duplicates_ids
 from .enums import ShippingMethodTypeEnum
 from .types import ShippingMethod, ShippingZone
 
@@ -47,22 +48,22 @@ class ShippingZoneCreateInput(graphene.InputObjectType):
             "zones."
         )
     )
-    addWarehouses = graphene.List(
-        graphene.ID, description="List of warehouses in this shipping zone",
+    add_warehouses = graphene.List(
+        graphene.ID, description="List of warehouses to assign to a shipping zone",
     )
 
 
 class ShippingZoneUpdateInput(ShippingZoneCreateInput):
-    removeWarehouses = graphene.List(
-        graphene.ID, description="List of warehouses in this shipping zone",
+    remove_warehouses = graphene.List(
+        graphene.ID, description="List of warehouses to unassign from a shipping zone",
     )
 
 
 class ShippingZoneMixin:
     @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):
-        duplicates_ids = cls.get_duplicates_ids(
-            data.get("addWarehouses"), data.get("removeWarehouses")
+        duplicates_ids = get_duplicates_ids(
+            data.get("add_warehouses"), data.get("remove_warehouses")
         )
         if duplicates_ids:
             error_msg = (
@@ -116,11 +117,11 @@ class ShippingZoneMixin:
     def _save_m2m(cls, info, instance, cleaned_data):
         super()._save_m2m(info, instance, cleaned_data)
 
-        add_warehouses = cleaned_data.get("addWarehouses")
+        add_warehouses = cleaned_data.get("add_warehouses")
         if add_warehouses:
             instance.warehouses.add(*add_warehouses)
 
-        remove_warehouses = cleaned_data.get("removeWarehouses")
+        remove_warehouses = cleaned_data.get("remove_warehouses")
         if remove_warehouses:
             instance.warehouses.remove(*remove_warehouses)
 

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -2,15 +2,13 @@ import graphene
 import graphene_django_optimizer as gql_optimizer
 from graphene import relay
 
-from ...core.permissions import ProductPermissions
 from ...shipping import models
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import CountryDisplay, MoneyRange
-from ..decorators import permission_required
 from ..translations.fields import TranslationField
 from ..translations.types import ShippingMethodTranslation
-from .enums import ShippingMethodTypeEnum
 from ..warehouse.types import Warehouse
+from .enums import ShippingMethodTypeEnum
 
 
 class ShippingMethod(CountableDjangoObjectType):
@@ -84,6 +82,5 @@ class ShippingZone(CountableDjangoObjectType):
         return root.shipping_methods.all()
 
     @staticmethod
-    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_warehouses(root: models.ShippingZone, *_args):
         return root.warehouses.all()

--- a/saleor/shipping/error_codes.py
+++ b/saleor/shipping/error_codes.py
@@ -9,3 +9,4 @@ class ShippingErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     UNIQUE = "unique"
+    CANNOT_ADD_AND_REMOVE = "cannot_add_and_remove"

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -221,9 +221,9 @@ UPDATE_SHIPPING_ZONE_QUERY = """
             shippingZone {
                 name
             }
-            errors {
+            shippingErrors {
                 field
-                message
+                code
             }
         }
     }
@@ -242,7 +242,7 @@ def test_update_shipping_zone(
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
-    assert not data["errors"]
+    assert not data["shippingErrors"]
     data = content["data"]["shippingZoneUpdate"]["shippingZone"]
     assert data["name"] == name
 
@@ -264,9 +264,8 @@ def test_update_shipping_zone_default_exists(
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
-    assert data["errors"]
-    assert data["errors"][0]["field"] == "default"
-    assert data["errors"][0]["message"] == ("Default shipping zone already exists.")
+    assert data["shippingErrors"][0]["field"] == "default"
+    assert data["shippingErrors"][0]["code"] == ShippingErrorCode.ALREADY_EXISTS.name
 
 
 def test_delete_shipping_zone(
@@ -302,9 +301,9 @@ PRICE_BASED_SHIPPING_QUERY = """
             name: $name, price: $price, shippingZone: $shippingZone,
             minimumOrderPrice: $minimumOrderPrice,
             maximumOrderPrice: $maximumOrderPrice, type: $type}) {
-        errors {
+        shippingErrors {
             field
-            message
+            code
         }
         shippingZone {
             id
@@ -387,10 +386,7 @@ def test_create_price_shipping_method_errors(
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]
-    assert (
-        data["errors"][0]["message"]
-        == "Maximum order price should be larger than the minimum order price."
-    )
+    assert data["shippingErrors"][0]["code"] == ShippingErrorCode.MAX_LESS_THAN_MIN.name
 
 
 WEIGHT_BASED_SHIPPING_QUERY = """
@@ -403,9 +399,9 @@ WEIGHT_BASED_SHIPPING_QUERY = """
                 name: $name, price: $price, shippingZone: $shippingZone,
                 minimumOrderWeight:$minimumOrderWeight,
                 maximumOrderWeight: $maximumOrderWeight, type: $type}) {
-            errors {
+            shippingErrors {
                 field
-                message
+                code
             }
             shippingMethod {
                 minimumOrderWeight {
@@ -479,10 +475,7 @@ def test_create_weight_shipping_method_errors(
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]
-    assert (
-        data["errors"][0]["message"]
-        == "Maximum order weight should be larger than the minimum order weight."
-    )
+    assert data["shippingErrors"][0]["code"] == ShippingErrorCode.MAX_LESS_THAN_MIN.name
 
 
 def test_update_shipping_method(
@@ -496,9 +489,9 @@ def test_update_shipping_method(
             id: $id, input: {
                 price: $price, shippingZone: $shippingZone,
                 type: $type, minimumOrderPrice: $minimumOrderPrice}) {
-            errors {
+            shippingErrors {
                 field
-                message
+                code
             }
             shippingZone {
                 id

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -108,7 +108,6 @@ CREATE_SHIPPING_ZONE_QUERY = """
 
 
 def test_create_shipping_zone(staff_api_client, warehouse, permission_manage_shipping):
-    query = CREATE_SHIPPING_ZONE_QUERY
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
     variables = {
         "name": "test shipping",
@@ -116,7 +115,7 @@ def test_create_shipping_zone(staff_api_client, warehouse, permission_manage_shi
         "addWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        CREATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneCreate"]
@@ -130,14 +129,13 @@ def test_create_shipping_zone(staff_api_client, warehouse, permission_manage_shi
 def test_create_shipping_zone_with_empty_warehouses(
     staff_api_client, permission_manage_shipping
 ):
-    query = CREATE_SHIPPING_ZONE_QUERY
     variables = {
         "name": "test shipping",
         "countries": ["PL"],
         "addWarehouses": [],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        CREATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneCreate"]
@@ -152,13 +150,12 @@ def test_create_shipping_zone_with_empty_warehouses(
 def test_create_shipping_zone_without_warehouses(
     staff_api_client, permission_manage_shipping
 ):
-    query = CREATE_SHIPPING_ZONE_QUERY
     variables = {
         "name": "test shipping",
         "countries": ["PL"],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        CREATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneCreate"]
@@ -173,7 +170,6 @@ def test_create_shipping_zone_without_warehouses(
 def test_create_default_shipping_zone(
     staff_api_client, warehouse, permission_manage_shipping
 ):
-    query = CREATE_SHIPPING_ZONE_QUERY
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
     variables = {
         "default": True,
@@ -182,7 +178,7 @@ def test_create_default_shipping_zone(
         "addWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        CREATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneCreate"]
@@ -200,10 +196,9 @@ def test_create_duplicated_default_shipping_zone(
     shipping_zone.default = True
     shipping_zone.save()
 
-    query = CREATE_SHIPPING_ZONE_QUERY
     variables = {"default": True, "name": "test shipping", "countries": ["PL"]}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        CREATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneCreate"]
@@ -249,12 +244,11 @@ UPDATE_SHIPPING_ZONE_QUERY = """
 def test_update_shipping_zone(
     staff_api_client, shipping_zone, permission_manage_shipping
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     name = "Parabolic name"
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     variables = {"id": shipping_id, "name": name, "countries": []}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -266,7 +260,6 @@ def test_update_shipping_zone(
 def test_update_shipping_zone_default_exists(
     staff_api_client, shipping_zone, permission_manage_shipping
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     default_zone = shipping_zone
     default_zone.default = True
     default_zone.pk = None
@@ -276,7 +269,7 @@ def test_update_shipping_zone_default_exists(
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     variables = {"id": shipping_id, "name": "Name", "countries": [], "default": True}
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -287,8 +280,6 @@ def test_update_shipping_zone_default_exists(
 def test_update_shipping_zone_add_warehouses(
     staff_api_client, shipping_zone, warehouses, permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
-
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     warehouse_ids = [
         graphene.Node.to_global_id("Warehouse", warehouse.pk)
@@ -302,7 +293,7 @@ def test_update_shipping_zone_add_warehouses(
         "addWarehouses": warehouse_ids,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -320,7 +311,6 @@ def test_update_shipping_zone_add_second_warehouses(
     warehouse_no_shipping_zone,
     permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     warehouse_id = graphene.Node.to_global_id(
         "Warehouse", warehouse_no_shipping_zone.pk
@@ -331,7 +321,7 @@ def test_update_shipping_zone_add_second_warehouses(
         "addWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -344,7 +334,6 @@ def test_update_shipping_zone_add_second_warehouses(
 def test_update_shipping_zone_remove_warehouses(
     staff_api_client, shipping_zone, warehouse, permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
     variables = {
@@ -353,7 +342,7 @@ def test_update_shipping_zone_remove_warehouses(
         "removeWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -365,7 +354,6 @@ def test_update_shipping_zone_remove_warehouses(
 def test_update_shipping_zone_remove_one_warehouses(
     staff_api_client, shipping_zone, warehouses, permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     for warehouse in warehouses:
         warehouse.shipping_zones.add(shipping_zone)
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
@@ -376,7 +364,7 @@ def test_update_shipping_zone_remove_one_warehouses(
         "removeWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -393,7 +381,6 @@ def test_update_shipping_zone_replace_warehouse(
     warehouse_no_shipping_zone,
     permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     assert shipping_zone.warehouses.first() == warehouse
 
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
@@ -408,7 +395,7 @@ def test_update_shipping_zone_replace_warehouse(
         "removeWarehouses": [remove_warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -421,7 +408,6 @@ def test_update_shipping_zone_replace_warehouse(
 def test_update_shipping_zone_same_warehouse_id_in_add_and_remove(
     staff_api_client, shipping_zone, warehouse, permission_manage_shipping,
 ):
-    query = UPDATE_SHIPPING_ZONE_QUERY
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
     variables = {
@@ -431,7 +417,7 @@ def test_update_shipping_zone_same_warehouse_id_in_add_and_remove(
         "removeWarehouses": [warehouse_id],
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        UPDATE_SHIPPING_ZONE_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
@@ -517,7 +503,6 @@ def test_create_shipping_method(
     expected_max_price,
     permission_manage_shipping,
 ):
-    query = PRICE_BASED_SHIPPING_QUERY
     name = "DHL"
     price = 12.34
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
@@ -530,7 +515,7 @@ def test_create_shipping_method(
         "type": ShippingMethodTypeEnum.PRICE.name,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        PRICE_BASED_SHIPPING_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]
@@ -546,7 +531,6 @@ def test_create_shipping_method(
 def test_create_price_shipping_method_errors(
     shipping_zone, staff_api_client, permission_manage_shipping
 ):
-    query = PRICE_BASED_SHIPPING_QUERY
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     variables = {
         "shippingZone": shipping_zone_id,
@@ -557,7 +541,7 @@ def test_create_price_shipping_method_errors(
         "type": ShippingMethodTypeEnum.PRICE.name,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        PRICE_BASED_SHIPPING_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]
@@ -612,7 +596,6 @@ def test_create_weight_based_shipping_method(
     expected_max_weight,
     permission_manage_shipping,
 ):
-    query = WEIGHT_BASED_SHIPPING_QUERY
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     variables = {
         "shippingZone": shipping_zone_id,
@@ -623,7 +606,7 @@ def test_create_weight_based_shipping_method(
         "type": ShippingMethodTypeEnum.WEIGHT.name,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        WEIGHT_BASED_SHIPPING_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]
@@ -635,7 +618,6 @@ def test_create_weight_based_shipping_method(
 def test_create_weight_shipping_method_errors(
     shipping_zone, staff_api_client, permission_manage_shipping
 ):
-    query = WEIGHT_BASED_SHIPPING_QUERY
     shipping_zone_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     variables = {
         "shippingZone": shipping_zone_id,
@@ -646,7 +628,7 @@ def test_create_weight_shipping_method_errors(
         "type": ShippingMethodTypeEnum.WEIGHT.name,
     }
     response = staff_api_client.post_graphql(
-        query, variables, permissions=[permission_manage_shipping]
+        WEIGHT_BASED_SHIPPING_QUERY, variables, permissions=[permission_manage_shipping]
     )
     content = get_graphql_content(response)
     data = content["data"]["shippingPriceCreate"]

--- a/tests/api/test_shipping_method.py
+++ b/tests/api/test_shipping_method.py
@@ -235,6 +235,7 @@ UPDATE_SHIPPING_ZONE_QUERY = """
             shippingErrors {
                 field
                 code
+                warehouses
             }
         }
     }
@@ -422,11 +423,12 @@ def test_update_shipping_zone_same_warehouse_id_in_add_and_remove(
     content = get_graphql_content(response)
     data = content["data"]["shippingZoneUpdate"]
     assert data["shippingErrors"]
-    assert data["shippingErrors"][0]["field"] == "warehouses"
+    assert data["shippingErrors"][0]["field"] == "removeWarehouses"
     assert (
         data["shippingErrors"][0]["code"]
         == ShippingErrorCode.CANNOT_ADD_AND_REMOVE.name
     )
+    assert data["shippingErrors"][0]["warehouses"][0] == warehouse_id
 
 
 def test_delete_shipping_zone(

--- a/tests/api/test_warehouse.py
+++ b/tests/api/test_warehouse.py
@@ -606,14 +606,14 @@ def test_shipping_zone_can_be_assigned_only_to_one_warehouse(
 
 def test_shipping_zone_assign_to_warehouse(
     staff_api_client,
-    warehouse_wo_shipping_zone,
+    warehouse_no_shipping_zone,
     shipping_zone,
     permission_manage_products,
 ):
-    assert not warehouse_wo_shipping_zone.shipping_zones.all()
+    assert not warehouse_no_shipping_zone.shipping_zones.all()
     staff_api_client.user.user_permissions.add(permission_manage_products)
     variables = {
-        "id": graphene.Node.to_global_id("Warehouse", warehouse_wo_shipping_zone.pk),
+        "id": graphene.Node.to_global_id("Warehouse", warehouse_no_shipping_zone.pk),
         "shippingZoneIds": [
             graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
         ],
@@ -622,21 +622,21 @@ def test_shipping_zone_assign_to_warehouse(
     staff_api_client.post_graphql(
         MUTATION_ASSIGN_SHIPPING_ZONE_WAREHOUSE, variables=variables
     )
-    warehouse_wo_shipping_zone.refresh_from_db()
+    warehouse_no_shipping_zone.refresh_from_db()
     shipping_zone.refresh_from_db()
-    assert warehouse_wo_shipping_zone.shipping_zones.first().pk == shipping_zone.pk
+    assert warehouse_no_shipping_zone.shipping_zones.first().pk == shipping_zone.pk
 
 
 def test_empty_shipping_zone_assign_to_warehouse(
     staff_api_client,
-    warehouse_wo_shipping_zone,
+    warehouse_no_shipping_zone,
     shipping_zone,
     permission_manage_products,
 ):
-    assert not warehouse_wo_shipping_zone.shipping_zones.all()
+    assert not warehouse_no_shipping_zone.shipping_zones.all()
     staff_api_client.user.user_permissions.add(permission_manage_products)
     variables = {
-        "id": graphene.Node.to_global_id("Warehouse", warehouse_wo_shipping_zone.pk),
+        "id": graphene.Node.to_global_id("Warehouse", warehouse_no_shipping_zone.pk),
         "shippingZoneIds": [],
     }
 
@@ -645,10 +645,10 @@ def test_empty_shipping_zone_assign_to_warehouse(
     )
     content = get_graphql_content(response)
     errors = content["data"]["assignWarehouseShippingZone"]["warehouseErrors"]
-    warehouse_wo_shipping_zone.refresh_from_db()
+    warehouse_no_shipping_zone.refresh_from_db()
     shipping_zone.refresh_from_db()
 
-    assert not warehouse_wo_shipping_zone.shipping_zones.all()
+    assert not warehouse_no_shipping_zone.shipping_zones.all()
     assert errors[0]["field"] == "shippingZoneId"
     assert errors[0]["code"] == "GRAPHQL_ERROR"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1897,9 +1897,11 @@ def warehouse(address, shipping_zone):
 
 
 @pytest.fixture
-def warehouse_wo_shipping_zone(address, shipping_zone):
+def warehouse_no_shipping_zone(address):
     warehouse = Warehouse.objects.create(
-        address=address, name="Example Warehouse", email="test@example.com"
+        address=address,
+        name="Warehouse withot shipping zone",
+        email="test2@example.com",
     )
     return warehouse
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1897,6 +1897,26 @@ def warehouse(address, shipping_zone):
 
 
 @pytest.fixture
+def warehouses(address):
+    return Warehouse.objects.bulk_create(
+        [
+            Warehouse(
+                address=address.get_copy(),
+                name="Warehouse1",
+                slug="warehouse1",
+                email="warehouse1@example.com",
+            ),
+            Warehouse(
+                address=address.get_copy(),
+                name="Warehouse2",
+                slug="warehouse2",
+                email="warehouse2@example.com",
+            ),
+        ]
+    )
+
+
+@pytest.fixture
 def warehouse_no_shipping_zone(address):
     warehouse = Warehouse.objects.create(
         address=address,


### PR DESCRIPTION
I want to merge this change because adding the ability to assign multiple warehouses in mutations to create/update a shipping zone.

In `shippingZoneCreate` mutation I add the field with warehouses to add to a shipping zone. 
In `shippingZoneUpdate` mutation I add fields with warehouses to add and remove from a shipping zone. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
