### PR TITLE
Fix availability for variants without inventory tracking

### DIFF
--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -56,6 +56,8 @@ def get_available_quantity_for_customer(
     stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
     if not stocks:
         return 0
+    if not variant.track_inventory:
+        return settings.MAX_CHECKOUT_LINE_QUANTITY
     return min(_get_available_quantity(stocks), settings.MAX_CHECKOUT_LINE_QUANTITY)
 
 
@@ -68,7 +70,7 @@ def get_quantity_allocated(variant: "ProductVariant", country_code: str) -> int:
 
 def is_variant_in_stock(variant: "ProductVariant", country_code: str) -> bool:
     """Check if variant is available in given country."""
-    quantity_available = get_available_quantity(variant, country_code)
+    quantity_available = get_available_quantity_for_customer(variant, country_code)
     return quantity_available > 0
 
 


### PR DESCRIPTION
I want to merge this change because fixing availability for variants without inventory tracking. It's fixed deprecated fields. In the near feature, we add `quantityAvailable` field with allow users to check available quantity for the product in a country. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
