### PR TITLE
Remove unused permission from db

### DIFF
--- a/saleor/account/migrations/0040_auto_20200415_0443.py
+++ b/saleor/account/migrations/0040_auto_20200415_0443.py
@@ -25,6 +25,9 @@ def change_extension_permission_to_plugin_permission(apps, schema_editor):
         user.user_permissions.remove(extension_permission)
         user.user_permissions.add(plugin_permission)
 
+    if extension_permission:
+        extension_permission.delete()
+
 
 class Migration(migrations.Migration):
 


### PR DESCRIPTION
I want to merge this change because...after renaming permission from `extension permission` to `plugin permission`, I want to delete permission with old name.
[#5487](https://github.com/mirumee/saleor/pull/5487)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [X] Privileged queries and mutations are guarded by proper permission checks
* [X] Database queries are optimized and the number of queries is constant
* [X] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
