### PR TITLE
Fix a race condition between Django and Celery

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -758,8 +758,12 @@ def create_order(
     order_created(order=order, user=user)
 
     # Send the order confirmation email
-    send_order_confirmation.delay(order.pk, redirect_url, user.pk)
-    send_staff_order_confirmation.delay(order.pk, redirect_url)
+    transaction.on_commit(
+        lambda: send_order_confirmation.delay(order.pk, redirect_url, user.pk)
+    )
+    transaction.on_commit(
+        lambda: send_staff_order_confirmation.delay(order.pk, redirect_url)
+    )
 
     return order
 

--- a/tests/api/benchmark/test_checkout_mutations.py
+++ b/tests/api/benchmark/test_checkout_mutations.py
@@ -3,7 +3,8 @@ from graphene import Node
 
 from saleor.checkout import calculations
 from saleor.checkout.models import Checkout
-from tests.api.utils import get_graphql_content
+
+from ..utils import get_graphql_content
 
 FRAGMENT_PRICE = """
     fragment Price on TaxedMoney {

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -10,6 +10,7 @@ from graphql_jwt.shortcuts import get_token
 
 from saleor.account.models import ServiceAccount, User
 
+from ..utils import flush_post_commit_hooks
 from .utils import assert_no_permission
 
 API_PATH = reverse("api")
@@ -91,7 +92,9 @@ class ApiClient(Client):
                 self.service_account.permissions.add(*permissions)
             else:
                 self.user.user_permissions.add(*permissions)
-        return super().post(API_PATH, data, **kwargs)
+        result = super().post(API_PATH, data, **kwargs)
+        flush_post_commit_hooks()
+        return result
 
     def post_multipart(self, *args, permissions=None, **kwargs):
         """Send a multipart POST request.

--- a/tests/test_checkout.py
+++ b/tests/test_checkout.py
@@ -37,6 +37,8 @@ from saleor.order import OrderEvents, OrderEventsEmails
 from saleor.order.models import OrderEvent
 from saleor.shipping.models import ShippingZone
 
+from .utils import flush_post_commit_hooks
+
 
 def test_is_valid_shipping_method(checkout_with_item, address, shipping_zone):
     checkout = checkout_with_item
@@ -111,6 +113,7 @@ def test_create_order_creates_expected_events(
         user=customer_user if not is_anonymous_user else AnonymousUser(),
         redirect_url="https://www.example.com",
     )
+    flush_post_commit_hooks()
 
     # Ensure only two events were created, and retrieve them
     placement_event, email_sent_event = order.events.all()  # type: OrderEvent

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,7 @@ from typing import Dict, Set, Union
 from urllib.parse import urlparse
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connections, transaction
 from PIL import Image
 from prices import Money
 
@@ -28,7 +29,6 @@ def create_image(image_name="product2"):
     img_data = BytesIO()
     image = Image.new("RGB", size=(1, 1), color=(255, 0, 0, 0))
     image.save(img_data, format="JPEG")
-    image_name = image_name
     image = SimpleUploadedFile(image_name + ".jpg", img_data.getvalue(), "image/png")
     return image, image_name
 
@@ -44,14 +44,16 @@ def money(amount):
 
 
 def generate_attribute_map(obj: Union[Product, ProductVariant]) -> Dict[int, Set[int]]:
-    """Generate a map from a product or variant instance, useful to quickly compare
-    the assigned attribute values against expected IDs.
+    """Generate a map from a product or variant instance.
+
+    Useful to quickly compare the assigned attribute values against expected IDs.
 
     The below association map will be returned.
-    {
-      attribute_pk (int) => {attribute_value_pk (int), ...}
-      ...
-    }
+
+        {
+            attribute_pk (int) => {attribute_value_pk (int), ...}
+            ...
+        }
     """
 
     qs = obj.attributes.select_related("assignment__attribute")
@@ -61,3 +63,16 @@ def generate_attribute_map(obj: Union[Product, ProductVariant]) -> Dict[int, Set
         assignment.attribute.pk: {value.pk for value in assignment.values.all()}
         for assignment in qs
     }
+
+
+def flush_post_commit_hooks():
+    """Run all pending `transaction.on_commit()` callbacks.
+
+    Forces all `on_commit()` hooks to run even if the transaction was not committed yet.
+    """
+    for alias in connections:
+        connection = transaction.get_connection(alias)
+        was_atomic = connection.in_atomic_block
+        connection.in_atomic_block = False
+        connection.run_and_clear_commit_hooks()
+        connection.in_atomic_block = was_atomic


### PR DESCRIPTION
This delays the task until the transaction is committed thus making sure the object actually exists by the time the worker tries to fetch it. We should consider wrapping most if not all celery tasks in `transaction.on_commit`, it's safe to execute outside a transaction.

Fixes #5455 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
