### PR TITLE
Use generic scalara instead of string in PaymentGateway config

### DIFF
--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -641,7 +641,7 @@ def expected_dummy_gateway():
     return {
         "id": "mirumee.payments.dummy",
         "name": "Dummy",
-        "config": [{"field": "store_customer_card", "value": "false"}],
+        "config": [{"field": "store_customer_card", "value": False}],
         "currencies": ["USD"],
     }
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -1,4 +1,5 @@
 import graphene
+from graphene.types.generic import GenericScalar
 from promise import Promise
 
 from ...checkout import calculations, models
@@ -21,7 +22,7 @@ from .dataloaders import CheckoutLinesByCheckoutTokenLoader
 
 class GatewayConfigLine(graphene.ObjectType):
     field = graphene.String(required=True, description="Gateway config key.")
-    value = graphene.String(description="Gateway config value for key.")
+    value = GenericScalar(description="Gateway config value for key.")
 
     class Meta:
         description = "Payment gateway client configuration key and value pair."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2012,7 +2012,7 @@ input FulfillmentUpdateTrackingInput {
 
 type GatewayConfigLine {
   field: String!
-  value: String
+  value: GenericScalar
 }
 
 scalar GenericScalar


### PR DESCRIPTION
This PR changes the type of `GatewayConfigLine` to `GenericScalar`.
Some payment gateway can require more advanced structure and with the current type, we are not able to pass them to a storefront.
