### PR TITLE
Add missing quantize method on checkout in Avatax plugin

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -1,5 +1,6 @@
 from typing import TYPE_CHECKING, Iterable, Optional
 
+from ..core.taxes import quantize_price
 from ..discount import DiscountInfo
 from ..plugins.manager import get_plugins_manager
 
@@ -18,9 +19,10 @@ def checkout_shipping_price(
 
     It takes in account all plugins.
     """
-    return get_plugins_manager().calculate_checkout_shipping(
+    calculated_checkout_shipping = get_plugins_manager().calculate_checkout_shipping(
         checkout, lines, discounts or []
     )
+    return quantize_price(calculated_checkout_shipping, checkout.currency)
 
 
 def checkout_subtotal(
@@ -33,9 +35,10 @@ def checkout_subtotal(
 
     It takes in account all plugins.
     """
-    return get_plugins_manager().calculate_checkout_subtotal(
+    calculated_checkout_subtotal = get_plugins_manager().calculate_checkout_subtotal(
         checkout, lines, discounts or []
     )
+    return quantize_price(calculated_checkout_subtotal, checkout.currency)
 
 
 def checkout_total(
@@ -51,9 +54,10 @@ def checkout_total(
 
     It takes in account all plugins.
     """
-    return get_plugins_manager().calculate_checkout_total(
+    calculated_checkout_total = get_plugins_manager().calculate_checkout_total(
         checkout, lines, discounts or []
     )
+    return quantize_price(calculated_checkout_total, checkout.currency)
 
 
 def checkout_line_total(
@@ -63,4 +67,7 @@ def checkout_line_total(
 
     It takes in account all plugins.
     """
-    return get_plugins_manager().calculate_checkout_line_total(line, discounts or [])
+    calculated_line_total = get_plugins_manager().calculate_checkout_line_total(
+        line, discounts or []
+    )
+    return quantize_price(calculated_line_total, line.checkout.currency)

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -2,6 +2,7 @@ import graphene
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
+from ...checkout import calculations
 from ...core.permissions import OrderPermissions
 from ...core.taxes import zero_taxed_money
 from ...core.utils import get_client_ip
@@ -69,11 +70,14 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
     @classmethod
     def calculate_total(cls, info, checkout):
         checkout_total = (
-            info.context.plugins.calculate_checkout_total(
-                checkout, lines=list(checkout), discounts=info.context.discounts
+            calculations.checkout_total(
+                checkout=checkout,
+                lines=list(checkout),
+                discounts=info.context.discounts,
             )
             - checkout.get_total_gift_cards_balance()
         )
+
         return max(checkout_total, zero_taxed_money(checkout_total.currency))
 
     @classmethod

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -7,7 +7,7 @@ from urllib.parse import urljoin
 from django.core.exceptions import ValidationError
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
-from ...core.taxes import TaxError, TaxType, quantize_price, zero_taxed_money
+from ...core.taxes import TaxError, TaxType, zero_taxed_money
 from ...discount import DiscountInfo
 from ..base_plugin import BasePlugin, ConfigurationTypeField
 from ..error_codes import PluginErrorCode

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -139,8 +139,9 @@ class AvataxPlugin(BasePlugin):
         voucher_value = checkout.discount
         if voucher_value:
             total -= voucher_value
-        total = max(total, zero_taxed_money(total.currency))
-        return quantize_price(total, total.currency)
+        return quantize_price(
+            max(total, zero_taxed_money(total.currency)), total.currency
+        )
 
     def _calculate_checkout_subtotal(
         self, currency: str, lines: List[Dict]

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -139,9 +139,7 @@ class AvataxPlugin(BasePlugin):
         voucher_value = checkout.discount
         if voucher_value:
             total -= voucher_value
-        return quantize_price(
-            max(total, zero_taxed_money(total.currency)), total.currency
-        )
+        return max(total, zero_taxed_money(total.currency))
 
     def _calculate_checkout_subtotal(
         self, currency: str, lines: List[Dict]
@@ -156,9 +154,7 @@ class AvataxPlugin(BasePlugin):
         sub_total_gross = Money(sub_net + sub_tax, currency)
         sub_total_net = Money(sub_net, currency)
 
-        return quantize_price(
-            TaxedMoney(net=sub_total_net, gross=sub_total_gross), currency
-        )
+        return TaxedMoney(net=sub_total_net, gross=sub_total_gross)
 
     def calculate_checkout_subtotal(
         self,
@@ -194,9 +190,7 @@ class AvataxPlugin(BasePlugin):
         shipping_gross = Money(amount=shipping_net + shipping_tax, currency=currency)
         shipping_net = Money(amount=shipping_net, currency=currency)
 
-        return quantize_price(
-            TaxedMoney(net=shipping_net, gross=shipping_gross), currency
-        )
+        return TaxedMoney(net=shipping_net, gross=shipping_gross)
 
     def calculate_checkout_shipping(
         self,

--- a/tests/plugins/test_avatax.py
+++ b/tests/plugins/test_avatax.py
@@ -169,7 +169,6 @@ def test_calculate_checkout_shipping(
     shipping_price = manager.calculate_checkout_shipping(
         checkout_with_item, list(checkout_with_item), [discount_info]
     )
-    shipping_price = quantize_price(shipping_price, shipping_price.currency)
     assert shipping_price == TaxedMoney(
         net=Money("8.13", "USD"), gross=Money("10.00", "USD")
     )

--- a/tests/plugins/test_avatax.py
+++ b/tests/plugins/test_avatax.py
@@ -169,6 +169,7 @@ def test_calculate_checkout_shipping(
     shipping_price = manager.calculate_checkout_shipping(
         checkout_with_item, list(checkout_with_item), [discount_info]
     )
+    shipping_price = quantize_price(shipping_price, shipping_price.currency)
     assert shipping_price == TaxedMoney(
         net=Money("8.13", "USD"), gross=Money("10.00", "USD")
     )


### PR DESCRIPTION
I want to merge this change because...closes https://github.com/mirumee/saleor/issues/5519

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [X] Privileged queries and mutations are guarded by proper permission checks
* [X] Database queries are optimized and the number of queries is constant
* [X] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
