### PR TITLE
Fix in email

### DIFF
--- a/templates/templated_email/compiled/confirm_order.html
+++ b/templates/templated_email/compiled/confirm_order.html
@@ -104,9 +104,15 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Order confirmation e-mail text" %}
-            Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{ order_details_url }}">{{ order_details_url }}</a>
-          {% endblocktrans %}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% if order_details_url %}
+            {% blocktrans trimmed context "Order confirmation e-mail text with payment details" %}
+              Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{ order_details_url }}">{{ order_details_url }}</a>
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans trimmed context "Order confirmation e-mail text" %}
+              Thank you for your order. Below is the list of ordered products.
+            {% endblocktrans %}
+          {% endif %}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/source/confirm_order.mjml
+++ b/templates/templated_email/source/confirm_order.mjml
@@ -14,9 +14,15 @@
           {% trans "Hi!" context "Standard e-mail greeting" %}
         </mj-text>
         <mj-text>
-          {% blocktrans trimmed context "Order confirmation e-mail text" %}
-            Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{ order_details_url }}">{{ order_details_url }}</a>
-          {% endblocktrans %}
+          {% if order_details_url %}
+            {% blocktrans trimmed context "Order confirmation e-mail text with payment details" %}
+              Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{ order_details_url }}">{{ order_details_url }}</a>
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans trimmed context "Order confirmation e-mail text" %}
+              Thank you for your order. Below is the list of ordered products.
+            {% endblocktrans %}
+          {% endif %}
         </mj-text>
       </mj-column>
     </mj-section>


### PR DESCRIPTION
I want to merge this change because... it fixes `confirmed_order` mjml template to work like plain text version and not display `order_details_url` if not provided

Fixes #5714 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
