### PR TITLE
Expose available payment gateways in Shop type

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -83,7 +83,9 @@ class Checkout(CountableDjangoObjectType):
         description="Shipping methods that can be used with this order.",
     )
     available_payment_gateways = graphene.List(
-        PaymentGateway, description="List of available payment gateways.", required=True
+        graphene.NonNull(PaymentGateway),
+        description="List of available payment gateways.",
+        required=True,
     )
     email = graphene.String(description="Email of a customer.", required=True)
     gift_cards = graphene.List(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -774,7 +774,7 @@ type Checkout implements Node & ObjectWithMetadata {
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   availableShippingMethods: [ShippingMethod]!
-  availablePaymentGateways: [PaymentGateway]!
+  availablePaymentGateways: [PaymentGateway!]!
   email: String!
   isShippingRequired: Boolean!
   lines: [CheckoutLine]
@@ -4353,6 +4353,7 @@ input ShippingZoneUpdateInput {
 }
 
 type Shop {
+  availablePaymentGateways: [PaymentGateway!]!
   geolocalization: Geolocalization
   authorizationKeys: [AuthorizationKey]!
   countries(languageCode: LanguageCodeEnum): [CountryDisplay]!

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -9,9 +9,11 @@ from ...account import models as account_models
 from ...core.permissions import SitePermissions, get_permissions
 from ...core.utils import get_client_ip, get_country_by_ip
 from ...menu import models as menu_models
+from ...plugins.manager import get_plugins_manager
 from ...product import models as product_models
 from ...site import models as site_models
 from ..account.types import Address, StaffNotificationRecipient
+from ..checkout.types import PaymentGateway
 from ..core.enums import WeightUnitsEnum
 from ..core.types.common import CountryDisplay, LanguageDisplay, Permission
 from ..core.utils import str_to_enum
@@ -62,6 +64,11 @@ class Geolocalization(graphene.ObjectType):
 
 
 class Shop(graphene.ObjectType):
+    available_payment_gateways = graphene.List(
+        graphene.NonNull(PaymentGateway),
+        description="List of available payment gateways.",
+        required=True,
+    )
     geolocalization = graphene.Field(
         Geolocalization, description="Customer's geolocalization data."
     )
@@ -157,6 +164,10 @@ class Shop(graphene.ObjectType):
         description = (
             "Represents a shop resource containing general shop data and configuration."
         )
+
+    @staticmethod
+    def resolve_available_payment_gateways(_, _info):
+        return [gtw for gtw in get_plugins_manager().list_payment_gateways()]
 
     @staticmethod
     @permission_required(SitePermissions.MANAGE_SETTINGS)

--- a/saleor/product/management/commands/update_all_products_minimal_variant_prices.py
+++ b/saleor/product/management/commands/update_all_products_minimal_variant_prices.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class Command(BaseCommand):
-    help = "Generate thumbnails for all images"
+    help = "Recalculates the minimal variant prices for all products."
 
     def handle(self, *args, **options):
         self.stdout.write('Updating "minimal_variant_price" field of all the products.')

--- a/tests/api/test_shop.py
+++ b/tests/api/test_shop.py
@@ -682,6 +682,24 @@ def test_query_geolocalization(user_api_client):
     assert data["country"] is None
 
 
+def test_query_available_payment_gateways(user_api_client):
+    query = """
+        query {
+            shop {
+                availablePaymentGateways {
+                    id
+                    name
+                }
+            }
+        }
+    """
+    response = user_api_client.post_graphql(query)
+    content = get_graphql_content(response)
+    data = content["data"]["shop"]["availablePaymentGateways"]
+    assert data[0]["id"] == "mirumee.payments.dummy"
+    assert data[0]["name"] == "Dummy"
+
+
 AUTHORIZATION_KEY_ADD = """
 mutation AddKey($key: String!, $password: String!, $keyType: AuthorizationKeyType!) {
     authorizationKeyAdd(input: {key: $key, password: $password}, keyType: $keyType) {


### PR DESCRIPTION
Now it was possible to get available payment gateways only from the `Checkout` type, but in the storefront, we need to be able to display them before actually creating the checkout object. This PR extends the `Shop` type to return the payment gateways from there as well.

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
