### PR TITLE
Drop permissions input field from staff mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add restriction to removing staff - #5450 by @IKarbowiak
 - Add restriction to bulk staff delete mutation - #5456 by @IKarbowiak
 - Exclude superuser from staff and groups restrictions - #5463 by @IKarbowiak
+- Drop permissions input field from staff mutations - #5471 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4333,7 +4333,6 @@ input StaffCreateInput {
   email: String
   isActive: Boolean
   note: String
-  permissions: [PermissionEnum]
   addGroups: [ID!]
   redirectUrl: String
 }
@@ -4401,7 +4400,6 @@ input StaffUpdateInput {
   email: String
   isActive: Boolean
   note: String
-  permissions: [PermissionEnum]
   addGroups: [ID!]
   removeGroups: [ID!]
 }

--- a/tests/api/benchmark/test_account.py
+++ b/tests/api/benchmark/test_account.py
@@ -181,8 +181,8 @@ def test_staff_create(
     content = get_graphql_content(response)
     data = content["data"]["staffCreate"]
 
-    assert User.objects.filter(is_staff=True).count() + staff_count + 1
-    assert data
+    assert User.objects.filter(is_staff=True).count() == staff_count + 1
+    assert data["user"]
     assert not data["staffErrors"]
 
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1532,12 +1532,10 @@ def test_staff_create(
         permission_manage_users.codename,
     }
     permissions = data["user"]["userPermissions"]
-    assert len(permissions) == 2
     assert {perm["code"].lower() for perm in permissions} == expected_perms
 
     # deprecated, to remove in #5389
     permissions = data["user"]["permissions"]
-    assert len(permissions) == 2
     assert {perm["code"].lower() for perm in permissions} == expected_perms
 
     staff_user = User.objects.get(email=email)
@@ -1617,12 +1615,10 @@ def test_staff_create_out_of_scope_group(
         permission_manage_users.codename,
     }
     permissions = data["user"]["userPermissions"]
-    assert len(permissions) == 2
     assert {perm["code"].lower() for perm in permissions} == expected_perms
 
     # deprecated, to remove in #5389
     permissions = data["user"]["permissions"]
-    assert len(permissions) == 2
     assert {perm["code"].lower() for perm in permissions} == expected_perms
 
     staff_user = User.objects.get(email=email)
@@ -1818,17 +1814,14 @@ def test_staff_update_groups_and_permissions(
     content = get_graphql_content(response)
     data = content["data"]["staffUpdate"]
     assert data["staffErrors"] == []
-    assert len(data["user"]["userPermissions"]) == 1
     assert {perm["code"].lower() for perm in data["user"]["userPermissions"]} == {
         permission_manage_orders.codename,
     }
-    assert len(data["user"]["permissionGroups"]) == 2
     assert {group["name"] for group in data["user"]["permissionGroups"]} == {
         group2.name,
         group3.name,
     }
     # deprecated, to remove in #5389
-    assert len(data["user"]["permissions"]) == 1
     assert {perm["code"].lower() for perm in data["user"]["permissions"]} == {
         permission_manage_orders.codename,
     }


### PR DESCRIPTION
Drop permissions input field from staff mutations. Groups will be used instead.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [x] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
