### PR TITLE
Drop useless handle typed errors methods

### DIFF
--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -383,20 +383,6 @@ class AttributeAssign(BaseMutation):
             )
 
     @classmethod
-    def handle_typed_errors(cls, errors: list, **extra):
-        typed_errors = [
-            cls._meta.error_type_class(  # type: ignore
-                field=e.field,
-                message=e.message,
-                code=code,
-                attributes=params.get("attributes") if params else None,
-            )
-            for e, code, params in errors
-        ]
-        extra.update({cls._meta.error_type_field: typed_errors})  # type: ignore
-        return cls(errors=[e[0] for e in errors], **extra)  # type: ignore
-
-    @classmethod
     def clean_operations(cls, product_type, product_attrs_pks, variant_attrs_pks):
         """Ensure the attributes are not already assigned to the product type."""
         attrs_pk = product_attrs_pks + variant_attrs_pks

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -99,20 +99,6 @@ class ShippingZoneMixin:
         return cleaned_input
 
     @classmethod
-    def handle_typed_errors(cls, errors: list, **extra):
-        typed_errors = [
-            cls._meta.error_type_class(  # type: ignore
-                field=e.field,
-                message=e.message,
-                code=code,
-                warehouses=params.get("warehouses") if params else None,
-            )
-            for e, code, params in errors
-        ]
-        extra.update({cls._meta.error_type_field: typed_errors})  # type: ignore
-        return cls(errors=[e[0] for e in errors], **extra)  # type: ignore
-
-    @classmethod
     @transaction.atomic
     def _save_m2m(cls, info, instance, cleaned_data):
         super()._save_m2m(info, instance, cleaned_data)


### PR DESCRIPTION
Drop useless handle typed errors methods - adding params is handle in BaseMutation right now.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
