### PR TITLE
Remove unused code

### DIFF
--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -1,5 +1,3 @@
-from uuid import uuid4
-
 import pytest
 from measurement.measures import Weight
 from prices import Money, TaxedMoney
@@ -30,22 +28,6 @@ def test_get_or_create_user_checkout(
     assert Checkout.objects.all().count() == 3
     assert checkout in checkouts
     assert checkout.user == admin_user
-
-
-def test_get_anonymous_checkout_from_token(anonymous_checkout, user_checkout):
-    checkout = utils.get_anonymous_checkout_from_token(anonymous_checkout.token)
-    assert Checkout.objects.all().count() == 2
-    assert checkout == anonymous_checkout
-
-    # test against new token
-    checkout = utils.get_anonymous_checkout_from_token(uuid4())
-    assert Checkout.objects.all().count() == 2
-    assert checkout is None
-
-    # test against getting checkout assigned to user
-    checkout = utils.get_anonymous_checkout_from_token(user_checkout.token)
-    assert Checkout.objects.all().count() == 2
-    assert checkout is None
 
 
 def test_get_user_checkout(

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -87,9 +87,9 @@ def test_last_change_update_foregin_key(checkout, shipping_method):
 
 
 def test_create_order_captured_payment_creates_expected_events(
-    request_checkout_with_item, customer_user, shipping_method, payment_txn_captured,
+    checkout_with_item, customer_user, shipping_method, payment_txn_captured,
 ):
-    checkout = request_checkout_with_item
+    checkout = checkout_with_item
     checkout_user = customer_user
 
     # Ensure not events are existing prior
@@ -209,9 +209,9 @@ def test_create_order_captured_payment_creates_expected_events(
 
 
 def test_create_order_captured_payment_creates_expected_events_anonymous_user(
-    request_checkout_with_item, customer_user, shipping_method, payment_txn_captured,
+    checkout_with_item, customer_user, shipping_method, payment_txn_captured,
 ):
-    checkout = request_checkout_with_item
+    checkout = checkout_with_item
     checkout_user = None
 
     # Ensure not events are existing prior
@@ -325,9 +325,9 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
 
 
 def test_create_order_preauth_payment_creates_expected_events(
-    request_checkout_with_item, customer_user, shipping_method, payment_txn_preauth,
+    checkout_with_item, customer_user, shipping_method, payment_txn_preauth,
 ):
-    checkout = request_checkout_with_item
+    checkout = checkout_with_item
     checkout_user = customer_user
 
     # Ensure not events are existing prior
@@ -418,9 +418,9 @@ def test_create_order_preauth_payment_creates_expected_events(
 
 
 def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
-    request_checkout_with_item, customer_user, shipping_method, payment_txn_preauth,
+    checkout_with_item, customer_user, shipping_method, payment_txn_preauth,
 ):
-    checkout = request_checkout_with_item
+    checkout = checkout_with_item
     checkout_user = None
 
     # Ensure not events are existing prior
@@ -505,19 +505,19 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
 
 
 def test_create_order_insufficient_stock(
-    request_checkout, customer_user, product_without_shipping
+    checkout, customer_user, product_without_shipping
 ):
     variant = product_without_shipping.variants.get()
-    add_variant_to_checkout(request_checkout, variant, 10, check_quantity=False)
-    request_checkout.user = customer_user
-    request_checkout.billing_address = customer_user.default_billing_address
-    request_checkout.shipping_address = customer_user.default_billing_address
-    request_checkout.save()
+    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.save()
 
     with pytest.raises(InsufficientStock):
         prepare_order_data(
-            checkout=request_checkout,
-            lines=list(request_checkout),
+            checkout=checkout,
+            lines=list(checkout),
             tracking_code="tracking_code",
             discounts=None,
         )
@@ -683,22 +683,22 @@ def test_create_order_with_many_gift_cards(
     )
 
 
-def test_note_in_created_order(request_checkout_with_item, address, customer_user):
-    request_checkout_with_item.shipping_address = address
-    request_checkout_with_item.note = "test_note"
-    request_checkout_with_item.save()
+def test_note_in_created_order(checkout_with_item, address, customer_user):
+    checkout_with_item.shipping_address = address
+    checkout_with_item.note = "test_note"
+    checkout_with_item.save()
     order = create_order(
-        checkout=request_checkout_with_item,
+        checkout=checkout_with_item,
         order_data=prepare_order_data(
-            checkout=request_checkout_with_item,
-            lines=list(request_checkout_with_item),
+            checkout=checkout_with_item,
+            lines=list(checkout_with_item),
             tracking_code="tracking_code",
             discounts=None,
         ),
         user=customer_user,
         redirect_url="https://www.example.com",
     )
-    assert order.customer_note == request_checkout_with_item.note
+    assert order.customer_note == checkout_with_item.note
 
 
 @pytest.mark.parametrize(

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -47,23 +47,6 @@ from ..warehouse.management import allocate_stock
 from . import AddressType
 from .models import Checkout, CheckoutLine
 
-COOKIE_NAME = "checkout"
-
-
-def get_checkout_from_request(request, checkout_queryset=Checkout.objects.all()):
-    """Fetch checkout from database or return a new instance based on cookie."""
-    if request.user.is_authenticated:
-        checkout, _ = get_user_checkout(request.user, checkout_queryset)
-        user = request.user
-    else:
-        token = request.get_signed_cookie(COOKIE_NAME, default=None)
-        checkout = get_anonymous_checkout_from_token(token, checkout_queryset)
-        user = None
-    if checkout is None:
-        checkout = Checkout(user=user)
-    checkout.set_country(request.country)
-    return checkout
-
 
 def get_user_checkout(
     user: User, checkout_queryset=Checkout.objects.all(), auto_create=False
@@ -82,11 +65,6 @@ def get_user_checkout(
             },
         )
     return checkout_queryset.filter(user=user).first(), False
-
-
-def get_anonymous_checkout_from_token(token, checkout_queryset=Checkout.objects.all()):
-    """Return an open unassigned checkout with given token if any."""
-    return checkout_queryset.filter(token=token, user=None).first()
 
 
 def update_checkout_quantity(checkout):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -416,24 +416,6 @@ def user_checkout_with_items(user_checkout, product_list):
 
 
 @pytest.fixture
-def request_checkout(checkout, monkeypatch):
-    # FIXME: Fixtures should not have any side effects
-    monkeypatch.setattr(
-        utils,
-        "get_checkout_from_request",
-        lambda request, checkout_queryset=None: checkout,
-    )
-    return checkout
-
-
-@pytest.fixture
-def request_checkout_with_item(product, request_checkout):
-    variant = product.variants.get()
-    add_variant_to_checkout(request_checkout, variant)
-    return request_checkout
-
-
-@pytest.fixture
 def order(customer_user):
     address = customer_user.default_billing_address.get_copy()
     return Order.objects.create(


### PR DESCRIPTION
This PR removes some unused code from the Saleor 1.0 era which I just accidentally found. We no longer use cookies to store checkout tokens for anonymous users.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
