### PR TITLE
Deactivate dummy credit card by default

### DIFF
--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -1,4 +1,5 @@
 from decimal import Decimal
+from unittest.mock import patch
 
 import graphene
 import pytest
@@ -498,6 +499,11 @@ def test_payment_capture_gateway_error(
     assert not txn.is_success
 
 
+@patch(
+    "saleor.payment.gateways.dummy_credit_card.plugin."
+    "DummyCreditCardGatewayPlugin.DEFAULT_ACTIVE",
+    True,
+)
 def test_payment_capture_gateway_dummy_credit_card_error(
     staff_api_client, permission_manage_orders, payment_txn_preauth, monkeypatch
 ):

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -701,12 +701,10 @@ def test_query_available_payment_gateways(user_api_client, sample_gateway):
     data = content["data"]["shop"]["availablePaymentGateways"]
     assert {gateway["id"] for gateway in data} == {
         "mirumee.payments.dummy",
-        "mirumee.payments.dummy_credit_card",
         "sampleDummy.active",
     }
     assert {gateway["name"] for gateway in data} == {
         "Dummy",
-        "Dummy Credit Card",
         "SampleDummy",
     }
 
@@ -720,12 +718,10 @@ def test_query_available_payment_gateways_specified_currency_USD(
     data = content["data"]["shop"]["availablePaymentGateways"]
     assert {gateway["id"] for gateway in data} == {
         "mirumee.payments.dummy",
-        "mirumee.payments.dummy_credit_card",
         "sampleDummy.active",
     }
     assert {gateway["name"] for gateway in data} == {
         "Dummy",
-        "Dummy Credit Card",
         "SampleDummy",
     }
 

--- a/saleor/payment/gateways/dummy_credit_card/plugin.py
+++ b/saleor/payment/gateways/dummy_credit_card/plugin.py
@@ -35,7 +35,7 @@ def require_active_plugin(fn):
 class DummyCreditCardGatewayPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.payments.dummy_credit_card"
     PLUGIN_NAME = GATEWAY_NAME
-    DEFAULT_ACTIVE = True
+    DEFAULT_ACTIVE = False
     DEFAULT_CONFIGURATION = [
         {"name": "Store customers card", "value": False},
         {"name": "Automatic payment capture", "value": True},

--- a/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
+++ b/saleor/payment/gateways/dummy_credit_card/tests/test_dummy_credit_card.py
@@ -13,6 +13,7 @@ from .. import (
     refund,
     void,
 )
+from ..plugin import DummyCreditCardGatewayPlugin
 
 NO_LONGER_ACTIVE = "This payment is no longer active."
 CANNOT_BE_AUTHORIZED_AGAIN = "Charged transactions cannot be authorized again."
@@ -25,6 +26,7 @@ CANNOT_CHARGE_MORE_THAN_UNCAPTURED = "Unable to charge more than un-captured amo
 
 @pytest.fixture(autouse=True)
 def setup_dummy_credit_card_gateway(settings):
+    DummyCreditCardGatewayPlugin.DEFAULT_ACTIVE = True
     settings.PLUGINS = [
         "saleor.payment.gateways.dummy_credit_card.plugin.DummyCreditCardGatewayPlugin"
     ]


### PR DESCRIPTION
Deactivate dummy credit card gateway by default. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
