### PR TITLE
Move celery timezone setting

### DIFF
--- a/saleor/celeryconf.py
+++ b/saleor/celeryconf.py
@@ -9,8 +9,6 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
 
 app = Celery("saleor")
 
-CELERY_TIMEZONE = "UTC"
-
 app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks()
 app.autodiscover_tasks(lambda: discover_plugins_modules(settings.PLUGINS))

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -68,7 +68,7 @@ DATABASES = {
 }
 
 
-TIME_ZONE = "America/Chicago"
+TIME_ZONE = "UTC"
 LANGUAGE_CODE = "en"
 LANGUAGES = [
     ("ar", "Arabic"),

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -471,6 +471,7 @@ GRAPHQL_JWT = {
 }
 
 # CELERY SETTINGS
+CELERY_TIMEZONE = TIME_ZONE
 CELERY_BROKER_URL = (
     os.environ.get("CELERY_BROKER_URL", os.environ.get("CLOUDAMQP_URL")) or ""
 )


### PR DESCRIPTION
I want to merge this change because... when I scheduled some custom periodic task I fount out that `CELERY_TIMEZONE` set in `celeryconf.py` has no effect. Celery is configured using `setting.py`, so I propose to move this config there and set it to for example Django default timezone.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
