### PR TITLE
Add missing cors header

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -96,6 +96,7 @@ class GraphQLView(View):
         response[
             "Access-Control-Allow-Headers"
         ] = "Origin, Content-Type, Accept, Authorization"
+        response["Access-Control-Allow-Credentials"] = "true"
         return response
 
     def render_playground(self, request):


### PR DESCRIPTION
I want to merge this change because the CORS policy will block requests without `Access-Control-Allow-Credentials` set to `true`. 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
