### PR TITLE
Drop no longer valid quantity input fields

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -28,7 +28,6 @@ from ....product.utils.attributes import (
     associate_attribute_values_to_instance,
     generate_name_for_variant,
 )
-from ....warehouse.management import set_stock_quantity
 from ...core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ...core.scalars import Decimal, WeightScalar
 from ...core.types import SeoInput, Upload
@@ -526,13 +525,6 @@ class ProductInput(graphene.InputObjectType):
             "a product doesn't use variants."
         )
     )
-    quantity = graphene.Int(
-        description=(
-            "[Deprecated] Use stocks input field instead. This field will be removed "
-            "after 2020-07-31. The total quantity of a product available for sale. "
-            "Note: this field is only used if a product doesn't use variants."
-        ),
-    )
     track_inventory = graphene.Boolean(
         description=(
             "Determines if the inventory of this product should be tracked. If false, "
@@ -951,11 +943,8 @@ class ProductCreate(ModelMutation):
                 product=instance, track_inventory=track_inventory, sku=sku
             )
             stocks = cleaned_input.get("stocks")
-            quantity = cleaned_input.get("quantity")
             if stocks:
                 cls.create_variant_stocks(variant, stocks)
-            elif quantity:  # DEPRECATED: Will be removed in 2.11 (issue #5325)
-                set_stock_quantity(variant, info.context.country, quantity)
 
         attributes = cleaned_input.get("attributes")
         if attributes:
@@ -1023,11 +1012,6 @@ class ProductUpdate(ProductCreate):
             if "track_inventory" in cleaned_input:
                 variant.track_inventory = cleaned_input["track_inventory"]
                 update_fields.append("track_inventory")
-            # DEPRECATED: Wil be removed in 2.11 (issue #5325).
-            # Use ProductVariantStocksUpdate insted.
-            if "quantity" in cleaned_input:
-                quantity = cleaned_input.get("quantity")
-                set_stock_quantity(variant, info.context.country, quantity)
             if "sku" in cleaned_input:
                 variant.sku = cleaned_input["sku"]
                 update_fields.append("sku")
@@ -1102,12 +1086,6 @@ class ProductVariantInput(graphene.InputObjectType):
     cost_price = Decimal(description="Cost price of the variant.")
     price_override = Decimal(description="Special price of the particular variant.")
     sku = graphene.String(description="Stock keeping unit.")
-    quantity = graphene.Int(
-        description=(
-            "[Deprecated] Use stocks input field instead. This field will be removed "
-            "after 2020-07-31. The total quantity of this variant available for sale."
-        ),
-    )
     track_inventory = graphene.Boolean(
         description=(
             "Determines if the inventory of this variant should be tracked. If false, "
@@ -1280,11 +1258,8 @@ class ProductVariantCreate(ModelMutation):
         # Recalculate the "minimal variant price" for the parent product
         update_product_minimal_variant_price_task.delay(instance.product_id)
         stocks = cleaned_input.get("stocks")
-        quantity = cleaned_input.get("quantity")
         if stocks:
             cls.create_variant_stocks(instance, stocks)
-        elif quantity:  # DEPRECATED: Will be removed in 2.11 (issue #5325)
-            set_stock_quantity(instance, info.context.country, quantity)
 
         attributes = cleaned_input.get("attributes")
         if attributes:

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -163,15 +163,14 @@ class ProductPricingInfo(BasePricingInfo):
 class ProductVariant(CountableDjangoObjectType):
     quantity = graphene.Int(
         required=True,
-        description="Quantity of a product in the store's possession, "
-        "including the allocated stock that is waiting for shipment.",
+        description="Quantity of a product available for sale.",
         deprecation_reason=(
             "Use the stock field instead. This field will be removed after 2020-07-31."
         ),
     )
     quantity_allocated = graphene.Int(
         required=False,
-        description="Quantity allocated for orders",
+        description="Quantity allocated for orders.",
         deprecation_reason=(
             "Use the stock field instead. This field will be removed after 2020-07-31."
         ),

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3252,7 +3252,6 @@ input ProductCreateInput {
   seo: SeoInput
   weight: WeightScalar
   sku: String
-  quantity: Int
   trackInventory: Boolean
   productType: ID!
   stocks: [StockInput!]
@@ -3366,7 +3365,6 @@ input ProductInput {
   seo: SeoInput
   weight: WeightScalar
   sku: String
-  quantity: Int
   trackInventory: Boolean
 }
 
@@ -3609,7 +3607,6 @@ input ProductVariantBulkCreateInput {
   costPrice: Decimal
   priceOverride: Decimal
   sku: String!
-  quantity: Int
   trackInventory: Boolean
   weight: WeightScalar
 }
@@ -3654,7 +3651,6 @@ input ProductVariantCreateInput {
   costPrice: Decimal
   priceOverride: Decimal
   sku: String
-  quantity: Int
   trackInventory: Boolean
   weight: WeightScalar
   product: ID!
@@ -3672,7 +3668,6 @@ input ProductVariantInput {
   costPrice: Decimal
   priceOverride: Decimal
   sku: String
-  quantity: Int
   trackInventory: Boolean
   weight: WeightScalar
 }


### PR DESCRIPTION
Drop no longer valid quantity input fields from Product and Variant mutations.
Resolves #5325

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [x] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
