### PR TITLE
Use INVALID_CREDENTIALS instead of INVALID_PASSWORD error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add accountErrors to CreateToken as a required field - #5437 by @koradon
 - Raise GraphQLError if filter has not valid IDs - #5460 by @gabmartinez
 - Fix missing accountError when JSONWebTokenError is raised in CreateToken - #5465 by @koradon
+- Use AccountErrorCode.INVALID_CREDENTIALS instead of INVALID_PASSWORD - #5495 by @koradon
 
 ## 2.9.0
 

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -384,7 +384,8 @@ class RequestEmailChange(BaseMutation):
             raise ValidationError(
                 {
                     "password": ValidationError(
-                        "Password isn't valid.", code=AccountErrorCode.INVALID_PASSWORD
+                        "Password isn't valid.",
+                        code=AccountErrorCode.INVALID_CREDENTIALS,
                     )
                 }
             )

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -213,7 +213,7 @@ class PasswordChange(BaseMutation):
                 {
                     "old_password": ValidationError(
                         "Old password isn't valid.",
-                        code=AccountErrorCode.INVALID_PASSWORD,
+                        code=AccountErrorCode.INVALID_CREDENTIALS,
                     )
                 }
             )

--- a/tests/api/test_account.py
+++ b/tests/api/test_account.py
@@ -3269,7 +3269,7 @@ def test_request_email_change_with_invalid_password(user_api_client, customer_us
     content = get_graphql_content(response)
     data = content["data"]["requestEmailChange"]
     assert not data["user"]
-    assert data["accountErrors"][0]["code"] == AccountErrorCode.INVALID_PASSWORD.name
+    assert data["accountErrors"][0]["code"] == AccountErrorCode.INVALID_CREDENTIALS.name
     assert data["accountErrors"][0]["field"] == "password"
 
 


### PR DESCRIPTION
I want to merge this change because...
We introduce `AccountErrorCode.INVALID_CREDENTIALS` which is less restrictive and can be used in any field.
<!-- Please mention all relevant issue numbers. -->
fixes #5467 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
