### PR TITLE
Update cancel fulfillment

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -64,7 +64,9 @@ class FulfillmentUpdateTrackingInput(graphene.InputObjectType):
 
 
 class FulfillmentCancelInput(graphene.InputObjectType):
-    restock = graphene.Boolean(description="Whether item lines are restocked.")
+    warehouse_id = graphene.ID(
+        description="ID of warehouse where items will be restock.", required=True
+    )
 
 
 class FulfillmentClearMeta(ClearMetaBaseMutation):
@@ -300,7 +302,10 @@ class FulfillmentCancel(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        restock = data.get("input").get("restock")
+        warehouse_id = data.get("input").get("warehouse_id")
+        warehouse = cls.get_node_or_error(
+            info, warehouse_id, only_type="Warehouse", field="warehouse_id"
+        )
         fulfillment = cls.get_node_or_error(info, data.get("id"), only_type=Fulfillment)
 
         if not fulfillment.can_edit():
@@ -314,5 +319,5 @@ class FulfillmentCancel(BaseMutation):
             )
 
         order = fulfillment.order
-        cancel_fulfillment(fulfillment, info.context.user, restock)
+        cancel_fulfillment(fulfillment, info.context.user, warehouse)
         return FulfillmentCancel(fulfillment=fulfillment, order=order)

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -320,4 +320,6 @@ class FulfillmentCancel(BaseMutation):
 
         order = fulfillment.order
         cancel_fulfillment(fulfillment, info.context.user, warehouse)
+        fulfillment.refresh_from_db(fields=["status"])
+        order.refresh_from_db(fields=["status"])
         return FulfillmentCancel(fulfillment=fulfillment, order=order)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -10,6 +10,7 @@ from ...order.models import FulfillmentStatus
 from ...order.utils import get_order_country, get_valid_shipping_methods_for_order
 from ...plugins.manager import get_plugins_manager
 from ...product.templatetags.product_images import get_product_image_thumbnail
+from ...warehouse import models as warehouse_models
 from ..account.types import User
 from ..core.connection import CountableDjangoObjectType
 from ..core.types.common import Image
@@ -55,6 +56,9 @@ class OrderEvent(CountableDjangoObjectType):
     lines = graphene.List(OrderEventOrderLineObject, description="The concerned lines.")
     fulfilled_items = graphene.List(
         lambda: FulfillmentLine, description="The lines fulfilled."
+    )
+    warehouse = graphene.Field(
+        Warehouse, description="The warehouse were items were restocked."
     )
 
     class Meta:
@@ -149,6 +153,11 @@ class OrderEvent(CountableDjangoObjectType):
     def resolve_fulfilled_items(root: models.OrderEvent, _info):
         lines = root.parameters.get("fulfilled_items", None)
         return models.FulfillmentLine.objects.filter(pk__in=lines)
+
+    @staticmethod
+    def resolve_warehouse(root: models.OrderEvent, _info):
+        warehouse = root.parameters.get("warehouse")
+        return warehouse_models.Warehouse.objects.filter(pk=warehouse).first()
 
 
 class FulfillmentLine(CountableDjangoObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2698,6 +2698,7 @@ type OrderEvent implements Node {
   oversoldItems: [String]
   lines: [OrderEventOrderLineObject]
   fulfilledItems: [FulfillmentLine]
+  warehouse: Warehouse
 }
 
 type OrderEventCountableConnection {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1767,7 +1767,7 @@ type FulfillmentCancel {
 }
 
 input FulfillmentCancelInput {
-  restock: Boolean
+  warehouseId: ID!
 }
 
 type FulfillmentClearMeta {

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -163,7 +163,10 @@ def cancel_fulfillment(
         order=fulfillment.order, user=user, fulfillment=fulfillment
     )
     events.fulfillment_restocked_items_event(
-        order=fulfillment.order, user=user, fulfillment=fulfillment
+        order=fulfillment.order,
+        user=user,
+        fulfillment=fulfillment,
+        warehouse_pk=warehouse.pk,
     )
     restock_fulfillment_lines(fulfillment, warehouse)
     fulfillment.status = FulfillmentStatus.CANCELED

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -213,7 +213,11 @@ def fulfillment_canceled_event(
 
 
 def fulfillment_restocked_items_event(
-    *, order: Order, user: UserType, fulfillment: Union[Order, Fulfillment]
+    *,
+    order: Order,
+    user: UserType,
+    fulfillment: Union[Order, Fulfillment],
+    warehouse_pk: Optional[int] = None,
 ) -> OrderEvent:
     if not _user_is_valid(user):
         user = None
@@ -221,7 +225,10 @@ def fulfillment_restocked_items_event(
         order=order,
         type=OrderEvents.FULFILLMENT_RESTOCKED_ITEMS,
         user=user,
-        parameters={"quantity": fulfillment.get_total_quantity()},
+        parameters={
+            "quantity": fulfillment.get_total_quantity(),
+            "warehouse": warehouse_pk,
+        },
     )
 
 

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -282,7 +282,7 @@ def restock_order_lines(order):
 def restock_fulfillment_lines(fulfillment, warehouse):
     """Return fulfilled products to corresponding stocks.
 
-    Return products to stocks and update order_line quantity_fulfilled value.
+    Return products to stocks and update order lines quantity fulfilled values.
     """
     order_lines = []
     for line in fulfillment:

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -279,18 +279,19 @@ def restock_order_lines(order):
             line.save(update_fields=["quantity_fulfilled"])
 
 
-def restock_fulfillment_lines(fulfillment):
-    """Return fulfilled products to corresponding stocks."""
-    country = get_order_country(fulfillment.order)
-    default_warehouse = Warehouse.objects.filter(
-        shipping_zones__countries__contains=country
-    ).first()
+def restock_fulfillment_lines(fulfillment, warehouse):
+    """Return fulfilled products to corresponding stocks.
 
+    Return products to stocks and update order_line quantity_fulfilled value.
+    """
+    order_lines = []
     for line in fulfillment:
         if line.order_line.variant and line.order_line.variant.track_inventory:
-            allocation = line.order_line.allocations.first()
-            warehouse = allocation.stock.warehouse if allocation else default_warehouse
             increase_stock(line.order_line, warehouse, line.quantity, allocate=True)
+            order_line = line.order_line
+            order_line.quantity_fulfilled -= line.quantity
+            order_lines.append(order_line)
+    OrderLine.objects.bulk_update(order_lines, ["quantity_fulfilled"])
 
 
 def sum_order_totals(qs):

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -490,6 +490,9 @@ CANCEL_FULFILLMENT_MUTATION = """
                     fulfillment {
                         status
                     }
+                    order {
+                        status
+                    }
                 }
         }
 """
@@ -506,8 +509,9 @@ def test_cancel_fulfillment(
         query, variables, permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
-    data = content["data"]["orderFulfillmentCancel"]["fulfillment"]
-    assert data["status"] == FulfillmentStatus.CANCELED.upper()
+    data = content["data"]["orderFulfillmentCancel"]
+    assert data["fulfillment"]["status"] == FulfillmentStatus.CANCELED.upper()
+    assert data["order"]["status"] == OrderStatus.UNFULFILLED.upper()
     event_cancelled, event_restocked_items = fulfillment.order.events.all()
     assert event_cancelled.type == (OrderEvents.FULFILLMENT_CANCELED)
     assert event_cancelled.parameters == {"composed_id": fulfillment.composed_id}

--- a/tests/api/test_fulfillment.py
+++ b/tests/api/test_fulfillment.py
@@ -511,7 +511,8 @@ def test_cancel_fulfillment(
 
     assert event_restocked_items.type == (OrderEvents.FULFILLMENT_RESTOCKED_ITEMS)
     assert event_restocked_items.parameters == {
-        "quantity": fulfillment.get_total_quantity()
+        "quantity": fulfillment.get_total_quantity(),
+        "warehouse": str(warehouse.pk),
     }
     assert event_restocked_items.user == staff_user
 

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -355,7 +355,12 @@ def test_draft_order_query(staff_api_client, permission_manage_orders, orders):
 
 
 def test_nested_order_events_query(
-    staff_api_client, permission_manage_orders, fulfilled_order, fulfillment, staff_user
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+    fulfillment,
+    staff_user,
+    warehouse,
 ):
     query = """
         query OrdersQuery {
@@ -384,6 +389,9 @@ def test_nested_order_events_query(
                             }
                             paymentId
                             paymentGateway
+                            warehouse {
+                                name
+                            }
                         }
                     }
                 }
@@ -403,6 +411,7 @@ def test_nested_order_events_query(
             "amount": "80.00",
             "quantity": "10",
             "composed_id": "10-10",
+            "warehouse": warehouse.pk,
         }
     )
     event.save()
@@ -432,6 +441,7 @@ def test_nested_order_events_query(
     ]
     assert data["paymentId"] is None
     assert data["paymentGateway"] is None
+    assert data["warehouse"]["name"] == warehouse.name
 
 
 def test_payment_information_order_events_query(

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -204,6 +204,10 @@ def test_restock_fulfillment_lines(fulfilled_order, warehouse):
     stock_2_quantity_allocated_before = get_quantity_allocated_for_stock(stock_2)
     stock_1_quantity_before = stock_1.quantity
     stock_2_quantity_before = stock_2.quantity
+    order_line_1 = line_1.order_line
+    order_line_2 = line_2.order_line
+    order_line_1_quantity_fulfilled_before = order_line_1.quantity_fulfilled
+    order_line_2_quantity_fulfilled_before = order_line_2.quantity_fulfilled
 
     restock_fulfillment_lines(fulfillment, warehouse)
 
@@ -217,6 +221,16 @@ def test_restock_fulfillment_lines(fulfilled_order, warehouse):
     )
     assert stock_1.quantity == stock_1_quantity_before + line_1.quantity
     assert stock_2.quantity == stock_2_quantity_before + line_2.quantity
+    order_line_1.refresh_from_db()
+    order_line_2.refresh_from_db()
+    assert (
+        order_line_1.quantity_fulfilled
+        == order_line_1_quantity_fulfilled_before - line_1.quantity
+    )
+    assert (
+        order_line_2.quantity_fulfilled
+        == order_line_2_quantity_fulfilled_before - line_2.quantity
+    )
 
 
 def test_update_order_status(fulfilled_order):

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -194,7 +194,7 @@ def test_restock_fulfilled_order_lines(fulfilled_order):
     assert stock_2.quantity == stock_2_quantity_before + line_2.quantity
 
 
-def test_restock_fulfillment_lines(fulfilled_order):
+def test_restock_fulfillment_lines(fulfilled_order, warehouse):
     fulfillment = fulfilled_order.fulfillments.first()
     line_1 = fulfillment.lines.first()
     line_2 = fulfillment.lines.last()
@@ -205,7 +205,7 @@ def test_restock_fulfillment_lines(fulfilled_order):
     stock_1_quantity_before = stock_1.quantity
     stock_2_quantity_before = stock_2.quantity
 
-    restock_fulfillment_lines(fulfillment)
+    restock_fulfillment_lines(fulfillment, warehouse)
 
     stock_1.refresh_from_db()
     stock_2.refresh_from_db()

--- a/tests/test_order_actions.py
+++ b/tests/test_order_actions.py
@@ -142,12 +142,12 @@ def test_clean_mark_order_as_paid(payment_txn_preauth):
         clean_mark_order_as_paid(order)
 
 
-def test_cancel_fulfillment(fulfilled_order):
+def test_cancel_fulfillment(fulfilled_order, warehouse):
     fulfillment = fulfilled_order.fulfillments.first()
     line_1 = fulfillment.lines.first()
     line_2 = fulfillment.lines.first()
 
-    cancel_fulfillment(fulfillment, None, restock=False)
+    cancel_fulfillment(fulfillment, None, warehouse)
 
     assert fulfillment.status == FulfillmentStatus.CANCELED
     assert fulfilled_order.status == OrderStatus.UNFULFILLED

--- a/tests/test_order_actions.py
+++ b/tests/test_order_actions.py
@@ -149,6 +149,8 @@ def test_cancel_fulfillment(fulfilled_order, warehouse):
 
     cancel_fulfillment(fulfillment, None, warehouse)
 
+    fulfillment.refresh_from_db()
+    fulfilled_order.refresh_from_db()
     assert fulfillment.status == FulfillmentStatus.CANCELED
     assert fulfilled_order.status == OrderStatus.UNFULFILLED
     assert line_1.order_line.quantity_fulfilled == 0


### PR DESCRIPTION
Replace `restock` with `warehouseId` field in FulfillmentCancelInput.
Restock items to the given warehouse.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
