### PR TITLE
Add restriction to removing staff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add delete group restriction - #5424 by @IKarbowiak
 - Add restrictions to delete users from group - #5438 by @IKarbowiak
 - Add restriction to deactivating staff - #5449 by @IKarbowiak
+- Add restriction to removing staff - #5450 by @IKarbowiak
 
 ## 2.9.0
 


### PR DESCRIPTION
Add restrictions for removing the staff user. Ensure that after removing the user for each permission, there will be at least one staff member who can manage it (has both “manage staff” and this permission).


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
