### PR TITLE
Update google merchant to get tax rate based by plugin manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop `json_content` field from the `Menu` model - #5761 by @maarcingebala
 - Strip warehouse name in mutations - #5766 by @koradon
 - Add missing OrderEvents during checkout flow - #5684 by @koradon
+- Update google merchant to get tax rate based by plugin manager - #5823 by @gabmartinez
 
 ## 2.10.1
 

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -10,7 +10,6 @@ from django.utils import timezone
 from django.utils.encoding import smart_text
 from django_countries.fields import Country
 
-from ..core.taxes import charge_taxes_on_shipping
 from ..discount import DiscountInfo
 from ..discount.utils import fetch_discounts
 from ..plugins.manager import get_plugins_manager
@@ -119,9 +118,7 @@ def item_brand(item: ProductVariant, attributes_dict, attribute_values_dict):
 
 
 def item_tax(
-    item: ProductVariant,
-    discounts: Iterable[DiscountInfo],
-    current_site: Site,
+    item: ProductVariant, discounts: Iterable[DiscountInfo], current_site: Site,
 ):
     """Return item tax.
 
@@ -230,7 +227,6 @@ def item_attributes(
 
 def write_feed(file_obj):
     """Write feed contents info provided file object."""
-    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
     writer = csv.DictWriter(file_obj, ATTRIBUTES, dialect=csv.excel_tab)
     writer.writeheader()
     categories = Category.objects.all()

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -121,7 +121,7 @@ def item_brand(item: ProductVariant, attributes_dict, attribute_values_dict):
 def item_tax(
     item: ProductVariant,
     discounts: Iterable[DiscountInfo],
-    is_charge_taxes_on_shipping: bool,
+    current_site: Site,
 ):
     """Return item tax.
 
@@ -133,8 +133,11 @@ def item_tax(
     tax_rate = get_plugins_manager().get_tax_rate_percentage_value(
         item.product.product_type, country
     )
-    tax_ship = "yes" if is_charge_taxes_on_shipping else "no"
-    return "%s::%s:%s" % (country.code, tax_rate, tax_ship)
+    if tax_rate:
+        is_charge_taxes_on_shipping = current_site.settings.charge_taxes_on_shipping
+        tax_ship = "yes" if is_charge_taxes_on_shipping else "no"
+        return "%s::%s:%s" % (country.code, tax_rate, tax_ship)
+    return None
 
 
 def item_group_id(item: ProductVariant):
@@ -192,7 +195,6 @@ def item_attributes(
     discounts: Iterable[DiscountInfo],
     attributes_dict,
     attribute_values_dict,
-    is_charge_taxes_on_shipping: bool,
 ):
     product_data = {
         "id": item_id(item),
@@ -215,7 +217,7 @@ def item_attributes(
     if sale_price != price:
         product_data["sale_price"] = sale_price
 
-    tax = item_tax(item, discounts, is_charge_taxes_on_shipping)
+    tax = item_tax(item, discounts, current_site)
     if tax:
         product_data["tax"] = tax
 
@@ -248,7 +250,6 @@ def write_feed(file_obj):
             discounts,
             attributes_dict,
             attribute_values_dict,
-            is_charge_taxes_on_shipping,
         )
         writer.writerow(item_data)
 

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -42,7 +42,7 @@ ATTRIBUTES = [
     "description",
 ]
 
-IS_CHARGE_TAXES_ON_SHIPPING = charge_taxes_on_shipping()
+IS_CHARGE_TAXES_ON_SHIPPING = False
 
 
 def get_feed_file_url():
@@ -225,6 +225,7 @@ def item_attributes(
 
 def write_feed(file_obj):
     """Write feed contents info provided file object."""
+    IS_CHARGE_TAXES_ON_SHIPPING = charge_taxes_on_shipping()
     writer = csv.DictWriter(file_obj, ATTRIBUTES, dialect=csv.excel_tab)
     writer.writeheader()
     categories = Category.objects.all()

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -42,6 +42,8 @@ ATTRIBUTES = [
     "description",
 ]
 
+IS_CHARGE_TAXES_ON_SHIPPING = charge_taxes_on_shipping()
+
 
 def get_feed_file_url():
     return default_storage.url(FILE_PATH)
@@ -129,7 +131,7 @@ def item_tax(item: ProductVariant, discounts: Iterable[DiscountInfo]):
     tax_rate = get_plugins_manager().get_tax_rate_percentage_value(
         item.product.product_type, country
     )
-    tax_ship = "yes" if charge_taxes_on_shipping() else "no"
+    tax_ship = "yes" if IS_CHARGE_TAXES_ON_SHIPPING else "no"
     return "%s::%s:%s" % (country.code, tax_rate, tax_ship)
 
 

--- a/saleor/data_feeds/google_merchant.py
+++ b/saleor/data_feeds/google_merchant.py
@@ -121,7 +121,7 @@ def item_brand(item: ProductVariant, attributes_dict, attribute_values_dict):
 def item_tax(
     item: ProductVariant,
     discounts: Iterable[DiscountInfo],
-    is_charge_taxes_on_shipping: bool
+    is_charge_taxes_on_shipping: bool,
 ):
     """Return item tax.
 

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -11,10 +11,12 @@ from ..google_merchant import (
     item_availability,
     item_google_product_category,
     write_feed,
+    charge_taxes_on_shipping,
 )
 
 
 def test_saleor_feed_items(product, site_settings):
+    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
     valid_variant = product.variants.first()
     items = get_feed_items()
     assert len(items) == 1
@@ -34,6 +36,7 @@ def test_saleor_feed_items(product, site_settings):
         discounts,
         attributes_dict,
         attribute_values_dict,
+        is_charge_taxes_on_shipping,
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -1,4 +1,5 @@
 import csv
+from django_prices_vatlayer.models import VAT
 from io import StringIO
 from unittest.mock import Mock
 
@@ -60,10 +61,12 @@ def test_category_formatter(db):
     assert item_google_product_category(sub_category_item, {}) == "Main > Sub"
 
 
-def test_tax_formatter(variant, site_settings):
+def test_tax_formatter(variant, vatlayer, tax_rates):
     discounts = []
+    VAT.objects.create(country_code="US", data=tax_rates)
     is_charge_taxes_on_shipping = charge_taxes_on_shipping()
-    assert item_tax(variant, discounts, is_charge_taxes_on_shipping) is None
+    item_tax_value = item_tax(variant, discounts, is_charge_taxes_on_shipping)
+    assert item_tax_value == "US::23:yes"
 
 
 def test_write_feed(product, monkeypatch):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -17,7 +17,6 @@ from ..google_merchant import (
 
 
 def test_saleor_feed_items(product, site_settings):
-    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
     valid_variant = product.variants.first()
     items = get_feed_items()
     assert len(items) == 1
@@ -37,7 +36,6 @@ def test_saleor_feed_items(product, site_settings):
         discounts,
         attributes_dict,
         attribute_values_dict,
-        is_charge_taxes_on_shipping,
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
@@ -57,12 +55,6 @@ def test_category_formatter(db):
     sub_category_item = Mock(product=Mock(category=sub_category))
     assert item_google_product_category(main_category_item, {}) == "Main"
     assert item_google_product_category(sub_category_item, {}) == "Main > Sub"
-
-
-def test_tax_formatter(variant, site_settings):
-    discounts = []
-    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
-    assert item_tax(variant, discounts, is_charge_taxes_on_shipping) == "US::0:yes"
 
 
 def test_write_feed(product, monkeypatch):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -4,9 +4,9 @@ from unittest.mock import Mock
 
 from django.utils.encoding import smart_text
 
+from ...core.taxes import charge_taxes_on_shipping
 from ...product.models import AttributeValue, Category
 from ..google_merchant import (
-    charge_taxes_on_shipping,
     get_feed_items,
     item_attributes,
     item_availability,

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -40,6 +40,7 @@ def test_saleor_feed_items(product, site_settings):
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
+    assert attributes.get("tax") == 'US::0:yes'
 
 
 def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 
 from django.utils.encoding import smart_text
 
+from ...core.taxes import charge_taxes_on_shipping
 from ...product.models import AttributeValue, Category
 from ..google_merchant import (
     get_feed_items,
@@ -15,6 +16,7 @@ from ..google_merchant import (
 
 
 def test_saleor_feed_items(product, site_settings):
+    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
     valid_variant = product.variants.first()
     items = get_feed_items()
     assert len(items) == 1
@@ -34,6 +36,7 @@ def test_saleor_feed_items(product, site_settings):
         discounts,
         attributes_dict,
         attribute_values_dict,
+        is_charge_taxes_on_shipping,
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock
 
 from django.utils.encoding import smart_text
 
-from ...core.taxes import charge_taxes_on_shipping
 from ...product.models import AttributeValue, Category
 from ..google_merchant import (
     get_feed_items,

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -6,12 +6,12 @@ from django.utils.encoding import smart_text
 
 from ...product.models import AttributeValue, Category
 from ..google_merchant import (
+    charge_taxes_on_shipping,
     get_feed_items,
     item_attributes,
     item_availability,
     item_google_product_category,
     write_feed,
-    charge_taxes_on_shipping,
 )
 
 

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -11,6 +11,7 @@ from ..google_merchant import (
     item_attributes,
     item_availability,
     item_google_product_category,
+    item_tax,
     write_feed,
 )
 
@@ -40,7 +41,6 @@ def test_saleor_feed_items(product, site_settings):
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
-    assert attributes.get("tax") == "US::0:yes"
 
 
 def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):
@@ -57,6 +57,12 @@ def test_category_formatter(db):
     sub_category_item = Mock(product=Mock(category=sub_category))
     assert item_google_product_category(main_category_item, {}) == "Main"
     assert item_google_product_category(sub_category_item, {}) == "Main > Sub"
+
+
+def test_tax_formatter(variant, site_settings):
+    discounts = []
+    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
+    assert item_tax(variant, discounts, is_charge_taxes_on_shipping) == "US::0:yes"
 
 
 def test_write_feed(product, monkeypatch):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -11,6 +11,7 @@ from ..google_merchant import (
     item_attributes,
     item_availability,
     item_google_product_category,
+    item_tax,
     write_feed,
 )
 
@@ -40,6 +41,7 @@ def test_saleor_feed_items(product, site_settings):
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
+    assert attributes.get("tax") is None
 
 
 def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):
@@ -56,6 +58,12 @@ def test_category_formatter(db):
     sub_category_item = Mock(product=Mock(category=sub_category))
     assert item_google_product_category(main_category_item, {}) == "Main"
     assert item_google_product_category(sub_category_item, {}) == "Main > Sub"
+
+
+def test_tax_formatter(variant, site_settings):
+    discounts = []
+    is_charge_taxes_on_shipping = charge_taxes_on_shipping()
+    assert item_tax(variant, discounts, is_charge_taxes_on_shipping) is None
 
 
 def test_write_feed(product, monkeypatch):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -10,7 +10,6 @@ from ..google_merchant import (
     item_attributes,
     item_availability,
     item_google_product_category,
-    item_tax,
     write_feed,
 )
 

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -40,7 +40,7 @@ def test_saleor_feed_items(product, site_settings):
     )
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
-    assert attributes.get("tax") == 'US::0:yes'
+    assert attributes.get("tax") == "US::0:yes"
 
 
 def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -17,13 +17,13 @@ from ..google_merchant import (
 )
 
 
-def test_saleor_feed_items(product, site_settings):
+def test_saleor_feed_items(product, discount_info, site_settings):
     is_charge_taxes_on_shipping = charge_taxes_on_shipping()
     valid_variant = product.variants.first()
     items = get_feed_items()
     assert len(items) == 1
     categories = Category.objects.all()
-    discounts = []
+    discounts = [discount_info]
     category_paths = {}
     attributes_dict = {}
     current_site = site_settings.site
@@ -43,6 +43,8 @@ def test_saleor_feed_items(product, site_settings):
     assert attributes.get("mpn") == valid_variant.sku
     assert attributes.get("availability") == "in stock"
     assert attributes.get("tax") is None
+    assert attributes.get("price") == "10.00 USD"
+    assert attributes.get("sale_price") == "5.00 USD"
 
 
 def test_saleor_get_feed_items_having_no_stock_info(variant, site_settings):

--- a/saleor/data_feeds/tests/test_data_feeds.py
+++ b/saleor/data_feeds/tests/test_data_feeds.py
@@ -1,9 +1,9 @@
 import csv
-from django_prices_vatlayer.models import VAT
 from io import StringIO
 from unittest.mock import Mock
 
 from django.utils.encoding import smart_text
+from django_prices_vatlayer.models import VAT
 
 from ...core.taxes import charge_taxes_on_shipping
 from ...product.models import AttributeValue, Category


### PR DESCRIPTION
I want to merge this change because it updates the google merchant data feeds to get the tax rate by the get_tax_rate_percentage_value method on the plugin manager.

fixes #4311

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
