### PR TITLE
Add quantityAvailable field to ProductVariant type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,10 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
-- Drop support for configuring Vatlayer plugin from settings file. - #5614 by @korycins
 
+- Drop support for configuring Vatlayer plugin from settings file. - #5614 by @korycins
 - Add ability to query category, collection or product by slug - #5574 by @koradon
+- Add `quantityAvailable` field to `ProductVariant` type - #5628 by @fowczarek
 
 ## 2.10.0
 - Use tags rather than time-based logs for information on requests - #5608 by @NyanKiyoshi

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -21,7 +21,6 @@ from ....product.utils.costs import get_margin_for_variant, get_product_costs_da
 from ....warehouse.availability import (
     get_available_quantity,
     get_available_quantity_for_customer,
-    get_max_available_quantity_for_customer,
     get_quantity_allocated,
     is_product_in_stock,
     is_variant_in_stock,
@@ -189,7 +188,8 @@ class ProductVariant(CountableDjangoObjectType):
         required=True,
         description="Quantity of a product available for sale.",
         deprecation_reason=(
-            "Use the stock field instead. This field will be removed after 2020-07-31."
+            "Use the quantity_available field instead. "
+            "This field will be removed after 2020-07-31."
         ),
     )
     price_override = graphene.Field(
@@ -274,8 +274,6 @@ class ProductVariant(CountableDjangoObjectType):
     def resolve_quantity_available(
         root: models.ProductVariant, info, country_code=None
     ):
-        if not country_code:
-            return get_max_available_quantity_for_customer(root)
         return get_available_quantity_for_customer(root, country_code)
 
     @staticmethod

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -252,7 +252,13 @@ class ProductVariant(CountableDjangoObjectType):
         required=True,
         description="Quantity of a product available for sale in one checkout.",
         country_code=graphene.Argument(
-            CountryCodeEnum, description="Two-letter ISO 3166-1 country code.",
+            CountryCodeEnum,
+            description=(
+                "Two-letter ISO 3166-1 country code. When provided, the exact quantity "
+                "from a warehouse operating in shipping zones that contain this "
+                "country will be returned. Otherwise, it will return the maximum "
+                "quantity from all shipping zones."
+            ),
         ),
     )
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -188,7 +188,7 @@ class ProductVariant(CountableDjangoObjectType):
         required=True,
         description="Quantity of a product available for sale.",
         deprecation_reason=(
-            "Use the quantity_available field instead. "
+            "Use the quantityAvailable field instead. "
             "This field will be removed after 2020-07-31."
         ),
     )
@@ -265,6 +265,7 @@ class ProductVariant(CountableDjangoObjectType):
         model = models.ProductVariant
 
     @staticmethod
+    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_stocks(root: models.ProductVariant, info, country_code=None):
         if not country_code:
             return root.stocks.annotate_available_quantity().all()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3720,7 +3720,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   quantity: Int! @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
   quantityAllocated: Int @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
-  stockQuantity: Int! @deprecated(reason: "Use the quantity_available field instead. This field will be removed after 2020-07-31.")
+  stockQuantity: Int! @deprecated(reason: "Use the quantityAvailable field instead. This field will be removed after 2020-07-31.")
   priceOverride: Money
   pricing: VariantPricingInfo
   isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
@@ -4567,7 +4567,6 @@ type Stock implements Node {
   productVariant: ProductVariant!
   quantity: Int!
   id: ID!
-  stockQuantity: Int!
   quantityAllocated: Int!
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3720,7 +3720,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   quantity: Int! @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
   quantityAllocated: Int @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
-  stockQuantity: Int! @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
+  stockQuantity: Int! @deprecated(reason: "Use the quantity_available field instead. This field will be removed after 2020-07-31.")
   priceOverride: Money
   pricing: VariantPricingInfo
   isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3733,6 +3733,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
   stocks(countryCode: CountryCode): [Stock]
+  quantityAvailable(countryCode: CountryCode): Int!
 }
 
 type ProductVariantBulkCreate {

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -1,5 +1,4 @@
 import graphene
-from django.conf import settings
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
@@ -61,10 +60,6 @@ class Warehouse(CountableDjangoObjectType):
 
 
 class Stock(CountableDjangoObjectType):
-    stock_quantity = graphene.Int(
-        description="Quantity of a product available for sale.", required=True
-    )
-
     quantity = graphene.Int(
         required=True,
         description="Quantity of a product in the warehouse's possession, "
@@ -79,14 +74,6 @@ class Stock(CountableDjangoObjectType):
         model = models.Stock
         interfaces = [graphene.relay.Node]
         only_fields = ["warehouse", "product_variant", "quantity", "quantity_allocated"]
-
-    @staticmethod
-    def resolve_stock_quantity(root, *_args):
-        quantity_allocated = root.allocations.aggregate(
-            quantity_allocated=Coalesce(Sum("quantity_allocated"), 0)
-        )["quantity_allocated"]
-        available_quantity = max(root.quantity - quantity_allocated, 0)
-        return min(available_quantity, settings.MAX_CHECKOUT_LINE_QUANTITY)
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -56,7 +56,12 @@ def get_available_quantity_for_customer(
     """Return maximum checkout line quantity.
 
     Returns maximum checkout quantity for the given variant and country code.
-    If country code is missing return maximum checkout quantity from shipping zones.
+    If country code is provided, the function returns the exact variant quantity
+    available in warehouses operating in shipping zones containing this country.
+    Otherwise, it returns the maximum quantity from all shipping zones.
+
+    The returned value is limited by `MAX_CHECKOUT_LINE_QUANTITY` setting to
+    limit the quantity of a variant that can be added in one checkout line.
     """
     query = Q(product_variant=variant)
     if country_code:

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -1,11 +1,11 @@
-from typing import TYPE_CHECKING
+from collections import defaultdict
+from typing import TYPE_CHECKING, Dict
 
 from django.conf import settings
-from django.db.models import Sum
+from django.db.models import Q, Sum
 from django.db.models.functions import Coalesce
 
 from ..core.exceptions import InsufficientStock
-from ..shipping.models import ShippingZone
 from .models import Stock, StockQuerySet
 
 if TYPE_CHECKING:
@@ -51,35 +51,39 @@ def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:
 
 
 def get_available_quantity_for_customer(
-    variant: "ProductVariant", country_code: str
+    variant: "ProductVariant", country_code: str = None
 ) -> int:
-    """Return maximum checkout line quantity."""
-    stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
+    """Return maximum checkout line quantity.
+
+    Returns maximum checkout quantity for the given variant and country code.
+    If country code is missing return maximum checkout quantity from shipping zones.
+    """
+    query = Q(product_variant=variant)
+    if country_code:
+        query &= Q(warehouse__shipping_zones__countries__contains=country_code)
+    stocks = (
+        Stock.objects.filter(query)
+        .annotate(
+            available_quantity=Sum("quantity")
+            - Coalesce(Sum("allocations__quantity_allocated"), 0)
+        )
+        .values_list("warehouse__shipping_zones", "available_quantity")
+    )
+
     if not stocks:
         return 0
     if not variant.track_inventory:
         return settings.MAX_CHECKOUT_LINE_QUANTITY
-    return min(_get_available_quantity(stocks), settings.MAX_CHECKOUT_LINE_QUANTITY)
 
+    available_quantity_in_shipping_zones: Dict = defaultdict(int)
+    for shipping_zone_pk, available_quantity in stocks:
+        available_quantity_in_shipping_zones[shipping_zone_pk] += available_quantity
 
-def get_max_available_quantity_for_customer(variant: "ProductVariant") -> int:
-    """Return maximum checkout line quantity for all shipping zones."""
-    availability_in_shipping_zones = (
-        ShippingZone.objects.filter(warehouses__stock__product_variant=variant)
-        .values("pk")
-        .annotate(
-            available_quantity=Sum("warehouses__stock__quantity")
-            - Coalesce(Sum("warehouses__stock__allocations__quantity_allocated"), 0)
-        )
-        .values_list("available_quantity", flat=True)
-    )
+    max_available_quantity = max(
+        available_quantity_in_shipping_zones.items(), key=lambda x: x[1]
+    )[1]
 
-    if not availability_in_shipping_zones:
-        return 0
-    if not variant.track_inventory:
-        return settings.MAX_CHECKOUT_LINE_QUANTITY
-    max_available_in_shipping_zone = max(availability_in_shipping_zones)
-    return min(max_available_in_shipping_zone, settings.MAX_CHECKOUT_LINE_QUANTITY)
+    return min(max_available_quantity, settings.MAX_CHECKOUT_LINE_QUANTITY)
 
 
 def get_quantity_allocated(variant: "ProductVariant", country_code: str) -> int:

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -96,9 +96,6 @@ class Stock(models.Model):
         unique_together = [["warehouse", "product_variant"]]
         ordering = ("pk",)
 
-    def __str__(self):
-        return f"{self.product_variant} - {self.warehouse.name}"
-
     def increase_stock(self, quantity: int, commit: bool = True):
         """Return given quantity of product to a stock."""
         self.quantity = F("quantity") + quantity

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -3411,6 +3411,70 @@ def test_variant_availability_without_inventory_tracking_not_available(
     assert variant_data["stockQuantity"] == 0
 
 
+@patch("saleor.graphql.product.types.products.get_available_quantity_for_customer")
+def test_variant_quantity_available_with_country_code(
+    mock_get_available_quantity_for_customer, api_client, variant
+):
+    query = """
+    query variantAvailability($id: ID!, $country: CountryCode) {
+        productVariant(id: $id) {
+            quantityAvailable(countryCode: $country)
+        }
+    }
+    """
+    country = "PL"
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": country,
+    }
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data
+    mock_get_available_quantity_for_customer.assert_called_once_with(variant, "PL")
+
+
+@patch("saleor.graphql.product.types.products.get_max_available_quantity_for_customer")
+def test_variant_quantity_available_without_country_code(
+    mock_get_max_available_quantity_for_customer, api_client, variant
+):
+    query = """
+    query variantAvailability($id: ID!) {
+        productVariant(id: $id) {
+            quantityAvailable
+        }
+    }
+    """
+    variables = {"id": graphene.Node.to_global_id("ProductVariant", variant.pk)}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data
+    mock_get_max_available_quantity_for_customer.assert_called_once_with(variant)
+
+
+@patch("saleor.graphql.product.types.products.get_max_available_quantity_for_customer")
+def test_variant_quantity_available_with_null_as_country_code(
+    mock_get_available_quantity_for_customer, api_client, variant
+):
+    query = """
+    query variantAvailability($id: ID!, $country: CountryCode) {
+        productVariant(id: $id) {
+            quantityAvailable(countryCode: $country)
+        }
+    }
+    """
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": None,
+    }
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data
+    mock_get_available_quantity_for_customer.assert_called_once_with(variant)
+
+
 @pytest.mark.parametrize(
     "collection_filter, count",
     [

--- a/tests/api/test_product.py
+++ b/tests/api/test_product.py
@@ -3434,9 +3434,9 @@ def test_variant_quantity_available_with_country_code(
     mock_get_available_quantity_for_customer.assert_called_once_with(variant, "PL")
 
 
-@patch("saleor.graphql.product.types.products.get_max_available_quantity_for_customer")
+@patch("saleor.graphql.product.types.products.get_available_quantity_for_customer")
 def test_variant_quantity_available_without_country_code(
-    mock_get_max_available_quantity_for_customer, api_client, variant
+    mock_get_available_quantity_for_customer, api_client, variant
 ):
     query = """
     query variantAvailability($id: ID!) {
@@ -3450,10 +3450,10 @@ def test_variant_quantity_available_without_country_code(
     content = get_graphql_content(response)
     variant_data = content["data"]["productVariant"]
     assert variant_data
-    mock_get_max_available_quantity_for_customer.assert_called_once_with(variant)
+    mock_get_available_quantity_for_customer.assert_called_once_with(variant, None)
 
 
-@patch("saleor.graphql.product.types.products.get_max_available_quantity_for_customer")
+@patch("saleor.graphql.product.types.products.get_available_quantity_for_customer")
 def test_variant_quantity_available_with_null_as_country_code(
     mock_get_available_quantity_for_customer, api_client, variant
 ):
@@ -3472,7 +3472,7 @@ def test_variant_quantity_available_with_null_as_country_code(
     content = get_graphql_content(response)
     variant_data = content["data"]["productVariant"]
     assert variant_data
-    mock_get_available_quantity_for_customer.assert_called_once_with(variant)
+    mock_get_available_quantity_for_customer.assert_called_once_with(variant, None)
 
 
 @pytest.mark.parametrize(

--- a/tests/api/test_stock.py
+++ b/tests/api/test_stock.py
@@ -19,7 +19,6 @@ query stock($id: ID!) {
         }
         quantity
         quantityAllocated
-        stockQuantity
     }
 }
 """
@@ -165,27 +164,3 @@ def test_query_stocks_with_filters_product_variant__product(
         total_count
         == Stock.objects.filter(product_variant__product__name=product.name).count()
     )
-
-
-def test_query_available_stock_quantity(
-    staff_api_client, permission_manage_products, stock, settings
-):
-    staff_api_client.user.user_permissions.add(permission_manage_products)
-    stock_id = graphene.Node.to_global_id("Stock", stock.pk)
-
-    available_quantity = stock.quantity - get_quantity_allocated_for_stock(stock)
-    # set MAX_CHECKOUT_LINE_QUANTITY smaller than available quantity
-    settings.MAX_CHECKOUT_LINE_QUANTITY = available_quantity - 1
-
-    response = staff_api_client.post_graphql(QUERY_STOCK, variables={"id": stock_id})
-    content = get_graphql_content(response)
-    content_quantity_available = content["data"]["stock"]["stockQuantity"]
-    assert content_quantity_available == settings.MAX_CHECKOUT_LINE_QUANTITY
-
-    # set MAX_CHECKOUT_LINE_QUANTITY larger than available quantity
-    settings.MAX_CHECKOUT_LINE_QUANTITY = available_quantity + 1
-
-    response = staff_api_client.post_graphql(QUERY_STOCK, variables={"id": stock_id})
-    content = get_graphql_content(response)
-    content_quantity_available = content["data"]["stock"]["stockQuantity"]
-    assert content_quantity_available == available_quantity

--- a/tests/test_stock_availability.py
+++ b/tests/test_stock_availability.py
@@ -7,9 +7,10 @@ from saleor.warehouse.availability import (
     check_stock_quantity,
     get_available_quantity,
     get_available_quantity_for_customer,
+    get_max_available_quantity_for_customer,
     get_quantity_allocated,
 )
-from saleor.warehouse.models import Allocation
+from saleor.warehouse.models import Allocation, Stock
 
 COUNTRY_CODE = "US"
 
@@ -88,6 +89,68 @@ def test_get_available_quantity_for_customer_without_stocks(variant_with_many_st
         variant_with_many_stocks, COUNTRY_CODE
     )
     assert available_quantity == 0
+
+
+def test_get_max_available_quantity_for_customer(
+    variant_with_many_stocks,
+    warehouse_no_shipping_zone,
+    shipping_zone_without_countries,
+):
+    warehouse_no_shipping_zone.shipping_zones.add(shipping_zone_without_countries)
+    Stock.objects.create(
+        warehouse=warehouse_no_shipping_zone,
+        product_variant=variant_with_many_stocks,
+        quantity=12,
+    )
+
+    available_quantity = get_max_available_quantity_for_customer(
+        variant_with_many_stocks
+    )
+    assert available_quantity == 12
+
+
+def test_get_max_available_quantity_for_customer_with_allocations(
+    variant_with_many_stocks, order_line_with_allocation_in_many_stocks
+):
+    available_quantity = get_max_available_quantity_for_customer(
+        variant_with_many_stocks
+    )
+    assert available_quantity == 4
+
+
+def test_get_max_available_quantity_for_customer_without_stocks(
+    variant_with_many_stocks,
+):
+    variant_with_many_stocks.stocks.all().delete()
+    available_quantity = get_max_available_quantity_for_customer(
+        variant_with_many_stocks
+    )
+    assert available_quantity == 0
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_get_max_available_quantity_for_customer_with_max(
+    variant_with_many_stocks, settings
+):
+    stock = variant_with_many_stocks.stocks.first()
+    stock.quantity = 16
+    stock.save(update_fields=["quantity"])
+    available_quantity = get_max_available_quantity_for_customer(
+        variant_with_many_stocks
+    )
+    assert available_quantity == settings.MAX_CHECKOUT_LINE_QUANTITY
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_get_max_available_quantity_for_customer_without_inventory_tracking(
+    variant_with_many_stocks, settings
+):
+    variant_with_many_stocks.track_inventory = False
+    variant_with_many_stocks.save(update_fields=["track_inventory"])
+    available_quantity = get_max_available_quantity_for_customer(
+        variant_with_many_stocks
+    )
+    assert available_quantity == settings.MAX_CHECKOUT_LINE_QUANTITY
 
 
 def test_get_quantity_allocated(


### PR DESCRIPTION
I want to merge this change because:
1. adding `quantityAvailable` field to `ProductVariant` type
2. add permissions to `stocks` field on `ProductVariant` type 
3. drop `stock_quantity` from `Stock` type

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
