### PR TITLE
Use WeightUnitsEnum in Weight type

### DIFF
--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -26,6 +26,7 @@ from ..enums import (
     TranslationErrorCode,
     WarehouseErrorCode,
     WebhookErrorCode,
+    WeightUnitsEnum,
     WishlistErrorCode,
 )
 from .money import VAT
@@ -231,7 +232,7 @@ class SeoInput(graphene.InputObjectType):
 
 
 class Weight(graphene.ObjectType):
-    unit = graphene.String(description="Weight unit.", required=True)
+    unit = WeightUnitsEnum(description="Weight unit.", required=True)
     value = graphene.Float(description="Weight value.", required=True)
 
     class Meta:

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -29,7 +29,7 @@ from ....product.tasks import update_variants_names
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
 from ....product.utils.attributes import associate_attribute_values_to_instance
 from ....warehouse.models import Allocation, Stock, Warehouse
-from ...core.enums import ReportingPeriod
+from ...core.enums import ReportingPeriod, WeightUnitsEnum
 from ...tests.utils import (
     assert_no_permission,
     get_graphql_content,
@@ -4281,14 +4281,14 @@ mutation createProduct(
 @pytest.mark.parametrize(
     "weight, expected_weight_value, expected_weight_unit",
     (
-        ("0", 0, "kg"),
-        (0, 0, "kg"),
-        (11.11, 11.11, "kg"),
-        (11, 11.0, "kg"),
-        ("11.11", 11.11, "kg"),
-        ({"value": 11.11, "unit": "kg"}, 11.11, "kg",),
-        ({"value": 11, "unit": "g"}, 11.0, "g",),
-        ({"value": "11.11", "unit": "ounce"}, 11.11, "oz",),
+        ("0", 0, WeightUnitsEnum.KG.name),
+        (0, 0, WeightUnitsEnum.KG.name),
+        (11.11, 11.11, WeightUnitsEnum.KG.name),
+        (11, 11.0, WeightUnitsEnum.KG.name),
+        ("11.11", 11.11, WeightUnitsEnum.KG.name),
+        ({"value": 11.11, "unit": "kg"}, 11.11, WeightUnitsEnum.KG.name,),
+        ({"value": 11, "unit": "g"}, 11.0, WeightUnitsEnum.G.name,),
+        ({"value": "11.11", "unit": "ounce"}, 11.11, WeightUnitsEnum.OZ.name,),
     ),
 )
 def test_create_product_with_weight_variable(
@@ -4326,14 +4326,14 @@ def test_create_product_with_weight_variable(
 @pytest.mark.parametrize(
     "weight, expected_weight_value, expected_weight_unit",
     (
-        ("0", 0, "kg"),
-        (0, 0, "kg"),
-        ("11.11", 11.11, "kg"),
-        ("11", 11.0, "kg"),
-        ('"11.11"', 11.11, "kg"),
-        ('{value: 11.11, unit: "kg"}', 11.11, "kg",),
-        ('{value: 11, unit: "g"}', 11.0, "g",),
-        ('{value: "11.11", unit: "ounce"}', 11.11, "oz",),
+        ("0", 0, WeightUnitsEnum.KG.name),
+        (0, 0, WeightUnitsEnum.KG.name),
+        ("11.11", 11.11, WeightUnitsEnum.KG.name),
+        ("11", 11.0, WeightUnitsEnum.KG.name),
+        ('"11.11"', 11.11, WeightUnitsEnum.KG.name),
+        ('{value: 11.11, unit: "kg"}', 11.11, WeightUnitsEnum.KG.name,),
+        ('{value: 11, unit: "g"}', 11.0, WeightUnitsEnum.G.name,),
+        ('{value: "11.11", unit: "ounce"}', 11.11, WeightUnitsEnum.OZ.name,),
     ),
 )
 def test_create_product_with_weight_input(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -9,6 +9,7 @@ from ....product.models import ProductVariant
 from ....product.utils.attributes import associate_attribute_values_to_instance
 from ....warehouse.error_codes import StockErrorCode
 from ....warehouse.models import Stock, Warehouse
+from ...core.enums import WeightUnitsEnum
 from ...tests.utils import get_graphql_content
 
 
@@ -170,7 +171,7 @@ def test_create_variant(
     assert data["sku"] == sku
     assert data["attributes"][0]["attribute"]["slug"] == variant_slug
     assert data["attributes"][0]["values"][0]["slug"] == variant_value
-    assert data["weight"]["unit"] == "kg"
+    assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
     assert data["weight"]["value"] == weight
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5631,7 +5631,7 @@ input WebhookUpdateInput {
 }
 
 type Weight {
-  unit: String!
+  unit: WeightUnitsEnum!
   value: Float!
 }
 

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -3,6 +3,7 @@ import pytest
 
 from ....shipping.error_codes import ShippingErrorCode
 from ....shipping.utils import get_countries_without_shipping_zone
+from ...core.enums import WeightUnitsEnum
 from ...tests.utils import get_graphql_content
 from ..types import ShippingMethodTypeEnum
 
@@ -616,8 +617,13 @@ WEIGHT_BASED_SHIPPING_QUERY = """
 @pytest.mark.parametrize(
     "min_weight, max_weight, expected_min_weight, expected_max_weight",
     (
-        (10.32, 15.64, {"value": 10.32, "unit": "kg"}, {"value": 15.64, "unit": "kg"}),
-        (10.92, None, {"value": 10.92, "unit": "kg"}, None),
+        (
+            10.32,
+            15.64,
+            {"value": 10.32, "unit": WeightUnitsEnum.KG.name},
+            {"value": 15.64, "unit": WeightUnitsEnum.KG.name},
+        ),
+        (10.92, None, {"value": 10.92, "unit": WeightUnitsEnum.KG.name}, None),
     ),
 )
 def test_create_weight_based_shipping_method(


### PR DESCRIPTION
Use `WeightUnitsEnum` in `Weight` type to maintain consistency with `Shop.defaultWeightUnit` field.
Resolves #5876 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
