### PR TITLE
Remove service account access to staff related operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add accountErrors to CreateToken as a required field - #5437 by @koradon
 - Raise GraphQLError if filter has not valid IDs - #5460 by @gabmartinez
 - Fix missing accountError when JSONWebTokenError is raised in CreateToken - #5465 by @koradon
+- Remove service account access to staff related operations - #5485 by @IKarbowiak
 
 ## 2.9.0
 

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -274,6 +274,7 @@ class BaseMutation(graphene.Mutation):
             return True
         service_account = getattr(context, "service_account", None)
         if service_account:
+            # for now MANAGE_STAFF permission for service account is not supported
             if AccountPermissions.MANAGE_STAFF in permissions:
                 return False
             return service_account.has_perms(permissions)

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -18,6 +18,7 @@ from graphql_jwt.exceptions import JSONWebTokenError, PermissionDenied
 
 from ...account import models
 from ...account.error_codes import AccountErrorCode
+from ...core.permissions import AccountPermissions
 from ..account.types import User
 from ..utils import get_nodes
 from .types import Error, Upload
@@ -272,8 +273,10 @@ class BaseMutation(graphene.Mutation):
         if context.user.has_perms(permissions):
             return True
         service_account = getattr(context, "service_account", None)
-        if service_account and service_account.has_perms(permissions):
-            return True
+        if service_account:
+            if AccountPermissions.MANAGE_STAFF in permissions:
+                return False
+            return service_account.has_perms(permissions)
         return False
 
     @classmethod

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -29,6 +29,7 @@ def _permission_required(perms: Iterable[Enum], context):
         return True
     service_account = getattr(context, "service_account", None)
     if service_account:
+        # for now MANAGE_STAFF permission for service account is not supported
         if AccountPermissions.MANAGE_STAFF in perms:
             return False
         return service_account.has_perms(perms)

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -5,6 +5,8 @@ from typing import Iterable, Union
 from graphql_jwt import exceptions
 from graphql_jwt.decorators import context
 
+from ..core.permissions import AccountPermissions
+
 
 def account_passes_test(test_func):
     """Determine if user/service_account has permission to access to content."""
@@ -26,8 +28,10 @@ def _permission_required(perms: Iterable[Enum], context):
     if context.user.has_perms(perms):
         return True
     service_account = getattr(context, "service_account", None)
-    if service_account and service_account.has_perms(perms):
-        return True
+    if service_account:
+        if AccountPermissions.MANAGE_STAFF in perms:
+            return False
+        return service_account.has_perms(perms)
     return False
 
 

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -1554,6 +1554,32 @@ def test_staff_create(
     )
 
 
+def test_staff_create_service_account_no_permission(
+    service_account_api_client,
+    staff_user,
+    media_root,
+    permission_group_manage_users,
+    permission_manage_products,
+    permission_manage_staff,
+    permission_manage_users,
+):
+    group = permission_group_manage_users
+    group.permissions.add(permission_manage_products)
+    staff_user.user_permissions.add(permission_manage_products, permission_manage_users)
+    email = "api_user@example.com"
+    variables = {
+        "email": email,
+        "redirect_url": "https://www.example.com",
+        "add_groups": [graphene.Node.to_global_id("Group", group.pk)],
+    }
+
+    response = service_account_api_client.post_graphql(
+        STAFF_CREATE_MUTATION, variables, permissions=[permission_manage_staff]
+    )
+
+    assert_no_permission(response)
+
+
 @patch("saleor.account.emails._send_set_password_email")
 def test_staff_create_out_of_scope_group(
     _send_set_password_email_mock,
@@ -1775,6 +1801,21 @@ def test_staff_update(staff_api_client, permission_manage_staff, media_root):
     assert not data["user"]["isActive"]
     # deprecated, to remove in #5389
     assert data["user"]["permissions"] == []
+
+
+def test_staff_update_service_account_no_permission(
+    service_account_api_client, permission_manage_staff, media_root
+):
+    query = STAFF_UPDATE_MUTATIONS
+    staff_user = User.objects.create(email="staffuser@example.com", is_staff=True)
+    id = graphene.Node.to_global_id("User", staff_user.id)
+    variables = {"id": id, "input": {"isActive": False}}
+
+    response = service_account_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_staff]
+    )
+
+    assert_no_permission(response)
 
 
 def test_staff_update_groups_and_permissions(
@@ -2173,6 +2214,21 @@ def test_staff_delete(staff_api_client, permission_manage_staff):
     data = content["data"]["staffDelete"]
     assert data["staffErrors"] == []
     assert not User.objects.filter(pk=staff_user.id).exists()
+
+
+def test_staff_delete_service_account_no_permission(
+    service_account_api_client, permission_manage_staff
+):
+    query = STAFF_DELETE_MUTATION
+    staff_user = User.objects.create(email="staffuser@example.com", is_staff=True)
+    user_id = graphene.Node.to_global_id("User", staff_user.id)
+    variables = {"id": user_id}
+
+    response = service_account_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_staff]
+    )
+
+    assert_no_permission(response)
 
 
 def test_staff_delete_out_of_scope_user(
@@ -3643,6 +3699,25 @@ def test_query_staff_members_with_filter_status(
     users = content["data"]["staffUsers"]["edges"]
 
     assert len(users) == count
+
+
+def test_query_staff_members_service_account_no_permission(
+    query_staff_users_with_filter, service_account_api_client, permission_manage_staff,
+):
+
+    User.objects.bulk_create(
+        [
+            User(email="second@example.com", is_staff=True, is_active=False),
+            User(email="third@example.com", is_staff=True, is_active=True),
+        ]
+    )
+
+    variables = {"filter": {"status": "DEACTIVATED"}}
+    response = service_account_api_client.post_graphql(
+        query_staff_users_with_filter, variables, permissions=[permission_manage_staff]
+    )
+
+    assert_no_permission(response)
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_meta_mutations.py
+++ b/tests/api/test_meta_mutations.py
@@ -179,21 +179,25 @@ def test_add_public_metadata_for_other_staff_as_staff(
     )
 
 
-def test_add_public_metadata_for_staff_as_service_account(
+def test_add_public_metadata_for_staff_as_service_account_no_permission(
     service_account_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PUBLIC_KEY, "value": PUBLIC_VALUE}],
+    }
 
     # when
-    response = execute_update_public_metadata_for_item(
-        service_account_api_client, permission_manage_staff, admin_id, "User"
+    response = service_account_api_client.post_graphql(
+        UPDATE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+        permissions=[permission_manage_staff],
     )
 
     # then
-    assert item_contains_proper_public_metadata(
-        response["data"]["updateMetadata"]["item"], admin_user, admin_id
-    )
+    assert_no_permission(response)
 
 
 def test_add_public_metadata_for_myself_as_customer(user_api_client):
@@ -656,23 +660,27 @@ def test_delete_public_metadata_for_other_staff_as_staff(
     )
 
 
-def test_delete_public_metadata_for_staff_as_service_account(
+def test_delete_public_metadata_for_staff_as_service_account_no_permission(
     service_account_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_user.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     admin_user.save(update_fields=["metadata"])
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PRIVATE_KEY],
+    }
 
     # when
-    response = execute_clear_public_metadata_for_item(
-        service_account_api_client, permission_manage_staff, admin_id, "User"
+    response = service_account_api_client.post_graphql(
+        DELETE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+        permissions=[permission_manage_staff],
     )
 
     # then
-    assert item_without_public_metadata(
-        response["data"]["deleteMetadata"]["item"], admin_user, admin_id
-    )
+    assert_no_permission(response)
 
 
 def test_delete_public_metadata_for_myself_as_customer(user_api_client):
@@ -1180,21 +1188,25 @@ def test_add_private_metadata_for_other_staff_as_staff(
     )
 
 
-def test_add_private_metadata_for_staff_as_service_account(
+def test_add_private_metadata_for_staff_as_service_account_no_permission(
     service_account_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "input": [{"key": PRIVATE_KEY, "value": PRIVATE_VALUE}],
+    }
 
     # when
-    response = execute_update_private_metadata_for_item(
-        service_account_api_client, permission_manage_staff, admin_id, "User"
+    response = service_account_api_client.post_graphql(
+        UPDATE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+        permissions=[permission_manage_staff],
     )
 
     # then
-    assert item_contains_proper_private_metadata(
-        response["data"]["updatePrivateMetadata"]["item"], admin_user, admin_id
-    )
+    assert_no_permission(response)
 
 
 def test_add_private_metadata_for_myself_as_customer_no_permission(user_api_client):
@@ -1677,23 +1689,27 @@ def test_delete_private_metadata_for_other_staff_as_staff(
     )
 
 
-def test_delete_private_metadata_for_staff_as_service_account(
+def test_delete_private_metadata_for_staff_as_service_account_no_permission(
     service_account_api_client, permission_manage_staff, admin_user
 ):
     # given
     admin_user.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
     admin_user.save(update_fields=["private_metadata"])
     admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+    variables = {
+        "id": admin_id,
+        "keys": [PRIVATE_KEY],
+    }
 
     # when
-    response = execute_clear_private_metadata_for_item(
-        service_account_api_client, permission_manage_staff, admin_id, "User"
+    response = service_account_api_client.post_graphql(
+        DELETE_PRIVATE_METADATA_MUTATION % "User",
+        variables,
+        permissions=[permission_manage_staff],
     )
 
     # then
-    assert item_without_private_metadata(
-        response["data"]["deletePrivateMetadata"]["item"], admin_user, admin_id
-    )
+    assert_no_permission(response)
 
 
 def test_delete_private_metadata_for_myself_as_customer_no_permission(user_api_client):

--- a/tests/api/test_meta_queries.py
+++ b/tests/api/test_meta_queries.py
@@ -137,12 +137,9 @@ def test_query_public_meta_for_staff_as_service_account(
     response = service_account_api_client.post_graphql(
         QUERY_USER_PUBLIC_META, variables, [permission_manage_staff]
     )
-    content = get_graphql_content(response)
 
     # then
-    metadata = content["data"]["user"]["metadata"][0]
-    assert metadata["key"] == PUBLIC_KEY
-    assert metadata["value"] == PUBLIC_VALUE
+    assert_no_permission(response)
 
 
 QUERY_CHECKOUT_PUBLIC_META = """
@@ -1480,12 +1477,9 @@ def test_query_private_meta_for_staff_as_service_account(
     response = service_account_api_client.post_graphql(
         QUERY_USER_PRIVATE_META, variables, [permission_manage_staff]
     )
-    content = get_graphql_content(response)
 
     # then
-    metadata = content["data"]["user"]["privateMetadata"][0]
-    assert metadata["key"] == PRIVATE_KEY
-    assert metadata["value"] == PRIVATE_VALUE
+    assert_no_permission(response)
 
 
 QUERY_CHECKOUT_PRIVATE_META = """


### PR DESCRIPTION
Ensure that the service account doesn't have access to any operation/query protected by `MANAGE_STAFF`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
