### PR TITLE
Fix/weight scalar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add tests for pagination - #5468 by @koradon
 - Add job abstract model and interface - #5510 by @IKarbowiak
 - Refactor implementation of allocation - #5445 by @fowczarek
+- Fix WeightScalar - #5530 by @koradon
 
 ## 2.9.0
 

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -2,6 +2,7 @@ import decimal
 
 import graphene
 from graphql.language import ast
+from graphql.error import GraphQLError
 from measurement.measures import Weight
 
 from ...core.weight import convert_weight, get_default_weight_unit
@@ -46,7 +47,7 @@ class WeightScalar(graphene.Scalar):
             default_unit = get_default_weight_unit()
             weight = Weight(**{default_unit: value})
         if not weight:
-            raise ValueError(f"Unsupported value: {value}")
+            raise GraphQLError(f"Unsupported value: {value}")
         return weight
 
     @staticmethod
@@ -66,7 +67,7 @@ class WeightScalar(graphene.Scalar):
         else:
             weight = WeightScalar.parse_literal_decimal(node)
         if not weight:
-            raise ValueError(f"Unsupported value: {node.value}")
+            raise GraphQLError(f"Unsupported value: {node.value}")
         return weight
 
     @staticmethod
@@ -88,7 +89,7 @@ class WeightScalar(graphene.Scalar):
                 try:
                     value = decimal.Decimal(field.value.value)
                 except decimal.DecimalException:
-                    return None
+                    raise GraphQLError(f"Unsupported value: {field.value.value}")
             if field.name.value == "unit":
                 unit = field.value.value
         return Weight(**{unit: value})

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -1,6 +1,7 @@
 import decimal
 
 import graphene
+from graphql.language import ast
 from measurement.measures import Weight
 
 from ...core.weight import convert_weight, get_default_weight_unit
@@ -34,14 +35,19 @@ class Decimal(graphene.Float):
 class WeightScalar(graphene.Scalar):
     @staticmethod
     def parse_value(value):
-        # Expects value to be a string "amount unit" separated by a single
-        # space.
-        try:
-            value = decimal.Decimal(value)
-        except decimal.DecimalException:
-            return None
-        default_unit = get_default_weight_unit()
-        return Weight(**{default_unit: value})
+        weight = None
+        if isinstance(value, dict):
+            weight = Weight(**{value["unit"]: value["value"]})
+        else:
+            try:
+                value = decimal.Decimal(value)
+            except decimal.DecimalException:
+                return None
+            default_unit = get_default_weight_unit()
+            weight = Weight(**{default_unit: value})
+        if not weight:
+            raise ValueError()
+        return weight
 
     @staticmethod
     def serialize(weight):
@@ -54,4 +60,35 @@ class WeightScalar(graphene.Scalar):
 
     @staticmethod
     def parse_literal(node):
-        return node
+        weight = None
+        if isinstance(node, ast.ObjectValue):
+            weight = WeightScalar.parse_literal_object(node)
+        else:
+            weight = WeightScalar.parse_literal_decimal(node)
+        if not weight:
+            raise ValueError()
+        return weight
+
+    @staticmethod
+    def parse_literal_decimal(node):
+        try:
+            value = decimal.Decimal(node.value)
+        except decimal.DecimalException:
+            return None
+        default_unit = get_default_weight_unit()
+        return Weight(**{default_unit: value})
+
+    @staticmethod
+    def parse_literal_object(node):
+        value = 0
+        unit = get_default_weight_unit()
+
+        for field in node.fields:
+            if field.name.value == "value":
+                try:
+                    value = decimal.Decimal(field.value.value)
+                except decimal.DecimalException:
+                    return None
+            if field.name.value == "unit":
+                unit = field.value.value
+        return Weight(**{unit: value})

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -46,7 +46,7 @@ class WeightScalar(graphene.Scalar):
             default_unit = get_default_weight_unit()
             weight = Weight(**{default_unit: value})
         if not weight:
-            raise ValueError()
+            raise ValueError(f"Unsupported value: {node.value}")
         return weight
 
     @staticmethod
@@ -66,7 +66,7 @@ class WeightScalar(graphene.Scalar):
         else:
             weight = WeightScalar.parse_literal_decimal(node)
         if not weight:
-            raise ValueError()
+            raise ValueError(f"Unsupported value: {node.value}")
         return weight
 
     @staticmethod

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -40,12 +40,7 @@ class WeightScalar(graphene.Scalar):
         if isinstance(value, dict):
             weight = Weight(**{value["unit"]: value["value"]})
         else:
-            try:
-                value = decimal.Decimal(value)
-            except decimal.DecimalException:
-                return None
-            default_unit = get_default_weight_unit()
-            weight = Weight(**{default_unit: value})
+            weight = WeightScalar.parse_decimal(value)
         if not weight:
             raise GraphQLError(f"Unsupported value: {value}")
         return weight
@@ -65,15 +60,15 @@ class WeightScalar(graphene.Scalar):
         if isinstance(node, ast.ObjectValue):
             weight = WeightScalar.parse_literal_object(node)
         else:
-            weight = WeightScalar.parse_literal_decimal(node)
+            weight = WeightScalar.parse_decimal(node.value)
         if not weight:
             raise GraphQLError(f"Unsupported value: {node.value}")
         return weight
 
     @staticmethod
-    def parse_literal_decimal(node):
+    def parse_decimal(value):
         try:
-            value = decimal.Decimal(node.value)
+            value = decimal.Decimal(value)
         except decimal.DecimalException:
             return None
         default_unit = get_default_weight_unit()

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -46,7 +46,7 @@ class WeightScalar(graphene.Scalar):
             default_unit = get_default_weight_unit()
             weight = Weight(**{default_unit: value})
         if not weight:
-            raise ValueError(f"Unsupported value: {node.value}")
+            raise ValueError(f"Unsupported value: {value}")
         return weight
 
     @staticmethod

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -3971,7 +3971,6 @@ mutation createProduct(
         $category: ID!
         $name: String!,
         $sku: String,
-        $quantity: Int,
         $basePrice: Decimal!
         $weight: WeightScalar
         $trackInventory: Boolean)
@@ -3983,7 +3982,6 @@ mutation createProduct(
                 name: $name,
                 sku: $sku,
                 trackInventory: $trackInventory,
-                quantity: $quantity,
                 basePrice: $basePrice,
                 weight: $weight
             })
@@ -4019,7 +4017,6 @@ mutation createProduct(
         $category: ID!
         $name: String!,
         $sku: String,
-        $quantity: Int,
         $basePrice: Decimal!
         $trackInventory: Boolean)
     {{
@@ -4030,7 +4027,6 @@ mutation createProduct(
                 name: $name,
                 sku: $sku,
                 trackInventory: $trackInventory,
-                quantity: $quantity,
                 basePrice: $basePrice,
                 weight: {weight}
             }})
@@ -4088,7 +4084,6 @@ def test_create_product_with_weight_variable(
         "category": category_id,
         "productType": product_type_id,
         "name": "Test",
-        "quantity": 8,
         "sku": "23434",
         "trackInventory": True,
         "basePrice": Decimal("19"),
@@ -4134,7 +4129,6 @@ def test_create_product_with_weight_input(
         "category": category_id,
         "productType": product_type_id,
         "name": "Test",
-        "quantity": 8,
         "sku": "23434",
         "trackInventory": True,
         "basePrice": Decimal("19"),

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -4066,38 +4066,38 @@ def test_create_product_with_weight_input(
 ):
     # Because we use Scalars for Weight this test query tests only a scenario when
     # weight value is passed by directly in input
-    MUTATION_CREATE_PRODUCT_WITH_WEIGHT_GQL_INPUT = f"""
-mutation createProduct(
-        $productType: ID!,
-        $category: ID!
-        $name: String!,
-        $sku: String,
-        $basePrice: Decimal!)
-    {{
-        productCreate(
-            input: {{
-                category: $category,
-                productType: $productType,
-                name: $name,
-                sku: $sku,
-                basePrice: $basePrice,
-                weight: {weight}
-            }})
+    query = f"""
+    mutation createProduct(
+            $productType: ID!,
+            $category: ID!
+            $name: String!,
+            $sku: String,
+            $basePrice: Decimal!)
         {{
-            product {{
-                id
-                weight{{
-                    value
-                    unit
+            productCreate(
+                input: {{
+                    category: $category,
+                    productType: $productType,
+                    name: $name,
+                    sku: $sku,
+                    basePrice: $basePrice,
+                    weight: {weight}
+                }})
+            {{
+                product {{
+                    id
+                    weight{{
+                        value
+                        unit
+                    }}
+                }}
+                productErrors {{
+                    message
+                    field
+                    code
                 }}
             }}
-            productErrors {{
-                message
-                field
-                code
-            }}
         }}
-    }}
     """
     category_id = graphene.Node.to_global_id("Category", category.pk)
     product_type_id = graphene.Node.to_global_id(
@@ -4111,7 +4111,7 @@ mutation createProduct(
         "basePrice": Decimal("19"),
     }
     response = staff_api_client.post_graphql(
-        MUTATION_CREATE_PRODUCT_WITH_WEIGHT_GQL_INPUT,
+        query,
         variables,
         permissions=[permission_manage_products],
     )

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -4111,9 +4111,7 @@ def test_create_product_with_weight_input(
         "basePrice": Decimal("19"),
     }
     response = staff_api_client.post_graphql(
-        query,
-        variables,
-        permissions=[permission_manage_products],
+        query, variables, permissions=[permission_manage_products],
     )
     content = get_graphql_content(response)
     result_weight = content["data"]["productCreate"]["product"]["weight"]

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -4100,9 +4100,6 @@ def test_create_product_with_weight_variable(
         permissions=[permission_manage_products],
     )
     content = get_graphql_content(response)
-    from pprint import pprint
-
-    pprint(content)
     result_weight = content["data"]["productCreate"]["product"]["weight"]
     assert result_weight["value"] == expected_weight_value
     assert result_weight["unit"] == expected_weight_unit
@@ -4148,9 +4145,6 @@ def test_create_product_with_weight_input(
         permissions=[permission_manage_products],
     )
     content = get_graphql_content(response)
-    from pprint import pprint
-
-    pprint(content)
     result_weight = content["data"]["productCreate"]["product"]["weight"]
     assert result_weight["value"] == expected_weight_value
     assert result_weight["unit"] == expected_weight_unit


### PR DESCRIPTION
I want to merge this change because...
Right now WeightScalar is only working when the value is passed by variable to mutation.
This PR fixes that and adds support for passing value directly to mutation input (mostly used in playground).
Now accepted values are:
```
weight: 10.0
weight: 10
weight: "10"
weight: "10.0"
weight: {
    value: 10 // and all combinations from above
    unit: "kg"
}
```
For both variable and input

<!-- Please mention all relevant issue numbers. -->
fixes #5496
# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
