### PR TITLE
Add url handler for plugins

### DIFF
--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -48,6 +48,7 @@ class BasePlugin:
     CONFIG_STRUCTURE = None
     DEFAULT_CONFIGURATION = []
     DEFAULT_ACTIVE = False
+    URL_ID = None
 
     def __init__(self, *, configuration: PluginConfigurationType, active: bool):
         self.configuration = self.get_plugin_configuration(configuration)
@@ -419,3 +420,17 @@ class BasePlugin:
             # Let's add a translated descriptions and labels
             self._append_config_structure(configuration)
         return configuration
+
+    @classmethod
+    def register_urls(cls):
+        """Append plugin urls to Saleor.
+
+        Register list of urls to Saleor. URL_ID is required to properly register plugin
+        views. Url will have a given structure:
+        [
+            /plugins/<plugin.URL_ID>/<registered_view1>
+            /plugins/<plugin.URL_ID>/<registered_view2>
+        ]
+        See sample usage - tests.plugins.sample_plugins.PluginSample
+        """
+        return NotImplemented

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -15,8 +15,7 @@ from .models import PluginConfiguration
 
 if TYPE_CHECKING:
     # flake8: noqa
-    from django.db.models.query import QuerySet
-    from .base_plugin import BasePlugin, PluginConfigurationType
+    from .base_plugin import BasePlugin
     from ..checkout.models import Checkout, CheckoutLine
     from ..product.models import Product, ProductType
     from ..account.models import Address, User

--- a/saleor/plugins/urls.py
+++ b/saleor/plugins/urls.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.urls import include, path
+from django.utils.module_loading import import_string
+
+
+def register_plugins_urls():
+    plugins = settings.PLUGINS
+    urlpatterns = []
+    for plugin_path in plugins:
+        PluginClass = import_string(plugin_path)
+        if not PluginClass.URL_ID:
+            continue
+        plugin_urls = PluginClass.register_urls()
+        if not plugin_urls:
+            continue
+        urlpatterns.append(path(f"{PluginClass.URL_ID}/", include(plugin_urls)))
+    return urlpatterns

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -7,6 +7,7 @@ from django.views.decorators.csrf import csrf_exempt
 from .data_feeds.urls import urlpatterns as feed_urls
 from .graphql.api import schema
 from .graphql.views import GraphQLView
+from .plugins.urls import register_plugins_urls
 from .product.views import digital_product
 
 urlpatterns = [
@@ -17,6 +18,7 @@ urlpatterns = [
         digital_product,
         name="digital-product",
     ),
+    url(r"plugins/", include(register_plugins_urls())),
 ]
 
 if settings.DEBUG:

--- a/tests/plugins/sample_plugins.py
+++ b/tests/plugins/sample_plugins.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING, Union
 
+from django.http import JsonResponse
+from django.urls import include, path
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
@@ -16,6 +18,7 @@ if TYPE_CHECKING:
 
 
 class PluginSample(BasePlugin):
+    URL_ID = "plugin-sample"
     PLUGIN_ID = "plugin.sample"
     PLUGIN_NAME = "PluginSample"
     PLUGIN_DESCRIPTION = "Test plugin description"
@@ -95,6 +98,26 @@ class PluginSample(BasePlugin):
         self, obj: Union["Product", "ProductType"], country: Country, previous_value
     ) -> Decimal:
         return Decimal("15.0").quantize(Decimal("1."))
+
+    @classmethod
+    def register_urls(cls):
+        def handle_request(request):
+            return JsonResponse({"plugin_id": cls.PLUGIN_ID, "msg": "Request handled"})
+
+        def handle_detail_request(request, pk):
+            return JsonResponse(
+                {
+                    "plugin_id": cls.PLUGIN_ID,
+                    "recieved_pk": pk,
+                    "msg": "Request handled",
+                }
+            )
+
+        urls = [
+            path("test-request/", handle_request),
+            path("test-request/<int:pk>/", handle_detail_request),
+        ]
+        return urls
 
 
 class PluginInactive(BasePlugin):

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -96,3 +96,12 @@ def test_change_user_address_in_anonymize_plugin_reset_phone(address, settings):
         address=address, address_type=None, user=None, previous_value=address
     )
     assert not new_address.phone
+
+
+def test_registered_urls(client, settings):
+    settings.PLUGINS = ["tests.plugins.sample_plugins.PluginSample"]
+    response = client.get("/plugins/plugin-sample/test-request/")
+    assert response.status_code == 200
+
+    response = client.get("/plugins/plugin-sample/test-request/11/")
+    assert response.status_code == 200

--- a/tests/plugins/test_urls.py
+++ b/tests/plugins/test_urls.py
@@ -1,0 +1,30 @@
+from saleor.plugins.urls import register_plugins_urls
+
+
+def test_register_plugins_urls(settings):
+    settings.PLUGINS = ["tests.plugins.sample_plugins.PluginSample"]
+
+    urls = register_plugins_urls()
+
+    assert len(urls) == 1
+    plugin_resolver = urls[0]
+    assert len(plugin_resolver.url_patterns) == 2
+
+    # direct call on index list because we know position of the patterns.
+    test_request = plugin_resolver.url_patterns[0]
+    test_request_detail = plugin_resolver.url_patterns[1]
+
+    assert test_request.lookup_str == (
+        "tests.plugins.sample_plugins.PluginSample."
+        "register_urls.<locals>.handle_request"
+    )
+    assert test_request_detail.lookup_str == (
+        "tests.plugins.sample_plugins.PluginSample."
+        "register_urls.<locals>.handle_detail_request"
+    )
+
+
+def test_test_register_plugins_urls_plugins_without_urls(settings):
+    settings.PLUGINS = ["tests.plugins.sample_plugins.ActivePlugin"]
+    urls = register_plugins_urls()
+    assert len(urls) == 0


### PR DESCRIPTION
Some plugins (especially payment gateways) require two ways of communication. This PR adds possibility to extend Saleor.urls by custom URLs defined by plugins.
This is an implementation for #4955

It adds:
- new flag to `BasePlugin` - `URL_ID` which is required to generate URL path for plugin
- new method to `BasePlugin` - `register_urls` which should return a list of Django URLs.

The structure of URLs will be as below:
 - `/plugins/<plugin.URL-ID>/register_view1` - where `register_view1` is view defined by a given plugin. 

Example of possible urls based on Braintree:
 - `plugins/braintree/webhooks/handle_payment`
