### PR TITLE
Fix checkout and order flow with variant without inventory tracking

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -26,7 +26,6 @@ from ...core.mutations import (
 from ...core.types.common import AccountError
 from ...meta.deprecated.mutations import ClearMetaBaseMutation, UpdateMetaBaseMutation
 
-
 BILLING_ADDRESS_FIELD = "default_billing_address"
 SHIPPING_ADDRESS_FIELD = "default_shipping_address"
 INVALID_TOKEN = "Invalid or expired token."

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -264,17 +264,18 @@ class DraftOrderComplete(BaseMutation):
         order.save()
 
         for line in order:
-            try:
-                allocate_stock(line, country, line.quantity)
-            except InsufficientStock as exc:
-                raise ValidationError(
-                    {
-                        "lines": ValidationError(
-                            f"Insufficient product stock: {exc.item}",
-                            code=OrderErrorCode.INSUFFICIENT_STOCK,
-                        )
-                    }
-                )
+            if line.variant.track_inventory:
+                try:
+                    allocate_stock(line, country, line.quantity)
+                except InsufficientStock as exc:
+                    raise ValidationError(
+                        {
+                            "lines": ValidationError(
+                                f"Insufficient product stock: {exc.item}",
+                                code=OrderErrorCode.INSUFFICIENT_STOCK,
+                            )
+                        }
+                    )
         order_created(order, user=info.context.user, from_draft=True)
 
         return DraftOrderComplete(order=order)

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -288,9 +288,9 @@ def restock_fulfillment_lines(fulfillment, warehouse):
     for line in fulfillment:
         if line.order_line.variant and line.order_line.variant.track_inventory:
             increase_stock(line.order_line, warehouse, line.quantity, allocate=True)
-            order_line = line.order_line
-            order_line.quantity_fulfilled -= line.quantity
-            order_lines.append(order_line)
+        order_line = line.order_line
+        order_line.quantity_fulfilled -= line.quantity
+        order_lines.append(order_line)
     OrderLine.objects.bulk_update(order_lines, ["quantity_fulfilled"])
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1267,6 +1267,22 @@ def fulfilled_order(order_with_lines):
 
 
 @pytest.fixture
+def fulfilled_order_without_inventory_tracking(
+    order_with_line_without_inventory_tracking,
+):
+    order = order_with_line_without_inventory_tracking
+    fulfillment = order.fulfillments.create(tracking_number="123")
+    line = order.lines.first()
+    stock = line.variant.stocks.get()
+    warehouse_pk = stock.warehouse.pk
+    fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
+    fulfill_order_line(line, line.quantity, warehouse_pk)
+    order.status = OrderStatus.FULFILLED
+    order.save(update_fields=["status"])
+    return order
+
+
+@pytest.fixture
 def fulfilled_order_with_cancelled_fulfillment(fulfilled_order):
     fulfillment = fulfilled_order.fulfillments.create()
     line_1 = fulfilled_order.lines.first()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -225,6 +225,16 @@ def checkout_with_single_item(checkout, product):
 
 
 @pytest.fixture
+def checkout_with_variant_without_inventory_tracking(
+    checkout, variant_without_inventory_tracking
+):
+    variant = variant_without_inventory_tracking
+    add_variant_to_checkout(checkout, variant, 1)
+    checkout.save()
+    return checkout
+
+
+@pytest.fixture
 def checkout_with_items(checkout, product_list, product):
     variant = product.variants.get()
     add_variant_to_checkout(checkout, variant, 1)


### PR DESCRIPTION
I want to merge this change because fixing checkout and order flow with variant without inventory tracking. 

To create an available product variant without inventory tracking staff users should crate stock with any quantity to allow selling that product variant from the proper warehouse. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
