### PR TITLE
Add restriction to bulk staff delete mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add restrictions to delete users from group - #5438 by @IKarbowiak
 - Add restriction to deactivating staff - #5449 by @IKarbowiak
 - Add restriction to removing staff - #5450 by @IKarbowiak
+- Add restriction to bulk staff delete mutation - #5456 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -61,10 +61,11 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
     @classmethod
     def clean_instances(cls, info, users):
         errors = defaultdict(list)
+        requestor = info.context.user
         cls.check_if_users_can_be_deleted(info, users, "ids", errors)
-        cls.check_if_requestor_can_manage_users(info, users, "ids", errors)
+        cls.check_if_requestor_can_manage_users(requestor, users, "ids", errors)
         cls.check_if_removing_left_not_manageable_permissions(
-            info, users, "ids", errors
+            requestor, users, "ids", errors
         )
         return ValidationError(errors) if errors else {}
 

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -63,7 +63,9 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         errors = defaultdict(list)
         cls.check_if_users_can_be_deleted(info, users, "ids", errors)
         cls.check_if_requestor_can_manage_users(info, users, "ids", errors)
-        cls.check_if_removing_left_not_manageable_permissions(users, "ids", errors)
+        cls.check_if_removing_left_not_manageable_permissions(
+            info, users, "ids", errors
+        )
         return ValidationError(errors) if errors else {}
 
 

--- a/saleor/graphql/account/bulk_mutations.py
+++ b/saleor/graphql/account/bulk_mutations.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import graphene
 from django.core.exceptions import ValidationError
 
@@ -5,14 +7,15 @@ from ...account import models
 from ...account.error_codes import AccountErrorCode
 from ...core.permissions import AccountPermissions
 from ..core.mutations import BaseBulkMutation, ModelBulkDeleteMutation
-from ..core.types.common import AccountError
+from ..core.types.common import AccountError, StaffError
+from .types import User
 from .utils import CustomerDeleteMixin, StaffDeleteMixin
 
 
 class UserBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = graphene.List(
-            graphene.ID, required=True, description="List of sale IDs to delete."
+            graphene.ID, required=True, description="List of user IDs to delete."
         )
 
     class Meta:
@@ -39,8 +42,29 @@ class StaffBulkDelete(StaffDeleteMixin, UserBulkDelete):
         description = "Deletes staff users."
         model = models.User
         permissions = (AccountPermissions.MANAGE_STAFF,)
-        error_type_class = AccountError
-        error_type_field = "account_errors"
+        error_type_class = StaffError
+        error_type_field = "staff_errors"
+
+    @classmethod
+    def perform_mutation(cls, _root, info, ids, **data):
+        instances = cls.get_nodes_or_error(ids, "id", User)
+        errors = cls.clean_instances(info, instances)
+        count = len(instances)
+        if not errors and count:
+            clean_instance_ids = [instance.pk for instance in instances]
+            qs = models.User.objects.filter(pk__in=clean_instance_ids)
+            cls.bulk_action(queryset=qs, **data)
+        else:
+            count = 0
+        return count, errors
+
+    @classmethod
+    def clean_instances(cls, info, users):
+        errors = defaultdict(list)
+        cls.check_if_users_can_be_deleted(info, users, "ids", errors)
+        cls.check_if_requestor_can_manage_users(info, users, "ids", errors)
+        cls.check_if_removing_left_not_manageable_permissions(users, "ids", errors)
+        return ValidationError(errors) if errors else {}
 
 
 class UserBulkSetActive(BaseBulkMutation):

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -28,7 +28,7 @@ from ..utils import (
     StaffDeleteMixin,
     UserDeleteMixin,
     get_groups_which_user_can_manage,
-    get_not_manageable_permissions_when_deactivate_or_remove_user,
+    get_not_manageable_permissions_when_deactivate_or_remove_users,
     get_out_of_scope_permissions,
     get_out_of_scope_users,
 )
@@ -365,8 +365,8 @@ class StaffUpdate(StaffCreate):
         active staff member who can manage it (has both “manage staff” and
         this permission).
         """
-        permissions = get_not_manageable_permissions_when_deactivate_or_remove_user(
-            user
+        permissions = get_not_manageable_permissions_when_deactivate_or_remove_users(
+            [user]
         )
         if permissions:
             # add error

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -257,6 +257,9 @@ def get_not_manageable_permissions_when_deactivate_or_remove_users(users: List["
         groups_data, set()
     )
 
+    if not manage_staff_users:
+        return not_manageable_permissions
+
     # remove deactivating or removing users from manage staff users
     manage_staff_users = manage_staff_users - user_pks
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -78,6 +78,11 @@ class StaffError(AccountError):
         description="List of permission group IDs which cause the error.",
         required=False,
     )
+    users = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of user IDs which causes the error.",
+        required=False,
+    )
 
 
 class CheckoutError(Error):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4318,7 +4318,7 @@ input SiteDomainInput {
 type StaffBulkDelete {
   errors: [Error!]!
   count: Int!
-  accountErrors: [AccountError!]!
+  staffErrors: [StaffError!]!
 }
 
 type StaffCreate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4350,6 +4350,7 @@ type StaffError {
   code: AccountErrorCode!
   permissions: [PermissionEnum!]
   groups: [ID!]
+  users: [ID!]
 }
 
 enum StaffMemberStatus {

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -119,6 +119,11 @@ def staff_api_client(staff_user):
 
 
 @pytest.fixture
+def superuser_api_client(superuser):
+    return ApiClient(user=superuser)
+
+
+@pytest.fixture
 def user_api_client(customer_user):
     return ApiClient(user=customer_user)
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -2239,7 +2239,7 @@ def test_staff_delete_errors(staff_user, customer_user, admin_user):
     info = Mock(context=Mock(user=staff_user))
     with pytest.raises(ValidationError) as e:
         StaffDelete.clean_instance(info, customer_user)
-    msg = "Cannot delete a non-staff user."
+    msg = "Cannot delete a non-staff users."
     assert e.value.error_dict["id"][0].message == msg
 
     # should not raise any errors

--- a/tests/api/test_account_utils.py
+++ b/tests/api/test_account_utils.py
@@ -13,7 +13,7 @@ from saleor.graphql.account.utils import (
     get_groups_which_user_can_manage,
     get_not_manageable_permissions_after_group_deleting,
     get_not_manageable_permissions_after_removing_users_from_group,
-    get_not_manageable_permissions_when_deactivate_or_remove_user,
+    get_not_manageable_permissions_when_deactivate_or_remove_users,
     get_out_of_scope_permissions,
     get_out_of_scope_users,
     get_user_permissions,
@@ -629,14 +629,14 @@ def test_get_not_manageable_permissions_when_deactivate_or_remove_user_no_permis
     group2.user_set.add(staff_user2, staff_user1)
     group3.user_set.add(staff_user2)
 
-    permissions = get_not_manageable_permissions_when_deactivate_or_remove_user(
-        staff_user1
+    permissions = get_not_manageable_permissions_when_deactivate_or_remove_users(
+        [staff_user1]
     )
 
     assert not permissions
 
 
-def test_get_not_manageable_permissions_when_deactivate_or_remove_user_some_permissions(
+def test_get_not_manageable_permissions_when_deactivate_or_remove_users_some_perms(
     staff_users,
     permission_manage_users,
     permission_manage_staff,
@@ -657,16 +657,19 @@ def test_get_not_manageable_permissions_when_deactivate_or_remove_user_some_perm
     group2.permissions.add(permission_manage_staff)
     group3.permissions.add(permission_manage_orders)
 
-    staff_user1, staff_user2, _ = staff_users
+    staff_user1, staff_user2, staff_user3 = staff_users
     group1.user_set.add(staff_user1)
-    group2.user_set.add(staff_user2, staff_user1)
+    group2.user_set.add(staff_user2, staff_user1, staff_user3)
     group3.user_set.add(staff_user2)
 
-    permissions = get_not_manageable_permissions_when_deactivate_or_remove_user(
-        staff_user1
+    permissions = get_not_manageable_permissions_when_deactivate_or_remove_users(
+        [staff_user1, staff_user2]
     )
 
-    assert permissions == {AccountPermissions.MANAGE_USERS.value}
+    assert permissions == {
+        AccountPermissions.MANAGE_USERS.value,
+        OrderPermissions.MANAGE_ORDERS.value,
+    }
 
 
 def test_get_not_manageable_permissions_deactivate_or_remove_user_cant_manage_staff(
@@ -694,8 +697,8 @@ def test_get_not_manageable_permissions_deactivate_or_remove_user_cant_manage_st
     group2.user_set.add(staff_user2)
     group3.user_set.add(staff_user2)
 
-    permissions = get_not_manageable_permissions_when_deactivate_or_remove_user(
-        staff_user1
+    permissions = get_not_manageable_permissions_when_deactivate_or_remove_users(
+        [staff_user1]
     )
 
     assert not permissions

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -704,6 +704,7 @@ STAFF_BULK_DELETE_MUTATION = """
                 code
                 field
                 permissions
+                users
             }
         }
     }
@@ -743,6 +744,7 @@ def test_delete_staff_members_left_not_manageable_permissions(
     permission_manage_users,
     permission_manage_orders,
 ):
+    """Ensure user can't delete users when some permissions will be not manageable."""
     query = STAFF_BULK_DELETE_MUTATION
 
     groups = Group.objects.bulk_create(
@@ -790,6 +792,54 @@ def test_delete_staff_members_left_not_manageable_permissions(
     ).exists()
 
 
+def test_delete_staff_members_superuser_can_delete_when_delete_left_notmanageable_perms(
+    superuser_api_client,
+    staff_users,
+    permission_manage_staff,
+    permission_manage_users,
+    permission_manage_orders,
+):
+    """Ensure that superuser can delete users even when not all permissions which be
+    manageable by other users.
+    """
+    query = STAFF_BULK_DELETE_MUTATION
+
+    groups = Group.objects.bulk_create(
+        [
+            Group(name="manage users"),
+            Group(name="manage staff"),
+            Group(name="manage orders"),
+        ]
+    )
+    group1, group2, group3 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+    group3.permissions.add(permission_manage_orders)
+
+    staff_user, staff_user1, staff_user2 = staff_users
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2, staff_user1, staff_user)
+    group3.user_set.add(staff_user1)
+
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("User", user.id)
+            for user in [staff_user1, staff_user2]
+        ]
+    }
+    response = superuser_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["staffBulkDelete"]
+    errors = data["staffErrors"]
+
+    assert not errors
+    assert data["count"] == 2
+    assert not User.objects.filter(
+        id__in=[user.id for user in [staff_user1, staff_user2]]
+    ).exists()
+
+
 def test_delete_staff_members_all_permissions_manageable(
     staff_api_client,
     staff_users,
@@ -797,6 +847,7 @@ def test_delete_staff_members_all_permissions_manageable(
     permission_manage_users,
     permission_manage_orders,
 ):
+    """Ensure user can delete users when all permissions will be manageable."""
     query = STAFF_BULK_DELETE_MUTATION
 
     groups = Group.objects.bulk_create(
@@ -827,6 +878,119 @@ def test_delete_staff_members_all_permissions_manageable(
         ]
     }
     response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["staffBulkDelete"]
+    errors = data["staffErrors"]
+
+    assert not errors
+    assert data["count"] == 2
+    assert not User.objects.filter(
+        id__in=[user.id for user in [staff_user1, staff_user2]]
+    ).exists()
+
+
+def test_delete_staff_members_out_of_scope_users(
+    staff_api_client,
+    staff_users,
+    permission_manage_staff,
+    permission_manage_users,
+    permission_manage_orders,
+):
+    """Ensure user can't delete users when some permissions will be not manageable."""
+    query = STAFF_BULK_DELETE_MUTATION
+
+    groups = Group.objects.bulk_create(
+        [
+            Group(name="manage users"),
+            Group(name="manage staff"),
+            Group(name="manage orders and users"),
+        ]
+    )
+    group1, group2, group3 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+    group3.permissions.add(permission_manage_orders, permission_manage_users)
+
+    staff_user, staff_user1, staff_user2 = staff_users
+    staff_user3 = User.objects.create(
+        email="staff3_test@example.com",
+        password="password",
+        is_staff=True,
+        is_active=True,
+    )
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2, staff_user1, staff_user3)
+    group3.user_set.add(staff_user1, staff_user3)
+
+    staff_user.user_permissions.add(permission_manage_users, permission_manage_staff)
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("User", user.id)
+            for user in [staff_user1, staff_user2]
+        ]
+    }
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["staffBulkDelete"]
+    errors = data["staffErrors"]
+
+    assert len(errors) == 1
+    assert data["count"] == 0
+    assert errors[0]["field"] == "ids"
+    assert errors[0]["code"] == AccountErrorCode.OUT_OF_SCOPE_USER.name
+    assert errors[0]["permissions"] is None
+    assert set(errors[0]["users"]) == {
+        graphene.Node.to_global_id("User", staff_user1.id)
+    }
+    assert User.objects.filter(
+        id__in=[user.id for user in [staff_user1, staff_user2]]
+    ).exists()
+
+
+def test_delete_staff_members_superuser_can_delete__out_of_scope_users(
+    superuser_api_client,
+    staff_users,
+    permission_manage_staff,
+    permission_manage_users,
+    permission_manage_orders,
+):
+    """Ensure superuser can delete users when some users has wider scope of permissions.
+    """
+    query = STAFF_BULK_DELETE_MUTATION
+
+    groups = Group.objects.bulk_create(
+        [
+            Group(name="manage users"),
+            Group(name="manage staff"),
+            Group(name="manage orders and users"),
+        ]
+    )
+    group1, group2, group3 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+    group3.permissions.add(permission_manage_orders, permission_manage_users)
+
+    staff_user, staff_user1, staff_user2 = staff_users
+    staff_user3 = User.objects.create(
+        email="staff3_test@example.com",
+        password="password",
+        is_staff=True,
+        is_active=True,
+    )
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2, staff_user1, staff_user3)
+    group3.user_set.add(staff_user1, staff_user3)
+
+    staff_user.user_permissions.add(permission_manage_users, permission_manage_staff)
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("User", user.id)
+            for user in [staff_user1, staff_user2]
+        ]
+    }
+    response = superuser_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["staffBulkDelete"]
     errors = data["staffErrors"]

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -2,8 +2,11 @@ from unittest.mock import patch
 
 import graphene
 import pytest
+from django.contrib.auth.models import Group
 
+from saleor.account.error_codes import AccountErrorCode
 from saleor.account.models import User
+from saleor.core.permissions import AccountPermissions, OrderPermissions
 from saleor.discount.models import Sale, Voucher
 from saleor.menu.models import Menu, MenuItem
 from saleor.order import OrderStatus, models as order_models
@@ -693,33 +696,97 @@ def test_delete_shipping_zones(
     ).exists()
 
 
+STAFF_BULK_DELETE_MUTATION = """
+    mutation staffBulkDelete($ids: [ID]!) {
+        staffBulkDelete(ids: $ids) {
+            count
+            staffErrors{
+                code
+                field
+                permissions
+            }
+        }
+    }
+"""
+
+
 def test_delete_staff_members(
     staff_api_client, user_list, permission_manage_staff, superuser
 ):
     *users, staff_1, staff_2 = user_list
     users.append(superuser)
 
-    query = """
-    mutation staffBulkDelete($ids: [ID]!) {
-        staffBulkDelete(ids: $ids) {
-            count
-        }
-    }
-    """
+    query = STAFF_BULK_DELETE_MUTATION
 
     variables = {
-        "ids": [graphene.Node.to_global_id("User", user.id) for user in user_list]
+        "ids": [
+            graphene.Node.to_global_id("User", user.id) for user in [staff_1, staff_2]
+        ]
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_staff]
     )
     content = get_graphql_content(response)
-
-    assert content["data"]["staffBulkDelete"]["count"] == 2
+    data = content["data"]["staffBulkDelete"]
+    assert data["count"] == 2
+    assert not data["staffErrors"]
     assert not User.objects.filter(
         id__in=[user.id for user in [staff_1, staff_2]]
     ).exists()
     assert User.objects.filter(id__in=[user.id for user in users]).count() == len(users)
+
+
+def test_delete_staff_members_left_not_manageable_permissions(
+    staff_api_client,
+    staff_users,
+    permission_manage_staff,
+    permission_manage_users,
+    permission_manage_orders,
+):
+    query = STAFF_BULK_DELETE_MUTATION
+
+    groups = Group.objects.bulk_create(
+        [
+            Group(name="manage users"),
+            Group(name="manage staff"),
+            Group(name="manage orders"),
+        ]
+    )
+    group1, group2, group3 = groups
+
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_staff)
+    group3.permissions.add(permission_manage_orders)
+
+    staff_user, staff_user1, staff_user2 = staff_users
+    group1.user_set.add(staff_user1)
+    group2.user_set.add(staff_user2, staff_user1, staff_user)
+    group3.user_set.add(staff_user1)
+
+    staff_user.user_permissions.add(
+        permission_manage_users, permission_manage_orders, permission_manage_staff
+    )
+    variables = {
+        "ids": [
+            graphene.Node.to_global_id("User", user.id)
+            for user in [staff_user1, staff_user2]
+        ]
+    }
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["staffBulkDelete"]
+    errors = data["staffErrors"]
+
+    assert len(errors) == 1
+    assert errors[0]["field"] == "ids"
+    assert errors[0]["code"] == AccountErrorCode.LEFT_NOT_MANAGEABLE_PERMISSION.name
+    assert set(errors[0]["permissions"]) == {
+        AccountPermissions.MANAGE_USERS.name,
+        OrderPermissions.MANAGE_ORDERS.name,
+    }
+    assert User.objects.filter(
+        id__in=[user.id for user in [staff_user1, staff_user2]]
+    ).exists()
 
 
 def test_delete_vouchers(staff_api_client, voucher_list, permission_manage_discounts):


### PR DESCRIPTION
Add restriction to bulk staff delete mutation.  Ensure that after removing users for each permission, there will be at least one staff member who can manage it (has both “manage staff” and this permission).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
