### PR TITLE
This fix an error an order is created and the discount name is null.

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -845,7 +845,7 @@ def add_voucher_to_checkout(checkout: Checkout, voucher: Voucher, discounts=None
     """
     discount = get_voucher_discount_for_checkout(voucher, checkout, discounts)
     checkout.voucher_code = voucher.code
-    checkout.discount_name = voucher.name
+    checkout.discount_name = voucher.name if voucher.name else ""
     checkout.translated_discount_name = (
         voucher.translated.name if voucher.translated.name != voucher.name else ""
     )


### PR DESCRIPTION
I want to merge this change because...

There is an error when an order is created and the discount name is null.
This was already fixed in the PR [#2932](https://github.com/mirumee/saleor/pull/2932)

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [X] Privileged queries and mutations are guarded by proper permission checks
* [X] Database queries are optimized and the number of queries is constant
* [X] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
