### PR TITLE
Add restrictions to delete users from group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add filter by ids to warehouses query - #5414 by @fowczarek
 - Allow assigning groups in staff mutations - #5418 by @IKarbowiak
 - Add delete group restriction - #5424 by @IKarbowiak
+- Add restrictions to delete users from group - #5438 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -18,6 +18,7 @@ from ...account.utils import (
 from ...core.enums import PermissionEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types.common import PermissionGroupError
+from ...core.utils import get_duplicates_ids
 from ..types import Group
 
 
@@ -315,21 +316,17 @@ class PermissionGroupUpdate(PermissionGroupCreate):
         Raise error if some of items are duplicated.
         """
         add_field, remove_field, error_class_field = fields
-        # break if any of comparing field is not in input
-        add_items = input_data.get(add_field)
-        remove_items = input_data.get(remove_field)
-        if not add_items or not remove_items:
-            return
-
-        common_items = set(input_data[add_field]) & set(input_data[remove_field])
-        if common_items:
+        duplicated_ids = get_duplicates_ids(
+            input_data.get(add_field), input_data.get(remove_field)
+        )
+        if duplicated_ids:
             # add error
             error_msg = (
                 "The same object cannot be in both list"
                 "for adding and removing items."
             )
             code = PermissionGroupErrorCode.CANNOT_ADD_AND_REMOVE.value
-            params = {error_class_field: list(common_items)}
+            params = {error_class_field: list(duplicated_ids)}
             cls.update_errors(errors, error_msg, None, code, params)
 
 

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -215,12 +215,12 @@ def get_not_manageable_permissions_after_group_deleting(group):
     """
     group_pk = group.pk
     groups_data = get_group_to_permissions_and_users_mapping()
-    not_manageable_permissions = groups_data[group_pk]["permissions"]
+    not_manageable_permissions = groups_data.pop(group_pk)["permissions"]
 
     # get users from groups with manage staff and look for not_manageable_permissions
     # if any of not_manageable_permissions is found it is removed from set
     manage_staff_users = get_users_and_look_for_permissions_in_groups_with_manage_staff(
-        group_pk, groups_data, not_manageable_permissions
+        groups_data, not_manageable_permissions
     )
 
     # check if management of all permissions provided by other groups
@@ -235,7 +235,7 @@ def get_not_manageable_permissions_after_group_deleting(group):
     # manage staff permissions groups, if any of not_manageable_permissions is found
     # it is removed from set
     look_for_permission_in_users_with_manage_staff(
-        group_pk, groups_data, manage_staff_users, not_manageable_permissions
+        groups_data, manage_staff_users, not_manageable_permissions
     )
 
     # return remaining not managable permissions
@@ -280,21 +280,18 @@ def get_group_to_permissions_and_users_mapping():
 
 
 def get_users_and_look_for_permissions_in_groups_with_manage_staff(
-    group_pk: int, groups_data: dict, permissions_to_find: Set[str],
+    groups_data: dict, permissions_to_find: Set[str],
 ):
     """Search for permissions in groups with manage staff and return their users.
 
     Args:
-        group_pk: pk of group which should be excluded for search
         groups_data: dict with groups data, key is a group pk and value is group data
             with permissions and users
         permissions_to_find: searched permissions
 
     """
     users_with_manage_staff: Set[int] = set()
-    for pk, data in groups_data.items():
-        if pk == group_pk:
-            continue
+    for data in groups_data.values():
         permissions = data["permissions"]
         users = data["users"]
         has_manage_staff = AccountPermissions.MANAGE_STAFF.value in permissions
@@ -310,24 +307,18 @@ def get_users_and_look_for_permissions_in_groups_with_manage_staff(
 
 
 def look_for_permission_in_users_with_manage_staff(
-    group_pk: int,
-    groups_data: dict,
-    users_to_check: Set[int],
-    permissions_to_find: Set[str],
+    groups_data: dict, users_to_check: Set[int], permissions_to_find: Set[str],
 ):
     """Search for permissions in user with manage staff groups.
 
     Args:
-        group_pk: pk of group which should be excluded for search
         groups_data: dict with groups data, key is a group pk and value is group data
             with permissions and users
         users_to_check: users with manage_staff
         permissions_to_find: searched permissions
 
     """
-    for pk, data in groups_data.items():
-        if pk == group_pk:
-            continue
+    for data in groups_data.values():
         permissions = data["permissions"]
         users = data["users"]
         common_users = users_to_check & users

--- a/tests/api/benchmark/test_permission_group.py
+++ b/tests/api/benchmark/test_permission_group.py
@@ -81,9 +81,6 @@ def test_permission_group_update(
     permission_manage_users,
     count_queries,
 ):
-    staff_user.user_permissions.add(
-        permission_manage_users, permission_manage_service_accounts
-    )
     query = """
     mutation PermissionGroupUpdate(
         $id: ID!, $input: PermissionGroupUpdateInput!) {
@@ -115,6 +112,7 @@ def test_permission_group_update(
         permission_manage_service_accounts, permission_manage_users
     )
     group = permission_group_manage_users
+    group.permissions.add(permission_manage_staff)
 
     variables = {
         "id": graphene.Node.to_global_id("Group", group.id),
@@ -172,7 +170,7 @@ def test_permission_group_delete(
         }
     }
     """
-    staff_user1, staff_user2 = staff_users
+    staff_user1, staff_user2, _ = staff_users
     staff_user1.user_permissions.add(
         permission_manage_orders, permission_manage_products
     )

--- a/tests/api/benchmark/test_permission_group.py
+++ b/tests/api/benchmark/test_permission_group.py
@@ -139,6 +139,81 @@ def test_permission_group_update(
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
+def test_permission_group_update_remove_users_with_manage_staff(
+    permission_group_manage_users,
+    staff_users,
+    permission_manage_staff,
+    staff_api_client,
+    permission_manage_service_accounts,
+    permission_manage_users,
+    permission_manage_orders,
+    count_queries,
+):
+    query = """
+    mutation PermissionGroupUpdate(
+        $id: ID!, $input: PermissionGroupUpdateInput!) {
+        permissionGroupUpdate(
+            id: $id, input: $input)
+        {
+            group{
+                id
+                name
+                permissions {
+                    name
+                    code
+                }
+                users {
+                    email
+                }
+            }
+            permissionGroupErrors{
+                field
+                code
+                permissions
+                users
+                message
+            }
+        }
+    }
+    """
+
+    staff_user, staff_user1, staff_user2 = staff_users
+
+    groups = Group.objects.bulk_create(
+        [Group(name="manage users"), Group(name="manage staff, order and users")]
+    )
+    group1, group2 = groups
+
+    group1.permissions.add(permission_manage_staff, permission_manage_users)
+    group2.permissions.add(
+        permission_manage_staff, permission_manage_orders, permission_manage_users
+    )
+
+    group1.user_set.add(staff_user1, staff_user2)
+    group2.user_set.add(staff_user2)
+
+    staff_user.user_permissions.add(permission_manage_users, permission_manage_orders)
+    variables = {
+        "id": graphene.Node.to_global_id("Group", group1.id),
+        "input": {
+            "removeUsers": [
+                graphene.Node.to_global_id("User", user.id)
+                for user in [staff_user1, staff_user2]
+            ],
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=(permission_manage_staff,)
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["permissionGroupUpdate"]
+
+    assert len(data["group"]["users"]) == 0
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
 def test_permission_group_delete(
     staff_users,
     permission_manage_staff,

--- a/tests/api/test_account_utils.py
+++ b/tests/api/test_account_utils.py
@@ -297,13 +297,10 @@ def test_get_group_to_permissions_and_users_mapping(
     permission_manage_products,
     permission_manage_users,
 ):
-    staff_user1, staff_user2 = staff_users
-    staff_user3_not_active = User.objects.create_user(
-        email="staff3_test@example.com",
-        password="password",
-        is_staff=True,
-        is_active=False,
-    )
+    staff_user1, staff_user2, staff_user3_not_active = staff_users
+    staff_user3_not_active.is_active = False
+    staff_user3_not_active.save()
+
     groups = Group.objects.bulk_create(
         [
             Group(name="manage users"),
@@ -433,13 +430,7 @@ def test_get_not_manageable_permissions_after_group_deleting(
     permission_manage_staff,
     permission_manage_discounts,
 ):
-    staff_user1, staff_user2 = staff_users
-    staff_user3 = User.objects.create_user(
-        email="staff3_test@example.com",
-        password="password",
-        is_staff=True,
-        is_active=False,
-    )
+    staff_user1, staff_user2, staff_user3 = staff_users
 
     groups = Group.objects.bulk_create(
         [
@@ -480,13 +471,7 @@ def test_get_not_manageable_permissions_after_group_deleting_some_cannot_be_mana
     permission_manage_staff,
     permission_manage_discounts,
 ):
-    staff_user1, staff_user2 = staff_users
-    staff_user3 = User.objects.create_user(
-        email="staff3_test@example.com",
-        password="password",
-        is_staff=True,
-        is_active=False,
-    )
+    staff_user1, staff_user2, staff_user3 = staff_users
 
     groups = Group.objects.bulk_create(
         [
@@ -551,7 +536,7 @@ def test_get_not_manageable_perms_removing_users_from_group_some_user_from_group
     group1.permissions.add(permission_manage_users)
     group2.permissions.add(permission_manage_staff)
 
-    staff_user1, staff_user2 = staff_users
+    staff_user1, staff_user2, _ = staff_users
     group1.user_set.add(*staff_users)
     group2.user_set.add(staff_user1)
 
@@ -576,7 +561,7 @@ def test_get_not_manageable_perms_removing_users_from_group_some_user_outside_gr
     group1.permissions.add(permission_manage_users)
     group2.permissions.add(permission_manage_staff, permission_manage_users)
 
-    staff_user1, staff_user2 = staff_users
+    staff_user1, staff_user2, _ = staff_users
     group1.user_set.add(staff_user1)
     group2.user_set.add(staff_user2)
 
@@ -609,7 +594,7 @@ def test_get_not_manageable_perms_removing_users_from_group_some_cannot_be_manag
     group2.permissions.add(permission_manage_staff)
     group3.permissions.add(permission_manage_users, permission_manage_orders)
 
-    staff_user1, staff_user2 = staff_users
+    staff_user1, staff_user2, _ = staff_users
     group1.user_set.add(staff_user1)
     group2.user_set.add(staff_user2)
     group3.user_set.add(staff_user1)

--- a/tests/api/test_account_utils.py
+++ b/tests/api/test_account_utils.py
@@ -8,6 +8,7 @@ from saleor.graphql.account.utils import (
     get_group_to_permissions_and_users_mapping,
     get_groups_which_user_can_manage,
     get_not_manageable_permissions_after_group_deleting,
+    get_not_manageable_permissions_after_removing_users_from_group,
     get_out_of_scope_permissions,
     get_out_of_scope_users,
     get_user_permissions,
@@ -517,3 +518,108 @@ def test_get_not_manageable_permissions_after_group_deleting_some_cannot_be_mana
         group1
     )
     assert non_managable_permissions == {"order.manage_orders"}
+
+
+def test_get_not_manageable_permissions_removing_users_from_group(
+    staff_users, permission_group_manage_users, permission_manage_staff
+):
+    """Ensure not returning permission when some of users stay in group and groups has
+    manage staff permission.
+    """
+    group = permission_group_manage_users
+    group.permissions.add(permission_manage_staff)
+    group.user_set.add(*staff_users)
+
+    permissions = get_not_manageable_permissions_after_removing_users_from_group(
+        group, staff_users[1:]
+    )
+
+    assert not permissions
+
+
+def test_get_not_manageable_perms_removing_users_from_group_some_user_from_group_can(
+    staff_users, permission_manage_users, permission_manage_staff
+):
+    """Ensure not returning permission for group without manage staff permission when
+    some of remaining users from group has manage staff permission from other source.
+    """
+    groups = Group.objects.bulk_create(
+        [Group(name="manage users"), Group(name="manage staff")]
+    )
+    group1, group2 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+
+    staff_user1, staff_user2 = staff_users
+    group1.user_set.add(*staff_users)
+    group2.user_set.add(staff_user1)
+
+    permissions = get_not_manageable_permissions_after_removing_users_from_group(
+        group1, [staff_user2]
+    )
+
+    assert not permissions
+
+
+def test_get_not_manageable_perms_removing_users_from_group_some_user_outside_group_can(
+    staff_users, permission_manage_users, permission_manage_staff
+):
+    """Ensure not returning permission for group, when managable of all permissions are
+    ensure by other groups.
+    """
+    groups = Group.objects.bulk_create(
+        [Group(name="manage users"), Group(name="manage staff and users")]
+    )
+    group1, group2 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff, permission_manage_users)
+
+    staff_user1, staff_user2 = staff_users
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2)
+
+    permissions = get_not_manageable_permissions_after_removing_users_from_group(
+        group1, [staff_user1]
+    )
+
+    assert not permissions
+
+
+def test_get_not_manageable_perms_removing_users_from_group_some_cannot_be_manage(
+    staff_users,
+    permission_manage_users,
+    permission_manage_staff,
+    permission_manage_orders,
+):
+    """Ensure returning permission for group, when not all permissions are ensure
+    by other groups.
+    """
+    groups = Group.objects.bulk_create(
+        [
+            Group(name="manage users"),
+            Group(name="manage staff"),
+            Group(name="manage users and orders"),
+        ]
+    )
+    group1, group2, group3 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+    group3.permissions.add(permission_manage_users, permission_manage_orders)
+
+    staff_user1, staff_user2 = staff_users
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2)
+    group3.user_set.add(staff_user1)
+
+    permissions = get_not_manageable_permissions_after_removing_users_from_group(
+        group1, [staff_user1]
+    )
+
+    assert permissions == {
+        permission_manage_users.content_type.app_label
+        + "."
+        + permission_manage_users.codename
+    }

--- a/tests/api/test_account_utils.py
+++ b/tests/api/test_account_utils.py
@@ -522,7 +522,7 @@ def test_get_not_manageable_permissions_removing_users_from_group(
     assert not permissions
 
 
-def test_get_not_manageable_perms_removing_users_from_group_some_user_from_group_can(
+def test_get_not_manageable_perms_removing_users_from_group_user_from_group_can_manage(
     staff_users, permission_manage_users, permission_manage_staff
 ):
     """Ensure not returning permission for group without manage staff permission when
@@ -547,7 +547,7 @@ def test_get_not_manageable_perms_removing_users_from_group_some_user_from_group
     assert not permissions
 
 
-def test_get_not_manageable_perms_removing_users_from_group_some_user_outside_group_can(
+def test_get_notmanageable_perms_removing_users_from_group_user_out_of_group_can_manage(
     staff_users, permission_manage_users, permission_manage_staff
 ):
     """Ensure not returning permission for group, when managable of all permissions are

--- a/tests/api/test_account_utils.py
+++ b/tests/api/test_account_utils.py
@@ -372,10 +372,10 @@ def test_get_users_and_look_for_permissions_in_groups_with_manage_staff():
         4: {"permissions": {"checkout.manage_checkouts"}, "users": {2}},
     }
     group_pk = 1
-    permissions_to_find = groups_data[group_pk]["permissions"]
+    permissions_to_find = groups_data.pop(group_pk)["permissions"]
 
     users = get_users_and_look_for_permissions_in_groups_with_manage_staff(
-        group_pk, groups_data, permissions_to_find
+        groups_data, permissions_to_find
     )
 
     assert users == {2, 3}
@@ -412,11 +412,11 @@ def test_look_for_permission_in_users_with_manage_staff():
         5: {"permissions": set(), "users": {1, 2, 3}},
     }
     group_pk = 1
-    permissions_to_find = groups_data[group_pk]["permissions"]
+    permissions_to_find = groups_data.pop(group_pk)["permissions"]
     users_to_check = {2, 3}
 
     look_for_permission_in_users_with_manage_staff(
-        group_pk, groups_data, users_to_check, permissions_to_find
+        groups_data, users_to_check, permissions_to_find
     )
 
     assert permissions_to_find == {"order.manage_orders"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -416,13 +416,23 @@ def staff_user(db):
 @pytest.fixture
 def staff_users(staff_user):
     """Return a staff members."""
-    staff_user2 = User.objects.create_user(
-        email="staff2_test@example.com",
-        password="password",
-        is_staff=True,
-        is_active=True,
+    staff_users = User.objects.bulk_create(
+        [
+            User(
+                email="staff1_test@example.com",
+                password="password",
+                is_staff=True,
+                is_active=True,
+            ),
+            User(
+                email="staff2_test@example.com",
+                password="password",
+                is_staff=True,
+                is_active=True,
+            ),
+        ]
     )
-    return [staff_user, staff_user2]
+    return [staff_user] + staff_users
 
 
 @pytest.fixture


### PR DESCRIPTION
Add validation when removing users from the permission group. Ensure that for each permission, there will be at least one staff member who can manage it (has both “manage staff” and this permission).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
