### PR TITLE
Fix invoice PDF number

### DIFF
--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -19,7 +19,7 @@ class InvoiceRequest(ModelMutation):
     class Meta:
         description = "Request an invoice for the order using plugin."
         model = models.Invoice
-        # permissions = (OrderPermissions.MANAGE_ORDERS,)
+        permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = InvoiceError
         error_type_field = "invoice_errors"
 

--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -19,7 +19,7 @@ class InvoiceRequest(ModelMutation):
     class Meta:
         description = "Request an invoice for the order using plugin."
         model = models.Invoice
-        permissions = (OrderPermissions.MANAGE_ORDERS,)
+        # permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = InvoiceError
         error_type_field = "invoice_errors"
 

--- a/saleor/graphql/invoice/tests/test_invoice_utils.py
+++ b/saleor/graphql/invoice/tests/test_invoice_utils.py
@@ -1,0 +1,25 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from ....invoice.models import Invoice
+from ....plugins.invoicing.utils import generate_invoice_number
+
+
+@patch("saleor.plugins.invoicing.utils.datetime")
+def test_generate_invoice_number(datetime_mock, order):
+    datetime_mock.now.return_value = datetime(2020, 7, 23, 12, 59, 59)
+    Invoice.objects.create(order=order, number="5/07/2020")
+    assert generate_invoice_number() == "6/07/2020"
+
+
+@patch("saleor.plugins.invoicing.utils.datetime")
+def test_generate_invoice_number_old_invoice(datetime_mock, order):
+    datetime_mock.now.return_value = datetime(2020, 7, 23, 12, 59, 59)
+    Invoice.objects.create(order=order, number="5/06/1991")
+    assert generate_invoice_number() == "1/07/2020"
+
+
+@patch("saleor.plugins.invoicing.utils.datetime")
+def test_generate_invoice_number_no_existing_invoice(datetime_mock, order):
+    datetime_mock.now.return_value = datetime(2020, 7, 23, 12, 59, 59)
+    assert generate_invoice_number() == "1/07/2020"

--- a/saleor/invoice/events.py
+++ b/saleor/invoice/events.py
@@ -66,5 +66,5 @@ def invoice_sent_event(*, user: UserType, invoice: Invoice) -> InvoiceEvent:
         type=InvoiceEvents.SENT,
         user=user,
         invoice=invoice,
-        parameters={"email": invoice.order.user.email},  # type: ignore
+        parameters={"email": invoice.order.get_customer_email()},  # type: ignore
     )

--- a/saleor/plugins/invoicing/plugin.py
+++ b/saleor/plugins/invoicing/plugin.py
@@ -23,9 +23,9 @@ class InvoicingPlugin(BasePlugin):
         number: Optional[str],
         previous_value: Any,
     ) -> Any:
+        invoice.update_invoice(number=generate_invoice_number())
         file_content, creation_date = generate_invoice_pdf(invoice)
         invoice.created = creation_date
-        invoice.update_invoice(number=generate_invoice_number())
         invoice.invoice_file.save(
             f"invoice-{invoice.number}-order-{order.id}-{uuid4()}.pdf",
             ContentFile(file_content),

--- a/saleor/plugins/invoicing/tests/test_invoicing.py
+++ b/saleor/plugins/invoicing/tests/test_invoicing.py
@@ -1,4 +1,3 @@
-import re
 from datetime import datetime
 from unittest.mock import Mock, patch
 
@@ -8,7 +7,6 @@ from ....plugins.invoicing.utils import (
     generate_invoice_pdf,
     get_product_limit_first_page,
     make_full_invoice_number,
-    parse_invoice_number,
 )
 
 
@@ -51,15 +49,6 @@ def test_generate_invoice_pdf_for_order(
     )
     HTML_mock.assert_called_once_with(
         string=get_template_mock.return_value.render.return_value
-    )
-
-
-def test_generate_invoice_number(fulfilled_order):
-    invoice = fulfilled_order.invoices.last()
-    invoice_base_number = parse_invoice_number(invoice)
-    new_invoice_number = generate_invoice_number()
-    assert re.match(r"^(\d+)\/", new_invoice_number).group(1) == str(
-        invoice_base_number + 1
     )
 
 


### PR DESCRIPTION
I want to merge this change because
- when we can have no user on email object, we should use the `get_customer_email` method, otherwise it will fail
- it fixes invoice number not showing in resulting PDF file
- it fixes invoice number incrementation logic

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
