### PR TITLE
Disable JWT expiration in production by default

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -462,8 +462,7 @@ GRAPHQL_JWT = {
     # How long until a token expires, default is 5m from graphql_jwt.settings
     "JWT_EXPIRATION_DELTA": timedelta(minutes=5),
     # Whether the JWT tokens should expire or not
-    # Enabled by default in production mode; disabled in development mode by default
-    "JWT_VERIFY_EXPIRATION": get_bool_from_env("JWT_VERIFY_EXPIRATION", not DEBUG),
+    "JWT_VERIFY_EXPIRATION": get_bool_from_env("JWT_VERIFY_EXPIRATION", False),
 }
 
 # CELERY SETTINGS


### PR DESCRIPTION
Disable JWT expiration in production by default. We'll re-enable it once we'll implement proper JWT refreshing in our frontend clients.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
