### PR TITLE
Restrict remove permissions from group

### DIFF
--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -97,11 +97,10 @@ class PermissionGroupCreate(ModelMutation):
         permission_items = cleaned_input.get(field)
         if permission_items:
             cleaned_input[field] = get_permissions(permission_items)
-            if requestor.is_superuser:
-                return
-            cls.ensure_can_manage_permissions(
-                requestor, errors, field, permission_items
-            )
+            if not requestor.is_superuser:
+                cls.ensure_can_manage_permissions(
+                    requestor, errors, field, permission_items
+                )
 
     @classmethod
     def ensure_can_manage_permissions(
@@ -255,12 +254,11 @@ class PermissionGroupUpdate(PermissionGroupCreate):
         permission_items = cleaned_input.get(field)
         if permission_items:
             cleaned_input[field] = get_permissions(permission_items)
-            if requestor.is_superuser:
-                return
-            cls.ensure_can_manage_permissions(
-                requestor, errors, field, permission_items
-            )
-            cls.ensure_permissions_can_be_removed(errors, group, permission_items)
+            if not requestor.is_superuser:
+                cls.ensure_can_manage_permissions(
+                    requestor, errors, field, permission_items
+                )
+                cls.ensure_permissions_can_be_removed(errors, group, permission_items)
 
     @classmethod
     def ensure_permissions_can_be_removed(

--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -11,6 +11,7 @@ from ....core.permissions import AccountPermissions, get_permissions
 from ...account.utils import (
     can_user_manage_group,
     get_not_manageable_permissions_after_group_deleting,
+    get_not_manageable_permissions_after_removing_perms_from_group,
     get_not_manageable_permissions_after_removing_users_from_group,
     get_out_of_scope_permissions,
     get_out_of_scope_users,
@@ -76,7 +77,7 @@ class PermissionGroupCreate(ModelMutation):
 
         requestor = info.context.user
         errors = defaultdict(list)
-        cls.clean_permissions(requestor, errors, cleaned_input)
+        cls.clean_permissions(requestor, instance, errors, cleaned_input)
         cls.clean_users(requestor, errors, cleaned_input, instance)
 
         if errors:
@@ -88,6 +89,7 @@ class PermissionGroupCreate(ModelMutation):
     def clean_permissions(
         cls,
         requestor: "User",
+        group: auth_models.Group,
         errors: Dict[Optional[str], List[ValidationError]],
         cleaned_input: dict,
     ):
@@ -95,6 +97,8 @@ class PermissionGroupCreate(ModelMutation):
         permission_items = cleaned_input.get(field)
         if permission_items:
             cleaned_input[field] = get_permissions(permission_items)
+            if requestor.is_superuser:
+                return
             cls.ensure_can_manage_permissions(
                 requestor, errors, field, permission_items
             )
@@ -111,8 +115,6 @@ class PermissionGroupCreate(ModelMutation):
 
         Requestor cannot manage permissions witch he doesn't have.
         """
-        if requestor.is_superuser:
-            return
         missing_permissions = get_out_of_scope_permissions(requestor, permission_items)
         if missing_permissions:
             # add error
@@ -244,17 +246,39 @@ class PermissionGroupUpdate(PermissionGroupCreate):
     def clean_permissions(
         cls,
         requestor: "User",
+        group: auth_models.Group,
         errors: Dict[Optional[str], List[ValidationError]],
         cleaned_input: dict,
     ):
-        super().clean_permissions(requestor, errors, cleaned_input)
+        super().clean_permissions(requestor, group, errors, cleaned_input)
         field = "remove_permissions"
         permission_items = cleaned_input.get(field)
         if permission_items:
             cleaned_input[field] = get_permissions(permission_items)
+            if requestor.is_superuser:
+                return
             cls.ensure_can_manage_permissions(
                 requestor, errors, field, permission_items
             )
+            cls.ensure_permissions_can_be_removed(errors, group, permission_items)
+
+    @classmethod
+    def ensure_permissions_can_be_removed(
+        cls, errors: dict, group: auth_models.Group, permissions: List["str"],
+    ):
+        missing_perms = get_not_manageable_permissions_after_removing_perms_from_group(
+            group, permissions
+        )
+        if missing_perms:
+            # add error
+            permission_codes = [PermissionEnum.get(code) for code in permissions]
+            msg = (
+                "Permissions cannot be removed, "
+                "some of permissions will not be manageable."
+            )
+            code = PermissionGroupErrorCode.LEFT_NOT_MANAGEABLE_PERMISSION.value
+            params = {"permissions": permission_codes}
+            cls.update_errors(errors, msg, "remove_permissions", code, params)
 
     @classmethod
     def clean_users(

--- a/tests/api/test_account_permission_group.py
+++ b/tests/api/test_account_permission_group.py
@@ -474,6 +474,67 @@ PERMISSION_GROUP_UPDATE_MUTATION = """
 
 
 def test_permission_group_update_mutation(
+    staff_users,
+    permission_manage_staff,
+    staff_api_client,
+    permission_manage_apps,
+    permission_manage_users,
+):
+    staff_user = staff_users[0]
+    staff_user.user_permissions.add(permission_manage_apps, permission_manage_users)
+    query = PERMISSION_GROUP_UPDATE_MUTATION
+
+    group1, group2 = Group.objects.bulk_create(
+        [Group(name="manage users"), Group(name="manage staff and users")]
+    )
+    group1.permissions.add(permission_manage_users)
+    group2.permissions.add(permission_manage_users, permission_manage_staff)
+
+    group1_user = staff_users[1]
+    group1.user_set.add(group1_user)
+    group2.user_set.add(staff_user)
+
+    # set of users emails being in a group
+    users = set(group1.user_set.values_list("email", flat=True))
+
+    variables = {
+        "id": graphene.Node.to_global_id("Group", group1.id),
+        "input": {
+            "name": "New permission group",
+            "addPermissions": [AppPermission.MANAGE_APPS.name],
+            "removePermissions": [AccountPermissions.MANAGE_USERS.name],
+            "addUsers": [graphene.Node.to_global_id("User", staff_user.pk)],
+            "removeUsers": [graphene.Node.to_global_id("User", group1_user.pk)],
+        },
+    }
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["permissionGroupUpdate"]
+    permission_group_data = data["group"]
+
+    # remove and add user email for comparing users set
+    users.remove(group1_user.email)
+    users.add(staff_user.email)
+
+    group1.refresh_from_db()
+    assert permission_group_data["name"] == group1.name
+    permissions = {
+        permission["name"] for permission in permission_group_data["permissions"]
+    }
+    assert set(group1.permissions.all().values_list("name", flat=True)) == permissions
+    permissions_codes = {
+        permission["code"].lower()
+        for permission in permission_group_data["permissions"]
+    }
+    assert (
+        set(group1.permissions.all().values_list("codename", flat=True))
+        == permissions_codes
+    )
+    assert set(group1.user_set.all().values_list("email", flat=True)) == users
+    assert data["permissionGroupErrors"] == []
+
+
+def test_permission_group_update_mutation_removing_perm_left_not_manageable_perms(
     permission_group_manage_users,
     staff_user,
     permission_manage_staff,
@@ -481,12 +542,10 @@ def test_permission_group_update_mutation(
     permission_manage_apps,
     permission_manage_users,
 ):
+    """Ensure user cannot remove permissions if it left not meanagable perms."""
     staff_user.user_permissions.add(permission_manage_apps, permission_manage_users)
     group = permission_group_manage_users
     query = PERMISSION_GROUP_UPDATE_MUTATION
-
-    # set of users emails being in a group
-    users = set(group.user_set.values_list("email", flat=True))
 
     group_user = group.user_set.first()
     variables = {
@@ -504,13 +563,56 @@ def test_permission_group_update_mutation(
     )
     content = get_graphql_content(response)
     data = content["data"]["permissionGroupUpdate"]
+    errors = data["permissionGroupErrors"]
+
+    assert not data["group"]
+    assert len(errors) == 1
+    assert errors[0]["field"] == "removePermissions"
+    assert (
+        errors[0]["code"]
+        == PermissionGroupErrorCode.LEFT_NOT_MANAGEABLE_PERMISSION.name
+    )
+    assert errors[0]["permissions"] == [AccountPermissions.MANAGE_USERS.name]
+    assert errors[0]["users"] is None
+    assert staff_user.groups.count() == 0
+
+
+def test_permission_group_update_mutation_superuser_can_remove_any_perms(
+    permission_group_manage_users,
+    permission_manage_staff,
+    superuser_api_client,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_users,
+):
+    """Ensure superuser can remove any permissions."""
+    group = permission_group_manage_users
+    query = PERMISSION_GROUP_UPDATE_MUTATION
+
+    # set of users emails being in a group
+    users = set(group.user_set.values_list("email", flat=True))
+
+    group_user = group.user_set.first()
+    variables = {
+        "id": graphene.Node.to_global_id("Group", group.id),
+        "input": {
+            "name": "New permission group",
+            "addPermissions": [AppPermission.MANAGE_APPS.name],
+            "removePermissions": [AccountPermissions.MANAGE_USERS.name],
+            "addUsers": [graphene.Node.to_global_id("User", staff_user.pk)],
+            "removeUsers": [graphene.Node.to_global_id("User", group_user.pk)],
+        },
+    }
+    response = superuser_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["permissionGroupUpdate"]
     permission_group_data = data["group"]
 
     # remove and add user email for comparing users set
     users.remove(group_user.email)
     users.add(staff_user.email)
 
-    group = Group.objects.get()
+    group.refresh_from_db()
     assert permission_group_data["name"] == group.name
     permissions = {
         permission["name"] for permission in permission_group_data["permissions"]


### PR DESCRIPTION
User shouldn't be allowed to remove any permission from the group.
Prevent removing permissions from the group which left not manageable permissions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
