### PR TITLE
Fix CreateToken mutation to use NonNull on errors field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,6 +183,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix bulk action checkboxes - #4618 by @dominik-zeglen
 - Fix rendering user avatar when it's empty #4546 by @maarcingebala
 - Remove Dashboard 2.0 files form Saleor repository - #4631 by @dominik-zeglen
+- Fix CreateToken mutation to use NonNull on errors field #5415 by @gabmartinez
 
 ### Other notable changes
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -587,7 +587,7 @@ class CreateToken(ObtainJSONWebToken):
     the mutation works.
     """
 
-    errors = graphene.List(Error, required=True)
+    errors = graphene.List(graphene.NonNull(Error), required=True)
     user = graphene.Field(User)
 
     @classmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1320,7 +1320,7 @@ type CountryDisplay {
 
 type CreateToken {
   token: String
-  errors: [Error]!
+  errors: [Error!]!
   user: User
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4035,7 +4035,7 @@ type ServiceAccountUpdatePrivateMeta {
 
 type SetPassword {
   token: String
-  errors: [Error]!
+  errors: [Error!]!
   user: User
   accountErrors: [AccountError!]
 }


### PR DESCRIPTION
I want to merge this change because it ensures the errors field can return non-nullable in  CreateToken mutation.

<!-- Please mention all relevant issue numbers. -->
#5415

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
