### PR TITLE
Get rid of PhonePrefixWidget

### DIFF
--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -8,7 +8,7 @@ from django_countries import countries
 
 from .models import Address
 from .validators import validate_possible_number
-from .widgets import DatalistTextWidget, PhonePrefixWidget
+from .widgets import DatalistTextWidget
 
 COUNTRY_FORMS = {}
 UNKNOWN_COUNTRIES = set()
@@ -107,7 +107,7 @@ class AddressForm(forms.ModelForm):
             "street_address_2": "Apartment, suite, unit, building, floor, etc",
         }
 
-    phone = PossiblePhoneNumberFormField(widget=PhonePrefixWidget, required=False)
+    phone = PossiblePhoneNumberFormField(required=False)
 
     def __init__(self, *args, **kwargs):
         autocomplete_type = kwargs.pop("autocomplete_type", None)

--- a/saleor/account/widgets.py
+++ b/saleor/account/widgets.py
@@ -1,32 +1,4 @@
-from django.forms import Select, TextInput
-from phonenumber_field.widgets import PhoneNumberPrefixWidget
-from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
-
-phone_prefixes = [
-    ("+{}".format(k), "+{}".format(k))
-    for (k, v) in sorted(COUNTRY_CODE_TO_REGION_CODE.items())
-]
-
-
-class PhonePrefixWidget(PhoneNumberPrefixWidget):
-    """Uses choices with tuple in a simple form of "+XYZ: +XYZ".
-
-    Workaround for an issue:
-    https://github.com/stefanfoulis/django-phonenumber-field/issues/82
-    """
-
-    def __init__(self, attrs=None):
-        widgets = (Select(attrs=attrs, choices=phone_prefixes), TextInput())
-        # pylint: disable=bad-super-call
-        super(PhoneNumberPrefixWidget, self).__init__(widgets, attrs)
-
-    def value_from_datadict(self, data, files, name):
-        value = super().value_from_datadict(data, files, name)
-        # FIXME: this is a hack, we should not be using a multiwidget
-        # in forms used by the API but here we are
-        if not value and name in data:
-            value = data[name]
-        return value
+from django.forms import Select
 
 
 class DatalistTextWidget(Select):


### PR DESCRIPTION
We don't render any actual widgets in the core, phone number is always passed as a single string.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
