### PR TITLE
Export products in batches

### DIFF
--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -105,10 +105,7 @@ def queryset_in_batches(queryset):
     """
     start_pk = 0
 
-    while True:
-        if not queryset.filter(pk__gt=start_pk).exists():
-            break
-
+    while queryset.filter(pk__gt=start_pk).exists():
         qs = queryset.filter(pk__gt=start_pk)
 
         pks = qs.values_list("pk", flat=True)

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -74,7 +74,6 @@ def export_products(
         file_name,
         file_type,
     )
-    send_email_with_link_to_download_csv(export_file, "export_products_success")
 
 
 def get_filename(model_name: str, file_type: str) -> str:
@@ -167,7 +166,7 @@ def export_products_in_batches(
         else:
             append_to_file(export_data, headers, export_file, file_type, delimiter)
 
-    send_email_with_link_to_download_csv(export_file, "export_products")
+    send_email_with_link_to_download_csv(export_file, "export_products_success")
 
 
 def create_csv_file_and_save_in_export_file(

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -1,14 +1,11 @@
-import os
 from tempfile import NamedTemporaryFile
 from typing import IO, TYPE_CHECKING, Dict, List, Set, Union
 
 import petl as etl
-from django.conf import settings
 from django.utils import timezone
 
 from ...celeryconf import app
 from ...core import JobStatus
-from ...core.utils import build_absolute_uri
 from ...product.models import Product
 from .. import FileTypes, events
 from ..emails import send_email_with_link_to_download_csv, send_export_failed_info

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -145,7 +145,7 @@ def export_products_in_batches(
         )
 
         export_data = get_products_data(
-            product_batch, export_fields, warehouses, attributes,
+            product_batch, export_fields, attributes, warehouses
         )
 
         append_to_file(export_data, headers, export_file, file_type, delimiter)

--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -10,7 +10,7 @@ from ...product.models import Product
 from .. import FileTypes, events
 from ..emails import send_email_with_link_to_download_csv, send_export_failed_info
 from ..models import ExportFile
-from .products_data import get_products_data
+from .products_data import get_export_fields_and_headers_info, get_products_data
 
 if TYPE_CHECKING:
     # flake8: noqa
@@ -53,7 +53,16 @@ def export_products(
     file_name = get_filename("product", file_type)
     queryset = get_product_queryset(scope)
 
-    export_data, csv_headers_mapping, headers = get_products_data(queryset, export_info)
+    export_fields, csv_headers_mapping, headers = get_export_fields_and_headers_info(
+        export_info
+    )
+
+    export_data = get_products_data(
+        queryset,
+        set(export_fields),
+        export_info.get("warehouses"),
+        export_info.get("attributes"),
+    )
 
     export_file = ExportFile.objects.get(pk=export_file_id)
     create_csv_file_and_save_in_export_file(

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -3,11 +3,11 @@ from collections import ChainMap, defaultdict
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 from django.conf import settings
-from django.db.models import Case, CharField, F, Value as V, When
+from django.db.models import Case, CharField, Value as V, When
 from django.db.models.functions import Concat
 
 from ...core.utils import build_absolute_uri
-from ...product.models import Attribute, ProductVariant
+from ...product.models import Attribute
 from ...warehouse.models import Warehouse
 
 if TYPE_CHECKING:
@@ -142,6 +142,10 @@ def get_attributes_headers(export_info: Dict[str, list]):
 
 
 def get_warehouses_headers(export_info: Dict[str, list]):
+    """Get headers for exported warehouses.
+
+    Headers are build from slug. Example: "slug-value (warehouse quantity)"
+    """
     warehouse_ids = export_info.get("warehouses")
     if not warehouse_ids:
         return []
@@ -228,7 +232,7 @@ def get_products_relations_data(
 
     If any many to many fields are in export_fields or some attribute_ids exists then
     dict with product relations fields is returned.
-    Otherwise it returns empty dict and set.
+    Otherwise it returns empty dict.
     """
     many_to_many_fields = set(
         ProductExportFields.HEADERS_TO_FIELDS_MAPPING["product_many_to_many"].values()
@@ -248,7 +252,6 @@ def prepare_products_relations_data(
     """Prepare data about products relation fields for given queryset.
 
     It return dict where key is a product pk, value is a dict with relation fields data.
-    It also returns set with attribute headers.
     """
     attribute_fields = ProductExportFields.PRODUCT_ATTRIBUTE_FIELDS
     result_data: Dict[int, dict] = defaultdict(dict)
@@ -296,12 +299,10 @@ def get_variants_relations_data(
 ):
     """Get data about variants relations fields.
 
-    If any many to many fields are in export_fields or some attribute_ids exists then
-    dict with product relations fields is returned. It also returns set with
-    attribute headers.
-    Otherwise it returns empty dict and set.
+    If any many to many fields are in export_fields or some attribute_ids or
+    warehouse_ids exists then dict with variant relations fields is returned.
+    Otherwise it returns empty dict.
     """
-    # TODO: change docstring
     many_to_many_fields = set(
         ProductExportFields.HEADERS_TO_FIELDS_MAPPING["variant_many_to_many"].values()
     )
@@ -320,6 +321,10 @@ def prepare_variants_relations_data(
     attribute_ids: Optional[List[int]],
     warehouse_ids: Optional[List[int]],
 ):
+    """Prepare data about variants relation fields for given queryset.
+
+    It return dict where key is a product pk, value is a dict with relation fields data.
+    """
     warehouse_fields = ProductExportFields.WAREHOUSE_FIELDS
     attribute_fields = ProductExportFields.VARIANT_ATTRIBUTE_FIELDS
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -1,6 +1,6 @@
 import os
 from collections import ChainMap, defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 from django.conf import settings
 from django.db.models import Case, CharField, Value as V, When
@@ -62,7 +62,9 @@ class ProductExportFields:
     }
 
 
-def get_export_fields_and_headers_info(export_info: Dict[str, list]):
+def get_export_fields_and_headers_info(
+    export_info: Dict[str, list]
+) -> Tuple[List[str], List[str], List[str]]:
     """Get export fields, all headers and headers mapping.
 
     Based on export_info returns exported fields, fields to headers mapping and
@@ -78,7 +80,9 @@ def get_export_fields_and_headers_info(export_info: Dict[str, list]):
     return export_fields, file_headers, data_headers
 
 
-def get_product_export_fields_and_headers(export_info: Dict[str, list]):
+def get_product_export_fields_and_headers(
+    export_info: Dict[str, list]
+) -> Tuple[List[str], List[str]]:
     """Get export fields from export info and prepare headers mapping.
 
     Based on given fields headers from export info, export fields set and
@@ -112,7 +116,7 @@ def get_product_export_fields_and_headers(export_info: Dict[str, list]):
     return export_fields, file_headers
 
 
-def get_attributes_headers(export_info: Dict[str, list]):
+def get_attributes_headers(export_info: Dict[str, list]) -> List[str]:
     """Get headers for exported attributes.
 
     Headers are build from slug and contains information if it's a product or variant
@@ -141,7 +145,7 @@ def get_attributes_headers(export_info: Dict[str, list]):
     return list(products_headers) + list(variant_headers)
 
 
-def get_warehouses_headers(export_info: Dict[str, list]):
+def get_warehouses_headers(export_info: Dict[str, list]) -> List[str]:
     """Get headers for exported warehouses.
 
     Headers are build from slug. Example: "slug-value (warehouse quantity)"
@@ -227,7 +231,7 @@ def get_products_data(
 
 def get_products_relations_data(
     queryset: "QuerySet", export_fields: Set[str], attribute_ids: Optional[List[int]]
-):
+) -> Dict[int, Dict[str, str]]:
     """Get data about product relations fields.
 
     If any many to many fields are in export_fields or some attribute_ids exists then
@@ -296,7 +300,7 @@ def get_variants_relations_data(
     export_fields: Set[str],
     attribute_ids: Optional[List[int]],
     warehouse_ids: Optional[List[int]],
-):
+) -> Dict[int, Dict[str, str]]:
     """Get data about variants relations fields.
 
     If any many to many fields are in export_fields or some attribute_ids or
@@ -320,7 +324,7 @@ def prepare_variants_relations_data(
     fields: Set[str],
     attribute_ids: Optional[List[int]],
     warehouse_ids: Optional[List[int]],
-):
+) -> Dict[int, Dict[str, str]]:
     """Prepare data about variants relation fields for given queryset.
 
     It return dict where key is a product pk, value is a dict with relation fields data.

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -265,7 +265,7 @@ def prepare_products_relations_data(
 
 
 def prepare_attribute_products_data(
-    queryset: "QuerySet", attribute_ids: Optional[List[int]],
+    queryset: "QuerySet", attribute_ids: List[int],
 ):
     result_data: Dict[int, dict] = defaultdict(dict)
 
@@ -273,19 +273,19 @@ def prepare_attribute_products_data(
     fields = set(attribute_fields.values())
     fields.add("pk")
 
-    attribute_data = queryset.filter(
-        attributes__assignment__attribute__pk__in=attribute_ids
-    ).values(*fields)
+    attribute_data = queryset.values(*fields)
 
     for data in attribute_data.iterator():
         pk = data.get("pk")
-        attribute = {
-            "slug": data[attribute_fields["slug"]],
-            "value": data[attribute_fields["value"]],
-        }
-        result_data = add_attribute_info_to_data(
-            pk, attribute, "product attribute", result_data
-        )
+        attribute_pk = data.pop(attribute_fields["attribute_pk"])
+        if str(attribute_pk) in attribute_ids:
+            attribute = {
+                "slug": data[attribute_fields["slug"]],
+                "value": data[attribute_fields["value"]],
+            }
+            result_data = add_attribute_info_to_data(
+                pk, attribute, "product attribute", result_data
+            )
 
     return result_data
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -163,8 +163,8 @@ def get_warehouses_headers(export_info: Dict[str, list]):
 def get_products_data(
     queryset: "QuerySet",
     export_fields: Set[str],
-    warehouse_ids: Optional[List[int]],
     attribute_ids: Optional[List[int]],
+    warehouse_ids: Optional[List[int]],
 ) -> List[Dict[str, Union[str, bool]]]:
     """Create data list of products and their variants with fields values.
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -1,6 +1,6 @@
 import os
 from collections import ChainMap, defaultdict
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 from django.conf import settings
 from django.db.models import Case, CharField, F, Value as V, When
@@ -469,11 +469,9 @@ def add_warehouse_info_to_data(
     """
 
     slug = warehouse_data["slug"]
-    warehouse_header = None
     if slug:
         warehouse_qty_header = f"{slug} (warehouse quantity)"
         if warehouse_qty_header not in result_data[pk]:
             result_data[pk][warehouse_qty_header] = warehouse_data["qty"]
-            warehouse_header = warehouse_qty_header
 
     return result_data

--- a/tests/test_csv_export.py
+++ b/tests/test_csv_export.py
@@ -346,7 +346,7 @@ def test_export_products_in_batches_for_csv(
         "attributes": [],
     }
     file_name = "test.csv"
-    export_fields = ["id", "name", "sku"]
+    export_fields = ["id", "name", "variants__sku"]
     expected_headers = ["id", "name", "variant sku"]
 
     table = etl.wrap([expected_headers])
@@ -408,7 +408,7 @@ def test_export_products_in_batches_for_xlsx(
         "warehouses": [],
         "attributes": [],
     }
-    export_fields = ["id", "name", "sku"]
+    export_fields = ["id", "name", "variants__sku"]
     expected_headers = ["id", "name", "variant sku"]
     file_name = "test.xlsx"
 

--- a/tests/test_csv_products_data.py
+++ b/tests/test_csv_products_data.py
@@ -65,7 +65,7 @@ def test_get_products_data(product, product_with_image, collection, image):
 
     # when
     result_data = get_products_data(
-        products, export_fields, warehouse_ids, attribute_ids
+        products, export_fields, attribute_ids, warehouse_ids
     )
 
     # then
@@ -142,7 +142,7 @@ def test_get_products_data_for_specified_attributes(
     attribute_ids = [str(attr.pk) for attr in Attribute.objects.all()][:1]
 
     # when
-    result_data = get_products_data(products, export_fields, [], attribute_ids)
+    result_data = get_products_data(products, export_fields, attribute_ids, [])
 
     # then
     expected_data = []
@@ -183,7 +183,7 @@ def test_get_products_data_for_specified_warehouses(
 
     # when
     result_data = get_products_data(
-        products, export_fields, warehouse_ids, attribute_ids
+        products, export_fields, attribute_ids, warehouse_ids
     )
 
     # then
@@ -227,7 +227,7 @@ def test_get_products_data_for_specified_warehouses_and_attributes(
 
     # when
     result_data = get_products_data(
-        products, export_fields, warehouse_ids, attribute_ids
+        products, export_fields, attribute_ids, warehouse_ids
     )
 
     # then


### PR DESCRIPTION
Export products in batches to avoid OOM errors.
Refactor for reducing exporting time.

Right now, memory usage for 50 000, 100 000 and 200 000 is the same. About 200 Mb.

#### Time-consuming and number of queries:
For CSV file:
- 200 000 products, **30 seconds**, 100 db queries
- 100 000 products, **18 seconds**, 60 db queries
- 50 000 products,  **10 seconds**, 40 db queries
- 20 000 products, **8 seconds**, 28 db queries

XLSX is slow. Append to file is really time-consuming, so I think, there is nothing we can do with that.
- 50 000 products, **10 minutes**, 47 db queries

Flow diagram:
![image](https://user-images.githubusercontent.com/40886528/83500906-ac9e8480-a4bf-11ea-8a25-566e074dea90.png)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
