### PR TITLE
Fixed JWT expired token being logged as unhandled error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
+- Fixed JWT expired token being flagged as unhandled error rather than handled. - #5603 by @NyanKiyoshi
 
 ## 2.10.0
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -22,7 +22,7 @@ from graphql.error import (
     format_error as format_graphql_error,
 )
 from graphql.execution import ExecutionResult
-from graphql_jwt.exceptions import PermissionDenied
+from graphql_jwt.exceptions import JSONWebTokenError
 
 from ..core.utils import is_valid_ipv4, is_valid_ipv6
 
@@ -58,7 +58,7 @@ class GraphQLView(View):
     middleware = None
     root_value = None
 
-    HANDLED_EXCEPTIONS = (GraphQLError, PermissionDenied)
+    HANDLED_EXCEPTIONS = (GraphQLError, JSONWebTokenError)
 
     def __init__(
         self, schema=None, executor=None, middleware=None, root_value=None, backend=None

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -1,6 +1,7 @@
 import ast
 import os.path
 import warnings
+from datetime import timedelta
 
 import dj_database_url
 import dj_email_url
@@ -473,9 +474,12 @@ AUTHENTICATION_BACKENDS = [
 # Django GraphQL JWT settings
 GRAPHQL_JWT = {
     "JWT_PAYLOAD_HANDLER": "saleor.graphql.utils.create_jwt_payload",
+    # How long until a token expires, default is 5m from graphql_jwt.settings
+    "JWT_EXPIRATION_DELTA": timedelta(minutes=5),
+    # Whether the JWT tokens should expire or not
+    # Enabled by default in production mode; disabled in development mode by default
+    "JWT_VERIFY_EXPIRATION": get_bool_from_env("JWT_VERIFY_EXPIRATION", not DEBUG),
 }
-if not DEBUG:
-    GRAPHQL_JWT["JWT_VERIFY_EXPIRATION"] = True  # type: ignore
 
 # CELERY SETTINGS
 CELERY_BROKER_URL = (


### PR DESCRIPTION
Closes #5601.

- Properly handle valid errors such as `JSONWebTokenExpired` coming from invalid JWT payload;
- Allow to toggle JWT verification whether `DEBUG` is enable or not (useful for testing each mode);
- Added the default value of `JWT_EXPIRATION_DELTA` as it allows the users to customize it if needed or at least know how long a token stays valid.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
