### PR TITLE
Update add users to group restrictions

### DIFF
--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -284,9 +284,9 @@ class PermissionGroupUpdate(PermissionGroupCreate):
 
         Requestor cannot manage users with wider scope of permissions.
         """
-        users = cleaned_input[field]
         if requestor.is_superuser:
             return
+        users = cleaned_input[field]
         out_of_scope_users = get_out_of_scope_users(requestor, users)
         if out_of_scope_users:
             # add error

--- a/tests/api/test_account_permission_group.py
+++ b/tests/api/test_account_permission_group.py
@@ -1214,7 +1214,7 @@ def test_permission_group_update_mutation_out_of_scope_users(
     permission_manage_orders,
     permission_manage_products,
 ):
-    """Ensure user cannot assign and unasign users whose permission scope
+    """Ensure user can assign and cannot unasign users whose permission scope
     is wider than requestor scope.
     Ensure superuser pass restrictions.
     """


### PR DESCRIPTION
Ensure that when the user can manage the group he can also add any user to this group (even if he doesn't have all user permissions).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
