### PR TITLE
 Fix typo on get used attribute values for variant name function

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -45,7 +45,7 @@ from ...warehouse.types import Warehouse
 from ..types import Category, Collection, Product, ProductImage, ProductVariant
 from ..utils import (
     create_stocks,
-    get_used_attibute_values_for_variant,
+    get_used_attribute_values_for_variant,
     get_used_variants_attribute_values,
     validate_attribute_input_for_product,
     validate_attribute_input_for_variant,
@@ -1324,7 +1324,7 @@ class ProductVariantUpdate(ProductVariantCreate):
         # Check if the variant is getting updated,
         # and the assigned attributes do not change
         if instance.product_id is not None:
-            assigned_attributes = get_used_attibute_values_for_variant(instance)
+            assigned_attributes = get_used_attribute_values_for_variant(instance)
             input_attribute_values = defaultdict(list)
             for attribute in attributes:
                 input_attribute_values[attribute.id].extend(attribute.values)

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -56,7 +56,7 @@ def validate_attribute_input_for_variant(instance: "Attribute", values: List[str
         )
 
 
-def get_used_attibute_values_for_variant(variant):
+def get_used_attribute_values_for_variant(variant):
     """Create a dict of attributes values for variant.
 
     Sample result is:
@@ -97,7 +97,7 @@ def get_used_variants_attribute_values(product):
     )
     used_attribute_values = []
     for variant in variants:
-        attribute_values = get_used_attibute_values_for_variant(variant)
+        attribute_values = get_used_attribute_values_for_variant(variant)
         used_attribute_values.append(attribute_values)
     return used_attribute_values
 


### PR DESCRIPTION
This PR fixes a simple typo in a function on product graphql utils file.

**get_used_attibute_values_for_variant** 

becomes

**get_used_attribute_values_for_variant**

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
