### PR TITLE
Fix/fetch only published items for anonymous user

### DIFF
--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -46,8 +46,9 @@ def resolve_digital_contents(info):
     return models.DigitalContent.objects.all()
 
 
-def resolve_product_by_slug(slug):
-    return models.Product.objects.filter(slug=slug).first()
+def resolve_product_by_slug(info, slug):
+    requestor = get_user_or_app_from_context(info.context)
+    return models.Product.objects.visible_to_user(requestor).filter(slug=slug).first()
 
 
 def resolve_products(info, stock_availability=None, **_kwargs):

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -33,8 +33,11 @@ def resolve_categories(info, level=None, **_kwargs):
     return qs.distinct()
 
 
-def resolve_collection_by_slug(slug):
-    return models.Collection.objects.filter(slug=slug).first()
+def resolve_collection_by_slug(info, slug):
+    requestor = get_user_or_app_from_context(info.context)
+    return (
+        models.Collection.objects.visible_to_user(requestor).filter(slug=slug).first()
+    )
 
 
 def resolve_collections(info, **_kwargs):

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -282,7 +282,7 @@ class ProductQueries(graphene.ObjectType):
         if id:
             return graphene.Node.get_node_from_global_id(info, id, Product)
         if slug:
-            return resolve_product_by_slug(slug=slug)
+            return resolve_product_by_slug(info, slug=slug)
 
     def resolve_products(self, info, **kwargs):
         return resolve_products(info, **kwargs)

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -264,7 +264,7 @@ class ProductQueries(graphene.ObjectType):
         if id:
             return graphene.Node.get_node_from_global_id(info, id, Collection)
         if slug:
-            return resolve_collection_by_slug(slug=slug)
+            return resolve_collection_by_slug(info, slug=slug)
 
     def resolve_collections(self, info, **kwargs):
         return resolve_collections(info, **kwargs)

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -47,6 +47,27 @@ def test_collection_query_by_slug(
     assert collection_data["name"] == collection.name
 
 
+def test_collection_query_unpublished_collection_by_slug(
+    user_api_client, collection, permission_manage_products
+):
+    # given
+    user = user_api_client.user
+    user.user_permissions.add(permission_manage_products)
+
+    collection.is_published = False
+    collection.save(update_fields=["is_published"])
+    variables = {"slug": collection.slug}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    collection_data = content["data"]["collection"]
+    assert collection_data is not None
+    assert collection_data["name"] == collection.name
+
+
 def test_collection_query_unpublished_collection_by_slug_and_anonympus_user(
     api_client, collection,
 ):

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -47,6 +47,23 @@ def test_collection_query_by_slug(
     assert collection_data["name"] == collection.name
 
 
+def test_collection_query_unpublished_collection_by_slug_and_anonympus_user(
+    api_client, collection,
+):
+    # given
+    collection.is_published = False
+    collection.save(update_fields=["is_published"])
+    variables = {"slug": collection.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_COLLECTION, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    collection_data = content["data"]["collection"]
+    assert collection_data is None
+
+
 def test_collection_query_error_when_id_and_slug_provided(
     user_api_client, collection, graphql_log_handler,
 ):

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -126,9 +126,9 @@ def test_product_query_by_id(
 
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
     content = get_graphql_content(response)
-    collection_data = content["data"]["product"]
-    assert collection_data is not None
-    assert collection_data["name"] == product.name
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == product.name
 
 
 def test_product_query_by_slug(
@@ -137,9 +137,9 @@ def test_product_query_by_slug(
     variables = {"slug": product.slug}
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
     content = get_graphql_content(response)
-    collection_data = content["data"]["product"]
-    assert collection_data is not None
-    assert collection_data["name"] == product.name
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == product.name
 
 
 def test_product_query_unpublished_products_by_slug(
@@ -158,9 +158,9 @@ def test_product_query_unpublished_products_by_slug(
 
     # then
     content = get_graphql_content(response)
-    collection_data = content["data"]["product"]
-    assert collection_data is not None
-    assert collection_data["name"] == product.name
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == product.name
 
 
 def test_product_query_unpublished_products_by_slug_and_anonympus_user(
@@ -176,8 +176,8 @@ def test_product_query_unpublished_products_by_slug_and_anonympus_user(
 
     # then
     content = get_graphql_content(response)
-    collection_data = content["data"]["product"]
-    assert collection_data is None
+    product_data = content["data"]["product"]
+    assert product_data is None
 
 
 def test_product_query_error_when_id_and_slug_provided(

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -142,6 +142,27 @@ def test_product_query_by_slug(
     assert collection_data["name"] == product.name
 
 
+def test_product_query_unpublished_products_by_slug(
+    user_api_client, product, permission_manage_products
+):
+    # given
+    user = user_api_client.user
+    user.user_permissions.add(permission_manage_products)
+
+    product.is_published = False
+    product.save(update_fields=["is_published"])
+    variables = {"slug": product.slug}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    collection_data = content["data"]["product"]
+    assert collection_data is not None
+    assert collection_data["name"] == product.name
+
+
 def test_product_query_unpublished_products_by_slug_and_anonympus_user(
     api_client, product,
 ):

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -142,6 +142,23 @@ def test_product_query_by_slug(
     assert collection_data["name"] == product.name
 
 
+def test_product_query_unpublished_products_by_slug_and_anonympus_user(
+    api_client, product,
+):
+    # given
+    product.is_published = False
+    product.save(update_fields=["is_published"])
+    variables = {"slug": product.slug}
+
+    # when
+    response = api_client.post_graphql(QUERY_PRODUCT, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    collection_data = content["data"]["product"]
+    assert collection_data is None
+
+
 def test_product_query_error_when_id_and_slug_provided(
     user_api_client, product, graphql_log_handler,
 ):


### PR DESCRIPTION
Prevent fetching unpublished collections and products by anonymous users.
Fixes #5844 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
