### PR TITLE
Update populatedb_data.json to use new weight format.

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -36,7 +36,6 @@ from ...core.weight import zero_weight
 from ...discount import DiscountValueType, VoucherType
 from ...discount.models import Sale, Voucher
 from ...discount.utils import fetch_discounts
-from ...plugins.manager import get_plugins_manager
 from ...giftcard.models import GiftCard
 from ...menu.models import Menu
 from ...menu.utils import update_menu
@@ -45,6 +44,7 @@ from ...order.utils import update_order_status
 from ...page.models import Page
 from ...payment import gateway
 from ...payment.utils import create_payment
+from ...plugins.manager import get_plugins_manager
 from ...product.models import (
     AssignedProductAttribute,
     AssignedVariantAttribute,
@@ -137,7 +137,7 @@ COLLECTION_IMAGES = {1: "summer.jpg", 2: "clothing.jpg"}
 def get_weight(weight):
     if not weight:
         return zero_weight()
-    value, unit = weight.split()
+    value, unit = weight.split(":")
     return Weight(**{unit: value})
 
 

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -25,7 +25,7 @@
                 "entityMap": {}
             },
             "parent": null,
-            "background_image": "category-backgrounds/accessories_cXABqme.jpg",
+            "background_image": "category-backgrounds/accessories_D67x97h.jpg",
             "background_image_alt": "",
             "lft": 1,
             "rght": 6,
@@ -59,7 +59,7 @@
                 "entityMap": {}
             },
             "parent": null,
-            "background_image": "category-backgrounds/groceries_Q8EWi6D.jpg",
+            "background_image": "category-backgrounds/groceries_nY0iaoF.jpg",
             "background_image_alt": "",
             "lft": 1,
             "rght": 6,
@@ -93,7 +93,7 @@
                 "entityMap": {}
             },
             "parent": null,
-            "background_image": "category-backgrounds/apparel_8VnaY4M.jpg",
+            "background_image": "category-backgrounds/apparel_qlg6QDz.jpg",
             "background_image_alt": "",
             "lft": 1,
             "rght": 10,
@@ -114,7 +114,7 @@
             "description": "",
             "description_json": {},
             "parent": 9,
-            "background_image": "category-backgrounds/apparel_1nWUfHj.jpg",
+            "background_image": "category-backgrounds/apparel_nEuWqXt.jpg",
             "background_image_alt": "",
             "lft": 2,
             "rght": 3,
@@ -135,7 +135,7 @@
             "description": "",
             "description_json": {},
             "parent": 9,
-            "background_image": "category-backgrounds/apparel_WWKtSmD.jpg",
+            "background_image": "category-backgrounds/apparel_U7MxAWo.jpg",
             "background_image_alt": "",
             "lft": 4,
             "rght": 5,
@@ -156,7 +156,7 @@
             "description": "",
             "description_json": {},
             "parent": 9,
-            "background_image": "category-backgrounds/apparel_tkqrz7K.jpg",
+            "background_image": "category-backgrounds/apparel_xoziiPz.jpg",
             "background_image_alt": "",
             "lft": 6,
             "rght": 7,
@@ -177,7 +177,7 @@
             "description": "",
             "description_json": {},
             "parent": 9,
-            "background_image": "category-backgrounds/apparel_hOnlE29.jpg",
+            "background_image": "category-backgrounds/apparel_LfFdurb.jpg",
             "background_image_alt": "",
             "lft": 8,
             "rght": 9,
@@ -198,7 +198,7 @@
             "description": "",
             "description_json": {},
             "parent": 8,
-            "background_image": "category-backgrounds/groceries_FJ8dnIs.jpg",
+            "background_image": "category-backgrounds/groceries_6I5MN02.jpg",
             "background_image_alt": "",
             "lft": 2,
             "rght": 3,
@@ -219,7 +219,7 @@
             "description": "",
             "description_json": {},
             "parent": 8,
-            "background_image": "category-backgrounds/groceries_y8mVDcs.jpg",
+            "background_image": "category-backgrounds/groceries_UkB6ATa.jpg",
             "background_image_alt": "",
             "lft": 4,
             "rght": 5,
@@ -240,7 +240,7 @@
             "description": "",
             "description_json": {},
             "parent": 7,
-            "background_image": "category-backgrounds/accessories_gqxufm3.jpg",
+            "background_image": "category-backgrounds/accessories_jnRKK3i.jpg",
             "background_image_alt": "",
             "lft": 2,
             "rght": 3,
@@ -261,7 +261,7 @@
             "description": "",
             "description_json": {},
             "parent": 7,
-            "background_image": "category-backgrounds/accessories_PB9mWQO.jpg",
+            "background_image": "category-backgrounds/accessories_us8G3dU.jpg",
             "background_image_alt": "",
             "lft": 4,
             "rght": 5,
@@ -283,7 +283,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -300,7 +300,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "0.2 kg"
+            "weight": "0.2:kg"
         }
     },
     {
@@ -317,7 +317,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -334,7 +334,7 @@
             "has_variants": false,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -351,7 +351,7 @@
             "has_variants": false,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -368,7 +368,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "0.5 kg"
+            "weight": "0.5:kg"
         }
     },
     {
@@ -385,7 +385,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -402,7 +402,7 @@
             "has_variants": true,
             "is_shipping_required": true,
             "is_digital": false,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -443,10 +443,10 @@
             "category": 20,
             "currency": "USD",
             "price_amount": "15.00",
-            "minimal_variant_price_amount": "7.50",
-            "updated_at": "2020-01-29T14:07:37.851Z",
+            "minimal_variant_price_amount": "13.50",
+            "updated_at": "2020-04-17T14:22:48.130Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -484,9 +484,9 @@
             "currency": "USD",
             "price_amount": "15.00",
             "minimal_variant_price_amount": "15.00",
-            "updated_at": "2020-01-29T14:07:37.934Z",
+            "updated_at": "2020-04-17T14:22:32.078Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -523,10 +523,10 @@
             "category": 20,
             "currency": "USD",
             "price_amount": "15.00",
-            "minimal_variant_price_amount": "7.50",
-            "updated_at": "2020-01-29T14:07:37.915Z",
+            "minimal_variant_price_amount": "15.00",
+            "updated_at": "2020-04-17T14:22:48.352Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -563,10 +563,10 @@
             "category": 20,
             "currency": "USD",
             "price_amount": "15.00",
-            "minimal_variant_price_amount": "10.50",
-            "updated_at": "2020-01-29T14:07:37.836Z",
+            "minimal_variant_price_amount": "13.50",
+            "updated_at": "2020-04-17T14:22:48.436Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -603,10 +603,10 @@
             "category": 20,
             "currency": "USD",
             "price_amount": "15.00",
-            "minimal_variant_price_amount": "12.00",
-            "updated_at": "2020-01-29T14:07:37.831Z",
+            "minimal_variant_price_amount": "15.00",
+            "updated_at": "2020-04-17T14:22:48.573Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -644,9 +644,9 @@
             "currency": "USD",
             "price_amount": "3.00",
             "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.862Z",
+            "updated_at": "2020-04-17T14:22:33.321Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -683,10 +683,10 @@
             "category": 14,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "1.50",
-            "updated_at": "2020-01-29T14:07:37.765Z",
+            "minimal_variant_price_amount": "3.00",
+            "updated_at": "2020-04-17T14:22:49.025Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -724,9 +724,9 @@
             "currency": "USD",
             "price_amount": "3.00",
             "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.807Z",
+            "updated_at": "2020-04-17T14:22:33.818Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -763,10 +763,10 @@
             "category": 14,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "2.10",
-            "updated_at": "2020-01-29T14:07:37.773Z",
+            "minimal_variant_price_amount": "2.70",
+            "updated_at": "2020-04-17T14:22:49.191Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -803,10 +803,10 @@
             "category": 14,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.870Z",
+            "minimal_variant_price_amount": "1.50",
+            "updated_at": "2020-04-17T14:22:34.373Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -843,10 +843,10 @@
             "category": 14,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "1.50",
-            "updated_at": "2020-01-29T14:07:37.812Z",
+            "minimal_variant_price_amount": "2.10",
+            "updated_at": "2020-04-17T14:22:49.354Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -883,10 +883,10 @@
             "category": 14,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.909Z",
+            "minimal_variant_price_amount": "2.10",
+            "updated_at": "2020-04-17T14:22:34.921Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -924,9 +924,9 @@
             "currency": "USD",
             "price_amount": "3.00",
             "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.826Z",
+            "updated_at": "2020-04-17T14:22:35.164Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -964,9 +964,9 @@
             "currency": "USD",
             "price_amount": "3.00",
             "minimal_variant_price_amount": "3.00",
-            "updated_at": "2020-01-29T14:07:37.780Z",
+            "updated_at": "2020-04-17T14:22:35.431Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1003,10 +1003,10 @@
             "category": 15,
             "currency": "USD",
             "price_amount": "15.00",
-            "minimal_variant_price_amount": "15.00",
-            "updated_at": "2020-01-29T14:07:37.920Z",
+            "minimal_variant_price_amount": "13.50",
+            "updated_at": "2020-04-17T14:22:35.729Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1044,9 +1044,9 @@
             "currency": "USD",
             "price_amount": "15.00",
             "minimal_variant_price_amount": "15.00",
-            "updated_at": "2020-01-29T14:07:37.980Z",
+            "updated_at": "2020-04-17T14:22:36.016Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1083,10 +1083,10 @@
             "category": 15,
             "currency": "USD",
             "price_amount": "3.00",
-            "minimal_variant_price_amount": "1.50",
-            "updated_at": "2020-01-29T14:07:37.929Z",
+            "minimal_variant_price_amount": "3.00",
+            "updated_at": "2020-04-17T14:22:48.853Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1123,10 +1123,10 @@
             "category": 15,
             "currency": "USD",
             "price_amount": "3.20",
-            "minimal_variant_price_amount": "3.20",
-            "updated_at": "2020-01-29T14:07:37.925Z",
+            "minimal_variant_price_amount": "1.60",
+            "updated_at": "2020-04-17T14:22:37.171Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1163,10 +1163,10 @@
             "category": 22,
             "currency": "USD",
             "price_amount": "20.00",
-            "minimal_variant_price_amount": "20.00",
-            "updated_at": "2020-01-29T14:07:37.822Z",
+            "minimal_variant_price_amount": "18.00",
+            "updated_at": "2020-04-17T14:22:38.060Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1203,10 +1203,10 @@
             "category": 22,
             "currency": "USD",
             "price_amount": "20.00",
-            "minimal_variant_price_amount": "14.00",
-            "updated_at": "2020-01-29T14:07:37.968Z",
+            "minimal_variant_price_amount": "10.00",
+            "updated_at": "2020-04-17T14:22:48.969Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1244,9 +1244,9 @@
             "currency": "USD",
             "price_amount": "59.00",
             "minimal_variant_price_amount": "59.00",
-            "updated_at": "2020-01-29T14:07:37.990Z",
+            "updated_at": "2020-04-17T14:22:38.672Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1284,9 +1284,9 @@
             "currency": "USD",
             "price_amount": "49.00",
             "minimal_variant_price_amount": "24.50",
-            "updated_at": "2020-01-29T14:07:37.974Z",
+            "updated_at": "2020-04-17T14:22:49.883Z",
             "charge_taxes": true,
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1324,9 +1324,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.818Z",
+            "updated_at": "2020-04-17T14:22:40.481Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1363,10 +1363,10 @@
             "category": 11,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.876Z",
+            "minimal_variant_price_amount": "15.00",
+            "updated_at": "2020-04-17T14:22:40.970Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1404,9 +1404,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.883Z",
+            "updated_at": "2020-04-17T14:22:41.332Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1443,10 +1443,10 @@
             "category": 11,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.892Z",
+            "minimal_variant_price_amount": "15.00",
+            "updated_at": "2020-04-17T14:22:41.931Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1484,9 +1484,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.903Z",
+            "updated_at": "2020-04-17T14:22:42.300Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1524,9 +1524,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "15.00",
-            "updated_at": "2020-01-29T14:07:37.945Z",
+            "updated_at": "2020-04-17T14:22:50.773Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1563,10 +1563,10 @@
             "category": 10,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "24.00",
-            "updated_at": "2020-01-29T14:07:37.939Z",
+            "minimal_variant_price_amount": "30.00",
+            "updated_at": "2020-04-17T14:22:50.918Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1603,10 +1603,10 @@
             "category": 10,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "24.00",
-            "updated_at": "2020-01-29T14:07:37.956Z",
+            "minimal_variant_price_amount": "30.00",
+            "updated_at": "2020-04-17T14:22:51.187Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1644,9 +1644,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.951Z",
+            "updated_at": "2020-04-17T14:22:45.309Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1683,10 +1683,10 @@
             "category": 12,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "21.00",
-            "updated_at": "2020-01-29T14:07:37.789Z",
+            "minimal_variant_price_amount": "30.00",
+            "updated_at": "2020-04-17T14:22:51.476Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1724,9 +1724,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.798Z",
+            "updated_at": "2020-04-17T14:22:46.458Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1764,9 +1764,9 @@
             "currency": "USD",
             "price_amount": "30.00",
             "minimal_variant_price_amount": "30.00",
-            "updated_at": "2020-01-29T14:07:37.842Z",
+            "updated_at": "2020-04-17T14:22:46.791Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1803,10 +1803,10 @@
             "category": 12,
             "currency": "USD",
             "price_amount": "30.00",
-            "minimal_variant_price_amount": "15.00",
-            "updated_at": "2020-01-29T14:07:37.961Z",
+            "minimal_variant_price_amount": "27.00",
+            "updated_at": "2020-04-17T14:22:52.023Z",
             "charge_taxes": true,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1824,7 +1824,7 @@
             "quantity": 116,
             "quantity_allocated": 17,
             "cost_price_amount": "5.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1842,7 +1842,7 @@
             "quantity": 22,
             "quantity_allocated": 3,
             "cost_price_amount": "10.00",
-            "weight": "2.5 kg"
+            "weight": "2.5:kg"
         }
     },
     {
@@ -1860,7 +1860,7 @@
             "quantity": 15,
             "quantity_allocated": 15,
             "cost_price_amount": "20.00",
-            "weight": "5.0 kg"
+            "weight": "5.0:kg"
         }
     },
     {
@@ -1878,7 +1878,7 @@
             "quantity": 43,
             "quantity_allocated": 19,
             "cost_price_amount": "5.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1896,7 +1896,7 @@
             "quantity": 110,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1914,7 +1914,7 @@
             "quantity": 125,
             "quantity_allocated": 14,
             "cost_price_amount": "25.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -1932,7 +1932,7 @@
             "quantity": 1235,
             "quantity_allocated": 4,
             "cost_price_amount": "5.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -1950,7 +1950,7 @@
             "quantity": 1223,
             "quantity_allocated": 12,
             "cost_price_amount": "10.00",
-            "weight": "2.5 kg"
+            "weight": "2.5:kg"
         }
     },
     {
@@ -1968,7 +1968,7 @@
             "quantity": 475,
             "quantity_allocated": 30,
             "cost_price_amount": "20.00",
-            "weight": "5.0 kg"
+            "weight": "5.0:kg"
         }
     },
     {
@@ -1986,7 +1986,7 @@
             "quantity": 998,
             "quantity_allocated": 12,
             "cost_price_amount": "5.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2004,7 +2004,7 @@
             "quantity": 760,
             "quantity_allocated": 9,
             "cost_price_amount": "10.00",
-            "weight": "2.5 kg"
+            "weight": "2.5:kg"
         }
     },
     {
@@ -2022,7 +2022,7 @@
             "quantity": 587,
             "quantity_allocated": 16,
             "cost_price_amount": "15.00",
-            "weight": "5.0 kg"
+            "weight": "5.0:kg"
         }
     },
     {
@@ -2040,7 +2040,7 @@
             "quantity": 427,
             "quantity_allocated": 16,
             "cost_price_amount": "5.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2058,7 +2058,7 @@
             "quantity": 516,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "2.5 kg"
+            "weight": "2.5:kg"
         }
     },
     {
@@ -2076,7 +2076,7 @@
             "quantity": 159,
             "quantity_allocated": 18,
             "cost_price_amount": "15.00",
-            "weight": "5.0 kg"
+            "weight": "5.0:kg"
         }
     },
     {
@@ -2094,7 +2094,7 @@
             "quantity": 1221,
             "quantity_allocated": 10,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2112,7 +2112,7 @@
             "quantity": 183,
             "quantity_allocated": 8,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2130,7 +2130,7 @@
             "quantity": 221,
             "quantity_allocated": 10,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2148,7 +2148,7 @@
             "quantity": 21244,
             "quantity_allocated": 13,
             "cost_price_amount": null,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2166,7 +2166,7 @@
             "quantity": 12159,
             "quantity_allocated": 28,
             "cost_price_amount": null,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2184,7 +2184,7 @@
             "quantity": 12141,
             "quantity_allocated": 20,
             "cost_price_amount": null,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2202,7 +2202,7 @@
             "quantity": 975534,
             "quantity_allocated": 17,
             "cost_price_amount": null,
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2220,7 +2220,7 @@
             "quantity": 9873,
             "quantity_allocated": 12,
             "cost_price_amount": "11.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2238,7 +2238,7 @@
             "quantity": 687,
             "quantity_allocated": 16,
             "cost_price_amount": "12.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2256,7 +2256,7 @@
             "quantity": 573,
             "quantity_allocated": 2,
             "cost_price_amount": "13.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2274,7 +2274,7 @@
             "quantity": 1020,
             "quantity_allocated": 21,
             "cost_price_amount": "13.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2292,7 +2292,7 @@
             "quantity": 1224,
             "quantity_allocated": 13,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2310,7 +2310,7 @@
             "quantity": 179,
             "quantity_allocated": 4,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2328,7 +2328,7 @@
             "quantity": 227,
             "quantity_allocated": 16,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2346,7 +2346,7 @@
             "quantity": 1220,
             "quantity_allocated": 9,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2364,7 +2364,7 @@
             "quantity": 185,
             "quantity_allocated": 10,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2382,7 +2382,7 @@
             "quantity": 223,
             "quantity_allocated": 12,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2400,7 +2400,7 @@
             "quantity": 1219,
             "quantity_allocated": 8,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2418,7 +2418,7 @@
             "quantity": 188,
             "quantity_allocated": 13,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2436,7 +2436,7 @@
             "quantity": 225,
             "quantity_allocated": 14,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2454,7 +2454,7 @@
             "quantity": 1219,
             "quantity_allocated": 8,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2472,7 +2472,7 @@
             "quantity": 191,
             "quantity_allocated": 16,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2490,7 +2490,7 @@
             "quantity": 225,
             "quantity_allocated": 14,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2508,7 +2508,7 @@
             "quantity": 1214,
             "quantity_allocated": 3,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2526,7 +2526,7 @@
             "quantity": 182,
             "quantity_allocated": 7,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2544,7 +2544,7 @@
             "quantity": 238,
             "quantity_allocated": 27,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2562,7 +2562,7 @@
             "quantity": 1222,
             "quantity_allocated": 11,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2580,7 +2580,7 @@
             "quantity": 178,
             "quantity_allocated": 3,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2598,7 +2598,7 @@
             "quantity": 224,
             "quantity_allocated": 13,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2616,7 +2616,7 @@
             "quantity": 1218,
             "quantity_allocated": 7,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2634,7 +2634,7 @@
             "quantity": 181,
             "quantity_allocated": 6,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2652,7 +2652,7 @@
             "quantity": 238,
             "quantity_allocated": 27,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2670,7 +2670,7 @@
             "quantity": 1221,
             "quantity_allocated": 10,
             "cost_price_amount": "1.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2688,7 +2688,7 @@
             "quantity": 181,
             "quantity_allocated": 6,
             "cost_price_amount": "1.50",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2706,7 +2706,7 @@
             "quantity": 237,
             "quantity_allocated": 26,
             "cost_price_amount": "2.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2724,7 +2724,7 @@
             "quantity": 9125,
             "quantity_allocated": 4,
             "cost_price_amount": "20.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2742,7 +2742,7 @@
             "quantity": 1,
             "quantity_allocated": 0,
             "cost_price_amount": "20.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2760,7 +2760,7 @@
             "quantity": 2,
             "quantity_allocated": 1,
             "cost_price_amount": "20.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2778,7 +2778,7 @@
             "quantity": 133,
             "quantity_allocated": 2,
             "cost_price_amount": "20.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2796,7 +2796,7 @@
             "quantity": 884,
             "quantity_allocated": 23,
             "cost_price_amount": "20.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2814,7 +2814,7 @@
             "quantity": 7625,
             "quantity_allocated": 14,
             "cost_price_amount": "10.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2832,7 +2832,7 @@
             "quantity": 980,
             "quantity_allocated": 9,
             "cost_price_amount": "20.00",
-            "weight": "1.0 kg"
+            "weight": "1.0:kg"
         }
     },
     {
@@ -2850,7 +2850,7 @@
             "quantity": 0,
             "quantity_allocated": 0,
             "cost_price_amount": null,
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2868,7 +2868,7 @@
             "quantity": 27,
             "quantity_allocated": 27,
             "cost_price_amount": "20.00",
-            "weight": "2.0 kg"
+            "weight": "2.0:kg"
         }
     },
     {
@@ -2886,7 +2886,7 @@
             "quantity": 1217,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2904,7 +2904,7 @@
             "quantity": 11,
             "quantity_allocated": 10,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2922,7 +2922,7 @@
             "quantity": 9819,
             "quantity_allocated": 1,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2940,7 +2940,7 @@
             "quantity": 2,
             "quantity_allocated": 1,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2958,7 +2958,7 @@
             "quantity": 5804,
             "quantity_allocated": 13,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2976,7 +2976,7 @@
             "quantity": 1227,
             "quantity_allocated": 14,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -2994,7 +2994,7 @@
             "quantity": 14,
             "quantity_allocated": 13,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3012,7 +3012,7 @@
             "quantity": 9822,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3030,7 +3030,7 @@
             "quantity": 5,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3048,7 +3048,7 @@
             "quantity": 5823,
             "quantity_allocated": 32,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3066,7 +3066,7 @@
             "quantity": 1217,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3084,7 +3084,7 @@
             "quantity": 9,
             "quantity_allocated": 8,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3102,7 +3102,7 @@
             "quantity": 9818,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3120,7 +3120,7 @@
             "quantity": 3,
             "quantity_allocated": 2,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3138,7 +3138,7 @@
             "quantity": 5820,
             "quantity_allocated": 29,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3156,7 +3156,7 @@
             "quantity": 1220,
             "quantity_allocated": 7,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3174,7 +3174,7 @@
             "quantity": 2,
             "quantity_allocated": 1,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3192,7 +3192,7 @@
             "quantity": 9823,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3210,7 +3210,7 @@
             "quantity": 7,
             "quantity_allocated": 6,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3228,7 +3228,7 @@
             "quantity": 5821,
             "quantity_allocated": 30,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3246,7 +3246,7 @@
             "quantity": 1223,
             "quantity_allocated": 10,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3264,7 +3264,7 @@
             "quantity": 9,
             "quantity_allocated": 8,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3282,7 +3282,7 @@
             "quantity": 9818,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3300,7 +3300,7 @@
             "quantity": 8,
             "quantity_allocated": 7,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3318,7 +3318,7 @@
             "quantity": 5817,
             "quantity_allocated": 26,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3336,7 +3336,7 @@
             "quantity": 1217,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3354,7 +3354,7 @@
             "quantity": 10,
             "quantity_allocated": 9,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3372,7 +3372,7 @@
             "quantity": 9824,
             "quantity_allocated": 6,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3390,7 +3390,7 @@
             "quantity": 2,
             "quantity_allocated": 1,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3408,7 +3408,7 @@
             "quantity": 5808,
             "quantity_allocated": 17,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3426,7 +3426,7 @@
             "quantity": 1220,
             "quantity_allocated": 7,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3444,7 +3444,7 @@
             "quantity": 9,
             "quantity_allocated": 8,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3462,7 +3462,7 @@
             "quantity": 9821,
             "quantity_allocated": 3,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3480,7 +3480,7 @@
             "quantity": 5,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3498,7 +3498,7 @@
             "quantity": 5812,
             "quantity_allocated": 21,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3516,7 +3516,7 @@
             "quantity": 1221,
             "quantity_allocated": 8,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3534,7 +3534,7 @@
             "quantity": 6,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3552,7 +3552,7 @@
             "quantity": 9818,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3570,7 +3570,7 @@
             "quantity": 2,
             "quantity_allocated": 1,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3588,7 +3588,7 @@
             "quantity": 5817,
             "quantity_allocated": 26,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3606,7 +3606,7 @@
             "quantity": 1213,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3624,7 +3624,7 @@
             "quantity": 3,
             "quantity_allocated": 2,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3642,7 +3642,7 @@
             "quantity": 9822,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3660,7 +3660,7 @@
             "quantity": 7,
             "quantity_allocated": 6,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3678,7 +3678,7 @@
             "quantity": 5808,
             "quantity_allocated": 17,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3696,7 +3696,7 @@
             "quantity": 1217,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3714,7 +3714,7 @@
             "quantity": 4,
             "quantity_allocated": 3,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3732,7 +3732,7 @@
             "quantity": 9823,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3750,7 +3750,7 @@
             "quantity": 1,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3768,7 +3768,7 @@
             "quantity": 5833,
             "quantity_allocated": 42,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3786,7 +3786,7 @@
             "quantity": 1224,
             "quantity_allocated": 11,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3804,7 +3804,7 @@
             "quantity": 11,
             "quantity_allocated": 10,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3822,7 +3822,7 @@
             "quantity": 9822,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3840,7 +3840,7 @@
             "quantity": 9,
             "quantity_allocated": 8,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3858,7 +3858,7 @@
             "quantity": 5812,
             "quantity_allocated": 21,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3876,7 +3876,7 @@
             "quantity": 1218,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3894,7 +3894,7 @@
             "quantity": 15,
             "quantity_allocated": 14,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3912,7 +3912,7 @@
             "quantity": 9823,
             "quantity_allocated": 5,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3930,7 +3930,7 @@
             "quantity": 3,
             "quantity_allocated": 2,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3948,7 +3948,7 @@
             "quantity": 5810,
             "quantity_allocated": 19,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3966,7 +3966,7 @@
             "quantity": 1217,
             "quantity_allocated": 4,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -3984,7 +3984,7 @@
             "quantity": 14,
             "quantity_allocated": 13,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -4002,7 +4002,7 @@
             "quantity": 9818,
             "quantity_allocated": 0,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -4020,7 +4020,7 @@
             "quantity": 3,
             "quantity_allocated": 2,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -4038,7 +4038,7 @@
             "quantity": 5818,
             "quantity_allocated": 27,
             "cost_price_amount": "10.00",
-            "weight": "0.0 kg"
+            "weight": "0.0:kg"
         }
     },
     {
@@ -6456,7 +6456,7 @@
         "fields": {
             "sort_order": 0,
             "product": 61,
-            "image": "products/saleordemoproduct_paints_01_oAlKeNM.png",
+            "image": "products/saleordemoproduct_paints_01_stdygda.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6467,7 +6467,7 @@
         "fields": {
             "sort_order": 0,
             "product": 62,
-            "image": "products/saleordemoproduct_paints_02_DZyELXo.png",
+            "image": "products/saleordemoproduct_paints_02_5n8zsUA.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6478,7 +6478,7 @@
         "fields": {
             "sort_order": 0,
             "product": 63,
-            "image": "products/saleordemoproduct_paints_03_tElEpXM.png",
+            "image": "products/saleordemoproduct_paints_03_wk2MTHi.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6489,7 +6489,7 @@
         "fields": {
             "sort_order": 0,
             "product": 64,
-            "image": "products/saleordemoproduct_paints_04_N0yrhDp.png",
+            "image": "products/saleordemoproduct_paints_04_DU4zZqT.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6500,7 +6500,7 @@
         "fields": {
             "sort_order": 0,
             "product": 65,
-            "image": "products/saleordemoproduct_paints_05_9ZaltWy.png",
+            "image": "products/saleordemoproduct_paints_05_juemr1c.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6511,7 +6511,7 @@
         "fields": {
             "sort_order": 0,
             "product": 71,
-            "image": "products/saleordemoproduct_fd_juice_06_HceOLxL.png",
+            "image": "products/saleordemoproduct_fd_juice_06_k9z7OUO.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6522,7 +6522,7 @@
         "fields": {
             "sort_order": 0,
             "product": 72,
-            "image": "products/saleordemoproduct_fd_juice_06_tfQaLPL.png",
+            "image": "products/saleordemoproduct_fd_juice_06_RjWl7u8.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6533,7 +6533,7 @@
         "fields": {
             "sort_order": 0,
             "product": 73,
-            "image": "products/saleordemoproduct_fd_juice_05_sZZW2Xo.png",
+            "image": "products/saleordemoproduct_fd_juice_05_MzkPidl.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6544,7 +6544,7 @@
         "fields": {
             "sort_order": 0,
             "product": 74,
-            "image": "products/saleordemoproduct_fd_juice_01_IPQVJWG.png",
+            "image": "products/saleordemoproduct_fd_juice_01_V6506Ts.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6555,7 +6555,7 @@
         "fields": {
             "sort_order": 0,
             "product": 75,
-            "image": "products/saleordemoproduct_fd_juice_03_9xujWY3.png",
+            "image": "products/saleordemoproduct_fd_juice_03_O142bWS.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6566,7 +6566,7 @@
         "fields": {
             "sort_order": 0,
             "product": 76,
-            "image": "products/saleordemoproduct_fd_juice_02_VcpACWv.png",
+            "image": "products/saleordemoproduct_fd_juice_02_BAzvnlK.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6577,7 +6577,7 @@
         "fields": {
             "sort_order": 0,
             "product": 77,
-            "image": "products/saleordemoproduct_fd_juice_03_i6kE2Y9.png",
+            "image": "products/saleordemoproduct_fd_juice_03_lZiLGKI.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6588,7 +6588,7 @@
         "fields": {
             "sort_order": 0,
             "product": 78,
-            "image": "products/saleordemoproduct_fd_juice_04_IJpmarG.png",
+            "image": "products/saleordemoproduct_fd_juice_04_g36b7LH.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6599,7 +6599,7 @@
         "fields": {
             "sort_order": 0,
             "product": 79,
-            "image": "products/saleordemoproduct_fd_juice_02_QNMJ5El.png",
+            "image": "products/saleordemoproduct_fd_juice_02_z9aL4aX.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6610,7 +6610,7 @@
         "fields": {
             "sort_order": 0,
             "product": 81,
-            "image": "products/saleordemoproduct_wine-red_Za6fbDb.png",
+            "image": "products/saleordemoproduct_wine-red_51nip0Q.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6621,7 +6621,7 @@
         "fields": {
             "sort_order": 0,
             "product": 82,
-            "image": "products/saleordemoproduct_wine-white_mFtF5hS.png",
+            "image": "products/saleordemoproduct_wine-white_e3ay13x.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6632,7 +6632,7 @@
         "fields": {
             "sort_order": 0,
             "product": 83,
-            "image": "products/saleordemoproduct_beer-02_1_4UI6ZYf.png",
+            "image": "products/saleordemoproduct_beer-02_1_G0GYtom.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6643,7 +6643,7 @@
         "fields": {
             "sort_order": 1,
             "product": 83,
-            "image": "products/saleordemoproduct_beer-02_2_nw4WMKj.png",
+            "image": "products/saleordemoproduct_beer-02_2_4yjTwGr.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6654,7 +6654,7 @@
         "fields": {
             "sort_order": 0,
             "product": 84,
-            "image": "products/saleordemoproduct_beer-01_1_5855gQX.png",
+            "image": "products/saleordemoproduct_beer-01_1_TunfUiv.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6665,7 +6665,7 @@
         "fields": {
             "sort_order": 1,
             "product": 84,
-            "image": "products/saleordemoproduct_beer-01_2_CtUhcIw.png",
+            "image": "products/saleordemoproduct_beer-01_2_ESV0Rte.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6676,7 +6676,7 @@
         "fields": {
             "sort_order": 0,
             "product": 85,
-            "image": "products/saleordemoproduct_cuschion01_WTYMHuY.png",
+            "image": "products/saleordemoproduct_cuschion01_pBGkXlA.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6687,7 +6687,7 @@
         "fields": {
             "sort_order": 0,
             "product": 86,
-            "image": "products/saleordemoproduct_cuschion02_HkMKj9u.png",
+            "image": "products/saleordemoproduct_cuschion02_YJsGAlj.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6698,7 +6698,7 @@
         "fields": {
             "sort_order": 0,
             "product": 87,
-            "image": "products/saleordemoproduct_sneakers_01_1_cYWlNte.png",
+            "image": "products/saleordemoproduct_sneakers_01_1_2r1OBiC.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6709,7 +6709,7 @@
         "fields": {
             "sort_order": 1,
             "product": 87,
-            "image": "products/saleordemoproduct_sneakers_01_2_1wpPloj.png",
+            "image": "products/saleordemoproduct_sneakers_01_2_34nhuNf.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6720,7 +6720,7 @@
         "fields": {
             "sort_order": 2,
             "product": 87,
-            "image": "products/saleordemoproduct_sneakers_01_3_93AdOzU.png",
+            "image": "products/saleordemoproduct_sneakers_01_3_9EUjwva.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6731,7 +6731,7 @@
         "fields": {
             "sort_order": 3,
             "product": 87,
-            "image": "products/saleordemoproduct_sneakers_01_4_oHljbOJ.png",
+            "image": "products/saleordemoproduct_sneakers_01_4_GnWInHA.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6742,7 +6742,7 @@
         "fields": {
             "sort_order": 0,
             "product": 88,
-            "image": "products/saleordemoproduct_sneakers_02_1_YEgefnA.png",
+            "image": "products/saleordemoproduct_sneakers_02_1_RlhHWcA.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6753,7 +6753,7 @@
         "fields": {
             "sort_order": 1,
             "product": 88,
-            "image": "products/saleordemoproduct_sneakers_02_2_dHzce7A.png",
+            "image": "products/saleordemoproduct_sneakers_02_2_WQmqmQD.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6764,7 +6764,7 @@
         "fields": {
             "sort_order": 2,
             "product": 88,
-            "image": "products/saleordemoproduct_sneakers_02_3_Z5uIzzB.png",
+            "image": "products/saleordemoproduct_sneakers_02_3_YylCXxs.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6775,7 +6775,7 @@
         "fields": {
             "sort_order": 3,
             "product": 88,
-            "image": "products/saleordemoproduct_sneakers_02_4_N3wSwso.png",
+            "image": "products/saleordemoproduct_sneakers_02_4_Gu0yFCa.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6786,7 +6786,7 @@
         "fields": {
             "sort_order": 0,
             "product": 89,
-            "image": "products/saleordemoproduct_cl_boot07_1_TBfMKTC.png",
+            "image": "products/saleordemoproduct_cl_boot07_1_tWVidbh.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6797,7 +6797,7 @@
         "fields": {
             "sort_order": 1,
             "product": 89,
-            "image": "products/saleordemoproduct_cl_boot07_2_2ivN4rh.png",
+            "image": "products/saleordemoproduct_cl_boot07_2_U3hk3Hh.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6808,7 +6808,7 @@
         "fields": {
             "sort_order": 0,
             "product": 107,
-            "image": "products/saleordemoproduct_cl_polo01_QzVHHcm.png",
+            "image": "products/saleordemoproduct_cl_polo01_yCZRhZO.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6819,7 +6819,7 @@
         "fields": {
             "sort_order": 0,
             "product": 108,
-            "image": "products/saleordemoproduct_cl_polo02_ciJhqR3.png",
+            "image": "products/saleordemoproduct_cl_polo02_wZTQnGf.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6830,7 +6830,7 @@
         "fields": {
             "sort_order": 0,
             "product": 109,
-            "image": "products/saleordemoproduct_cl_polo03-woman_n6YLhKo.png",
+            "image": "products/saleordemoproduct_cl_polo03-woman_J9K34ZP.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6841,7 +6841,7 @@
         "fields": {
             "sort_order": 0,
             "product": 110,
-            "image": "products/saleordemoproduct_cl_polo04-woman_CodBZ5u.png",
+            "image": "products/saleordemoproduct_cl_polo04-woman_mQe8FkA.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6852,7 +6852,7 @@
         "fields": {
             "sort_order": 0,
             "product": 111,
-            "image": "products/saleordemoproduct_cl_boot01_1_VcJYN2e.png",
+            "image": "products/saleordemoproduct_cl_boot01_1_bLHxD4F.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6863,7 +6863,7 @@
         "fields": {
             "sort_order": 1,
             "product": 111,
-            "image": "products/saleordemoproduct_cl_boot01_2_UOZKCom.png",
+            "image": "products/saleordemoproduct_cl_boot01_2_9k9Mz4l.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6874,7 +6874,7 @@
         "fields": {
             "sort_order": 2,
             "product": 111,
-            "image": "products/saleordemoproduct_cl_boot01_3_57XgZyv.png",
+            "image": "products/saleordemoproduct_cl_boot01_3_oveC30U.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6885,7 +6885,7 @@
         "fields": {
             "sort_order": 0,
             "product": 112,
-            "image": "products/saleordemoproduct_cl_boot03_1_6Rn0nQC.png",
+            "image": "products/saleordemoproduct_cl_boot03_1_biaCKC2.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6896,7 +6896,7 @@
         "fields": {
             "sort_order": 1,
             "product": 112,
-            "image": "products/saleordemoproduct_cl_boot03_2_yhoyRpu.png",
+            "image": "products/saleordemoproduct_cl_boot03_2_2r0mXDy.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6907,7 +6907,7 @@
         "fields": {
             "sort_order": 0,
             "product": 113,
-            "image": "products/saleordemoproduct_cl_boot06_1_UcBLi8k.png",
+            "image": "products/saleordemoproduct_cl_boot06_1_9i85eGr.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6918,7 +6918,7 @@
         "fields": {
             "sort_order": 1,
             "product": 113,
-            "image": "products/saleordemoproduct_cl_boot06_2_k9ZWc6e.png",
+            "image": "products/saleordemoproduct_cl_boot06_2_Oo2Xhzm.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6929,7 +6929,7 @@
         "fields": {
             "sort_order": 0,
             "product": 114,
-            "image": "products/saleordemoproduct_cl_boot06_1_09Hhw6s.png",
+            "image": "products/saleordemoproduct_cl_boot06_1_k99mhKI.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6940,7 +6940,7 @@
         "fields": {
             "sort_order": 1,
             "product": 114,
-            "image": "products/saleordemoproduct_cl_boot06_2_7cmpaDa.png",
+            "image": "products/saleordemoproduct_cl_boot06_2_JAHsuvj.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6951,7 +6951,7 @@
         "fields": {
             "sort_order": 0,
             "product": 115,
-            "image": "products/saleordemoproduct_cl_bogo01_1_ZTxBvNd.png",
+            "image": "products/saleordemoproduct_cl_bogo01_1_j7H8d5R.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6962,7 +6962,7 @@
         "fields": {
             "sort_order": 0,
             "product": 116,
-            "image": "products/saleordemoproduct_cl_bogo02_1_q4DzbUK.png",
+            "image": "products/saleordemoproduct_cl_bogo02_1_0zMVF4G.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6973,7 +6973,7 @@
         "fields": {
             "sort_order": 0,
             "product": 117,
-            "image": "products/saleordemoproduct_cl_bogo03_1_kqGABYk.png",
+            "image": "products/saleordemoproduct_cl_bogo03_1_ECVOjfU.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6984,7 +6984,7 @@
         "fields": {
             "sort_order": 0,
             "product": 118,
-            "image": "products/saleordemoproduct_cl_bogo04_1_GXXZ6Xy.png",
+            "image": "products/saleordemoproduct_cl_bogo04_1_Yw7vYBV.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -6995,7 +6995,7 @@
         "fields": {
             "sort_order": 1,
             "product": 118,
-            "image": "products/saleordemoproduct_cl_bogo04_2_5aI63Yw.png",
+            "image": "products/saleordemoproduct_cl_bogo04_2_7AACjM1.png",
             "ppoi": "0.5x0.5",
             "alt": ""
         }
@@ -7084,7 +7084,7 @@
             "seo_description": null,
             "name": "Summer collection",
             "slug": "summer-collection",
-            "background_image": "collection-backgrounds/summer_4axBcWf.jpg",
+            "background_image": "collection-backgrounds/summer_NwQRrlU.jpg",
             "background_image_alt": "",
             "description": "The Saleor Summer Collection features a range of products that feel the heat of the market. A demo store for all seasons. Saleor captures the open source, e-commerce sun.",
             "description_json": {
@@ -7115,7 +7115,7 @@
             "seo_description": null,
             "name": "Winter sale",
             "slug": "winter-sale",
-            "background_image": "collection-backgrounds/clothing_AagrQJ0.jpg",
+            "background_image": "collection-backgrounds/clothing_5N8owkB.jpg",
             "background_image_alt": "",
             "description": "The Saleor Winter Sale is snowed under with seasonal offers. Unreal products at unreal prices. Literally, they are not real products, but the Saleor demo store is a genuine e-commerce leader.",
             "description_json": {


### PR DESCRIPTION
# Summary
* Update populatedb_data.json
* Fix random_data.py line splitting on weight inputs
* Run pre-commit

In the future, to update the populate_db.json all one needs to do is run
```console
$ python manage.py dumpdata products saleor/static/_populatedb_data.json
```

Then use some file merge tool (such as PyCharm's merge tool) to copy over the manual changes to the file (ie the inventory counts that are not programmatic). In the future, it might we wise to make this randomly generated and not dependant on the `populatedb_data.json` file.

# Impact

* ~New migrations~
* ~New/Updated API fields or mutations~
* ~Deprecated API fields or mutations~
* ~Removed API types, fields, or mutations~

Fixes #5290

# Pull Request Checklist

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
