### PR TITLE
Add trans tags to email templates

### DIFF
--- a/templates/templated_email/compiled/confirm_fulfillment.html
+++ b/templates/templated_email/compiled/confirm_fulfillment.html
@@ -266,8 +266,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">Item</th>
-              <th style="padding: 5px; text-align: right;" align="right">Quantity</th>
+              <th style="padding: 5px; text-align: left;" align="left">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="padding: 5px; text-align: right;" align="right">{% trans "Quantity" context "Quantity ordered of a product" %}</th>
             </tr>
           </thead>
           <tbody>
@@ -284,8 +284,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">Item</th>
-              <th style="padding: 5px; text-align: right;" align="right">Download Link</th>
+              <th style="padding: 5px; text-align: left;" align="left">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="padding: 5px; text-align: right;" align="right">{% trans "Download Link" context "Ordered item download links" %}</th>
             </tr>
           </thead>
           <tbody>

--- a/templates/templated_email/compiled/update_fulfillment.html
+++ b/templates/templated_email/compiled/update_fulfillment.html
@@ -254,8 +254,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">Item</th>
-              <th style="padding: 5px; text-align: right;" align="right">Quantity</th>
+              <th style="padding: 5px; text-align: left;" align="left">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="padding: 5px; text-align: right;" align="right">{% trans "Quantity" context "Quantity ordered of a product" %}</th>
             </tr>
           </thead>
           <tbody>
@@ -272,8 +272,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">Item</th>
-              <th style="padding: 5px; text-align: right;" align="right">Download Link</th>
+              <th style="padding: 5px; text-align: left;" align="left">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="padding: 5px; text-align: right;" align="right">{% trans "Download Link" context "Ordered item download links" %}</th>
             </tr>
           </thead>
           <tbody>

--- a/templates/templated_email/source/partials/_fulfillment_lines.mjml
+++ b/templates/templated_email/source/partials/_fulfillment_lines.mjml
@@ -8,8 +8,8 @@
         <table style="width:100%">
           <thead class="table-header-row">
             <tr>
-              <th style="text-align: left;">Item</th>
-              <th style="text-align: right;">Quantity</th>
+              <th style="text-align: left;">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="text-align: right;">{% trans "Quantity" context "Quantity ordered of a product" %}</th>
             </tr>
           </thead>
           <tbody>
@@ -26,8 +26,8 @@
         <table style="width:100%">
           <thead class="table-header-row">
             <tr>
-              <th style="text-align: left;">Item</th>
-              <th style="text-align: right;">Download Link</th>
+              <th style="text-align: left;">{% trans "Item" context "Ordered item name" %}</th>
+              <th style="text-align: right;">{% trans "Download Link" context "Ordered item download links" %}</th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
I want to merge this change because it adds missing translation tags to email templates

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
