### PR TITLE
ProductVariantStocksUpdate should accept empty list

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -437,14 +437,15 @@ class ProductVariantStocksUpdate(ProductVariantStocksCreate):
         variant = cls.get_node_or_error(
             info, data["variant_id"], only_type=ProductVariant
         )
-        warehouse_ids = [stock["warehouse"] for stock in stocks]
-        cls.check_for_duplicates(warehouse_ids, errors)
-        if errors:
-            raise ValidationError(errors)
-        warehouses = cls.get_nodes_or_error(
-            warehouse_ids, "warehouse", only_type=Warehouse
-        )
-        cls.update_or_create_variant_stocks(variant, stocks, warehouses)
+        if stocks:
+            warehouse_ids = [stock["warehouse"] for stock in stocks]
+            cls.check_for_duplicates(warehouse_ids, errors)
+            if errors:
+                raise ValidationError(errors)
+            warehouses = cls.get_nodes_or_error(
+                warehouse_ids, "warehouse", only_type=Warehouse
+            )
+            cls.update_or_create_variant_stocks(variant, stocks, warehouses)
         return cls(product_variant=variant)
 
     @classmethod

--- a/tests/api/test_variant.py
+++ b/tests/api/test_variant.py
@@ -1708,6 +1708,24 @@ def test_product_variant_stocks_update(
         assert res in expected_result
 
 
+def test_product_variant_stocks_update_with_empty_stock_list(
+    staff_api_client, variant, warehouse, permission_manage_products
+):
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    stocks = []
+    variables = {"variantId": variant_id, "stocks": stocks}
+    response = staff_api_client.post_graphql(
+        VARIANT_STOCKS_UPDATE_MUTATIONS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantStocksUpdate"]
+
+    assert not data["bulkStockErrors"]
+    assert len(data["productVariant"]["stocks"]) == len(stocks)
+
+
 def test_variant_stocks_update_stock_duplicated_warehouse(
     staff_api_client, variant, warehouse, permission_manage_products
 ):


### PR DESCRIPTION
I want to merge this change because resolve #5636 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
