### PR TITLE
Unify permission group mutations

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3043,9 +3043,9 @@ type PermissionGroupCreate {
 }
 
 input PermissionGroupCreateInput {
+  addPermissions: [PermissionEnum!]
+  addUsers: [ID!]
   name: String!
-  permissions: [PermissionEnum!]
-  users: [ID!]
 }
 
 type PermissionGroupDelete {
@@ -3093,10 +3093,10 @@ type PermissionGroupUpdate {
 }
 
 input PermissionGroupUpdateInput {
-  name: String
   addPermissions: [PermissionEnum!]
-  removePermissions: [PermissionEnum!]
   addUsers: [ID!]
+  name: String
+  removePermissions: [PermissionEnum!]
   removeUsers: [ID!]
 }
 

--- a/tests/api/benchmark/test_permission_group.py
+++ b/tests/api/benchmark/test_permission_group.py
@@ -52,11 +52,11 @@ def test_permission_group_create(
     variables = {
         "input": {
             "name": "New permission group",
-            "permissions": [
+            "addPermissions": [
                 AccountPermissions.MANAGE_USERS.name,
                 AccountPermissions.MANAGE_SERVICE_ACCOUNTS.name,
             ],
-            "users": [graphene.Node.to_global_id("User", staff_user.id)],
+            "addUsers": [graphene.Node.to_global_id("User", staff_user.id)],
         }
     }
     response = staff_api_client.post_graphql(


### PR DESCRIPTION
Unify `PermissionGroup` mutations to the solution which is used in `Staff` and `ShippingZone` mutations

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
