### PR TITLE
Better way of handling token expiration and old type of jwt tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
+
 ## [Unreleased]
 
 - Add our implementation of UUID scalar - #5646 by @koradon
@@ -9,9 +10,11 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix specific product voucher in draft orders - #5727 by @fowczarek
 - Explicit country assignment in default shipping zones - #5736 by @maarcingebala
 - Drop `json_content` field from the `Menu` model - #5761 by @maarcingebala
-- Refactor JWT support - These changes could require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins
 - Strip warehouse name in mutations - #5766 by @koradon
 - Add missing OrderEvents during checkout flow - #5684 by @koradon
+    ### Breaking Changes
+   - Refactor JWT support - These changes could require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins
+
 
 ## 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix specific product voucher in draft orders - #5727 by @fowczarek
 - Explicit country assignment in default shipping zones - #5736 by @maarcingebala
 - Drop `json_content` field from the `Menu` model - #5761 by @maarcingebala
-- Refactor JWT support - These changes would require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins
+- Refactor JWT support - These changes could require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins
 - Strip warehouse name in mutations - #5766 by @koradon
 - Add missing OrderEvents during checkout flow - #5684 by @koradon
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix specific product voucher in draft orders - #5727 by @fowczarek
 - Explicit country assignment in default shipping zones - #5736 by @maarcingebala
 - Drop `json_content` field from the `Menu` model - #5761 by @maarcingebala
-- Refactor JWT support - #5734 by @korycins
+- Refactor JWT support - These changes would require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins
 - Strip warehouse name in mutations - #5766 by @koradon
 - Add missing OrderEvents during checkout flow - #5684 by @koradon
 

--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -1,3 +1,5 @@
+from jwt.exceptions import PyJWTError
+
 from ..checkout.error_codes import CheckoutErrorCode
 
 
@@ -39,3 +41,7 @@ class PermissionDenied(Exception):
         if message is None:
             message = default_message
         super().__init__(message)
+
+
+class ExpiredUserSignatureError(PyJWTError):
+    pass

--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -1,5 +1,3 @@
-from jwt.exceptions import PyJWTError
-
 from ..checkout.error_codes import CheckoutErrorCode
 
 
@@ -41,7 +39,3 @@ class PermissionDenied(Exception):
         if message is None:
             message = default_message
         super().__init__(message)
-
-
-class ExpiredUserSignatureError(PyJWTError):
-    pass

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -5,8 +5,10 @@ import graphene
 import jwt
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
+from jwt import InvalidTokenError
 
 from ..account.models import User
+from .exceptions import ExpiredUserSignatureError
 
 JWT_ALGORITHM = "HS256"
 JWT_AUTH_HEADER = "HTTP_AUTHORIZATION"
@@ -16,13 +18,9 @@ JWT_REFRESH_TYPE = "refresh"
 JWT_REFRESH_TOKEN_COOKIE_NAME = "refreshToken"
 
 
-def jwt_base_payload(exp_delta: Optional[timedelta] = None) -> Dict[str, Any]:
+def jwt_base_payload(exp_delta: timedelta) -> Dict[str, Any]:
     utc_now = datetime.utcnow()
-    payload = {
-        "iat": utc_now,
-    }
-    if exp_delta:
-        payload["exp"] = utc_now + exp_delta
+    payload = {"iat": utc_now, "exp": utc_now + exp_delta}
     return payload
 
 
@@ -32,8 +30,6 @@ def jwt_user_payload(
     exp_delta: timedelta,
     additional_payload: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
-    if not settings.JWT_EXPIRE:
-        exp_delta = None  # type: ignore
 
     payload = jwt_base_payload(exp_delta)
     payload.update(
@@ -58,7 +54,10 @@ def jwt_encode(payload: Dict[str, Any]) -> str:
 
 def jwt_decode(token: str) -> Dict[str, Any]:
     return jwt.decode(
-        token, settings.SECRET_KEY, algorithms=JWT_ALGORITHM  # type: ignore
+        token,
+        settings.SECRET_KEY,  # type: ignore
+        algorithms=JWT_ALGORITHM,
+        verify_expiration=settings.JWT_EXPIRE,
     )
 
 
@@ -96,13 +95,24 @@ def get_token_from_request(request: WSGIRequest) -> Optional[str]:
 
 def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:
     user = User.objects.filter(email=payload["email"], is_active=True).first()
-    if user and user.jwt_token_key == payload["token"]:
-        return user
-    return None
+    user_jwt_token = payload.get("token")
+    if not user_jwt_token or not user:
+        raise InvalidTokenError(
+            "Invalid token. Create new one by using tokenCreate mutation."
+        )
+    if user.jwt_token_key != user_jwt_token:
+        raise ExpiredUserSignatureError(
+            "User requested to expire this token. Create new one by using tokenCreate "
+            "mutation."
+        )
+    return user
 
 
 def get_user_from_access_token(token: str) -> Optional[User]:
     payload = jwt_decode(token)
-    if payload["type"] != JWT_ACCESS_TYPE:
-        return None
+    jwt_type = payload.get("type")
+    if jwt_type != JWT_ACCESS_TYPE:
+        raise InvalidTokenError(
+            "Invalid token. Create new one by using tokenCreate mutation."
+        )
     return get_user_from_payload(payload)

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -5,7 +5,6 @@ import graphene
 import jwt
 from django.conf import settings
 from django.core.handlers.wsgi import WSGIRequest
-from jwt import InvalidTokenError
 
 from ..account.models import User
 
@@ -96,11 +95,11 @@ def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:
     user = User.objects.filter(email=payload["email"], is_active=True).first()
     user_jwt_token = payload.get("token")
     if not user_jwt_token or not user:
-        raise InvalidTokenError(
+        raise jwt.InvalidTokenError(
             "Invalid token. Create new one by using tokenCreate mutation."
         )
     if user.jwt_token_key != user_jwt_token:
-        raise InvalidTokenError(
+        raise jwt.InvalidTokenError(
             "Invalid token. Create new one by using tokenCreate mutation."
         )
     return user
@@ -110,7 +109,7 @@ def get_user_from_access_token(token: str) -> Optional[User]:
     payload = jwt_decode(token)
     jwt_type = payload.get("type")
     if jwt_type != JWT_ACCESS_TYPE:
-        raise InvalidTokenError(
+        raise jwt.InvalidTokenError(
             "Invalid token. Create new one by using tokenCreate mutation."
         )
     return get_user_from_payload(payload)

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -8,7 +8,6 @@ from django.core.handlers.wsgi import WSGIRequest
 from jwt import InvalidTokenError
 
 from ..account.models import User
-from .exceptions import ExpiredUserSignatureError
 
 JWT_ALGORITHM = "HS256"
 JWT_AUTH_HEADER = "HTTP_AUTHORIZATION"
@@ -101,7 +100,7 @@ def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:
             "Invalid token. Create new one by using tokenCreate mutation."
         )
     if user.jwt_token_key != user_jwt_token:
-        raise ExpiredUserSignatureError(
+        raise InvalidTokenError(
             "User requested to expire this token. Create new one by using tokenCreate "
             "mutation."
         )

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -101,8 +101,7 @@ def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:
         )
     if user.jwt_token_key != user_jwt_token:
         raise InvalidTokenError(
-            "User requested to expire this token. Create new one by using tokenCreate "
-            "mutation."
+            "Invalid token. Create new one by using tokenCreate mutation."
         )
     return user
 

--- a/saleor/core/tests/test_auth_backend.py
+++ b/saleor/core/tests/test_auth_backend.py
@@ -4,7 +4,6 @@ from freezegun import freeze_time
 from jwt import ExpiredSignatureError, InvalidSignatureError, InvalidTokenError
 
 from ..auth_backend import JSONWebTokenBackend
-from ..exceptions import ExpiredUserSignatureError
 from ..jwt import (
     JWT_ACCESS_TYPE,
     JWT_ALGORITHM,
@@ -86,7 +85,7 @@ def test_user_deactivated_token(rf, staff_user):
     staff_user.save()
     request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
     backend = JSONWebTokenBackend()
-    with pytest.raises(ExpiredUserSignatureError):
+    with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 

--- a/saleor/core/tests/test_auth_backend.py
+++ b/saleor/core/tests/test_auth_backend.py
@@ -1,14 +1,16 @@
 import jwt
 import pytest
 from freezegun import freeze_time
-from jwt import ExpiredSignatureError, InvalidSignatureError
+from jwt import ExpiredSignatureError, InvalidSignatureError, InvalidTokenError
 
 from ..auth_backend import JSONWebTokenBackend
+from ..exceptions import ExpiredUserSignatureError
 from ..jwt import (
     JWT_ACCESS_TYPE,
     JWT_ALGORITHM,
     create_access_token,
     create_refresh_token,
+    jwt_encode,
     jwt_user_payload,
 )
 
@@ -27,14 +29,16 @@ def test_user_deactivated(rf, staff_user):
     access_token = create_access_token(staff_user)
     request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
     backend = JSONWebTokenBackend()
-    assert backend.authenticate(request) is None
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
 
 
 def test_incorect_type_of_token(rf, staff_user):
     token = create_refresh_token(staff_user)
     request = rf.request(HTTP_AUTHORIZATION=f"JWT {token}")
     backend = JSONWebTokenBackend()
-    assert backend.authenticate(request) is None
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
 
 
 def test_incorrect_token(rf, staff_user, settings):
@@ -72,7 +76,8 @@ def test_user_doesnt_exist(rf, staff_user):
     staff_user.delete()
     request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
     backend = JSONWebTokenBackend()
-    assert backend.authenticate(request) is None
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
 
 
 def test_user_deactivated_token(rf, staff_user):
@@ -81,4 +86,31 @@ def test_user_deactivated_token(rf, staff_user):
     staff_user.save()
     request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
     backend = JSONWebTokenBackend()
-    assert backend.authenticate(request) is None
+    with pytest.raises(ExpiredUserSignatureError):
+        backend.authenticate(request)
+
+
+def test_user_payload_doesnt_have_user_token(rf, staff_user, settings):
+    access_payload = jwt_user_payload(
+        staff_user, JWT_ACCESS_TYPE, settings.JWT_TTL_ACCESS
+    )
+    del access_payload["token"]
+    access_token = jwt_encode(access_payload)
+
+    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_user_has_old_token_type(rf, staff_user, settings):
+    settings.JWT_EXPIRE = False
+    access_token = (
+        "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJlbWFpbCI6ImFkbWluQGV4YW1wbGUuY29tIiwiZ"
+        "XhwIjoxNTYwMTczNDI2LCJvcmlnSWF0IjoxNTYwMTczMTI2fQ.QrYkGfEqnwC-d--EHATAfXoWURJf"
+        "lFfbntR7BESI9mg"
+    )
+    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)

--- a/saleor/graphql/account/mutations/jwt.py
+++ b/saleor/graphql/account/mutations/jwt.py
@@ -40,7 +40,10 @@ def get_payload(token):
 
 
 def get_user(payload):
-    user = get_user_from_payload(payload)
+    try:
+        user = get_user_from_payload(payload)
+    except Exception:
+        user = None
     if not user:
         raise ValidationError(
             "Invalid token", code=AccountErrorCode.JWT_INVALID_TOKEN.value

--- a/saleor/graphql/account/tests/mutations/test_tokens_deactivate_all.py
+++ b/saleor/graphql/account/tests/mutations/test_tokens_deactivate_all.py
@@ -48,7 +48,6 @@ def test_deactivate_all_user_tokens_access_token(user_api_client, customer_user)
     user_api_client.token = token
     response = user_api_client.post_graphql(MUTATION_DEACTIVATE_ALL_USER_TOKENS)
     content = get_graphql_content(response)
-
     errors = content["data"]["tokensDeactivateAll"]["accountErrors"]
     assert not errors
 
@@ -57,7 +56,7 @@ def test_deactivate_all_user_tokens_access_token(user_api_client, customer_user)
     content = json.loads(response.content.decode("utf8"))
     assert len(content["errors"]) == 1
     assert content["errors"][0]["extensions"]["exception"]["code"] == (
-        "ExpiredUserSignatureError"
+        "InvalidTokenError"
     )
 
     assert content["data"]["me"] is None

--- a/saleor/graphql/account/tests/mutations/test_tokens_deactivate_all.py
+++ b/saleor/graphql/account/tests/mutations/test_tokens_deactivate_all.py
@@ -1,3 +1,5 @@
+import json
+
 from django.middleware.csrf import _get_new_csrf_token
 from freezegun import freeze_time
 
@@ -52,7 +54,12 @@ def test_deactivate_all_user_tokens_access_token(user_api_client, customer_user)
 
     query = "{me { id }}"
     response = user_api_client.post_graphql(query)
-    content = get_graphql_content(response)
+    content = json.loads(response.content.decode("utf8"))
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["extensions"]["exception"]["code"] == (
+        "ExpiredUserSignatureError"
+    )
+
     assert content["data"]["me"] is None
 
 


### PR DESCRIPTION
- Change way of handling tokens when JWT_EXPIRE is set to False
- Raise exceptions when token payload doesn't have all required fields