### PR TITLE
Match supported gateways in checkout and shop type

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -31,19 +31,6 @@ from ..mutations import (
 from ..utils import clean_checkout_payment, clean_checkout_shipping
 
 
-@pytest.fixture(autouse=True)
-def setup_dummy_gateway(settings):
-    settings.PLUGINS = ["saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin"]
-    return settings
-
-
-@pytest.fixture
-def add_sample_gateway(settings):
-    settings.PLUGINS += [
-        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
-    ]
-
-
 def test_clean_shipping_method_after_shipping_address_changes_stay_the_same(
     checkout_with_single_item, address, shipping_method, other_shipping_method
 ):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -559,8 +559,8 @@ def expected_dummy_gateway():
     }
 
 
-GET_CHECKOUT_QUERY = """
-query getCheckout($token: UUID!) {
+GET_CHECKOUT_PAYMENTS_QUERY = """
+query getCheckoutPayments($token: UUID!) {
     checkout(token: $token) {
         availablePaymentGateways {
             id
@@ -578,7 +578,7 @@ query getCheckout($token: UUID!) {
 def test_checkout_available_payment_gateways(
     api_client, checkout_with_item, expected_dummy_gateway
 ):
-    query = GET_CHECKOUT_QUERY
+    query = GET_CHECKOUT_PAYMENTS_QUERY
     expected_warning = (
         "Default currency used for Dummy. "
         "DEFAULT_CURRENCY setting is deprecated, "
@@ -597,12 +597,12 @@ def test_checkout_available_payment_gateways(
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_checkout_available_payment_gateways_currency_specified_USD(
-    api_client, checkout_with_item, expected_dummy_gateway, add_sample_gateway
+    api_client, checkout_with_item, expected_dummy_gateway, sample_gateway
 ):
     checkout_with_item.currency = "USD"
     checkout_with_item.save(update_fields=["currency"])
 
-    query = GET_CHECKOUT_QUERY
+    query = GET_CHECKOUT_PAYMENTS_QUERY
 
     variables = {"token": str(checkout_with_item.token)}
     response = api_client.post_graphql(query, variables)
@@ -617,12 +617,12 @@ def test_checkout_available_payment_gateways_currency_specified_USD(
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_checkout_available_payment_gateways_currency_specified_PLN(
-    api_client, checkout_with_item, expected_dummy_gateway, add_sample_gateway
+    api_client, checkout_with_item, expected_dummy_gateway, sample_gateway
 ):
     checkout_with_item.currency = "PLN"
     checkout_with_item.save(update_fields=["currency"])
 
-    query = GET_CHECKOUT_QUERY
+    query = GET_CHECKOUT_PAYMENTS_QUERY
 
     variables = {"token": str(checkout_with_item.token)}
     response = api_client.post_graphql(query, variables)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -20,6 +20,7 @@ from ....order.models import Order
 from ....payment import TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.manager import PluginsManager
+from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
 from ....warehouse.models import Stock
 from ....warehouse.tests.utils import get_available_quantity_for_stock
 from ...tests.utils import assert_no_permission, get_graphql_content
@@ -34,6 +35,13 @@ from ..utils import clean_checkout_payment, clean_checkout_shipping
 def setup_dummy_gateway(settings):
     settings.PLUGINS = ["saleor.payment.gateways.dummy.plugin.DummyGatewayPlugin"]
     return settings
+
+
+@pytest.fixture
+def add_sample_gateway(settings):
+    settings.PLUGINS += [
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
+    ]
 
 
 def test_clean_shipping_method_after_shipping_address_changes_stay_the_same(
@@ -564,23 +572,26 @@ def expected_dummy_gateway():
     }
 
 
+GET_CHECKOUT_QUERY = """
+query getCheckout($token: UUID!) {
+    checkout(token: $token) {
+        availablePaymentGateways {
+            id
+            name
+            config {
+                field
+                value
+            }
+        }
+    }
+}
+"""
+
+
 def test_checkout_available_payment_gateways(
     api_client, checkout_with_item, expected_dummy_gateway
 ):
-    query = """
-    query getCheckout($token: UUID!) {
-        checkout(token: $token) {
-           availablePaymentGateways {
-               id
-               name
-               config {
-                   field
-                   value
-               }
-           }
-        }
-    }
-    """
+    query = GET_CHECKOUT_QUERY
     expected_warning = (
         "Default currency used for Dummy. "
         "DEFAULT_CURRENCY setting is deprecated, "
@@ -595,6 +606,45 @@ def test_checkout_available_payment_gateways(
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
     assert data["availablePaymentGateways"] == [expected_dummy_gateway]
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_checkout_available_payment_gateways_currency_specified_USD(
+    api_client, checkout_with_item, expected_dummy_gateway, add_sample_gateway
+):
+    checkout_with_item.currency = "USD"
+    checkout_with_item.save(update_fields=["currency"])
+
+    query = GET_CHECKOUT_QUERY
+
+    variables = {"token": str(checkout_with_item.token)}
+    response = api_client.post_graphql(query, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+    assert {gateway["id"] for gateway in data["availablePaymentGateways"]} == {
+        expected_dummy_gateway["id"],
+        ActiveDummyPaymentGateway.PLUGIN_ID,
+    }
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_checkout_available_payment_gateways_currency_specified_PLN(
+    api_client, checkout_with_item, expected_dummy_gateway, add_sample_gateway
+):
+    checkout_with_item.currency = "PLN"
+    checkout_with_item.save(update_fields=["currency"])
+
+    query = GET_CHECKOUT_QUERY
+
+    variables = {"token": str(checkout_with_item.token)}
+    response = api_client.post_graphql(query, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+    assert (
+        data["availablePaymentGateways"][0]["id"] == ActiveDummyPaymentGateway.PLUGIN_ID
+    )
 
 
 def test_checkout_available_shipping_methods(

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -237,8 +237,8 @@ class Checkout(CountableDjangoObjectType):
         )
 
     @staticmethod
-    def resolve_available_payment_gateways(_: models.Checkout, _info):
-        return [gtw for gtw in get_plugins_manager().list_payment_gateways()]
+    def resolve_available_payment_gateways(root: models.Checkout, _info):
+        return get_plugins_manager().list_payment_gateways(currency=root.currency)
 
     @staticmethod
     def resolve_gift_cards(root: models.Checkout, _info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4370,7 +4370,7 @@ input ShippingZoneUpdateInput {
 }
 
 type Shop {
-  availablePaymentGateways: [PaymentGateway!]!
+  availablePaymentGateways(currency: String): [PaymentGateway!]!
   geolocalization: Geolocalization
   authorizationKeys: [AuthorizationKey]!
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -682,23 +682,56 @@ def test_query_geolocalization(user_api_client):
     assert data["country"] is None
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_query_available_payment_gateways(user_api_client):
-    query = """
-        query {
-            shop {
-                availablePaymentGateways {
-                    id
-                    name
-                }
+AVAILABLE_PAYMENT_GATEWAYS_QUERY = """
+    query Shop($currency: String){
+        shop {
+            availablePaymentGateways(currency: $currency) {
+                id
+                name
             }
         }
-    """
+    }
+"""
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_available_payment_gateways(user_api_client, add_sample_gateway):
+    query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
     data = content["data"]["shop"]["availablePaymentGateways"]
-    assert data[0]["id"] == "mirumee.payments.dummy"
-    assert data[0]["name"] == "Dummy"
+    assert {gateway["id"] for gateway in data} == {
+        "mirumee.payments.dummy",
+        "sampleDummy.active",
+    }
+    assert {gateway["name"] for gateway in data} == {"Dummy", "SampleDummy"}
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_available_payment_gateways_specified_currency_USD(
+    user_api_client, add_sample_gateway
+):
+    query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
+    response = user_api_client.post_graphql(query, {"currency": "USD"})
+    content = get_graphql_content(response)
+    data = content["data"]["shop"]["availablePaymentGateways"]
+    assert {gateway["id"] for gateway in data} == {
+        "mirumee.payments.dummy",
+        "sampleDummy.active",
+    }
+    assert {gateway["name"] for gateway in data} == {"Dummy", "SampleDummy"}
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_query_available_payment_gateways_specified_currency_PLN(
+    user_api_client, add_sample_gateway
+):
+    query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
+    response = user_api_client.post_graphql(query, {"currency": "PLN"})
+    content = get_graphql_content(response)
+    data = content["data"]["shop"]["availablePaymentGateways"]
+    assert data[0]["id"] == "sampleDummy.active"
+    assert data[0]["name"] == "SampleDummy"
 
 
 AUTHORIZATION_KEY_ADD = """

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -695,7 +695,7 @@ AVAILABLE_PAYMENT_GATEWAYS_QUERY = """
 
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_query_available_payment_gateways(user_api_client, add_sample_gateway):
+def test_query_available_payment_gateways(user_api_client, sample_gateway):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
@@ -709,7 +709,7 @@ def test_query_available_payment_gateways(user_api_client, add_sample_gateway):
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_query_available_payment_gateways_specified_currency_USD(
-    user_api_client, add_sample_gateway
+    user_api_client, sample_gateway
 ):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query, {"currency": "USD"})
@@ -724,7 +724,7 @@ def test_query_available_payment_gateways_specified_currency_USD(
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_query_available_payment_gateways_specified_currency_PLN(
-    user_api_client, add_sample_gateway
+    user_api_client, sample_gateway
 ):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query, {"currency": "PLN"})

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import graphene
 from django.conf import settings
 from django.utils import translation
@@ -66,6 +68,11 @@ class Geolocalization(graphene.ObjectType):
 class Shop(graphene.ObjectType):
     available_payment_gateways = graphene.List(
         graphene.NonNull(PaymentGateway),
+        currency=graphene.Argument(
+            graphene.String,
+            description="A currency for which gateways will be returned.",
+            required=False,
+        ),
         description="List of available payment gateways.",
         required=True,
     )
@@ -166,8 +173,8 @@ class Shop(graphene.ObjectType):
         )
 
     @staticmethod
-    def resolve_available_payment_gateways(_, _info):
-        return [gtw for gtw in get_plugins_manager().list_payment_gateways()]
+    def resolve_available_payment_gateways(_, _info, currency: Optional[str] = None):
+        return get_plugins_manager().list_payment_gateways(currency=currency)
 
     @staticmethod
     @permission_required(SitePermissions.MANAGE_SETTINGS)

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -124,12 +124,12 @@ class ActivePaymentGateway(BasePlugin):
 
 
 class ActiveDummyPaymentGateway(BasePlugin):
-    PLUGIN_ID = "dummy.active"
+    PLUGIN_ID = "sampleDummy.active"
     CLIENT_CONFIG = [
         {"field": "foo", "value": "bar"},
         {"field": "supported_currencies", "value": ["PLN", "USD"]},
     ]
-    PLUGIN_NAME = "dummy"
+    PLUGIN_NAME = "SampleDummy"
     DEFAULT_ACTIVE = True
 
     def process_payment(self, payment_information, previous_value):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -183,6 +183,13 @@ def setup_dummy_gateway(settings):
     return settings
 
 
+@pytest.fixture
+def add_sample_gateway(settings):
+    settings.PLUGINS += [
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
+    ]
+
+
 @pytest.fixture(autouse=True)
 def site_settings(db, settings) -> SiteSettings:
     """Create a site and matching site settings.

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -184,7 +184,7 @@ def setup_dummy_gateway(settings):
 
 
 @pytest.fixture
-def add_sample_gateway(settings):
+def sample_gateway(settings):
     settings.PLUGINS += [
         "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway"
     ]


### PR DESCRIPTION
- For the `Checkout` type in `availablePaymentGateways` return only gateways which supports checkout currency
- For the `Shop` type allow specifying currency for `availablePaymentGateways`. Return only gateways that support given currency, if not currency given, return all of the payment gateways.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
