### PR TITLE
Add edit channel mutation

### DIFF
--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -31,3 +31,23 @@ class ChannelCreate(ModelMutation):
     @classmethod
     def get_type_for_model(cls):
         return Channel
+
+
+class ChannelUpdateInput(graphene.InputObjectType):
+    name = graphene.String(description="Name of the channel.")
+    slug = graphene.String(description="Slug of the channel.")
+
+
+class ChannelUpdate(ModelMutation):
+    class Arguments:
+        id = graphene.ID(required=True, description="ID of a channel to update.")
+        input = ChannelUpdateInput(
+            description="Fields required to update a channel.", required=True
+        )
+
+    class Meta:
+        description = "Update a channel."
+        model = models.Channel
+        permissions = (ChannelPermission.MANAGE_CHANNELS,)
+        error_type_class = ChannelError
+        error_type_field = "channel_errors"

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -2,7 +2,7 @@ import graphene
 
 from ...core.permissions import ChannelPermission
 from ..decorators import permission_required
-from .mutations import ChannelCreate
+from .mutations import ChannelCreate, ChannelUpdate
 from .resolvers import resolve_channel, resolve_channels
 from .types import Channel
 
@@ -28,3 +28,4 @@ class ChannelQueries(graphene.ObjectType):
 
 class ChannelMutations(graphene.ObjectType):
     channel_create = ChannelCreate.Field()
+    channel_update = ChannelUpdate.Field()

--- a/saleor/graphql/channel/tests/test_channel_update_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_update_mutations.py
@@ -1,0 +1,208 @@
+import graphene
+
+from ....channel.error_codes import ChannelErrorCode
+from ...tests.utils import assert_no_permission, get_graphql_content
+
+CHANNEL_UPDATE_MUTATION = """
+    mutation UpdateChannel($id: ID!,$input: ChannelUpdateInput!){
+        channelUpdate(id: $id, input: $input){
+            channel{
+                id
+                name
+                slug
+                currencyCode
+            }
+            channelErrors{
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+def test_channel_update_mutation_as_staff_user(
+    permission_manage_channels, staff_api_client, channel
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "newName"
+    slug = "new_slug"
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["channelUpdate"]
+    assert not data["channelErrors"]
+    channel_data = data["channel"]
+    channel.refresh_from_db()
+    assert channel_data["name"] == channel.name == name
+    assert channel_data["slug"] == channel.slug == slug
+    assert channel_data["currencyCode"] == channel.currency_code == "USD"
+
+
+def test_channel_update_mutation_as_app(
+    permission_manage_channels, app_api_client, channel
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "newName"
+    slug = "new_slug"
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = app_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["channelUpdate"]
+    assert not data["channelErrors"]
+    channel_data = data["channel"]
+    channel.refresh_from_db()
+    assert channel_data["name"] == channel.name == name
+    assert channel_data["slug"] == channel.slug == slug
+    assert channel_data["currencyCode"] == channel.currency_code == "USD"
+
+
+def test_channel_update_mutation_as_customer(user_api_client, channel):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "newName"
+    slug = "new_slug"
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = user_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION, variables=variables, permissions=(),
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_channel_update_mutation_as_anonymous(api_client, channel):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "newName"
+    slug = "new_slug"
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION, variables=variables, permissions=(),
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_channel_update_mutation_with_invalid_slug(
+    permission_manage_channels, staff_api_client, channel
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "testName"
+    slug = "Invalid slug"
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    error = content["data"]["channelUpdate"]["channelErrors"][0]
+    assert error["field"] == "slug"
+    assert error["code"] == ChannelErrorCode.INVALID.name
+
+
+def test_channel_update_mutation_with_duplicated_slug(
+    permission_manage_channels, staff_api_client, channel, channel_PLN
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "New Channel"
+    slug = channel_PLN.slug
+    variables = {"id": channel_id, "input": {"name": name, "slug": slug}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    error = content["data"]["channelUpdate"]["channelErrors"][0]
+    assert error["field"] == "slug"
+    assert error["code"] == ChannelErrorCode.UNIQUE.name
+
+
+def test_channel_update_mutation_only_name(
+    permission_manage_channels, staff_api_client, channel
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = "newName"
+    slug = channel.slug
+    variables = {"id": channel_id, "input": {"name": name}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["channelUpdate"]
+    assert not data["channelErrors"]
+    channel_data = data["channel"]
+    channel.refresh_from_db()
+    assert channel_data["name"] == channel.name == name
+    assert channel_data["slug"] == channel.slug == slug
+    assert channel_data["currencyCode"] == channel.currency_code == "USD"
+
+
+def test_channel_update_mutation_only_slug(
+    permission_manage_channels, staff_api_client, channel
+):
+    # given
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+    name = channel.name
+    slug = "new_slug"
+    variables = {"id": channel_id, "input": {"slug": slug}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHANNEL_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_channels,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["channelUpdate"]
+    assert not data["channelErrors"]
+    channel_data = data["channel"]
+    channel.refresh_from_db()
+    assert channel_data["name"] == channel.name == name
+    assert channel_data["slug"] == channel.slug == slug
+    assert channel_data["currencyCode"] == channel.currency_code == "USD"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -798,6 +798,17 @@ enum ChannelErrorCode {
   UNIQUE
 }
 
+type ChannelUpdate {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  channelErrors: [ChannelError!]!
+  channel: Channel
+}
+
+input ChannelUpdateInput {
+  name: String
+  slug: String
+}
+
 type Checkout implements Node & ObjectWithMetadata {
   created: DateTime!
   lastChange: DateTime!
@@ -2514,6 +2525,7 @@ type Mutation {
   checkoutUpdatePrivateMetadata(id: ID!, input: MetaInput!): CheckoutUpdatePrivateMeta @deprecated(reason: "Use the `updatePrivateMetadata` mutation. This field will be removed after 2020-07-31.")
   checkoutClearPrivateMetadata(id: ID!, input: MetaPath!): CheckoutClearPrivateMeta @deprecated(reason: "Use the `deletePrivateMetadata` mutation. This field will be removed after 2020-07-31.")
   channelCreate(input: ChannelCreateInput!): ChannelCreate
+  channelUpdate(id: ID!, input: ChannelUpdateInput!): ChannelUpdate
   appCreate(input: AppInput!): AppCreate
   appUpdate(id: ID!, input: AppInput!): AppUpdate
   appDelete(id: ID!): AppDelete


### PR DESCRIPTION
I want to merge this change because I'm adding edit channel mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
