### PR TITLE
Add ability to query category, collection or product by slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed JWT expired token being flagged as unhandled error rather than handled. - #5603 by @NyanKiyoshi
 - Refactor read-only middleware - #5602 by @maarcingebala
 - Fix availability for variants without inventory tracking - #5605 by @fowczarek
+- Add ability to query category, collection or product by slug - #5574 by @koradon
 
 ## 2.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Drop support for configuring Vatlayer plugin from settings file. - #5614 by @korycins
+
+- Add ability to query category, collection or product by slug - #5574 by @koradon
+
 ## 2.10.0
 
 - OpenTracing support - #5188 by @tomaszszymanski129
@@ -111,7 +114,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fixed JWT expired token being flagged as unhandled error rather than handled. - #5603 by @NyanKiyoshi
 - Refactor read-only middleware - #5602 by @maarcingebala
 - Fix availability for variants without inventory tracking - #5605 by @fowczarek
-- Add ability to query category, collection or product by slug - #5574 by @koradon
 
 ## 2.9.0
 

--- a/saleor/graphql/core/validators.py
+++ b/saleor/graphql/core/validators.py
@@ -1,0 +1,12 @@
+from graphql.error import GraphQLError
+
+
+def validate_query_args(**kwargs):
+    id = kwargs.get("id")
+    slug = kwargs.get("slug")
+    name = kwargs.get("name")
+
+    if id and slug:
+        raise GraphQLError("Argument 'id' cannot be combined with 'slug'")
+    if id and name:
+        raise GraphQLError("Argument 'id' cannot be combined with 'name'")

--- a/saleor/graphql/core/validators.py
+++ b/saleor/graphql/core/validators.py
@@ -1,12 +1,12 @@
 from graphql.error import GraphQLError
 
 
-def validate_query_args(**kwargs):
-    id = kwargs.get("id")
-    slug = kwargs.get("slug")
-    name = kwargs.get("name")
-
-    if id and slug:
-        raise GraphQLError("Argument 'id' cannot be combined with 'slug'")
-    if id and name:
-        raise GraphQLError("Argument 'id' cannot be combined with 'name'")
+def validate_one_of_args_is_in_query(arg1_name, arg1, arg2_name, arg2):
+    if arg1 and arg2:
+        raise GraphQLError(
+            f"Argument '{arg1_name}' cannot be combined with '{arg2_name}'"
+        )
+    if not arg1 and not arg2:
+        raise GraphQLError(
+            f"Either '{arg1_name}'  or '{arg2_name}' argument is required"
+        )

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -1,18 +1,22 @@
 import graphene
+from graphql.error import GraphQLError
 
 from ...menu import models
 from ..utils.filters import filter_by_query_param
 from .types import Menu
+from ..core.validators import validate_query_args
 
 MENU_SEARCH_FIELDS = ("name",)
 MENU_ITEM_SEARCH_FIELDS = ("name",)
 
 
 def resolve_menu(info, menu_id=None, name=None):
-    assert menu_id or name, "No ID or name provided."
-    if name is not None:
+    validate_query_args(id=menu_id, name=name)
+    if menu_id:
+        return graphene.Node.get_node_from_global_id(info, menu_id, Menu)
+    if name:
         return models.Menu.objects.filter(name=name).first()
-    return graphene.Node.get_node_from_global_id(info, menu_id, Menu)
+    raise GraphQLError("Either 'id' or 'slug' argument is required")
 
 
 def resolve_menus(info, query, **_kwargs):

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -3,8 +3,8 @@ from graphql.error import GraphQLError
 
 from ...menu import models
 from ..utils.filters import filter_by_query_param
-from .types import Menu
 from ..core.validators import validate_query_args
+from .types import Menu
 
 MENU_SEARCH_FIELDS = ("name",)
 MENU_ITEM_SEARCH_FIELDS = ("name",)

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -2,8 +2,8 @@ import graphene
 from graphql.error import GraphQLError
 
 from ...menu import models
-from ..utils.filters import filter_by_query_param
 from ..core.validators import validate_query_args
+from ..utils.filters import filter_by_query_param
 from .types import Menu
 
 MENU_SEARCH_FIELDS = ("name",)

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -1,8 +1,7 @@
 import graphene
-from graphql.error import GraphQLError
 
 from ...menu import models
-from ..core.validators import validate_query_args
+from ..core.validators import validate_one_of_args_is_in_query
 from ..utils.filters import filter_by_query_param
 from .types import Menu
 
@@ -11,12 +10,11 @@ MENU_ITEM_SEARCH_FIELDS = ("name",)
 
 
 def resolve_menu(info, menu_id=None, name=None):
-    validate_query_args(id=menu_id, name=name)
+    validate_one_of_args_is_in_query("id", menu_id, "name", name)
     if menu_id:
         return graphene.Node.get_node_from_global_id(info, menu_id, Menu)
     if name:
         return models.Menu.objects.filter(name=name).first()
-    raise GraphQLError("Either 'id' or 'slug' argument is required")
 
 
 def resolve_menus(info, query, **_kwargs):

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -22,6 +22,13 @@ def resolve_attributes(info, qs=None, in_category=None, in_collection=None, **_k
     return qs.distinct()
 
 
+def resolve_category_by_slug(info, slug):
+    try:
+        return models.Category.objects.get(slug=slug)
+    except models.Category.DoesNotExist:
+        return None
+
+
 def resolve_categories(info, level=None, **_kwargs):
     qs = models.Category.objects.prefetch_related("children")
     if level is not None:

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -22,7 +22,7 @@ def resolve_attributes(info, qs=None, in_category=None, in_collection=None, **_k
     return qs.distinct()
 
 
-def resolve_category_by_slug(info, slug):
+def resolve_category_by_slug(slug):
     return models.Category.objects.filter(slug=slug).first()
 
 
@@ -33,6 +33,10 @@ def resolve_categories(info, level=None, **_kwargs):
     return qs.distinct()
 
 
+def resolve_collection_by_slug(slug):
+    return models.Collection.objects.filter(slug=slug).first()
+
+
 def resolve_collections(info, **_kwargs):
     user = info.context.user
     return models.Collection.objects.visible_to_user(user)
@@ -40,6 +44,10 @@ def resolve_collections(info, **_kwargs):
 
 def resolve_digital_contents(info):
     return models.DigitalContent.objects.all()
+
+
+def resolve_product_by_slug(slug):
+    return models.Product.objects.filter(slug=slug).first()
 
 
 def resolve_products(info, stock_availability=None, **_kwargs):

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -23,10 +23,7 @@ def resolve_attributes(info, qs=None, in_category=None, in_collection=None, **_k
 
 
 def resolve_category_by_slug(info, slug):
-    try:
-        return models.Category.objects.get(slug=slug)
-    except models.Category.DoesNotExist:
-        return None
+    return models.Category.objects.filter(slug=slug).first()
 
 
 def resolve_categories(info, level=None, **_kwargs):

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -1,10 +1,10 @@
 import graphene
 from graphql.error import GraphQLError
 
-from ..core.validators import validate_query_args
 from ...core.permissions import ProductPermissions
 from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
+from ..core.validators import validate_query_args
 from ..decorators import permission_required
 from ..translations.mutations import (
     AttributeTranslate,
@@ -107,8 +107,8 @@ from .mutations.products import (
 )
 from .resolvers import (
     resolve_attributes,
-    resolve_category_by_slug,
     resolve_categories,
+    resolve_category_by_slug,
     resolve_collection_by_slug,
     resolve_collections,
     resolve_digital_contents,

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -1,10 +1,9 @@
 import graphene
-from graphql.error import GraphQLError
 
 from ...core.permissions import ProductPermissions
 from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
-from ..core.validators import validate_query_args
+from ..core.validators import validate_one_of_args_is_in_query
 from ..decorators import permission_required
 from ..translations.mutations import (
     AttributeTranslate,
@@ -254,20 +253,18 @@ class ProductQueries(graphene.ObjectType):
         return resolve_categories(info, level=level, **kwargs)
 
     def resolve_category(self, info, id=None, slug=None):
-        validate_query_args(id=id, slug=slug)
+        validate_one_of_args_is_in_query("id", id, "slug", slug)
         if id:
             return graphene.Node.get_node_from_global_id(info, id, Category)
         if slug:
             return resolve_category_by_slug(slug=slug)
-        raise GraphQLError("Either 'id' or 'slug' argument is required")
 
     def resolve_collection(self, info, id=None, slug=None):
-        validate_query_args(id=id, slug=slug)
+        validate_one_of_args_is_in_query("id", id, "slug", slug)
         if id:
             return graphene.Node.get_node_from_global_id(info, id, Collection)
         if slug:
             return resolve_collection_by_slug(slug=slug)
-        raise GraphQLError("Either 'id' or 'slug' argument is required")
 
     def resolve_collections(self, info, **kwargs):
         return resolve_collections(info, **kwargs)
@@ -281,12 +278,11 @@ class ProductQueries(graphene.ObjectType):
         return resolve_digital_contents(info)
 
     def resolve_product(self, info, id=None, slug=None):
-        validate_query_args(id=id, slug=slug)
+        validate_one_of_args_is_in_query("id", id, "slug", slug)
         if id:
             return graphene.Node.get_node_from_global_id(info, id, Product)
         if slug:
             return resolve_product_by_slug(slug=slug)
-        raise GraphQLError("Either 'id' or 'slug' argument is required")
 
     def resolve_products(self, info, **kwargs):
         return resolve_products(info, **kwargs)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3887,7 +3887,7 @@ type Query {
   attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
   attribute(id: ID!): Attribute
   categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  category(id: ID!): Category
+  category(id: ID, slug: String): Category
   collection(id: ID!): Collection
   collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID!): Product

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3888,9 +3888,9 @@ type Query {
   attribute(id: ID!): Attribute
   categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   category(id: ID, slug: String): Category
-  collection(id: ID!): Collection
+  collection(id: ID, slug: String): Collection
   collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
-  product(id: ID!): Product
+  product(id: ID, slug: String): Product
   products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
   productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,5 +1,6 @@
 import json
 
+import logging
 import graphene
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -13,6 +14,8 @@ from saleor.app.models import App
 
 from ..utils import flush_post_commit_hooks
 from .utils import assert_no_permission
+
+from saleor.graphql.views import handled_errors_logger, unhandled_errors_logger
 
 API_PATH = reverse("api")
 
@@ -141,6 +144,28 @@ def api_client():
 def schema_context():
     params = {"user": AnonymousUser()}
     return graphene.types.Context(**params)
+
+
+class LoggingHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.messages = []
+
+    def emit(self, record: logging.LogRecord):
+        exc_type, exc_value, _tb = record.exc_info
+        self.messages.append(
+            f"{record.name}[{record.levelname.upper()}].{exc_type.__name__}"
+        )
+
+
+@pytest.fixture
+def graphql_log_handler():
+    log_handler = LoggingHandler()
+
+    unhandled_errors_logger.addHandler(log_handler)
+    handled_errors_logger.addHandler(log_handler)
+
+    return log_handler
 
 
 @pytest.fixture

--- a/tests/api/conftest.py
+++ b/tests/api/conftest.py
@@ -1,6 +1,6 @@
 import json
-
 import logging
+
 import graphene
 import pytest
 from django.contrib.auth.models import AnonymousUser
@@ -11,11 +11,10 @@ from graphql_jwt.shortcuts import get_token
 
 from saleor.account.models import User
 from saleor.app.models import App
+from saleor.graphql.views import handled_errors_logger, unhandled_errors_logger
 
 from ..utils import flush_post_commit_hooks
 from .utils import assert_no_permission
-
-from saleor.graphql.views import handled_errors_logger, unhandled_errors_logger
 
 API_PATH = reverse("api")
 

--- a/tests/api/test_category.py
+++ b/tests/api/test_category.py
@@ -3,16 +3,15 @@ from unittest.mock import Mock, patch
 
 import graphene
 import pytest
-
 from django.template.defaultfilters import slugify
 from graphql_relay import to_global_id
 
 from saleor.product.error_codes import ProductErrorCode
 from saleor.product.models import Category
 from tests.api.utils import (
+    construct_query_input,
     get_graphql_content,
     get_multipart_request_body,
-    construct_query_input,
 )
 from tests.utils import create_image, create_pdf_file_with_image_ext
 
@@ -54,6 +53,8 @@ def test_category_query(
         assert graphql_log_handler.messages == [
             "saleor.graphql.errors.handled[ERROR].GraphQLError"
         ]
+        content = get_graphql_content(response, ignore_errors=True)
+        assert len(content["errors"]) == 1
     else:
         response = user_api_client.post_graphql(query)
         content = get_graphql_content(response)

--- a/tests/api/test_collection.py
+++ b/tests/api/test_collection.py
@@ -10,43 +10,69 @@ from saleor.product.error_codes import ProductErrorCode
 from saleor.product.models import Collection
 from tests.utils import create_image, create_pdf_file_with_image_ext
 
-from .utils import (
-    construct_query_input,
-    get_graphql_content,
-    get_multipart_request_body,
-)
+from .utils import get_graphql_content, get_multipart_request_body
 
-
-@pytest.mark.parametrize(
-    "arguments, expected_error",
-    ((["id"], False), (["slug"], False), ([], True), (["id", "slug"], True)),
-)
-def test_collection_query(
-    arguments, expected_error, user_api_client, collection, graphql_log_handler
-):
-    query_input = construct_query_input(arguments=arguments, obj=collection)
-    query = f"""
-    query {{
-        collection{query_input} {{
+QUERY_COLLECTION = """
+    query ($id: ID, $slug: String){
+        collection(
+            id: $id,
+            slug: $slug,
+        ) {
             id
             name
-        }}
-    }}
+        }
+    }
     """
 
-    if expected_error:
-        response = user_api_client.post_graphql(query)
-        assert graphql_log_handler.messages == [
-            "saleor.graphql.errors.handled[ERROR].GraphQLError"
-        ]
-        content = get_graphql_content(response, ignore_errors=True)
-        assert len(content["errors"]) == 1
-    else:
-        response = user_api_client.post_graphql(query)
-        content = get_graphql_content(response)
-        collection_data = content["data"]["collection"]
-        assert collection_data is not None
-        assert collection_data["name"] == collection.name
+
+def test_collection_query_by_id(
+    user_api_client, collection,
+):
+    variables = {"id": graphene.Node.to_global_id("Collection", collection.pk)}
+
+    response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+    content = get_graphql_content(response)
+    collection_data = content["data"]["collection"]
+    assert collection_data is not None
+    assert collection_data["name"] == collection.name
+
+
+def test_collection_query_by_slug(
+    user_api_client, collection,
+):
+    variables = {"slug": collection.slug}
+    response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+    content = get_graphql_content(response)
+    collection_data = content["data"]["collection"]
+    assert collection_data is not None
+    assert collection_data["name"] == collection.name
+
+
+def test_collection_query_error_when_id_and_slug_provided(
+    user_api_client, collection, graphql_log_handler,
+):
+    variables = {
+        "id": graphene.Node.to_global_id("Collection", collection.pk),
+        "slug": collection.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+    assert graphql_log_handler.messages == [
+        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+    ]
+    content = get_graphql_content(response, ignore_errors=True)
+    assert len(content["errors"]) == 1
+
+
+def test_collection_query_error_when_no_param(
+    user_api_client, collection, graphql_log_handler,
+):
+    variables = {}
+    response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+    assert graphql_log_handler.messages == [
+        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+    ]
+    content = get_graphql_content(response, ignore_errors=True)
+    assert len(content["errors"]) == 1
 
 
 def test_collections_query(

--- a/tests/api/test_collection.py
+++ b/tests/api/test_collection.py
@@ -11,9 +11,9 @@ from saleor.product.models import Collection
 from tests.utils import create_image, create_pdf_file_with_image_ext
 
 from .utils import (
+    construct_query_input,
     get_graphql_content,
     get_multipart_request_body,
-    construct_query_input,
 )
 
 
@@ -39,6 +39,8 @@ def test_collection_query(
         assert graphql_log_handler.messages == [
             "saleor.graphql.errors.handled[ERROR].GraphQLError"
         ]
+        content = get_graphql_content(response, ignore_errors=True)
+        assert len(content["errors"]) == 1
     else:
         response = user_api_client.post_graphql(query)
         content = get_graphql_content(response)

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -9,7 +9,7 @@ from saleor.menu.models import Menu, MenuItem
 from saleor.product.models import Category
 from tests.api.utils import get_graphql_content
 
-from .utils import assert_no_permission, menu_item_to_json, construct_query_input
+from .utils import assert_no_permission, construct_query_input, menu_item_to_json
 
 
 def test_validate_menu_item_instance(category, page):
@@ -44,6 +44,8 @@ def test_collection_query(
         assert graphql_log_handler.messages == [
             "saleor.graphql.errors.handled[ERROR].GraphQLError"
         ]
+        content = get_graphql_content(response, ignore_errors=True)
+        assert len(content["errors"]) == 1
     else:
         response = user_api_client.post_graphql(query)
         content = get_graphql_content(response)

--- a/tests/api/test_menu.py
+++ b/tests/api/test_menu.py
@@ -9,7 +9,7 @@ from saleor.menu.models import Menu, MenuItem
 from saleor.product.models import Category
 from tests.api.utils import get_graphql_content
 
-from .utils import assert_no_permission, construct_query_input, menu_item_to_json
+from .utils import assert_no_permission, menu_item_to_json
 
 
 def test_validate_menu_item_instance(category, page):
@@ -22,36 +22,67 @@ def test_validate_menu_item_instance(category, page):
     _validate_menu_item_instance({"category": None}, "category", Category)
 
 
-@pytest.mark.parametrize(
-    "arguments, expected_error",
-    ((["id"], False), (["name"], False), ([], True), (["id", "name"], True)),
-)
-def test_collection_query(
-    arguments, expected_error, user_api_client, menu, graphql_log_handler
-):
-    query_input = construct_query_input(arguments=arguments, obj=menu)
-    query = f"""
-    query {{
-        menu{query_input} {{
+QUERY_MENU = """
+    query ($id: ID, $name: String){
+        menu(
+            id: $id,
+            name: $name,
+        ) {
             id
             name
-        }}
-    }}
+        }
+    }
     """
 
-    if expected_error:
-        response = user_api_client.post_graphql(query)
-        assert graphql_log_handler.messages == [
-            "saleor.graphql.errors.handled[ERROR].GraphQLError"
-        ]
-        content = get_graphql_content(response, ignore_errors=True)
-        assert len(content["errors"]) == 1
-    else:
-        response = user_api_client.post_graphql(query)
-        content = get_graphql_content(response)
-        menu_data = content["data"]["menu"]
-        assert menu_data is not None
-        assert menu_data["name"] == menu.name
+
+def test_menu_query_by_id(
+    user_api_client, menu,
+):
+    variables = {"id": graphene.Node.to_global_id("Menu", menu.pk)}
+
+    response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
+    content = get_graphql_content(response)
+    menu_data = content["data"]["menu"]
+    assert menu_data is not None
+    assert menu_data["name"] == menu.name
+
+
+def test_menu_query_by_name(
+    user_api_client, menu,
+):
+    variables = {"name": menu.name}
+    response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
+    content = get_graphql_content(response)
+    menu_data = content["data"]["menu"]
+    assert menu_data is not None
+    assert menu_data["name"] == menu.name
+
+
+def test_menu_query_error_when_id_and_name_provided(
+    user_api_client, menu, graphql_log_handler,
+):
+    variables = {
+        "id": graphene.Node.to_global_id("Menu", menu.pk),
+        "name": menu.name,
+    }
+    response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
+    assert graphql_log_handler.messages == [
+        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+    ]
+    content = get_graphql_content(response, ignore_errors=True)
+    assert len(content["errors"]) == 1
+
+
+def test_menu_query_error_when_no_param(
+    user_api_client, menu, graphql_log_handler,
+):
+    variables = {}
+    response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
+    assert graphql_log_handler.messages == [
+        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+    ]
+    content = get_graphql_content(response, ignore_errors=True)
+    assert len(content["errors"]) == 1
 
 
 def test_menu_query(user_api_client, menu):

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -36,8 +36,8 @@ from tests.utils import create_image, create_pdf_file_with_image_ext
 
 from .utils import (
     assert_no_permission,
-    get_multipart_request_body,
     construct_query_input,
+    get_multipart_request_body,
 )
 
 
@@ -130,6 +130,8 @@ def test_collection_query(
         assert graphql_log_handler.messages == [
             "saleor.graphql.errors.handled[ERROR].GraphQLError"
         ]
+        content = get_graphql_content(response, ignore_errors=True)
+        assert len(content["errors"]) == 1
     else:
         response = user_api_client.post_graphql(query)
         content = get_graphql_content(response)

--- a/tests/api/test_view.py
+++ b/tests/api/test_view.py
@@ -1,4 +1,3 @@
-import logging
 from unittest import mock
 
 import graphene
@@ -7,7 +6,6 @@ from django.test import override_settings
 
 from saleor.demo.views import EXAMPLE_QUERY
 from saleor.graphql.product.types import Product
-from saleor.graphql.views import handled_errors_logger, unhandled_errors_logger
 
 from .conftest import API_PATH
 from .utils import _get_graphql_content_from_response, get_graphql_content
@@ -127,28 +125,6 @@ def test_graphql_execution_exception(monkeypatch, api_client):
     assert response.status_code == 400
     content = _get_graphql_content_from_response(response)
     assert content["errors"][0]["message"] == "Spanish inquisition"
-
-
-class LoggingHandler(logging.Handler):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.messages = []
-
-    def emit(self, record: logging.LogRecord):
-        exc_type, exc_value, _tb = record.exc_info
-        self.messages.append(
-            f"{record.name}[{record.levelname.upper()}].{exc_type.__name__}"
-        )
-
-
-@pytest.fixture
-def graphql_log_handler():
-    log_handler = LoggingHandler()
-
-    unhandled_errors_logger.addHandler(log_handler)
-    handled_errors_logger.addHandler(log_handler)
-
-    return log_handler
 
 
 def test_invalid_query_graphql_errors_are_logged_in_another_logger(

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,4 +1,6 @@
 import json
+from typing import List
+import graphene
 
 from django.core.serializers.json import DjangoJSONEncoder
 
@@ -62,3 +64,22 @@ def menu_item_to_json(menu_item):
     item_json = get_menu_item_as_dict(menu_item)
     item_json["child_items"] = []
     return item_json
+
+
+def construct_query_input(arguments: List, obj: object) -> str:
+    obj_pk = graphene.Node.to_global_id(obj.__class__.__name__, obj.pk)
+    id_arg = ""
+    slug_arg = ""
+    name_arg = ""
+    if "id" in arguments:
+        id_arg = f'id: "{obj_pk}",'
+    if "slug" in arguments:
+        slug_arg = f'slug: "{obj.slug}",'
+    if "name" in arguments:
+        name_arg = f'name: "{obj.name}",'
+
+    query_input = ""
+    if arguments:
+        query_input = f"({id_arg} {slug_arg} {name_arg})"
+
+    return query_input

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,7 +1,7 @@
 import json
 from typing import List
-import graphene
 
+import graphene
 from django.core.serializers.json import DjangoJSONEncoder
 
 from saleor.graphql.core.utils import snake_to_camel_case

--- a/tests/api/utils.py
+++ b/tests/api/utils.py
@@ -1,7 +1,5 @@
 import json
-from typing import List
 
-import graphene
 from django.core.serializers.json import DjangoJSONEncoder
 
 from saleor.graphql.core.utils import snake_to_camel_case
@@ -64,22 +62,3 @@ def menu_item_to_json(menu_item):
     item_json = get_menu_item_as_dict(menu_item)
     item_json["child_items"] = []
     return item_json
-
-
-def construct_query_input(arguments: List, obj: object) -> str:
-    obj_pk = graphene.Node.to_global_id(obj.__class__.__name__, obj.pk)
-    id_arg = ""
-    slug_arg = ""
-    name_arg = ""
-    if "id" in arguments:
-        id_arg = f'id: "{obj_pk}",'
-    if "slug" in arguments:
-        slug_arg = f'slug: "{obj.slug}",'
-    if "name" in arguments:
-        name_arg = f'name: "{obj.name}",'
-
-    query_input = ""
-    if arguments:
-        query_input = f"({id_arg} {slug_arg} {name_arg})"
-
-    return query_input


### PR DESCRIPTION
It would be easier for storefront to be able to query Category, Collection or Product, simply by its slug and not by its id.
This is one possible solution to this issue that will not break the existing storefront.
Let's discuss.

<!-- Please mention all relevant issue numbers. -->
Fixes #4999

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
