### PR TITLE
Fix: The products that are out of stock are not filtered as expected …

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -99,11 +99,10 @@ def sort_qs(qs, sort_by):
 
 
 def filter_products_by_stock_availability(qs, stock_availability):
-    qs = qs.annotate(total_quantity=Sum("variants__quantity"))
     if stock_availability == StockAvailability.IN_STOCK:
-        qs = qs.filter(total_quantity__gt=0)
+        qs = qs.filter(variants__quantity__isnull=False).extra(where=["product_productvariant.quantity > product_productvariant.quantity_allocated"]).distinct()
     elif stock_availability == StockAvailability.OUT_OF_STOCK:
-        qs = qs.filter(total_quantity=0)
+        qs = qs.filter(variants__quantity__isnull=False).extra(where=["product_productvariant.quantity <= product_productvariant.quantity_allocated"]).distinct()
     return qs
 
 


### PR DESCRIPTION
I want to merge this change because...

The products that are in stock, and out of stock, are not filtered as expected in the dashboard.

This modification:

- Validates the quantity in stock considering the quantity already allocated (if a product has quantity 5 and has a quantity allocated of 5 too, then the product should not be considered in stock).

- In case of an OUT_OF_STOCK query, if a variant is out of stock, then the product is considered out of stock.

Please note that with this modification, if a product P has two variants A and B, and the first one is in stock, and the second one is out of stock, then:

- An OUT_OF_STOCK query, returns P, because it as a variant out of stock.
- An IN_STOCK query, returns P too, because it as a variant in stock.

So, a product that has variants (more than 1), could be OUT_OF_STOCK and IN_STOCK at the same time.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [X] Privileged queries and mutations are guarded by proper permission checks
* [X] Database queries are optimized and the number of queries is constant
* [X] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
