### PR TITLE
Return weights in default weight unit

### DIFF
--- a/saleor/core/tests/test_core.py
+++ b/saleor/core/tests/test_core.py
@@ -8,7 +8,6 @@ from django.core.management import CommandError, call_command
 from django.db.utils import DataError
 from django.templatetags.static import static
 from django.test import RequestFactory, override_settings
-from measurement.measures import Weight
 
 from ...account.models import Address, User
 from ...account.utils import create_superuser
@@ -29,7 +28,6 @@ from ..utils import (
     get_currency_for_country,
     random_data,
 )
-from ..weight import WeightUnits, convert_weight
 
 type_schema = {
     "Vegetable": {
@@ -219,12 +217,6 @@ def test_storages_not_setting_s3_bucket_domain(storage, settings):
     storage = S3MediaStorage()
     assert storage.bucket_name == "media-bucket"
     assert storage.custom_domain is None
-
-
-def test_convert_weight():
-    weight = Weight(kg=1)
-    expected_result = Weight(g=1000)
-    assert convert_weight(weight, WeightUnits.GRAM) == expected_result
 
 
 def test_build_absolute_uri(site_settings, settings):

--- a/saleor/core/tests/test_weight.py
+++ b/saleor/core/tests/test_weight.py
@@ -1,0 +1,52 @@
+import pytest
+from measurement.measures import Weight
+
+from ..weight import (
+    WeightUnits,
+    convert_weight,
+    covert_weight_to_default_weight_unit,
+    get_default_weight_unit,
+)
+
+
+def test_convert_weight():
+    # given
+    weight = Weight(kg=1)
+    expected_result = Weight(g=1000)
+
+    # when
+    result = convert_weight(weight, WeightUnits.GRAM)
+
+    # then
+    assert result == expected_result
+
+
+def test_get_default_weight_unit(site_settings):
+    # when
+    result = get_default_weight_unit()
+
+    # then
+    assert result == site_settings.default_weight_unit
+
+
+@pytest.mark.parametrize(
+    "default_weight_unit, expected_value",
+    [
+        (WeightUnits.KILOGRAM, Weight(kg=1)),
+        (WeightUnits.GRAM, Weight(g=1000)),
+        (WeightUnits.POUND, Weight(lb=2.205)),
+        (WeightUnits.OUNCE, Weight(oz=35.274)),
+    ],
+)
+def test_covert_weight_to_default_weight_unit(
+    default_weight_unit, expected_value, site_settings
+):
+    # given
+    site_settings.default_weight_unit = default_weight_unit
+    site_settings.save(update_fields=["default_weight_unit"])
+
+    # when
+    result = covert_weight_to_default_weight_unit(Weight(kg=1))
+
+    # then
+    assert result == expected_value

--- a/saleor/core/tests/test_weight.py
+++ b/saleor/core/tests/test_weight.py
@@ -4,7 +4,7 @@ from measurement.measures import Weight
 from ..weight import (
     WeightUnits,
     convert_weight,
-    covert_weight_to_default_weight_unit,
+    convert_weight_to_default_weight_unit,
     get_default_weight_unit,
 )
 
@@ -38,7 +38,7 @@ def test_get_default_weight_unit(site_settings):
         (WeightUnits.OUNCE, Weight(oz=35.274)),
     ],
 )
-def test_covert_weight_to_default_weight_unit(
+def test_convert_weight_to_default_weight_unit(
     default_weight_unit, expected_value, site_settings
 ):
     # given
@@ -46,7 +46,7 @@ def test_covert_weight_to_default_weight_unit(
     site_settings.save(update_fields=["default_weight_unit"])
 
     # when
-    result = covert_weight_to_default_weight_unit(Weight(kg=1))
+    result = convert_weight_to_default_weight_unit(Weight(kg=1))
 
     # then
     assert result == expected_value

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -53,4 +53,6 @@ def covert_weight_to_default_weight_unit(weight):
     default_unit = get_default_weight_unit()
     if weight and weight.unit != default_unit:
         weight = convert_weight(weight, default_unit)
+    elif weight:
+        weight.value = round(weight.value, 3)
     return weight

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -39,9 +39,18 @@ def convert_weight(weight, unit):
     # Weight amount from the Weight instance can be retrived in serveral units
     # via its properties. eg. Weight(lb=10).kg
     converted_weight = getattr(weight, unit)
-    return Weight(**{unit: converted_weight})
+    weight = Weight(**{unit: converted_weight})
+    weight.value = round(weight.value, 3)
+    return weight
 
 
 def get_default_weight_unit():
     site = Site.objects.get_current()
     return site.settings.default_weight_unit
+
+
+def covert_weight_to_default_weight_unit(weight):
+    default_unit = get_default_weight_unit()
+    if weight and weight.unit != default_unit:
+        weight = convert_weight(weight, default_unit)
+    return weight

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -35,7 +35,7 @@ def zero_weight():
     return Weight(kg=0)
 
 
-def convert_weight(weight, unit):
+def convert_weight(weight: Weight, unit: str) -> Weight:
     # Weight amount from the Weight instance can be retrived in serveral units
     # via its properties. eg. Weight(lb=10).kg
     converted_weight = getattr(weight, unit)
@@ -49,10 +49,12 @@ def get_default_weight_unit():
     return site.settings.default_weight_unit
 
 
-def covert_weight_to_default_weight_unit(weight):
+def covert_weight_to_default_weight_unit(weight: Weight) -> Weight:
+    """Weight is kept in one unit, but should be returned in site default unit."""
     default_unit = get_default_weight_unit()
-    if weight and weight.unit != default_unit:
-        weight = convert_weight(weight, default_unit)
-    elif weight:
-        weight.value = round(weight.value, 3)
+    if weight is not None:
+        if weight.unit != default_unit:
+            weight = convert_weight(weight, default_unit)
+        else:
+            weight.value = round(weight.value, 3)
     return weight

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -36,6 +36,7 @@ def zero_weight():
 
 
 def convert_weight(weight: Weight, unit: str) -> Weight:
+    """Covert weight to given unit and round it to 3 digits after decimal point."""
     # Weight amount from the Weight instance can be retrived in serveral units
     # via its properties. eg. Weight(lb=10).kg
     converted_weight = getattr(weight, unit)
@@ -49,7 +50,7 @@ def get_default_weight_unit():
     return site.settings.default_weight_unit
 
 
-def covert_weight_to_default_weight_unit(weight: Weight) -> Weight:
+def convert_weight_to_default_weight_unit(weight: Weight) -> Weight:
     """Weight is kept in one unit, but should be returned in site default unit."""
     default_unit = get_default_weight_unit()
     if weight is not None:

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -5,7 +5,7 @@ from graphql.error import GraphQLError
 from graphql.language import ast
 from measurement.measures import Weight
 
-from ...core.weight import convert_weight, get_default_weight_unit
+from ...core.weight import covert_weight_to_default_weight_unit, get_default_weight_unit
 
 
 class Decimal(graphene.Float):
@@ -48,9 +48,7 @@ class WeightScalar(graphene.Scalar):
     @staticmethod
     def serialize(weight):
         if isinstance(weight, Weight):
-            default_unit = get_default_weight_unit()
-            if weight.unit != default_unit:
-                weight = convert_weight(weight, default_unit)
+            weight = covert_weight_to_default_weight_unit(weight)
             return str(weight)
         return None
 

--- a/saleor/graphql/core/scalars.py
+++ b/saleor/graphql/core/scalars.py
@@ -5,7 +5,10 @@ from graphql.error import GraphQLError
 from graphql.language import ast
 from measurement.measures import Weight
 
-from ...core.weight import covert_weight_to_default_weight_unit, get_default_weight_unit
+from ...core.weight import (
+    convert_weight_to_default_weight_unit,
+    get_default_weight_unit,
+)
 
 
 class Decimal(graphene.Float):
@@ -48,7 +51,7 @@ class WeightScalar(graphene.Scalar):
     @staticmethod
     def serialize(weight):
         if isinstance(weight, Weight):
-            weight = covert_weight_to_default_weight_unit(weight)
+            weight = convert_weight_to_default_weight_unit(weight)
             return str(weight)
         return None
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -9,9 +9,11 @@ from django.core.exceptions import ValidationError
 from django.utils.dateparse import parse_datetime
 from django.utils.text import slugify
 from graphql_relay import to_global_id
+from measurement.measures import Weight
 from prices import Money
 
 from ....core.taxes import TaxType
+from ....core.weight import WeightUnits
 from ....plugins.manager import PluginsManager
 from ....product import AttributeInputType
 from ....product.error_codes import ProductErrorCode
@@ -114,6 +116,10 @@ QUERY_PRODUCT = """
         ) {
             id
             name
+            weight {
+                unit
+                value
+            }
         }
     }
     """
@@ -129,6 +135,52 @@ def test_product_query_by_id(
     product_data = content["data"]["product"]
     assert product_data is not None
     assert product_data["name"] == product.name
+
+
+def test_product_query_by_id_weight_returned_in_default_unit(
+    user_api_client, product, site_settings
+):
+    # given
+    product.weight = Weight(kg=10)
+    product.save(update_fields=["weight"])
+
+    site_settings.default_weight_unit = WeightUnits.POUND
+    site_settings.save(update_fields=["default_weight_unit"])
+
+    variables = {"id": graphene.Node.to_global_id("Product", product.pk)}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == product.name
+    assert product_data["weight"]["value"] == 22.046
+    assert product_data["weight"]["unit"] == WeightUnits.POUND.upper()
+
+
+def test_product_query_by_id_weight_is_rounded(user_api_client, product, site_settings):
+    # given
+    product.weight = Weight(kg=1.83456)
+    product.save(update_fields=["weight"])
+
+    site_settings.default_weight_unit = WeightUnits.KILOGRAM
+    site_settings.save(update_fields=["default_weight_unit"])
+
+    variables = {"id": graphene.Node.to_global_id("Product", product.pk)}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == product.name
+    assert product_data["weight"]["value"] == 1.835
+    assert product_data["weight"]["unit"] == WeightUnits.KILOGRAM.upper()
 
 
 def test_product_query_by_slug(
@@ -996,6 +1048,46 @@ def test_sort_products_product_type_name(
     product_type_name_0 = edges[0]["node"]["productType"]["name"]
     product_type_name_1 = edges[1]["node"]["productType"]["name"]
     assert product_type_name_0 < product_type_name_1
+
+
+QUERY_PRODUCT_TYPE = """
+    query ($id: ID!){
+        productType(
+            id: $id,
+        ) {
+            id
+            name
+            weight {
+                unit
+                value
+            }
+        }
+    }
+    """
+
+
+def test_product_type_query_by_id_weight_returned_in_default_unit(
+    user_api_client, product_type, site_settings
+):
+    # given
+    product_type.weight = Weight(kg=10)
+    product_type.save(update_fields=["weight"])
+
+    site_settings.default_weight_unit = WeightUnits.OUNCE
+    site_settings.save(update_fields=["default_weight_unit"])
+
+    variables = {"id": graphene.Node.to_global_id("ProductType", product_type.pk)}
+
+    # when
+    response = user_api_client.post_graphql(QUERY_PRODUCT_TYPE, variables=variables)
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["productType"]
+    assert product_data is not None
+    assert product_data["name"] == product_type.name
+    assert product_data["weight"]["value"] == 352.73999999999995
+    assert product_data["weight"]["unit"] == WeightUnits.OUNCE.upper()
 
 
 CREATE_PRODUCT_MUTATION = """

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -8,7 +8,7 @@ from graphene_federation import key
 from graphql.error import GraphQLError
 
 from ....core.permissions import ProductPermissions
-from ....core.weight import covert_weight_to_default_weight_unit
+from ....core.weight import convert_weight_to_default_weight_unit
 from ....product import models
 from ....product.templatetags.product_images import (
     get_product_image_thumbnail,
@@ -426,7 +426,7 @@ class ProductVariant(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_weight(root: models.ProductVariant, _info, **_kwargs):
-        return covert_weight_to_default_weight_unit(root.weight)
+        return convert_weight_to_default_weight_unit(root.weight)
 
 
 @key(fields="id")
@@ -628,7 +628,7 @@ class Product(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_weight(root: models.Product, _info, **_kwargs):
-        return covert_weight_to_default_weight_unit(root.weight)
+        return convert_weight_to_default_weight_unit(root.weight)
 
 
 @key(fields="id")
@@ -713,7 +713,7 @@ class ProductType(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_weight(root: models.ProductType, _info, **_kwargs):
-        return covert_weight_to_default_weight_unit(root.weight)
+        return convert_weight_to_default_weight_unit(root.weight)
 
 
 @key(fields="id")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -8,6 +8,7 @@ from graphene_federation import key
 from graphql.error import GraphQLError
 
 from ....core.permissions import ProductPermissions
+from ....core.weight import covert_weight_to_default_weight_unit
 from ....product import models
 from ....product.templatetags.product_images import (
     get_product_image_thumbnail,
@@ -423,6 +424,10 @@ class ProductVariant(CountableDjangoObjectType):
     def __resolve_reference(root, _info, **_kwargs):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
+    @staticmethod
+    def resolve_weight(root: models.ProductVariant, _info, **_kwargs):
+        return covert_weight_to_default_weight_unit(root.weight)
+
 
 @key(fields="id")
 class Product(CountableDjangoObjectType):
@@ -621,6 +626,10 @@ class Product(CountableDjangoObjectType):
     def __resolve_reference(root, _info, **_kwargs):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
+    @staticmethod
+    def resolve_weight(root: models.Product, _info, **_kwargs):
+        return covert_weight_to_default_weight_unit(root.weight)
+
 
 @key(fields="id")
 class ProductType(CountableDjangoObjectType):
@@ -701,6 +710,10 @@ class ProductType(CountableDjangoObjectType):
     @staticmethod
     def __resolve_reference(root, _info, **_kwargs):
         return graphene.Node.get_node_from_global_id(_info, root.id)
+
+    @staticmethod
+    def resolve_weight(root: models.ProductType, _info, **_kwargs):
+        return covert_weight_to_default_weight_unit(root.weight)
 
 
 @key(fields="id")

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -1,24 +1,29 @@
 import graphene
 import pytest
+from measurement.measures import Weight
 
+from ....core.weight import WeightUnits
 from ....shipping.error_codes import ShippingErrorCode
 from ....shipping.utils import get_countries_without_shipping_zone
 from ...core.enums import WeightUnitsEnum
 from ...tests.utils import get_graphql_content
 from ..types import ShippingMethodTypeEnum
 
-
-def test_shipping_zone_query(
-    staff_api_client, shipping_zone, permission_manage_shipping
-):
-    shipping = shipping_zone
-    query = """
+SHIPPING_ZONE_QUERY = """
     query ShippingQuery($id: ID!) {
         shippingZone(id: $id) {
             name
             shippingMethods {
                 price {
                     amount
+                }
+                minimumOrderWeight {
+                    value
+                    unit
+                }
+                maximumOrderWeight {
+                    value
+                    unit
                 }
             }
             priceRange {
@@ -31,12 +36,24 @@ def test_shipping_zone_query(
             }
         }
     }
-    """
+"""
+
+
+def test_shipping_zone_query(
+    staff_api_client, shipping_zone, permission_manage_shipping
+):
+    # given
+    shipping = shipping_zone
+    query = SHIPPING_ZONE_QUERY
     ID = graphene.Node.to_global_id("ShippingZone", shipping.id)
     variables = {"id": ID}
+
+    # when
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_shipping]
     )
+
+    # then
     content = get_graphql_content(response)
 
     shipping_data = content["data"]["shippingZone"]
@@ -47,6 +64,51 @@ def test_shipping_zone_query(
     data_price_range = shipping_data["priceRange"]
     assert data_price_range["start"]["amount"] == price_range.start.amount
     assert data_price_range["stop"]["amount"] == price_range.stop.amount
+
+
+def test_shipping_zone_query_weights_returned_in_default_unit(
+    staff_api_client, shipping_zone, permission_manage_shipping, site_settings
+):
+    # given
+    shipping = shipping_zone
+    shipping_method = shipping.shipping_methods.first()
+    shipping_method.minimum_order_weight = Weight(kg=1)
+    shipping_method.maximum_order_weight = Weight(kg=10)
+    shipping_method.save(update_fields=["minimum_order_weight", "maximum_order_weight"])
+
+    site_settings.default_weight_unit = WeightUnits.GRAM
+    site_settings.save(update_fields=["default_weight_unit"])
+
+    query = SHIPPING_ZONE_QUERY
+    ID = graphene.Node.to_global_id("ShippingZone", shipping.id)
+    variables = {"id": ID}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_shipping]
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    shipping_data = content["data"]["shippingZone"]
+    assert shipping_data["name"] == shipping.name
+    num_of_shipping_methods = shipping_zone.shipping_methods.count()
+    assert len(shipping_data["shippingMethods"]) == num_of_shipping_methods
+    price_range = shipping.price_range
+    data_price_range = shipping_data["priceRange"]
+    assert data_price_range["start"]["amount"] == price_range.start.amount
+    assert data_price_range["stop"]["amount"] == price_range.stop.amount
+    assert shipping_data["shippingMethods"][0]["minimumOrderWeight"]["value"] == 1000
+    assert (
+        shipping_data["shippingMethods"][0]["minimumOrderWeight"]["unit"]
+        == WeightUnits.GRAM.upper()
+    )
+    assert shipping_data["shippingMethods"][0]["maximumOrderWeight"]["value"] == 10000
+    assert (
+        shipping_data["shippingMethods"][0]["maximumOrderWeight"]["unit"]
+        == WeightUnits.GRAM.upper()
+    )
 
 
 def test_shipping_zones_query(

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene import relay
 
+from ...core.weight import covert_weight_to_default_weight_unit
 from ...shipping import models
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import CountryDisplay, MoneyRange
@@ -32,6 +33,12 @@ class ShippingMethod(CountableDjangoObjectType):
             "name",
             "price",
         ]
+
+    def resolve_maximum_order_weight(root: models.ShippingMethod, *_args):
+        return covert_weight_to_default_weight_unit(root.maximum_order_weight)
+
+    def resolve_minimum_order_weight(root: models.ShippingMethod, *_args):
+        return covert_weight_to_default_weight_unit(root.minimum_order_weight)
 
 
 class ShippingZone(CountableDjangoObjectType):

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene import relay
 
-from ...core.weight import covert_weight_to_default_weight_unit
+from ...core.weight import convert_weight_to_default_weight_unit
 from ...shipping import models
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import CountryDisplay, MoneyRange
@@ -35,10 +35,10 @@ class ShippingMethod(CountableDjangoObjectType):
         ]
 
     def resolve_maximum_order_weight(root: models.ShippingMethod, *_args):
-        return covert_weight_to_default_weight_unit(root.maximum_order_weight)
+        return convert_weight_to_default_weight_unit(root.maximum_order_weight)
 
     def resolve_minimum_order_weight(root: models.ShippingMethod, *_args):
-        return covert_weight_to_default_weight_unit(root.minimum_order_weight)
+        return convert_weight_to_default_weight_unit(root.minimum_order_weight)
 
 
 class ShippingZone(CountableDjangoObjectType):


### PR DESCRIPTION
Weights should be returned in shop default unit weights.
Fixes #5874
Fixes #5875 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog

![image](https://user-images.githubusercontent.com/40886528/87769279-b4bb4500-c81d-11ea-90bf-8c9470f78be8.png)
![image](https://user-images.githubusercontent.com/40886528/87769311-c00e7080-c81d-11ea-8915-c9e109bd2659.png)
![image](https://user-images.githubusercontent.com/40886528/87770402-4a0b0900-c81f-11ea-9397-9199bc0dc14e.png)




