### PR TITLE
Fix product search filter

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -180,7 +180,7 @@ def filter_stock_availability(qs, _, value):
 def filter_search(qs, _, value):
     if value:
         search = picker.pick_backend()
-        qs &= search(value).distinct()
+        qs = qs.distinct() & search(value).distinct()
     return qs
 
 


### PR DESCRIPTION
In some cases `filter_search` method raises an error, when qs is not distincted. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
