### PR TITLE
Fix OrderFulfill shouldn't create empty fulfillments

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -216,12 +216,13 @@ class OrderFulfill(BaseMutation):
         lines_for_warehouses = defaultdict(list)
         for line, order_line in zip(lines, order_lines):
             for stock in line["stocks"]:
-                warehouse_pk = from_global_id_strict_type(
-                    stock["warehouse"], only_type=Warehouse, field="warehouse"
-                )
-                lines_for_warehouses[warehouse_pk].append(
-                    {"order_line": order_line, "quantity": stock["quantity"]}
-                )
+                if stock["quantity"] > 0:
+                    warehouse_pk = from_global_id_strict_type(
+                        stock["warehouse"], only_type=Warehouse, field="warehouse"
+                    )
+                    lines_for_warehouses[warehouse_pk].append(
+                        {"order_line": order_line, "quantity": stock["quantity"]}
+                    )
 
         data["order_lines"] = order_lines
         data["quantities"] = quantities_for_lines


### PR DESCRIPTION
I want to merge this change because OrderFulfill shouldn't create empty fulfillments

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
