### PR TITLE
Remove task from sending fulfillment update

### DIFF
--- a/saleor/order/emails.py
+++ b/saleor/order/emails.py
@@ -101,7 +101,6 @@ def send_staff_order_confirmation(order_pk, redirect_url):
         send_templated_mail(**staff_email_data)
 
 
-@app.task
 def send_fulfillment_confirmation(order_pk, fulfillment_pk):
     email_data = collect_data_for_fullfillment_email(
         order_pk, CONFIRM_FULFILLMENT_TEMPLATE, fulfillment_pk
@@ -110,7 +109,7 @@ def send_fulfillment_confirmation(order_pk, fulfillment_pk):
 
 
 def send_fulfillment_confirmation_to_customer(order, fulfillment, user):
-    send_fulfillment_confirmation.delay(order.pk, fulfillment.pk)
+    send_fulfillment_confirmation(order.pk, fulfillment.pk)
 
     events.email_sent_event(
         order=order, user=user, email_type=events.OrderEventsEmails.FULFILLMENT


### PR DESCRIPTION
I want to merge this change because this more hot fix then proper solution.

Right now, when buying *DIGITAL* product, which is automatically fulfilled, when this task is in queue, in 99% of runs it returns error:
Fulfillment.DoesNotExist
Fulfillment matching query does not exist.

Looks like some strange bug with async actions, but removing it from queue, just running as normal function fixes problem.

As I said, that's not really ready to merge solution, more like reporting issue with fast proposal if someone is using automatic fulfillment.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
