### PR TITLE
Fix isort crashing

### DIFF
--- a/saleor/core/utils/json_serializer.py
+++ b/saleor/core/utils/json_serializer.py
@@ -1,4 +1,5 @@
-from django.core.serializers.json import DjangoJSONEncoder, Serializer as JsonSerializer
+from django.core.serializers.json import DjangoJSONEncoder
+from django.core.serializers.json import Serializer as JsonSerializer
 from draftjs_sanitizer import SafeJSONEncoder
 from prices import Money
 

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -4,7 +4,9 @@ from django.contrib.auth import password_validation
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
 
-from ....account import emails, events as account_events, models, utils
+from ....account import emails
+from ....account import events as account_events
+from ....account import models, utils
 from ....account.error_codes import AccountErrorCode
 from ....account.utils import create_jwt_token, decode_jwt_token
 from ....checkout import AddressType

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -5,7 +5,8 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from graphql_jwt.exceptions import PermissionDenied
 
-from ....account import events as account_events, models
+from ....account import events as account_events
+from ....account import models
 from ....account.emails import (
     send_set_password_email_with_url,
     send_user_password_reset_email_with_url,
@@ -25,7 +26,6 @@ from ...core.mutations import (
 )
 from ...core.types.common import AccountError
 from ...meta.deprecated.mutations import ClearMetaBaseMutation, UpdateMetaBaseMutation
-
 
 BILLING_ADDRESS_FIELD = "default_billing_address"
 SHIPPING_ADDRESS_FIELD = "default_shipping_address"

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -7,7 +7,8 @@ from django.db import transaction
 from graphql_jwt.decorators import staff_member_required
 from graphql_jwt.exceptions import PermissionDenied
 
-from ....account import events as account_events, models, utils
+from ....account import events as account_events
+from ....account import models, utils
 from ....account.emails import send_set_password_email_with_url
 from ....account.error_codes import AccountErrorCode
 from ....account.thumbnails import create_user_avatar_thumbnails

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -1,5 +1,6 @@
 import graphene
-from django.contrib.auth import get_user_model, models as auth_models
+from django.contrib.auth import get_user_model
+from django.contrib.auth import models as auth_models
 from graphene import relay
 from graphene_federation import key
 from graphql_jwt.exceptions import PermissionDenied

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -30,7 +30,8 @@ from ...core.permissions import OrderPermissions
 from ...core.taxes import TaxError
 from ...core.utils.url import validate_storefront_url
 from ...discount import models as voucher_model
-from ...payment import PaymentError, gateway, models as payment_models
+from ...payment import PaymentError, gateway
+from ...payment import models as payment_models
 from ...payment.interface import AddressData
 from ...payment.utils import store_customer_id
 from ...product import models as product_models

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -2,7 +2,8 @@ import json
 from typing import Any, Dict, Iterable, List, Tuple, Union
 
 import graphene
-from django.db.models import Model as DjangoModel, Q, QuerySet
+from django.db.models import Model as DjangoModel
+from django.db.models import Q, QuerySet
 from graphene.relay.connection import Connection
 from graphene_django.types import DjangoObjectType
 from graphql.error import GraphQLError

--- a/saleor/graphql/core/enums.py
+++ b/saleor/graphql/core/enums.py
@@ -3,7 +3,8 @@ import graphene
 from ...account import error_codes as account_error_codes
 from ...app import error_codes as app_error_codes
 from ...checkout import error_codes as checkout_error_codes
-from ...core import JobStatus, error_codes as core_error_codes
+from ...core import JobStatus
+from ...core import error_codes as core_error_codes
 from ...core.permissions import get_permissions_enum_list
 from ...core.weight import WeightUnits
 from ...discount import error_codes as discount_error_codes

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -1,4 +1,5 @@
-from ...payment import gateway as payment_gateway, models
+from ...payment import gateway as payment_gateway
+from ...payment import models
 from ...payment.utils import fetch_customer_id
 from ..utils.filters import filter_by_query_param
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -16,11 +16,8 @@ from django.views.generic import View
 from graphene_django.settings import graphene_settings
 from graphene_django.views import instantiate_middleware
 from graphql import GraphQLDocument, get_default_backend
-from graphql.error import (
-    GraphQLError,
-    GraphQLSyntaxError,
-    format_error as format_graphql_error,
-)
+from graphql.error import GraphQLError, GraphQLSyntaxError
+from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 from graphql_jwt.exceptions import PermissionDenied
 

--- a/tests/api/test_bulk_delete.py
+++ b/tests/api/test_bulk_delete.py
@@ -9,7 +9,8 @@ from saleor.account.models import User
 from saleor.core.permissions import AccountPermissions, OrderPermissions
 from saleor.discount.models import Sale, Voucher
 from saleor.menu.models import Menu, MenuItem
-from saleor.order import OrderStatus, models as order_models
+from saleor.order import OrderStatus
+from saleor.order import models as order_models
 from saleor.page.models import Page
 from saleor.product.models import (
     Attribute,

--- a/tests/api/test_order.py
+++ b/tests/api/test_order.py
@@ -20,7 +20,8 @@ from saleor.graphql.order.mutations.orders import (
 )
 from saleor.graphql.order.utils import validate_draft_order
 from saleor.graphql.payment.types import PaymentChargeStatusEnum
-from saleor.order import OrderStatus, events as order_events
+from saleor.order import OrderStatus
+from saleor.order import events as order_events
 from saleor.order.error_codes import OrderErrorCode
 from saleor.order.models import Order, OrderEvent
 from saleor.payment import ChargeStatus, CustomPaymentChoices, PaymentError


### PR DESCRIPTION
I want to merge this change because... it fixes `isort --check-only` crashing

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
