### PR TITLE
Fix productVariantStocksCreate should accept empty stocks input

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -373,10 +373,11 @@ class ProductVariantStocksCreate(BaseMutation):
         variant = cls.get_node_or_error(
             info, data["variant_id"], only_type=ProductVariant
         )
-        warehouses = cls.clean_stocks_input(variant, stocks, errors)
-        if errors:
-            raise ValidationError(errors)
-        create_stocks(variant, stocks, warehouses)
+        if stocks:
+            warehouses = cls.clean_stocks_input(variant, stocks, errors)
+            if errors:
+                raise ValidationError(errors)
+            create_stocks(variant, stocks, warehouses)
         return cls(product_variant=variant)
 
     @classmethod


### PR DESCRIPTION
I want to merge this change because `productVariantStocksCreate` shouldn't return error on the empty list as stocks input. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
