### PR TITLE
Fix for extending an configuration of plugins

### DIFF
--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -352,7 +352,7 @@ class BasePlugin:
                         new_value = new_value.lower() == "true"
                     config_item.update([("value", new_value)])
 
-        # Get new keys that are not exists in current_config and extend it.
+        # Get new keys that don't exist in current_config and extend it.
         current_config_keys = set(c_field["name"] for c_field in current_config)
         configuration_to_update_dict = {
             c_field["name"]: c_field["value"] for c_field in configuration_to_update

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -352,6 +352,22 @@ class BasePlugin:
                         new_value = new_value.lower() == "true"
                     config_item.update([("value", new_value)])
 
+        # Get new keys that are not exists in current_config and extend it.
+        current_config_keys = set(c_field["name"] for c_field in current_config)
+        configuration_to_update_dict = {
+            c_field["name"]: c_field["value"] for c_field in configuration_to_update
+        }
+        missing_keys = set(configuration_to_update_dict.keys()) - current_config_keys
+        for missing_key in missing_keys:
+            if not config_structure.get(missing_key):
+                continue
+            current_config.append(
+                {
+                    "name": missing_key,
+                    "value": configuration_to_update_dict[missing_key],
+                }
+            )
+
     @classmethod
     def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
         """Validate if provided configuration is correct.
@@ -397,8 +413,7 @@ class BasePlugin:
         config_structure = getattr(cls, "CONFIG_STRUCTURE") or {}
         desired_config_keys = set(config_structure.keys())
 
-        config = configuration or []
-        configured_keys = set(d["name"] for d in config)
+        configured_keys = set(d["name"] for d in configuration)
         missing_keys = desired_config_keys - configured_keys
 
         if not missing_keys:
@@ -409,7 +424,7 @@ class BasePlugin:
             return
 
         update_values = [copy(k) for k in default_config if k["name"] in missing_keys]
-        config.extend(update_values)
+        configuration.extend(update_values)
 
     @classmethod
     def get_default_active(cls):
@@ -418,6 +433,8 @@ class BasePlugin:
     def get_plugin_configuration(
         self, configuration: PluginConfigurationType
     ) -> PluginConfigurationType:
+        if not configuration:
+            configuration = []
         self._update_configuration_structure(configuration)
         if configuration:
             # Let's add a translated descriptions and labels

--- a/saleor/plugins/migrations/0004_drop_support_for_env_vatlayer_access_key.py
+++ b/saleor/plugins/migrations/0004_drop_support_for_env_vatlayer_access_key.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+
+def assign_access_key(apps, schema):
+    vatlayer_configuration = (
+        apps.get_model("plugins", "PluginConfiguration")
+        .objects.filter(identifier="mirumee.taxes.vatlayer")
+        .first()
+    )
+
+    if vatlayer_configuration:
+        vatlayer_configuration.active = False
+        vatlayer_configuration.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("plugins", "0003_auto_20200429_0142"),
+    ]
+
+    operations = [
+        migrations.RunPython(assign_access_key),
+    ]

--- a/saleor/plugins/migrations/0004_drop_support_for_env_vatlayer_access_key.py
+++ b/saleor/plugins/migrations/0004_drop_support_for_env_vatlayer_access_key.py
@@ -1,7 +1,7 @@
 from django.db import migrations
 
 
-def assign_access_key(apps, schema):
+def deactivate_vatlayer(apps, schema):
     vatlayer_configuration = (
         apps.get_model("plugins", "PluginConfiguration")
         .objects.filter(identifier="mirumee.taxes.vatlayer")
@@ -20,5 +20,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(assign_access_key),
+        migrations.RunPython(deactivate_vatlayer),
     ]

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -288,8 +288,9 @@ class VatlayerPlugin(BasePlugin):
         """Validate if provided configuration is correct."""
         configuration = plugin_configuration.configuration
         configuration = {item["name"]: item["value"] for item in configuration}
-        access_key = configuration["Access key"]
-        if not access_key and plugin_configuration.active:
+
+        access_key = configuration.get("Access key")
+        if plugin_configuration.active and not access_key:
             raise ValidationError(
                 {
                     "Access key": ValidationError(

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -18,6 +18,7 @@ def plugin_configuration(db):
             "name": PluginSample.PLUGIN_NAME,
         },
     )
+    configuration.refresh_from_db()
     return configuration
 
 

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -49,9 +49,7 @@ def test_update_config_items_skips_new_keys_when_doesnt_exsist_in_conf_structure
 
 
 def test_update_config_items_adds_new_keys(monkeypatch):
-    data_to_update = [
-        {"name": "New-field", "value": "content"},
-    ]
+    # Add new definition of field to CONFIG_STRUCTURE
     monkeypatch.setattr(
         PluginSample,
         "CONFIG_STRUCTURE",
@@ -64,11 +62,17 @@ def test_update_config_items_adds_new_keys(monkeypatch):
             **PluginSample.CONFIG_STRUCTURE,
         },
     )
+
+    data_to_update = [
+        {"name": "New-field", "value": "content"},
+    ]
     plugin_sample = PluginSample(
         configuration=PluginSample.DEFAULT_CONFIGURATION,
         active=PluginSample.DEFAULT_ACTIVE,
     )
-    current_config = PluginSample.DEFAULT_CONFIGURATION
+    current_config = [
+        {"name": "Username", "value": "admin"},
+    ]
 
     plugin_sample._update_config_items(data_to_update, current_config)
     assert any([config_field["name"] == "New-field" for config_field in current_config])

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -32,6 +32,94 @@ def test_update_config_items_convert_to_bool_value():
     assert get_config_value("Use sandbox", plugin_sample.configuration) is False
 
 
+def test_update_config_items_skips_new_keys_when_doesnt_exsit_in_conf_structure():
+    data_to_update = [
+        {"name": "New-field", "value": "content"},
+    ]
+    plugin_sample = PluginSample(
+        configuration=PluginSample.DEFAULT_CONFIGURATION,
+        active=PluginSample.DEFAULT_ACTIVE,
+    )
+    current_config = PluginSample.DEFAULT_CONFIGURATION
+
+    plugin_sample._update_config_items(data_to_update, current_config)
+    assert not all(
+        [config_field["name"] == "New-field" for config_field in current_config]
+    )
+
+
+def test_update_config_items_adds_new_keys():
+    data_to_update = [
+        {"name": "New-field", "value": "content"},
+    ]
+    PluginSample.CONFIG_STRUCTURE["New-field"] = {
+        "type": ConfigurationTypeField.STRING,
+        "help_text": "New input field",
+        "label": "New field",
+    }
+    plugin_sample = PluginSample(
+        configuration=PluginSample.DEFAULT_CONFIGURATION,
+        active=PluginSample.DEFAULT_ACTIVE,
+    )
+    current_config = PluginSample.DEFAULT_CONFIGURATION
+
+    plugin_sample._update_config_items(data_to_update, current_config)
+    assert any([config_field["name"] == "New-field" for config_field in current_config])
+
+
+def test_save_plugin_configuration(plugin_configuration):
+    cleaned_data = {"configuration": [{"name": "Username", "value": "new-username"}]}
+    PluginSample.save_plugin_configuration(plugin_configuration, cleaned_data)
+    plugin_configuration.refresh_from_db()
+    configuration = plugin_configuration.configuration
+    configuration_dict = {
+        c_field["name"]: c_field["value"] for c_field in configuration
+    }
+    assert configuration_dict["Username"] == "new-username"
+
+
+def test_save_plugin_configuration_adds_new_field(plugin_configuration):
+    PluginSample.CONFIG_STRUCTURE["Token"] = {
+        "type": ConfigurationTypeField.PASSWORD,
+        "help_text": "New input field",
+        "label": "New field",
+    }
+    cleaned_data = {"configuration": [{"name": "Token", "value": "token-data"}]}
+    PluginSample.save_plugin_configuration(plugin_configuration, cleaned_data)
+    plugin_configuration.refresh_from_db()
+    configuration = plugin_configuration.configuration
+    configuration_dict = {
+        c_field["name"]: c_field["value"] for c_field in configuration
+    }
+    assert configuration_dict.get("Token") == "token-data"
+
+
+def test_save_plugin_configuration_skips_new_field_when_doesnt_exsit_in_conf_structure(
+    plugin_configuration,
+):
+    cleaned_data = {"configuration": [{"name": "Token", "value": "token-data"}]}
+    PluginSample.save_plugin_configuration(plugin_configuration, cleaned_data)
+    plugin_configuration.refresh_from_db()
+    configuration = plugin_configuration.configuration
+    configuration_dict = {
+        c_field["name"]: c_field["value"] for c_field in configuration
+    }
+    assert not configuration_dict.get("Token")
+
+
+def test_base_plugin__update_configuration_structure_when_old_config_is_empty(
+    monkeypatch, plugin_configuration
+):
+    plugin_configuration.configuration = []
+    plugin_configuration.save()
+    PluginSample._update_configuration_structure(plugin_configuration.configuration)
+    plugin_configuration.save()
+    plugin_configuration.refresh_from_db()
+    assert len(plugin_configuration.configuration) == len(
+        PluginSample.DEFAULT_CONFIGURATION
+    )
+
+
 def test_base_plugin__update_configuration_structure_configuration_has_change(
     monkeypatch, plugin_configuration
 ):

--- a/tests/plugins/test_plugins.py
+++ b/tests/plugins/test_plugins.py
@@ -32,7 +32,7 @@ def test_update_config_items_convert_to_bool_value():
     assert get_config_value("Use sandbox", plugin_sample.configuration) is False
 
 
-def test_update_config_items_skips_new_keys_when_doesnt_exsit_in_conf_structure():
+def test_update_config_items_skips_new_keys_when_doesnt_exsist_in_conf_structure():
     data_to_update = [
         {"name": "New-field", "value": "content"},
     ]
@@ -48,15 +48,22 @@ def test_update_config_items_skips_new_keys_when_doesnt_exsit_in_conf_structure(
     )
 
 
-def test_update_config_items_adds_new_keys():
+def test_update_config_items_adds_new_keys(monkeypatch):
     data_to_update = [
         {"name": "New-field", "value": "content"},
     ]
-    PluginSample.CONFIG_STRUCTURE["New-field"] = {
-        "type": ConfigurationTypeField.STRING,
-        "help_text": "New input field",
-        "label": "New field",
-    }
+    monkeypatch.setattr(
+        PluginSample,
+        "CONFIG_STRUCTURE",
+        {
+            "New-field": {
+                "type": ConfigurationTypeField.STRING,
+                "help_text": "New input field",
+                "label": "New field",
+            },
+            **PluginSample.CONFIG_STRUCTURE,
+        },
+    )
     plugin_sample = PluginSample(
         configuration=PluginSample.DEFAULT_CONFIGURATION,
         active=PluginSample.DEFAULT_ACTIVE,
@@ -78,12 +85,19 @@ def test_save_plugin_configuration(plugin_configuration):
     assert configuration_dict["Username"] == "new-username"
 
 
-def test_save_plugin_configuration_adds_new_field(plugin_configuration):
-    PluginSample.CONFIG_STRUCTURE["Token"] = {
-        "type": ConfigurationTypeField.PASSWORD,
-        "help_text": "New input field",
-        "label": "New field",
-    }
+def test_save_plugin_configuration_adds_new_field(plugin_configuration, monkeypatch):
+    monkeypatch.setattr(
+        PluginSample,
+        "CONFIG_STRUCTURE",
+        {
+            "Token": {
+                "type": ConfigurationTypeField.PASSWORD,
+                "help_text": "New input field",
+                "label": "New field",
+            },
+            **PluginSample.CONFIG_STRUCTURE,
+        },
+    )
     cleaned_data = {"configuration": [{"name": "Token", "value": "token-data"}]}
     PluginSample.save_plugin_configuration(plugin_configuration, cleaned_data)
     plugin_configuration.refresh_from_db()
@@ -94,7 +108,7 @@ def test_save_plugin_configuration_adds_new_field(plugin_configuration):
     assert configuration_dict.get("Token") == "token-data"
 
 
-def test_save_plugin_configuration_skips_new_field_when_doesnt_exsit_in_conf_structure(
+def test_save_plugin_configuration_skips_new_field_when_doesnt_exsist_in_conf_structure(
     plugin_configuration,
 ):
     cleaned_data = {"configuration": [{"name": "Token", "value": "token-data"}]}
@@ -108,7 +122,7 @@ def test_save_plugin_configuration_skips_new_field_when_doesnt_exsit_in_conf_str
 
 
 def test_base_plugin__update_configuration_structure_when_old_config_is_empty(
-    monkeypatch, plugin_configuration
+    plugin_configuration,
 ):
     plugin_configuration.configuration = []
     plugin_configuration.save()


### PR DESCRIPTION
- Fix for losing reference for configuration object in `get_plugin_configuration` method
- Vatlayer plugin - set active to false if used with VATLAYER_ACCESS_KEY variable
- Fix for saving data in plugin config
- Add tests