### PR TITLE
Add filter by ids to warehouses query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add benchmarks to checkout mutations - #5339 by @fowczarek
 - Add pagination tests - #5363 by @fowczarek
 - Add ability to assign multiple warehouses in mutations to create/update a shipping zone - #5399 by @fowczarek
+- Add filter by ids to warehouses query - #5414 by @fowczarek
 
 
 ## 2.9.0

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4911,6 +4911,7 @@ enum WarehouseErrorCode {
 
 input WarehouseFilterInput {
   search: String
+  ids: [ID]
 }
 
 type WarehouseShippingZoneAssign {

--- a/saleor/graphql/warehouse/filters.py
+++ b/saleor/graphql/warehouse/filters.py
@@ -1,4 +1,5 @@
 import django_filters
+from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...warehouse.models import Stock, Warehouse
 from ..core.types import FilterInputObjectType
@@ -44,6 +45,7 @@ def filter_search_stock(qs, _, value):
 
 class WarehouseFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_search_warehouse)
+    ids = GlobalIDMultipleChoiceFilter(field_name="id")
 
     class Meta:
         model = Warehouse

--- a/tests/api/test_warehouse.py
+++ b/tests/api/test_warehouse.py
@@ -260,6 +260,44 @@ def test_query_warehouse_with_filters_email(
     assert total_count == 0
 
 
+def test_query_warehouse_with_filters_by_ids(
+    staff_api_client, permission_manage_products, warehouse, warehouse_no_shipping_zone
+):
+    warehouse_ids = [
+        graphene.Node.to_global_id("Warehouse", warehouse.id),
+        graphene.Node.to_global_id("Warehouse", warehouse_no_shipping_zone.id),
+    ]
+    variables_exists = {"filters": {"ids": warehouse_ids}}
+    response_exists = staff_api_client.post_graphql(
+        QUERY_WAREHOUSES_WITH_FILTERS,
+        variables=variables_exists,
+        permissions=[permission_manage_products],
+    )
+    content_exists = get_graphql_content(response_exists)
+
+    content_warehouses = content_exists["data"]["warehouses"]["edges"]
+    for content_warehouse in content_warehouses:
+        assert content_warehouse["node"]["id"] in warehouse_ids
+    assert content_exists["data"]["warehouses"]["totalCount"] == 2
+
+
+def test_query_warehouse_with_filters_by_id(
+    staff_api_client, permission_manage_products, warehouse, warehouse_no_shipping_zone
+):
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.id)
+    variables_exists = {"filters": {"ids": [warehouse_id]}}
+    response_exists = staff_api_client.post_graphql(
+        QUERY_WAREHOUSES_WITH_FILTERS,
+        variables=variables_exists,
+        permissions=[permission_manage_products],
+    )
+    content_exists = get_graphql_content(response_exists)
+
+    content_warehouses = content_exists["data"]["warehouses"]["edges"]
+    assert content_warehouses[0]["node"]["id"] == warehouse_id
+    assert content_exists["data"]["warehouses"]["totalCount"] == 1
+
+
 def test_mutation_create_warehouse(
     staff_api_client, permission_manage_products, shipping_zone
 ):


### PR DESCRIPTION
I want to merge this change because adding filter by ids to warehouses query.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
