### PR TITLE
Deprecate the "type" field in the AttributeValue type

### DIFF
--- a/saleor/graphql/product/types/attributes.py
+++ b/saleor/graphql/product/types/attributes.py
@@ -32,11 +32,16 @@ def resolve_attribute_value_type(attribute_value):
 class AttributeValue(CountableDjangoObjectType):
     name = graphene.String(description=AttributeValueDescriptions.NAME)
     slug = graphene.String(description=AttributeValueDescriptions.SLUG)
-    type = AttributeValueType(description=AttributeValueDescriptions.TYPE)
+    type = AttributeValueType(
+        description=AttributeValueDescriptions.TYPE,
+        deprecation_reason=(
+            "Use the `inputType` field to determine the type of attribute's value. "
+            "This field will be removed after 2020-07-31."
+        ),
+    )
     translation = TranslationField(
         AttributeValueTranslation, type_name="attribute value"
     )
-
     input_type = AttributeInputTypeEnum(description=AttributeDescriptions.INPUT_TYPE)
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -502,7 +502,7 @@ type AttributeValue implements Node {
   id: ID!
   name: String
   slug: String
-  type: AttributeValueType
+  type: AttributeValueType @deprecated(reason: "Use the `inputType` field to determine the type of attribute's value. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   inputType: AttributeInputTypeEnum
 }


### PR DESCRIPTION
This PR deprecates the `AttributeValue.type` field. It was added a long time ago in one of the first attribute implementations. The idea was to use regex to check the type of the value: string, URL, or hexadecimal color. This shouldn't be used since we have input types that will determine the type of values.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations

# Pull Request Checklist

<!-- Please keep this section. It will make maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
