### PR TITLE
Reuse queryset functions in stock-related logic

### DIFF
--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -274,8 +274,8 @@ class ProductVariant(CountableDjangoObjectType):
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_stocks(root: models.ProductVariant, info, country_code=None):
         if not country_code:
-            return root.stocks.annotate_available_quantity().all()
-        return root.stocks.annotate_available_quantity().for_country(country_code).all()
+            return root.stocks.annotate_available_quantity()
+        return root.stocks.for_country(country_code).annotate_available_quantity()
 
     @staticmethod
     def resolve_quantity_available(

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict
 
 from django.conf import settings
-from django.db.models import Q, Sum
+from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from ..core.exceptions import InsufficientStock
@@ -64,17 +64,12 @@ def get_available_quantity_for_customer(
     The returned value is limited by `MAX_CHECKOUT_LINE_QUANTITY` setting to
     limit the quantity of a variant that can be added in one checkout line.
     """
-    query = Q(product_variant=variant)
+
+    stocks = Stock.objects.filter(product_variant=variant)
     if country_code:
-        query &= Q(warehouse__shipping_zones__countries__contains=country_code)
-    stocks = (
-        Stock.objects.filter(query)
-        .annotate(
-            available_quantity=Sum("quantity", distinct=True)
-            - Coalesce(Sum("allocations__quantity_allocated"), 0)
-        )
-        .values_list("warehouse__shipping_zones", "available_quantity")
-    )
+        stocks = stocks.for_country(country_code)
+    stocks = stocks.annotate_available_quantity()
+    stocks = stocks.values_list("warehouse__shipping_zones", "available_quantity")
 
     if not stocks:
         return 0
@@ -88,7 +83,6 @@ def get_available_quantity_for_customer(
     max_available_quantity = max(
         available_quantity_in_shipping_zones.items(), key=lambda x: x[1]
     )[1]
-
     return min(max_available_quantity, settings.MAX_CHECKOUT_LINE_QUANTITY)
 
 
@@ -105,32 +99,22 @@ def is_variant_in_stock(variant: "ProductVariant", country_code: str) -> bool:
     return quantity_available > 0
 
 
-def stocks_for_product(product: "Product", country_code: str):
-    return (
-        Stock.objects.annotate_available_quantity()
-        .for_country(country_code)
-        .filter(product_variant__product_id=product.pk)
-    )
-
-
 def is_product_in_stock(product: "Product", country_code: str) -> bool:
     """Check if there is any variant of given product available in given country."""
-    return any(
-        stocks_for_product(product, country_code).values_list(
-            "available_quantity", flat=True
-        )
-    )
+    stocks = Stock.objects.get_product_stocks_for_country(
+        country_code, product
+    ).annotate_available_quantity()
+    return any(stocks.values_list("available_quantity", flat=True))
 
 
 def are_all_product_variants_in_stock(product: "Product", country_code: str) -> bool:
     """Check if all variants of given product are available in given country."""
-    product_stocks = (
-        stocks_for_product(product, country_code)
-        .values_list("available_quantity", "product_variant_id")
-        .all()
-    )
-    are_all_available = all([elem[0] for elem in product_stocks])
-    variants_with_stocks = [elem[1] for elem in product_stocks]
+    stocks = Stock.objects.get_product_stocks_for_country(
+        country_code, product
+    ).annotate_available_quantity()
+    stocks = stocks.values_list("available_quantity", "product_variant_id").all()
+    are_all_available = all([elem[0] for elem in stocks])
+    variants_with_stocks = [elem[1] for elem in stocks]
 
     product_variants = product.variants.exclude(id__in=variants_with_stocks).exists()
     return are_all_available and not product_variants

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Coalesce
 
 from ..account.models import Address
 from ..order.models import OrderLine
-from ..product.models import ProductVariant
+from ..product.models import Product, ProductVariant
 from ..shipping.models import ShippingZone
 
 
@@ -79,6 +79,11 @@ class StockQuerySet(models.QuerySet):
         Note it will raise a 'Stock.DoesNotExist' exception if no such stock is found.
         """
         return self.for_country(country_code).filter(product_variant=product_variant)
+
+    def get_product_stocks_for_country(self, country_code: str, product: Product):
+        return self.for_country(country_code).filter(
+            product_variant__product_id=product.pk
+        )
 
 
 class Stock(models.Model):


### PR DESCRIPTION
This PR refactors usage of QS functions in logic to calculate stock availability. Instead of duplicating some of the ORM calls, I tried to use only methods that are defined in the queryset, for better code-reuse and readability.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
