### PR TITLE
Rafactor output fields of model mutations

### DIFF
--- a/saleor/graphql/account/mutations/permission_group.py
+++ b/saleor/graphql/account/mutations/permission_group.py
@@ -20,7 +20,6 @@ from ...core.enums import PermissionEnum
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types.common import PermissionGroupError
 from ...core.utils import get_duplicates_ids
-from ..types import Group
 
 if TYPE_CHECKING:
     from ....account.models import User
@@ -44,8 +43,6 @@ class PermissionGroupCreateInput(PermissionGroupInput):
 
 
 class PermissionGroupCreate(ModelMutation):
-    group = graphene.Field(Group, description="The newly created group.")
-
     class Arguments:
         input = PermissionGroupCreateInput(
             description="Input fields to create permission group.", required=True
@@ -181,8 +178,6 @@ class PermissionGroupUpdateInput(PermissionGroupInput):
 
 
 class PermissionGroupUpdate(PermissionGroupCreate):
-    group = graphene.Field(Group, description="Group which was edited.")
-
     class Arguments:
         id = graphene.ID(description="ID of the group to update.", required=True)
         input = PermissionGroupUpdateInput(

--- a/saleor/graphql/meta/deprecated/mutations.py
+++ b/saleor/graphql/meta/deprecated/mutations.py
@@ -3,10 +3,21 @@ import graphene
 from django.core.exceptions import ImproperlyConfigured
 from graphene_django.registry import get_global_registry
 
-from ...core.mutations import BaseMutation, get_model_name, get_output_fields
+from ...core.mutations import BaseMutation, get_model_name
 from .types import MetaInput, MetaPath
 
 registry = get_global_registry()
+
+
+def get_output_fields(model, return_field_name):
+    """Return mutation output field for model instance."""
+    model_type = registry.get_type_for_model(model)
+    if not model_type:
+        raise ImproperlyConfigured(
+            "Unable to find type for model %s in graphene registry" % model.__name__
+        )
+    fields = {return_field_name: graphene.Field(model_type)}
+    return fields
 
 
 class MetaUpdateOptions(graphene.types.mutation.MutationOptions):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3176,8 +3176,8 @@ enum PermissionEnum {
 
 type PermissionGroupCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  group: Group
   permissionGroupErrors: [PermissionGroupError!]!
+  group: Group
 }
 
 input PermissionGroupCreateInput {
@@ -3226,8 +3226,8 @@ input PermissionGroupSortingInput {
 
 type PermissionGroupUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  group: Group
   permissionGroupErrors: [PermissionGroupError!]!
+  group: Group
 }
 
 input PermissionGroupUpdateInput {
@@ -4337,8 +4337,8 @@ type ShippingZoneCountableEdge {
 
 type ShippingZoneCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
+  shippingZone: ShippingZone
 }
 
 input ShippingZoneCreateInput {
@@ -4356,8 +4356,8 @@ type ShippingZoneDelete {
 
 type ShippingZoneUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  shippingZone: ShippingZone
   shippingErrors: [ShippingError!]!
+  shippingZone: ShippingZone
 }
 
 input ShippingZoneUpdateInput {
@@ -5126,14 +5126,14 @@ input WarehouseFilterInput {
 
 type WarehouseShippingZoneAssign {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouse: Warehouse
   warehouseErrors: [WarehouseError!]!
+  warehouse: Warehouse
 }
 
 type WarehouseShippingZoneUnassign {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  warehouse: Warehouse
   warehouseErrors: [WarehouseError!]!
+  warehouse: Warehouse
 }
 
 enum WarehouseSortField {
@@ -5199,8 +5199,8 @@ input WebhookCreateInput {
 
 type WebhookDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  webhook: Webhook
   webhookErrors: [WebhookError!]!
+  webhook: Webhook
 }
 
 type WebhookError {
@@ -5266,8 +5266,8 @@ input WebhookSortingInput {
 
 type WebhookUpdate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
-  webhook: Webhook
   webhookErrors: [WebhookError!]!
+  webhook: Webhook
 }
 
 input WebhookUpdateInput {

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -122,8 +122,6 @@ class ShippingZoneMixin:
 
 
 class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):
-    shipping_zone = graphene.Field(ShippingZone, description="Created shipping zone.")
-
     class Arguments:
         input = ShippingZoneCreateInput(
             description="Fields required to create a shipping zone.", required=True
@@ -138,8 +136,6 @@ class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):
 
 
 class ShippingZoneUpdate(ShippingZoneMixin, ModelMutation):
-    shipping_zone = graphene.Field(ShippingZone, description="Updated shipping zone.")
-
     class Arguments:
         id = graphene.ID(description="ID of a shipping zone to update.", required=True)
         input = ShippingZoneUpdateInput(

--- a/saleor/graphql/warehouse/mutations.py
+++ b/saleor/graphql/warehouse/mutations.py
@@ -69,10 +69,6 @@ class WarehouseCreate(WarehouseMixin, ModelMutation, I18nMixin):
 
 
 class WarehouseShippingZoneAssign(WarehouseMixin, ModelMutation, I18nMixin):
-    warehouse = graphene.Field(
-        Warehouse, description="A warehouse to add shipping zone."
-    )
-
     class Meta:
         model = models.Warehouse
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
@@ -99,10 +95,6 @@ class WarehouseShippingZoneAssign(WarehouseMixin, ModelMutation, I18nMixin):
 
 
 class WarehouseShippingZoneUnassign(WarehouseMixin, ModelMutation, I18nMixin):
-    warehouse = graphene.Field(
-        Warehouse, description="A warehouse to add shipping zone."
-    )
-
     class Meta:
         model = models.Warehouse
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -7,7 +7,6 @@ from ...webhook.error_codes import WebhookErrorCode
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types.common import WebhookError
 from .enums import WebhookEventTypeEnum
-from .types import Webhook
 
 
 class WebhookCreateInput(graphene.InputObjectType):
@@ -124,8 +123,6 @@ class WebhookUpdateInput(graphene.InputObjectType):
 
 
 class WebhookUpdate(ModelMutation):
-    webhook = graphene.Field(Webhook)
-
     class Arguments:
         id = graphene.ID(required=True, description="ID of a webhook to update.")
         input = WebhookUpdateInput(
@@ -164,8 +161,6 @@ class WebhookUpdate(ModelMutation):
 
 
 class WebhookDelete(ModelDeleteMutation):
-    webhook = graphene.Field(Webhook)
-
     class Arguments:
         id = graphene.ID(required=True, description="ID of a webhook to delete.")
 


### PR DESCRIPTION
Add options to set model mutation output type by override `get_type_for_model` method.
Remove unnecessary overriding of output fields of model mutations.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
