### PR TITLE
Fix: Multiple Checkouts

### DIFF
--- a/saleor/static/js/components/disable-button.js
+++ b/saleor/static/js/components/disable-button.js
@@ -1,0 +1,10 @@
+export default $(document).ready(e => {
+    let $formButton = $('form:has(.btn-only-once)');
+    if (!$formButton)
+        return;
+    $formButton.submit(function(e){
+        let $button = $('.btn-only-once', $(this));
+        $button.prop('disabled', true);
+    })
+});
+  

--- a/saleor/static/js/storefront.js
+++ b/saleor/static/js/storefront.js
@@ -16,3 +16,4 @@ import "./components/sorter";
 import "./components/styleguide";
 import "./components/variant-picker";
 import "./components/description-json";
+import "./components/disable-button"

--- a/templates/checkout/summary.html
+++ b/templates/checkout/summary.html
@@ -12,7 +12,7 @@
       <h2>{% trans "Add a note to your order" context "Checkout summary note title" %}</h2>
           {% bootstrap_form note_form show_label=False %}
       <p class="text-md-right">
-        <button type="submit" class="btn btn-primary">
+        <button type="submit" class="btn btn-primary btn-only-once">
           {% trans "Order & Pay" context "Checkout summary primary action" %}
         </button>
       </p>


### PR DESCRIPTION
I want to merge this change because...

When I click the "Order & Pay" button in the frontstore, multiple orders are created at once.
To avoid multiple orders creation, at UI level, the button is dissabled once was clicked.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [X] Privileged queries and mutations are guarded by proper permission checks
* [X] Database queries are optimized and the number of queries is constant
* [X] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [X] Changes are mentioned in the changelog
