### PR TITLE
Set checkout country to one from shipping address

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -225,6 +225,13 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         user = info.context.user
         country = info.context.country.code
 
+        # set country to one from shipping address
+        shipping_address = cleaned_input.get("shipping_address")
+        if shipping_address and shipping_address.country:
+            if shipping_address.country != country:
+                country = shipping_address.country
+        cleaned_input["country"] = country
+
         # Resolve and process the lines, retrieving the variants and quantities
         lines = data.pop("lines", None)
         if lines:
@@ -267,8 +274,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     def save(cls, info, instance: models.Checkout, cleaned_input):
         # Create the checkout object
         instance.save()
-        country = info.context.country
-        instance.set_country(country.code, commit=True)
+        country = cleaned_input["country"]
+        instance.set_country(country, commit=True)
 
         # Retrieve the lines to create
         variants = cleaned_input.get("variants")

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -519,9 +519,11 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         cls, lines, country
     ) -> Tuple[List[product_models.ProductVariant], List[int]]:
         variant_ids = [line.variant.id for line in lines]
-        variants = product_models.ProductVariant.objects.filter(
-            id__in=variant_ids
-        ).prefetch_related("product__product_type")
+        variants = list(
+            product_models.ProductVariant.objects.filter(
+                id__in=variant_ids
+            ).prefetch_related("product__product_type")
+        )
         quantities = [line.quantity for line in lines]
 
         check_lines_quantity(variants, quantities, country)
@@ -567,9 +569,9 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         if shipping_address and shipping_address.country:
             if shipping_address.country != country:
                 country = shipping_address.country
-        checkout.set_country(country)
+        checkout.set_country(country, commit=True)
 
-        # Resolve and process the lines, retrieving the variants and quantities
+        # Resolve and process the lines, validating variants quantities
         if lines:
             cls.process_checkout_lines(lines, country)
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -515,9 +515,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         error_type_field = "checkout_errors"
 
     @classmethod
-    def process_checkout_lines(
-        cls, lines, country
-    ) -> Tuple[List[product_models.ProductVariant], List[int]]:
+    def process_checkout_lines(cls, lines, country) -> None:
         variant_ids = [line.variant.id for line in lines]
         variants = list(
             product_models.ProductVariant.objects.filter(
@@ -527,8 +525,6 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         quantities = [line.quantity for line in lines]
 
         check_lines_quantity(variants, quantities, country)
-
-        return variants, quantities
 
     @classmethod
     def perform_mutation(cls, _root, info, checkout_id, shipping_address):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2,11 +2,11 @@ import uuid
 from decimal import Decimal
 from unittest import mock
 from unittest.mock import ANY, patch
-from django.test import override_settings
 
 import graphene
 import pytest
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 from prices import Money, TaxedMoney
 
 from ....account.models import User

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -558,7 +558,7 @@ def test_checkout_create_sets_country_from_shipping_address_country(
 
 
 @override_settings(DEFAULT_COUNTRY="DE")
-def test_checkout_create_check_lines_quantity_different_shipping_zone_insufficient_stocks(  # NOQA
+def test_checkout_create_check_lines_quantity_for_zone_insufficient_stocks(
     user_api_client,
     variant_with_many_stocks_different_shipping_zones,
     graphql_address_data,

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -560,12 +560,13 @@ def test_checkout_create_check_lines_quantity_different_shipping_zone_insufficie
     variant_with_many_stocks_different_shipping_zones,
     graphql_address_data,
 ):
+    """Check if insufficient stock exception will be raised.
+    If item from checkout will not have enough quantity in correct shipping zone for
+    shipping address INSUFICIENT_STOCK checkout error should be raised."""
     variant = variant_with_many_stocks_different_shipping_zones
-    stock = Stock.objects.filter(
+    Stock.objects.filter(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
-    ).first()
-    stock.quantity = 0
-    stock.save()
+    ).update(quantity=0)
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     test_email = "test@example.com"
     shipping_address = graphql_address_data
@@ -1402,11 +1403,9 @@ def test_checkout_shipping_address_update_insufficient_stocks(
     checkout = Checkout.objects.create()
     checkout.set_country("PL", commit=True)
     add_variant_to_checkout(checkout, variant, 1)
-    stock = Stock.objects.filter(
+    Stock.objects.filter(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
-    ).first()
-    stock.quantity = 0
-    stock.save()
+    ).update(quantity=0)
     assert checkout.shipping_address is None
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2,6 +2,7 @@ import uuid
 from decimal import Decimal
 from unittest import mock
 from unittest.mock import ANY, patch
+from django.test import override_settings
 
 import graphene
 import pytest
@@ -527,6 +528,7 @@ def test_checkout_create_check_lines_quantity_multiple_warehouse(
     assert data["errors"][0]["field"] == "quantity"
 
 
+@override_settings(DEFAULT_COUNTRY="DE")
 def test_checkout_create_sets_country_from_shipping_address_country(
     user_api_client,
     variant_with_many_stocks_different_shipping_zones,
@@ -555,6 +557,7 @@ def test_checkout_create_sets_country_from_shipping_address_country(
     assert checkout.country == "US"
 
 
+@override_settings(DEFAULT_COUNTRY="DE")
 def test_checkout_create_check_lines_quantity_different_shipping_zone_insufficient_stocks(  # NOQA
     user_api_client,
     variant_with_many_stocks_different_shipping_zones,
@@ -1345,6 +1348,7 @@ def test_checkout_shipping_address_update(
     "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
     wraps=update_checkout_shipping_method_if_invalid,
 )
+@override_settings(DEFAULT_COUNTRY="DE")
 def test_checkout_shipping_address_update_changes_checkout_country(
     mocked_update_shipping_method,
     user_api_client,
@@ -1393,6 +1397,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
     wraps=update_checkout_shipping_method_if_invalid,
 )
+@override_settings(DEFAULT_COUNTRY="DE")
 def test_checkout_shipping_address_update_insufficient_stocks(
     mocked_update_shipping_method,
     user_api_client,

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -550,7 +550,7 @@ def test_checkout_create_check_lines_quantity_from_shipping_address_country(
     response = user_api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
     content = get_graphql_content(response)
     data = content["data"]["checkoutCreate"]
-    assert data["created"] == True
+    assert data["created"] is True
     checkout = Checkout.objects.first()
     assert checkout.country == "US"
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -496,6 +496,27 @@ def shipping_zone(db):  # pylint: disable=W0613
 
 
 @pytest.fixture
+def shipping_zones(db):
+    shipping_zone_poland = ShippingZone.objects.create(name="Poland", countries=["PL"])
+    shipping_zone_poland.shipping_methods.create(
+        name="DHL",
+        minimum_order_price=Money(0, "USD"),
+        type=ShippingMethodType.PRICE_BASED,
+        price=Money(10, "USD"),
+        shipping_zone=shipping_zone,
+    )
+    shipping_zone_usa = ShippingZone.objects.create(name="USA", countries=["USA"])
+    shipping_zone_usa.shipping_methods.create(
+        name="DHL",
+        minimum_order_price=Money(0, "USD"),
+        type=ShippingMethodType.PRICE_BASED,
+        price=Money(10, "USD"),
+        shipping_zone=shipping_zone,
+    )
+    return [shipping_zone_poland, shipping_zone_usa]
+
+
+@pytest.fixture
 def shipping_zone_without_countries(db):  # pylint: disable=W0613
     shipping_zone = ShippingZone.objects.create(name="Europe", countries=[])
     shipping_zone.shipping_methods.create(
@@ -854,6 +875,16 @@ def variant(product) -> ProductVariant:
 @pytest.fixture
 def variant_with_many_stocks(variant, warehouses_with_shipping_zone):
     warehouses = warehouses_with_shipping_zone
+    Stock.objects.create(warehouse=warehouses[0], product_variant=variant, quantity=4)
+    Stock.objects.create(warehouse=warehouses[1], product_variant=variant, quantity=3)
+    return variant
+
+
+@pytest.fixture
+def variant_with_many_stocks_different_shipping_zones(
+    variant, warehouses_with_different_shipping_zone
+):
+    warehouses = warehouses_with_different_shipping_zone
     Stock.objects.create(warehouse=warehouses[0], product_variant=variant, quantity=4)
     Stock.objects.create(warehouse=warehouses[1], product_variant=variant, quantity=3)
     return variant
@@ -2090,6 +2121,13 @@ def warehouses(address):
 
 @pytest.fixture
 def warehouses_with_shipping_zone(warehouses, shipping_zone):
+    warehouses[0].shipping_zones.add(shipping_zone)
+    warehouses[1].shipping_zones.add(shipping_zone)
+    return warehouses
+
+
+@pytest.fixture
+def warehouses_with_different_shipping_zone(warehouses, shipping_zone):
     warehouses[0].shipping_zones.add(shipping_zone)
     warehouses[1].shipping_zones.add(shipping_zone)
     return warehouses

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -497,7 +497,12 @@ def shipping_zone(db):  # pylint: disable=W0613
 
 @pytest.fixture
 def shipping_zones(db):
-    shipping_zone_poland = ShippingZone.objects.create(name="Poland", countries=["PL"])
+    shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(
+        [
+            ShippingZone(name="Poland", countries=["PL"]),
+            ShippingZone(name="USA", countries=["US"]),
+        ]
+    )
     shipping_zone_poland.shipping_methods.create(
         name="DHL",
         minimum_order_price=Money(0, "USD"),
@@ -505,7 +510,6 @@ def shipping_zones(db):
         price=Money(10, "USD"),
         shipping_zone=shipping_zone,
     )
-    shipping_zone_usa = ShippingZone.objects.create(name="USA", countries=["US"])
     shipping_zone_usa.shipping_methods.create(
         name="DHL",
         minimum_order_price=Money(0, "USD"),
@@ -875,8 +879,12 @@ def variant(product) -> ProductVariant:
 @pytest.fixture
 def variant_with_many_stocks(variant, warehouses_with_shipping_zone):
     warehouses = warehouses_with_shipping_zone
-    Stock.objects.create(warehouse=warehouses[0], product_variant=variant, quantity=4)
-    Stock.objects.create(warehouse=warehouses[1], product_variant=variant, quantity=3)
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=warehouses[0], product_variant=variant, quantity=4),
+            Stock(warehouse=warehouses[1], product_variant=variant, quantity=3),
+        ]
+    )
     return variant
 
 
@@ -885,8 +893,12 @@ def variant_with_many_stocks_different_shipping_zones(
     variant, warehouses_with_different_shipping_zone
 ):
     warehouses = warehouses_with_different_shipping_zone
-    Stock.objects.create(warehouse=warehouses[0], product_variant=variant, quantity=4)
-    Stock.objects.create(warehouse=warehouses[1], product_variant=variant, quantity=3)
+    Stock.objects.bulk_create(
+        [
+            Stock(warehouse=warehouses[0], product_variant=variant, quantity=4),
+            Stock(warehouse=warehouses[1], product_variant=variant, quantity=3),
+        ]
+    )
     return variant
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -505,7 +505,7 @@ def shipping_zones(db):
         price=Money(10, "USD"),
         shipping_zone=shipping_zone,
     )
-    shipping_zone_usa = ShippingZone.objects.create(name="USA", countries=["USA"])
+    shipping_zone_usa = ShippingZone.objects.create(name="USA", countries=["US"])
     shipping_zone_usa.shipping_methods.create(
         name="DHL",
         minimum_order_price=Money(0, "USD"),
@@ -2127,9 +2127,9 @@ def warehouses_with_shipping_zone(warehouses, shipping_zone):
 
 
 @pytest.fixture
-def warehouses_with_different_shipping_zone(warehouses, shipping_zone):
-    warehouses[0].shipping_zones.add(shipping_zone)
-    warehouses[1].shipping_zones.add(shipping_zone)
+def warehouses_with_different_shipping_zone(warehouses, shipping_zones):
+    warehouses[0].shipping_zones.add(shipping_zones[0])
+    warehouses[1].shipping_zones.add(shipping_zones[1])
     return warehouses
 
 


### PR DESCRIPTION
This also checks if variants in checkouts are available in the shipping zone from shipping country

I want to merge this change because...
Fixes #5780
Fixes #5781 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
