### PR TITLE
Add using fulfillment tracking number as url

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-14 03:45-0500\n"
+"POT-Creation-Date: 2020-05-14 08:33-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -155,7 +155,8 @@ msgid ""
 msgstr ""
 
 #: templates/templated_email/order/confirm_fulfillment.email:15
-#: templates/templated_email/source/confirm_fulfillment.mjml:20
+#: templates/templated_email/source/confirm_fulfillment.mjml:25
+#: templates/templated_email/source/update_fulfillment.mjml:25
 #, python-format
 msgctxt "Fulfillment confirmation email text"
 msgid "You can track your shipment with %(tracking_number)s code."
@@ -352,7 +353,16 @@ msgctxt "Fulfillment confirmation email text"
 msgid "Thank you for your order. Below is the list of fulfilled products."
 msgstr ""
 
-#: templates/templated_email/source/confirm_fulfillment.mjml:27
+#: templates/templated_email/source/confirm_fulfillment.mjml:21
+#: templates/templated_email/source/update_fulfillment.mjml:21
+#, python-format
+msgctxt "Fulfillment confirmation email text"
+msgid ""
+"You can track your shipment with <a href=\"%(tracking_number)s\">"
+"%(tracking_number)s</a> link."
+msgstr ""
+
+#: templates/templated_email/source/confirm_fulfillment.mjml:33
 msgctxt "Fulfillment digital products email text"
 msgid "You can download your digital products by clicking in download link(s)."
 msgstr ""
@@ -489,10 +499,4 @@ msgctxt "Fulfillment update email text"
 msgid ""
 "Your shipping status has been updated. Below is the list of ordered products "
 "that have been updated with new tracking number."
-msgstr ""
-
-#: templates/templated_email/source/update_fulfillment.mjml:20
-#, python-format
-msgctxt "Fulfillment update email text"
-msgid "You can track your shipment with %(tracking_number)s code."
 msgstr ""

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 from operator import attrgetter
+from re import match
 from typing import Optional
 from uuid import uuid4
 
@@ -457,6 +458,10 @@ class Fulfillment(ModelWithMetadata):
 
     def get_total_quantity(self):
         return sum([line.quantity for line in self])
+
+    @property
+    def is_tracking_number_url(self):
+        return bool(match(r"^[-\w]+://", self.tracking_number))
 
 
 class FulfillmentLine(models.Model):

--- a/templates/templated_email/compiled/confirm_fulfillment.html
+++ b/templates/templated_email/compiled/confirm_fulfillment.html
@@ -107,9 +107,15 @@
             Thank you for your order. Below is the list of fulfilled products.
           {% endblocktrans %}
           {% if fulfillment.tracking_number %}
-            {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
-              You can track your shipment with {{ tracking_number }} code.
-            {% endblocktrans %}
+            {% if fulfillment.is_tracking_number_url %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with <a href="{{ tracking_number }}">{{ tracking_number }}</a> link.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with {{ tracking_number }} code.
+              {% endblocktrans %}
+            {% endif %}
           {% endif %}</div>
     
               </td>

--- a/templates/templated_email/compiled/update_fulfillment.html
+++ b/templates/templated_email/compiled/update_fulfillment.html
@@ -107,9 +107,15 @@
             Your shipping status has been updated. Below is the list of ordered products that have been updated with new tracking number.
           {% endblocktrans %}
           {% if fulfillment.tracking_number %}
-            {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment update email text" %}
-              You can track your shipment with {{ tracking_number }} code.
-            {% endblocktrans %}
+            {% if fulfillment.is_tracking_number_url %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with <a href="{{ tracking_number }}">{{ tracking_number }}</a> link.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with {{ tracking_number }} code.
+              {% endblocktrans %}
+            {% endif %}
           {% endif %}</div>
     
               </td>

--- a/templates/templated_email/source/confirm_fulfillment.mjml
+++ b/templates/templated_email/source/confirm_fulfillment.mjml
@@ -17,9 +17,15 @@
             Thank you for your order. Below is the list of fulfilled products.
           {% endblocktrans %}
           {% if fulfillment.tracking_number %}
-            {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
-              You can track your shipment with {{ tracking_number }} code.
-            {% endblocktrans %}
+            {% if fulfillment.is_tracking_number_url %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with <a href="{{ tracking_number }}">{{ tracking_number }}</a> link.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with {{ tracking_number }} code.
+              {% endblocktrans %}
+            {% endif %}
           {% endif %}
         </mj-text>
         <mj-text>

--- a/templates/templated_email/source/update_fulfillment.mjml
+++ b/templates/templated_email/source/update_fulfillment.mjml
@@ -17,9 +17,15 @@
             Your shipping status has been updated. Below is the list of ordered products that have been updated with new tracking number.
           {% endblocktrans %}
           {% if fulfillment.tracking_number %}
-            {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment update email text" %}
-              You can track your shipment with {{ tracking_number }} code.
-            {% endblocktrans %}
+            {% if fulfillment.is_tracking_number_url %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with <a href="{{ tracking_number }}">{{ tracking_number }}</a> link.
+              {% endblocktrans %}
+            {% else %}
+              {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
+                You can track your shipment with {{ tracking_number }} code.
+              {% endblocktrans %}
+            {% endif %}
           {% endif %}
         </mj-text>
       </mj-column>

--- a/tests/test_order.py
+++ b/tests/test_order.py
@@ -256,6 +256,14 @@ def test_update_order_status(fulfilled_order):
     assert fulfilled_order.status == OrderStatus.UNFULFILLED
 
 
+def test_validate_fulfillment_tracking_number_as_url(fulfilled_order):
+    fulfillment = fulfilled_order.fulfillments.first()
+    assert not fulfillment.is_tracking_number_url
+    fulfillment.tracking_number = "https://www.example.com"
+    fulfillment.save()
+    assert fulfillment.is_tracking_number_url
+
+
 def test_order_queryset_confirmed(draft_order):
     other_orders = [
         Order.objects.create(status=OrderStatus.UNFULFILLED),


### PR DESCRIPTION
I want to merge this change because very often Fulfillment reference_number takes form of URL to courier web page with shipment details.
I wanted to distinguish that and display as link in confirm_fulfillment and update_fulfillment email templates. 
![screencapture](https://user-images.githubusercontent.com/6453010/80734759-ea4e6d00-8b0f-11ea-8a63-ad4f577a06dd.png)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
