### PR TITLE
Add endpoint handler for plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Merge `manage_webhooks` permission with `manage_apps` - #5556 by @korycins
 - Add App support - #5767 by @korycins
-
+- Add webhook handler to BasePlugin and PluginManager - #5884 by @korycins
 - Invoices backend - #5732 by @tomaszszymanski129
+
 ### Breaking Changes
 
 - Refactor JWT support - These changes could require a handling JWT token in the storefront. Storefront needs to handle a case when the backend returns the exception about the invalid token. - #5734, #5816 by @korycins

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -2,6 +2,8 @@ from copy import copy
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, List, Optional, Union
 
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse
 from django_countries.fields import Country
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
@@ -56,6 +58,13 @@ class BasePlugin:
 
     def __str__(self):
         return self.PLUGIN_NAME
+
+    def webhook(self, request: WSGIRequest, path: str, previous_value) -> HttpResponse:
+        """Handle received http request.
+
+        Overwrite this method if the plugin expects the incoming requests.
+        """
+        return NotImplemented
 
     def change_user_address(
         self,

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING, Union
 
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse, HttpResponseNotFound, JsonResponse
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
@@ -46,6 +48,13 @@ class PluginSample(BasePlugin):
             "label": "Private key",
         },
     }
+
+    def webhook(self, request: WSGIRequest, path: str, previous_value) -> HttpResponse:
+        if path == "/webhook/paid":
+            return JsonResponse(data={"received": True, "paid": True})
+        if path == "/webhook/failed":
+            return JsonResponse(data={"received": True, "paid": False})
+        return HttpResponseNotFound()
 
     def calculate_checkout_total(self, checkout, lines, discounts, previous_value):
         total = Money("1.0", currency=checkout.currency)

--- a/saleor/plugins/tests/test_views.py
+++ b/saleor/plugins/tests/test_views.py
@@ -1,0 +1,23 @@
+import pytest
+
+from .sample_plugins import PluginInactive, PluginSample
+
+
+@pytest.mark.parametrize(
+    "plugin_id, plugin_path, status_code",
+    [
+        (PluginSample.PLUGIN_ID, "/webhook/paid", 200),
+        (PluginInactive.PLUGIN_ID, "/webhook/paid", 404),
+        ("wrong.id", "/webhook/", 404),
+    ],
+)
+def test_plugin_webhook_view(
+    plugin_id, plugin_path, status_code, client, settings, monkeypatch
+):
+    settings.PLUGINS = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+
+    response = client.post(f"/plugins/{plugin_id}{plugin_path}")
+    assert response.status_code == status_code

--- a/saleor/plugins/views.py
+++ b/saleor/plugins/views.py
@@ -1,0 +1,9 @@
+from django.core.handlers.wsgi import WSGIRequest
+from django.http import HttpResponse
+
+from .manager import get_plugins_manager
+
+
+def handle_plugin_webhook(request: WSGIRequest, plugin_id: str) -> HttpResponse:
+    manager = get_plugins_manager()
+    return manager.webhook(request, plugin_id)

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -7,6 +7,7 @@ from django.views.decorators.csrf import csrf_exempt
 from .data_feeds.urls import urlpatterns as feed_urls
 from .graphql.api import schema
 from .graphql.views import GraphQLView
+from .plugins.views import handle_plugin_webhook
 from .product.views import digital_product
 
 urlpatterns = [
@@ -16,6 +17,11 @@ urlpatterns = [
         r"^digital-download/(?P<token>[0-9A-Za-z_\-]+)/$",
         digital_product,
         name="digital-product",
+    ),
+    url(
+        r"plugins/(?P<plugin_id>[.0-9A-Za-z_\-]+)/",
+        handle_plugin_webhook,
+        name="plugins",
     ),
 ]
 


### PR DESCRIPTION
- Add webhook handler which can be used by plugins.

Example:
 Request to  `/plugins/vatlayer/some/path` will call `VatlayerPlugin.webhook` method

`VatlayerPlugin` will receive the `request` WSGIRequest object and internal plugin path `/some/path`.
This is super useful when we need to have the possibility to communicate with external service. 

it closes https://github.com/mirumee/saleor/issues/4955