### PR TITLE
Add order fulfill mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add job abstract model and interface - #5510 by @IKarbowiak
 - Refactor implementation of allocation - #5445 by @fowczarek
 - Fix WeightScalar - #5530 by @koradon
+- Add OrderFulfill mutation - #5525 by @fowczarek
 
 ## 2.9.0
 

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -22,7 +22,6 @@ from .mutations.fulfillments import (
     FulfillmentCancel,
     FulfillmentClearMeta,
     FulfillmentClearPrivateMeta,
-    FulfillmentCreate,
     FulfillmentUpdateMeta,
     FulfillmentUpdatePrivateMeta,
     FulfillmentUpdateTracking,
@@ -175,7 +174,6 @@ class OrderMutations(graphene.ObjectType):
     )
     order_fulfill = OrderFulfill.Field()
     order_fulfillment_cancel = FulfillmentCancel.Field()
-    order_fulfillment_create = FulfillmentCreate.Field()
     order_fulfillment_update_tracking = FulfillmentUpdateTracking.Field()
     order_fulfillment_clear_meta = FulfillmentClearMeta.Field(
         deprecation_reason=(

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -26,6 +26,7 @@ from .mutations.fulfillments import (
     FulfillmentUpdateMeta,
     FulfillmentUpdatePrivateMeta,
     FulfillmentUpdateTracking,
+    OrderFulfill,
 )
 from .mutations.orders import (
     OrderAddNote,
@@ -172,6 +173,7 @@ class OrderMutations(graphene.ObjectType):
             "after 2020-07-31."
         )
     )
+    order_fulfill = OrderFulfill.Field()
     order_fulfillment_cancel = FulfillmentCancel.Field()
     order_fulfillment_create = FulfillmentCreate.Field()
     order_fulfillment_update_tracking = FulfillmentUpdateTracking.Field()

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -21,6 +21,7 @@ from ..meta.types import ObjectWithMetadata
 from ..payment.types import OrderAction, Payment, PaymentChargeStatusEnum
 from ..product.types import ProductVariant
 from ..shipping.types import ShippingMethod
+from ..warehouse.types import Warehouse
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum
 from .utils import validate_draft_order
 
@@ -169,6 +170,11 @@ class Fulfillment(CountableDjangoObjectType):
         FulfillmentLine, description="List of lines for the fulfillment."
     )
     status_display = graphene.String(description="User-friendly fulfillment status.")
+    warehouse = graphene.Field(
+        Warehouse,
+        required=False,
+        description=("Warehouse from fulfillment was fulfilled."),
+    )
 
     class Meta:
         description = "Represents order fulfillment."
@@ -189,6 +195,11 @@ class Fulfillment(CountableDjangoObjectType):
     @staticmethod
     def resolve_status_display(root: models.Fulfillment, _info):
         return root.get_status_display()
+
+    @staticmethod
+    def resolve_warehouse(root: models.Fulfillment, _info):
+        line = root.lines.first()
+        return line.stock.warehouse if line and line.stock else None
 
     @staticmethod
     @permission_required(OrderPermissions.MANAGE_ORDERS)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1774,28 +1774,10 @@ type FulfillmentClearPrivateMeta {
   fulfillment: Fulfillment
 }
 
-type FulfillmentCreate {
-  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  fulfillment: Fulfillment
-  order: Order
-  orderErrors: [OrderError!]!
-}
-
-input FulfillmentCreateInput {
-  trackingNumber: String
-  notifyCustomer: Boolean
-  lines: [FulfillmentLineInput]!
-}
-
 type FulfillmentLine implements Node {
   id: ID!
   quantity: Int!
   orderLine: OrderLine
-}
-
-input FulfillmentLineInput {
-  orderLineId: ID
-  quantity: Int
 }
 
 enum FulfillmentStatus {
@@ -2404,7 +2386,6 @@ type Mutation {
   orderClearMeta(input: MetaPath!, token: UUID!): OrderClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
   orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
-  orderFulfillmentCreate(input: FulfillmentCreateInput!, order: ID): FulfillmentCreate
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
   orderFulfillmentClearMeta(id: ID!, input: MetaPath!): FulfillmentClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderFulfillmentClearPrivateMeta(id: ID!, input: MetaPath!): FulfillmentClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1751,6 +1751,7 @@ type Fulfillment implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   lines: [FulfillmentLine]
   statusDisplay: String
+  warehouse: Warehouse
 }
 
 type FulfillmentCancel {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2673,6 +2673,7 @@ enum OrderErrorCode {
   VOID_INACTIVE_PAYMENT
   ZERO_QUANTITY
   INSUFFICIENT_STOCK
+  DUPLICATED_INPUT_ITEM
 }
 
 type OrderEvent implements Node {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2402,6 +2402,7 @@ type Mutation {
   orderCapture(amount: Decimal!, id: ID!): OrderCapture
   orderClearPrivateMeta(id: ID!, input: MetaPath!): OrderClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation instead. This field will be removed after 2020-07-31.")
   orderClearMeta(input: MetaPath!, token: UUID!): OrderClearMeta @deprecated(reason: "Use the `deleteMetadata` mutation instead. This field will be removed after 2020-07-31.")
+  orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
   orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
   orderFulfillmentCreate(input: FulfillmentCreateInput!, order: ID): FulfillmentCreate
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
@@ -2767,6 +2768,28 @@ input OrderFilterInput {
   customer: String
   created: DateRangeInput
   search: String
+}
+
+type OrderFulfill {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  fulfillments: [Fulfillment]
+  order: Order
+  orderErrors: [OrderError!]!
+}
+
+input OrderFulfillInput {
+  lines: [OrderFulfillLineInput!]!
+  notifyCustomer: Boolean
+}
+
+input OrderFulfillLineInput {
+  orderLineId: ID
+  stocks: [OrderFulfillStockInput!]!
+}
+
+input OrderFulfillStockInput {
+  quantity: Int
+  warehouse: ID
 }
 
 type OrderLine implements Node {

--- a/saleor/order/error_codes.py
+++ b/saleor/order/error_codes.py
@@ -23,3 +23,4 @@ class OrderErrorCode(Enum):
     VOID_INACTIVE_PAYMENT = "void_inactive_payment"
     ZERO_QUANTITY = "zero_quantity"
     INSUFFICIENT_STOCK = "insufficient_stock"
+    DUPLICATED_INPUT_ITEM = "duplicated_input_item"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1211,9 +1211,11 @@ def fulfilled_order(order_with_lines):
     line_1 = order.lines.first()
     line_2 = order.lines.last()
     fulfillment.lines.create(order_line=line_1, quantity=line_1.quantity)
-    fulfill_order_line(line_1, line_1.quantity)
+    warehouse_1_pk = line_1.allocations.get().stock.warehouse.pk
+    fulfill_order_line(line_1, line_1.quantity, warehouse_1_pk)
     fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity)
-    fulfill_order_line(line_2, line_2.quantity)
+    warehouse_2_pk = line_2.allocations.get().stock.warehouse.pk
+    fulfill_order_line(line_2, line_2.quantity, warehouse_2_pk)
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
     return order

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1207,14 +1207,16 @@ def order_events(order):
 @pytest.fixture
 def fulfilled_order(order_with_lines):
     order = order_with_lines
-    fulfillment = order.fulfillments.create()
+    fulfillment = order.fulfillments.create(tracking_number="123")
     line_1 = order.lines.first()
+    stock_1 = line_1.allocations.get().stock
+    warehouse_1_pk = stock_1.warehouse.pk
     line_2 = order.lines.last()
-    fulfillment.lines.create(order_line=line_1, quantity=line_1.quantity)
-    warehouse_1_pk = line_1.allocations.get().stock.warehouse.pk
+    stock_2 = line_2.allocations.get().stock
+    warehouse_2_pk = stock_2.warehouse.pk
+    fulfillment.lines.create(order_line=line_1, quantity=line_1.quantity, stock=stock_1)
     fulfill_order_line(line_1, line_1.quantity, warehouse_1_pk)
-    fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity)
-    warehouse_2_pk = line_2.allocations.get().stock.warehouse.pk
+    fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity, stock=stock_2)
     fulfill_order_line(line_2, line_2.quantity, warehouse_2_pk)
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])

--- a/tests/test_fulfullments_actions.py
+++ b/tests/test_fulfullments_actions.py
@@ -1,0 +1,317 @@
+from unittest.mock import patch
+
+import pytest
+
+from saleor.core.exceptions import InsufficientStock
+from saleor.order.actions import create_fulfillments
+from saleor.order.models import FulfillmentLine, OrderStatus
+from saleor.warehouse.models import Allocation, Stock
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    [fulfillment] = create_fulfillments(
+        staff_user, order, fulfillment_lines_for_warehouses, True
+    )
+
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == order_line1.variant.stocks.get()
+    assert fulfillment_lines[0].quantity == 3
+    assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
+    assert fulfillment_lines[1].quantity == 2
+
+    assert order.status == OrderStatus.FULFILLED
+    assert order.fulfillments.get() == fulfillment
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 3
+    assert order_line2.quantity_fulfilled == 2
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 0
+    )
+
+    mock_email_fulfillment.assert_called_once_with(
+        order, order.fulfillments.get(), staff_user
+    )
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_without_email(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    [fulfillment] = create_fulfillments(
+        staff_user, order, fulfillment_lines_for_warehouses, False
+    )
+
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == order_line1.variant.stocks.get()
+    assert fulfillment_lines[0].quantity == 3
+    assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
+    assert fulfillment_lines[1].quantity == 2
+
+    assert order.status == OrderStatus.FULFILLED
+    assert order.fulfillments.get() == fulfillment
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 3
+    assert order_line2.quantity_fulfilled == 2
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 0
+    )
+
+    mock_email_fulfillment.assert_not_called()
+
+
+def test_create_fulfillments_many_warehouses(
+    staff_user, order_with_lines, warehouses,
+):
+    order = order_with_lines
+    warehouse1, warehouse2 = warehouses
+    order_line1, order_line2 = order.lines.all()
+
+    stock_w1_l1 = Stock(
+        warehouse=warehouse1, product_variant=order_line1.variant, quantity=3
+    )
+    stock_w1_l2 = Stock(
+        warehouse=warehouse1, product_variant=order_line2.variant, quantity=1
+    )
+    stock_w2_l2 = Stock(
+        warehouse=warehouse2, product_variant=order_line2.variant, quantity=1
+    )
+    Stock.objects.bulk_create([stock_w1_l1, stock_w1_l2, stock_w2_l2])
+    fulfillment_lines_for_warehouses = {
+        str(warehouse1.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 1},
+        ],
+        str(warehouse2.pk): [{"order_line": order_line2, "quantity": 1}],
+    }
+
+    [fulfillment1, fulfillment2] = create_fulfillments(
+        staff_user, order, fulfillment_lines_for_warehouses, False
+    )
+
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == stock_w1_l1
+    assert fulfillment_lines[0].quantity == 3
+    assert fulfillment_lines[1].stock == stock_w1_l2
+    assert fulfillment_lines[1].quantity == 1
+    assert fulfillment_lines[2].stock == stock_w2_l2
+    assert fulfillment_lines[2].quantity == 1
+
+    assert order.status == OrderStatus.FULFILLED
+    assert order.fulfillments.get(fulfillment_order=1) == fulfillment1
+    assert order.fulfillments.get(fulfillment_order=2) == fulfillment2
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 3
+    assert order_line2.quantity_fulfilled == 2
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 0
+    )
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_with_one_line_empty_quantity(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": 0},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    [fulfillment] = create_fulfillments(
+        staff_user, order, fulfillment_lines_for_warehouses, True
+    )
+
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == order_line2.variant.stocks.get()
+    assert fulfillment_lines[0].quantity == 2
+
+    assert order.status == OrderStatus.PARTIALLY_FULFILLED
+    assert order.fulfillments.get() == fulfillment
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 0
+    assert order_line2.quantity_fulfilled == 2
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 1
+    )
+
+    mock_email_fulfillment.assert_called_once_with(
+        order, order.fulfillments.get(), staff_user
+    )
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_without_allocations(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    Allocation.objects.filter(order_line__order=order).delete()
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    [fulfillment] = create_fulfillments(
+        staff_user, order, fulfillment_lines_for_warehouses, True
+    )
+
+    order.refresh_from_db()
+    fulfillment_lines = FulfillmentLine.objects.filter(
+        fulfillment__order=order
+    ).order_by("pk")
+    assert fulfillment_lines[0].stock == order_line1.variant.stocks.get()
+    assert fulfillment_lines[0].quantity == 3
+    assert fulfillment_lines[1].stock == order_line2.variant.stocks.get()
+    assert fulfillment_lines[1].quantity == 2
+
+    assert order.status == OrderStatus.FULFILLED
+    assert order.fulfillments.get() == fulfillment
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 3
+    assert order_line2.quantity_fulfilled == 2
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 0
+    )
+
+    mock_email_fulfillment.assert_called_once_with(
+        order, order.fulfillments.get(), staff_user
+    )
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_warehouse_with_out_of_stock(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    order_line1.allocations.all().delete()
+    stock = order_line1.variant.stocks.get(warehouse=warehouse)
+    stock.quantity = 2
+    stock.save(update_fields=["quantity"])
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    with pytest.raises(InsufficientStock):
+        create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
+
+    order.refresh_from_db()
+    assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.fulfillments.all().count() == 0
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 0
+    assert order_line2.quantity_fulfilled == 0
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 1
+    )
+
+    mock_email_fulfillment.assert_not_called()
+
+
+@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
+def test_create_fulfillments_warehouse_without_stock(
+    mock_email_fulfillment, staff_user, order_with_lines, warehouse_no_shipping_zone,
+):
+    order = order_with_lines
+    order_line1, order_line2 = order.lines.all()
+    fulfillment_lines_for_warehouses = {
+        str(warehouse_no_shipping_zone.pk): [
+            {"order_line": order_line1, "quantity": 3},
+            {"order_line": order_line2, "quantity": 2},
+        ]
+    }
+
+    with pytest.raises(InsufficientStock):
+        create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
+
+    order.refresh_from_db()
+    assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0
+
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.fulfillments.all().count() == 0
+
+    order_line1, order_line2 = order.lines.all()
+    assert order_line1.quantity_fulfilled == 0
+    assert order_line2.quantity_fulfilled == 0
+
+    assert (
+        Allocation.objects.filter(
+            order_line__order=order, quantity_allocated__gt=0
+        ).count()
+        == 2
+    )
+
+    mock_email_fulfillment.assert_not_called()

--- a/tests/test_order_actions.py
+++ b/tests/test_order_actions.py
@@ -174,7 +174,7 @@ def test_fulfill_order_line(order_with_lines):
     stock = Stock.objects.get(product_variant=variant)
     stock_quantity_after = stock.quantity - line.quantity
 
-    fulfill_order_line(line, line.quantity)
+    fulfill_order_line(line, line.quantity, stock.warehouse.pk)
 
     stock.refresh_from_db()
     assert stock.quantity == stock_quantity_after
@@ -187,7 +187,7 @@ def test_fulfill_order_line_with_variant_deleted(order_with_lines):
 
     line.refresh_from_db()
 
-    fulfill_order_line(line, line.quantity)
+    fulfill_order_line(line, line.quantity, "warehouse_pk")
 
 
 def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
@@ -202,7 +202,7 @@ def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
     # stock should not change
     stock_quantity_after = stock.quantity
 
-    fulfill_order_line(line, line.quantity)
+    fulfill_order_line(line, line.quantity, stock.warehouse.pk)
 
     stock.refresh_from_db()
     assert stock.quantity == stock_quantity_after


### PR DESCRIPTION
I want to merge this change because 
1. [x] Add order fulfill mutation
1. [x] Remove fulfillment create mutation
1. [x] Add warehouse to fulfillment query

![mermaid-diagram-20200423111429](https://user-images.githubusercontent.com/43955230/80081910-e17bfb00-8553-11ea-8976-c7f425c76db8.png)


Known problems should be resolve in separate PR's:
1. ~~We should move the whole logic related to create fulfilments outside mutation.~~(Done after review)
2. We should make all stocks and allocations in one time for all fulfillments(allow `decrease_stock` to handle many lines on one call)
3. After point 2. we should refactor fulfillment create to deallocate all stock in one operation instead of doing it line by line. 



# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [x] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
