### PR TITLE
Add supported currencies to payment plugins

### DIFF
--- a/saleor/core/payments.py
+++ b/saleor/core/payments.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     # flake8: noqa
@@ -13,7 +13,9 @@ if TYPE_CHECKING:
 
 class PaymentInterface(ABC):
     @abstractmethod
-    def list_payment_gateways(self, active_only: bool = True) -> List[dict]:
+    def list_payment_gateways(
+        self, currency: Optional[str] = None, active_only: bool = True
+    ) -> List[dict]:
         pass
 
     @abstractmethod

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -155,6 +155,7 @@ FRAGMENT_CHECKOUT = (
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_create_checkout(
     api_client,
@@ -228,6 +229,7 @@ def test_create_checkout(
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_add_shipping_to_checkout(
     api_client, checkout_with_shipping_address, shipping_method, count_queries,
@@ -261,6 +263,7 @@ def test_add_shipping_to_checkout(
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_add_billing_address_to_checkout(
     api_client, graphql_address_data, checkout_with_shipping_method, count_queries
@@ -370,6 +373,7 @@ def test_update_checkout_lines(
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_checkout_shipping_address_update(
     api_client, graphql_address_data, checkout_with_variant, count_queries
@@ -403,6 +407,7 @@ def test_checkout_shipping_address_update(
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_checkout_email_update(api_client, checkout_with_variant, count_queries):
     query = (
@@ -432,6 +437,7 @@ def test_checkout_email_update(api_client, checkout_with_variant, count_queries)
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_checkout_voucher_code(
     api_client, checkout_with_billing_address, voucher, count_queries

--- a/saleor/graphql/checkout/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_homepage.py
@@ -4,6 +4,7 @@ from ....tests.utils import get_graphql_content
 
 
 @pytest.mark.django_db
+@pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.count_queries(autouse=False)
 def test_user_checkout_details(user_api_client, customer_checkout, count_queries):
     query = """

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -581,7 +581,11 @@ def test_checkout_available_payment_gateways(
         }
     }
     """
-    expected_warning = "Default currency for Dummy is used."
+    expected_warning = (
+        "Default currency used for Dummy. "
+        "DEFAULT_CURRENCY setting is deprecated, "
+        "please configure supported currencies for this gateway."
+    )
     variables = {"token": str(checkout_with_item.token)}
     with warnings.catch_warnings(record=True) as warns:
         response = api_client.post_graphql(query, variables)

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -714,6 +714,7 @@ def set_dummy_customer_id(customer_user, dummy_customer_id):
     return customer_user
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_list_payment_sources(
     mocker, dummy_customer_id, set_dummy_customer_id, user_api_client
 ):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1167,6 +1167,7 @@ input ConfigurationItemInput {
 enum ConfigurationTypeFieldEnum {
   STRING
   BOOLEAN
+  LIST
   SECRET
   PASSWORD
 }

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -682,6 +682,7 @@ def test_query_geolocalization(user_api_client):
     assert data["country"] is None
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_query_available_payment_gateways(user_api_client):
     query = """
         query {

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -69,7 +69,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments."
+            "help_text": "Determines if Saleor should store cards on payments"
             " in Braintree customer.",
             "label": "Store customers card",
         },

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -49,17 +49,17 @@ class BraintreeGatewayPlugin(BasePlugin):
     CONFIG_STRUCTURE = {
         "Public API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Braintree public API key",
+            "help_text": "Provide Braintree public API key.",
             "label": "Public API key",
         },
         "Secret API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Braintree secret API key",
+            "help_text": "Provide Braintree secret API key.",
             "label": "Secret API key",
         },
         "Merchant ID": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Braintree merchant ID",
+            "help_text": "Provide Braintree merchant ID.",
             "label": "Merchant ID",
         },
         "Use sandbox": {
@@ -69,7 +69,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments"
+            "help_text": "Determines if Saleor should store cards on payments."
             " in Braintree customer.",
             "label": "Store customers card",
         },
@@ -85,7 +85,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         },
         "Supported currencies": {
             "type": ConfigurationTypeField.LIST,
-            "help_text": "Determines currencies supported by gateway",
+            "help_text": "Determines currencies supported by gateway.",
             "label": "Supported currencies",
         },
     }

--- a/saleor/payment/gateways/braintree/tests/test_braintree.py
+++ b/saleor/payment/gateways/braintree/tests/test_braintree.py
@@ -84,6 +84,7 @@ def gateway_config():
             "public_key": "456",
             "private_key": "789",
         },
+        supported_currencies=["USD"],
     )
 
 

--- a/saleor/payment/gateways/dummy/plugin.py
+++ b/saleor/payment/gateways/dummy/plugin.py
@@ -52,7 +52,7 @@ class DummyGatewayPlugin(BasePlugin):
         },
         "Supported currencies": {
             "type": ConfigurationTypeField.LIST,
-            "help_text": "Determines currencies supported by gateway",
+            "help_text": "Determines currencies supported by gateway.",
             "label": "Supported currencies",
         },
     }

--- a/saleor/payment/gateways/dummy/plugin.py
+++ b/saleor/payment/gateways/dummy/plugin.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING
 
 from saleor.plugins.base_plugin import BasePlugin, ConfigurationTypeField
 
+from ..utils import get_supported_currencies
 from . import (
     GatewayConfig,
     authorize,
@@ -36,6 +37,7 @@ class DummyGatewayPlugin(BasePlugin):
     DEFAULT_CONFIGURATION = [
         {"name": "Store customers card", "value": False},
         {"name": "Automatic payment capture", "value": True},
+        {"name": "Supported currencies", "value": []},
     ]
     CONFIG_STRUCTURE = {
         "Store customers card": {
@@ -48,6 +50,11 @@ class DummyGatewayPlugin(BasePlugin):
             "help_text": "Determines if Saleor should automaticaly capture payments.",
             "label": "Automatic payment capture",
         },
+        "Supported currencies": {
+            "type": ConfigurationTypeField.LIST,
+            "help_text": "Determines currencies supported by gateway",
+            "label": "Supported currencies",
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -56,6 +63,7 @@ class DummyGatewayPlugin(BasePlugin):
         self.config = GatewayConfig(
             gateway_name=GATEWAY_NAME,
             auto_capture=configuration["Automatic payment capture"],
+            supported_currencies=configuration["Supported currencies"],
             connection_params={},
             store_customer=configuration["Store customers card"],
         )
@@ -106,4 +114,8 @@ class DummyGatewayPlugin(BasePlugin):
     @require_active_plugin
     def get_payment_config(self, previous_value):
         config = self._get_gateway_config()
-        return [{"field": "store_customer_card", "value": config.store_customer}]
+        currencies = get_supported_currencies(config, GATEWAY_NAME)
+        return [
+            {"field": "store_customer_card", "value": config.store_customer},
+            {"field": "supported_currencies", "value": currencies},
+        ]

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -45,7 +45,7 @@ class RazorpayGatewayPlugin(BasePlugin):
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments."
+            "help_text": "Determines if Saleor should store cards on payments "
             "in Stripe customer.",
             "label": "Store customers card",
         },

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -35,17 +35,17 @@ class RazorpayGatewayPlugin(BasePlugin):
     CONFIG_STRUCTURE = {
         "Public API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide  public API key",
+            "help_text": "Provide  public API key.",
             "label": "Public API key",
         },
         "Secret API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Stripe secret API key",
+            "help_text": "Provide Stripe secret API key.",
             "label": "Secret API key",
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments"
+            "help_text": "Determines if Saleor should store cards on payments."
             "in Stripe customer.",
             "label": "Store customers card",
         },
@@ -56,7 +56,7 @@ class RazorpayGatewayPlugin(BasePlugin):
         },
         "Supported currencies": {
             "type": ConfigurationTypeField.LIST,
-            "help_text": "Determines currencies supported by gateway",
+            "help_text": "Determines currencies supported by gateway.",
             "label": "Supported currencies",
         },
     }

--- a/saleor/payment/gateways/razorpay/tests/test_razorpay.py
+++ b/saleor/payment/gateways/razorpay/tests/test_razorpay.py
@@ -27,6 +27,7 @@ def gateway_config():
     return GatewayConfig(
         gateway_name="razorpay",
         auto_capture=False,
+        supported_currencies=["USD"],
         connection_params={
             "public_key": "public",
             "private_key": "secret",

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -45,17 +45,17 @@ class StripeGatewayPlugin(BasePlugin):
     CONFIG_STRUCTURE = {
         "Public API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Stripe public API key",
+            "help_text": "Provide Stripe public API key.",
             "label": "Public API key",
         },
         "Secret API key": {
             "type": ConfigurationTypeField.SECRET,
-            "help_text": "Provide Stripe secret API key",
+            "help_text": "Provide Stripe secret API key.",
             "label": "Secret API key",
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments"
+            "help_text": "Determines if Saleor should store cards on payments."
             "in Stripe customer.",
             "label": "Store customers card",
         },
@@ -66,7 +66,7 @@ class StripeGatewayPlugin(BasePlugin):
         },
         "Supported currencies": {
             "type": ConfigurationTypeField.LIST,
-            "help_text": "Determines currencies supported by gateway",
+            "help_text": "Determines currencies supported by gateway.",
             "label": "Supported currencies",
         },
     }

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -55,7 +55,7 @@ class StripeGatewayPlugin(BasePlugin):
         },
         "Store customers card": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should store cards on payments."
+            "help_text": "Determines if Saleor should store cards on payments "
             "in Stripe customer.",
             "label": "Store customers card",
         },

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -2,6 +2,7 @@ from typing import TYPE_CHECKING, List
 
 from saleor.plugins.base_plugin import BasePlugin, ConfigurationTypeField
 
+from ..utils import get_supported_currencies
 from . import (
     GatewayConfig,
     authorize,
@@ -38,6 +39,7 @@ class StripeGatewayPlugin(BasePlugin):
         {"name": "Secret API key", "value": None},
         {"name": "Store customers card", "value": False},
         {"name": "Automatic payment capture", "value": True},
+        {"name": "Supported currencies", "value": []},
     ]
 
     CONFIG_STRUCTURE = {
@@ -62,6 +64,11 @@ class StripeGatewayPlugin(BasePlugin):
             "help_text": "Determines if Saleor should automaticaly capture payments.",
             "label": "Automatic payment capture",
         },
+        "Supported currencies": {
+            "type": ConfigurationTypeField.LIST,
+            "help_text": "Determines currencies supported by gateway",
+            "label": "Supported currencies",
+        },
     }
 
     def __init__(self, *args, **kwargs):
@@ -70,6 +77,7 @@ class StripeGatewayPlugin(BasePlugin):
         self.config = GatewayConfig(
             gateway_name=GATEWAY_NAME,
             auto_capture=configuration["Automatic payment capture"],
+            supported_currencies=configuration["Supported currencies"],
             connection_params={
                 "public_key": configuration["Public API key"],
                 "private_key": configuration["Secret API key"],
@@ -121,7 +129,9 @@ class StripeGatewayPlugin(BasePlugin):
     @require_active_plugin
     def get_payment_config(self, previous_value):
         config = self._get_gateway_config()
+        currencies = get_supported_currencies(config, GATEWAY_NAME)
         return [
             {"field": "api_key", "value": config.connection_params["public_key"]},
             {"field": "store_customer_card", "value": config.store_customer},
+            {"field": "supported_currencies", "value": currencies},
         ]

--- a/saleor/payment/gateways/stripe/tests/test_stripe.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe.py
@@ -37,6 +37,7 @@ def gateway_config():
     return GatewayConfig(
         gateway_name="stripe",
         auto_capture=True,
+        supported_currencies=["USD"],
         connection_params={
             "public_key": "public",
             "private_key": "secret",

--- a/saleor/payment/gateways/utils.py
+++ b/saleor/payment/gateways/utils.py
@@ -9,7 +9,6 @@ if TYPE_CHECKING:
 
 def get_supported_currencies(config: "GatewayConfig", gateway_name: str) -> List[str]:
     currencies = config.supported_currencies
-    print(config)
     if not currencies:
         currencies = [settings.DEFAULT_CURRENCY]
         warnings.warn(f"Default currency for {gateway_name} is used.")

--- a/saleor/payment/gateways/utils.py
+++ b/saleor/payment/gateways/utils.py
@@ -11,5 +11,9 @@ def get_supported_currencies(config: "GatewayConfig", gateway_name: str) -> List
     currencies = config.supported_currencies
     if not currencies:
         currencies = [settings.DEFAULT_CURRENCY]
-        warnings.warn(f"Default currency for {gateway_name} is used.")
+        warnings.warn(
+            f"Default currency used for {gateway_name}. "
+            "DEFAULT_CURRENCY setting is deprecated, "
+            "please configure supported currencies for this gateway."
+        )
     return currencies

--- a/saleor/payment/gateways/utils.py
+++ b/saleor/payment/gateways/utils.py
@@ -1,0 +1,16 @@
+import warnings
+from typing import TYPE_CHECKING, List
+
+from django.conf import settings
+
+if TYPE_CHECKING:
+    from ..interface import GatewayConfig
+
+
+def get_supported_currencies(config: "GatewayConfig", gateway_name: str) -> List[str]:
+    currencies = config.supported_currencies
+    print(config)
+    if not currencies:
+        currencies = [settings.DEFAULT_CURRENCY]
+        warnings.warn(f"Default currency for {gateway_name} is used.")
+    return currencies

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 
 @dataclass
@@ -86,6 +86,7 @@ class GatewayConfig:
 
     gateway_name: str
     auto_capture: bool
+    supported_currencies: List[str]
     # Each gateway has different connection data so we are not able to create
     # a unified structure
     connection_params: Dict[str, Any]

--- a/saleor/payment/tests/test_gateways_utils.py
+++ b/saleor/payment/tests/test_gateways_utils.py
@@ -32,7 +32,11 @@ def test_get_supported_currencies_default_currency(gateway_config):
     with warnings.catch_warnings(record=True) as warns:
         currencies = get_supported_currencies(gateway_config, "Test")
 
-        expected_warning = "Default currency for Test is used."
+        expected_warning = (
+            "Default currency used for Test. "
+            "DEFAULT_CURRENCY setting is deprecated, "
+            "please configure supported currencies for this gateway."
+        )
         assert any([str(warning.message) == expected_warning for warning in warns])
 
     # then

--- a/saleor/payment/tests/test_gateways_utils.py
+++ b/saleor/payment/tests/test_gateways_utils.py
@@ -1,0 +1,39 @@
+import warnings
+
+import pytest
+
+from ..gateways.utils import get_supported_currencies
+from ..interface import GatewayConfig
+
+
+@pytest.fixture
+def gateway_config():
+    return GatewayConfig(
+        gateway_name="Dummy",
+        auto_capture=True,
+        supported_currencies=[],
+        connection_params={"secret-key": "dummy"},
+    )
+
+
+def test_get_supported_currencies(gateway_config):
+    # given
+    gateway_config.supported_currencies = ["PLN", "USD"]
+
+    # when
+    currencies = get_supported_currencies(gateway_config, "Test")
+
+    # then
+    assert currencies == ["PLN", "USD"]
+
+
+def test_get_supported_currencies_default_currency(gateway_config):
+    # when
+    with warnings.catch_warnings(record=True) as warns:
+        currencies = get_supported_currencies(gateway_config, "Test")
+
+        expected_warning = "Default currency for Test is used."
+        assert any([str(warning.message) == expected_warning for warning in warns])
+
+    # then
+    assert currencies == ["USD"]

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -64,6 +64,7 @@ def gateway_config():
     return GatewayConfig(
         gateway_name="Dummy",
         auto_capture=True,
+        supported_currencies=["USD"],
         connection_params={"secret-key": "nobodylikesspanishinqusition"},
     )
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -24,11 +24,13 @@ PluginConfigurationType = List[dict]
 class ConfigurationTypeField:
     STRING = "String"
     BOOLEAN = "Boolean"
+    LIST = "List"
     SECRET = "Secret"
     PASSWORD = "Password"
     CHOICES = [
         (STRING, "Field is a String"),
         (BOOLEAN, "Field is a Boolean"),
+        (LIST, "Field is a List"),
         (SECRET, "Field is a Secret"),
         (PASSWORD, "Field is a Password"),
     ]

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
 import opentracing
 from django.conf import settings
@@ -320,8 +320,15 @@ class PluginsManager(PaymentInterface):
             if payment_method in type(plugin).__dict__
         ]
 
-    def list_payment_gateways(self, active_only: bool = True) -> List[dict]:
+    def list_payment_gateways(
+        self, currency: Optional[str] = None, active_only: bool = True
+    ) -> List[dict]:
         payment_plugins = self.list_payment_plugin_names(active_only=active_only)
+        # if currency is given return only gateways which support given currency
+        if currency:
+            return self.__get_payment_gateways_for_specific_currency(
+                currency, payment_plugins
+            )
         return [
             {
                 "id": plugin_id,
@@ -330,6 +337,23 @@ class PluginsManager(PaymentInterface):
             }
             for plugin_id, plugin_name in payment_plugins
         ]
+
+    def __get_payment_gateways_for_specific_currency(
+        self, currency: str, payment_plugins: List[tuple]
+    ) -> List[dict]:
+        """Return only gateways which support given currency."""
+        gateways = []
+        for plugin_id, plugin_name in payment_plugins:
+            config = self.__get_payment_config(plugin_id)
+            for item in config:
+                if (
+                    item["field"] == "supported_currencies"
+                    and currency in item["value"]
+                ):
+                    gateways.append(
+                        {"id": plugin_id, "name": plugin_name, "config": config}
+                    )
+        return gateways
 
     def __get_payment_config(self, gateway: str) -> List[dict]:
         method_name = "get_payment_config"

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
 import opentracing
 from django.conf import settings

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -109,8 +109,27 @@ class ActivePlugin(BasePlugin):
 
 class ActivePaymentGateway(BasePlugin):
     PLUGIN_ID = "gateway.active"
-    CLIENT_CONFIG = [{"field": "foo", "value": "bar"}]
+    CLIENT_CONFIG = [
+        {"field": "foo", "value": "bar"},
+        {"field": "supported_currencies", "value": ["USD"]},
+    ]
     PLUGIN_NAME = "braintree"
+    DEFAULT_ACTIVE = True
+
+    def process_payment(self, payment_information, previous_value):
+        pass
+
+    def get_payment_config(self, previous_value):
+        return self.CLIENT_CONFIG
+
+
+class ActiveDummyPaymentGateway(BasePlugin):
+    PLUGIN_ID = "dummy.active"
+    CLIENT_CONFIG = [
+        {"field": "foo", "value": "bar"},
+        {"field": "supported_currencies", "value": ["PLN", "USD"]},
+    ]
+    PLUGIN_NAME = "dummy"
     DEFAULT_ACTIVE = True
 
     def process_payment(self, payment_information, previous_value):

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -8,6 +8,7 @@ from ...core.taxes import TaxType
 from ..manager import PluginsManager, get_plugins_manager
 from ..models import PluginConfiguration
 from ..tests.sample_plugins import (
+    ActiveDummyPaymentGateway,
     ActivePaymentGateway,
     InactivePaymentGateway,
     PluginInactive,
@@ -286,3 +287,50 @@ def test_manager_serve_list_all_payment_gateways():
     ]
     manager = PluginsManager(plugins=plugins)
     assert manager.list_payment_gateways(active_only=False) == expected_gateways
+
+
+def test_manager_serve_list_all_payment_gateways_specified_currency():
+    expected_gateways = [
+        {
+            "id": ActiveDummyPaymentGateway.PLUGIN_ID,
+            "name": ActiveDummyPaymentGateway.PLUGIN_NAME,
+            "config": ActiveDummyPaymentGateway.CLIENT_CONFIG,
+        },
+    ]
+
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.ActivePaymentGateway",
+        "saleor.plugins.tests.sample_plugins.InactivePaymentGateway",
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway",
+    ]
+    manager = PluginsManager(plugins=plugins)
+    assert (
+        manager.list_payment_gateways(currency="PLN", active_only=False)
+        == expected_gateways
+    )
+
+
+def test_manager_serve_list_all_payment_gateways_specified_currency_two_gateways():
+    expected_gateways = [
+        {
+            "id": ActivePaymentGateway.PLUGIN_ID,
+            "name": ActivePaymentGateway.PLUGIN_NAME,
+            "config": ActivePaymentGateway.CLIENT_CONFIG,
+        },
+        {
+            "id": ActiveDummyPaymentGateway.PLUGIN_ID,
+            "name": ActiveDummyPaymentGateway.PLUGIN_NAME,
+            "config": ActiveDummyPaymentGateway.CLIENT_CONFIG,
+        },
+    ]
+
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.ActivePaymentGateway",
+        "saleor.plugins.tests.sample_plugins.InactivePaymentGateway",
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway",
+    ]
+    manager = PluginsManager(plugins=plugins)
+    assert (
+        manager.list_payment_gateways(currency="USD", active_only=False)
+        == expected_gateways
+    )


### PR DESCRIPTION
Add supported currencies to payment plugins. 

- `list_payment_gateways` contains info about supported currencies in `config`. 
- `list_payment_gateways` allows returning only payment plugins which support the specified currency
- if `supported currencies` are not specified, `DEFAULT_CURRENCY` from `settings` is used, and waring is showed in console
- `supported currencies` will be able to specify in dashboard

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
