### PR TITLE
Add validation to require variant price

### DIFF
--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -82,9 +82,9 @@ def test_mutation_returns_error_field_in_camel_case(
 ):
     # costPrice is snake case variable (cost_price) in the backend
     query = """
-    mutation testCamel($id: ID!, $cost: Decimal) {
+    mutation testCamel($id: ID!, $price: Decimal, $cost: Decimal) {
         productVariantUpdate(id: $id,
-        input: {costPrice: $cost, trackInventory: false}) {
+        input: {costPrice: $cost, price: $price, trackInventory: false}) {
             errors {
                 field
                 message
@@ -97,6 +97,7 @@ def test_mutation_returns_error_field_in_camel_case(
     """
     variables = {
         "id": graphene.Node.to_global_id("ProductVariant", variant.id),
+        "price": 15,
         "cost": 12.1234,
     }
     response = staff_api_client.post_graphql(
@@ -164,9 +165,8 @@ def test_mutation_decimal_input(
     staff_api_client, variant, stock, permission_manage_products
 ):
     query = """
-    mutation decimalInput($id: ID!, $cost: Decimal) {
-        productVariantUpdate(id: $id,
-        input: {costPrice: $cost}) {
+    mutation decimalInput($id: ID!, $cost: Decimal, $price: Decimal) {
+        productVariantUpdate(id: $id, input: {costPrice: $cost, price: $price}) {
             errors {
                 field
                 message
@@ -181,6 +181,7 @@ def test_mutation_decimal_input(
     """
     variables = {
         "id": graphene.Node.to_global_id("ProductVariant", variant.id),
+        "price": 15,
         "cost": 12.12,
         "quantity": 17,
     }
@@ -196,9 +197,8 @@ def test_mutation_decimal_input_without_arguments(
     staff_api_client, variant, permission_manage_products
 ):
     query = """
-    mutation {
-        productVariantUpdate(id: "%(variant_id)s",
-        input: {costPrice: "%(cost)s"}) {
+    mutation ProductVariantUpdate($id: ID!, $price: Decimal, $costPrice: Decimal) {
+        productVariantUpdate(id: $id, input: {costPrice: $costPrice, price: $price}) {
             errors {
                 field
                 message
@@ -210,12 +210,14 @@ def test_mutation_decimal_input_without_arguments(
             }
         }
     }
-    """ % {
-        "variant_id": graphene.Node.to_global_id("ProductVariant", variant.id),
+    """
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.id),
         "cost": 12.12,
+        "price": 15,
     }
     response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_products]
     )
     content = get_graphql_content(response)
     data = content["data"]["productVariantUpdate"]

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1191,6 +1191,18 @@ class ProductVariantCreate(ModelMutation):
                     }
                 )
             cleaned_input["cost_price_amount"] = cost_price
+
+        price = cleaned_input.get("price")
+        if price is None:
+            raise ValidationError(
+                {
+                    "price": ValidationError(
+                        "Variant price is required.",
+                        code=ProductErrorCode.REQUIRED.value,
+                    )
+                }
+            )
+
         if "price" in cleaned_input:
             price = cleaned_input.pop("price")
             if price is not None and price < 0:


### PR DESCRIPTION
After recent changes with migrating the price from products to variants, this field became mandatory. It is required at the model level and the validation error was returned in API, but it used the field name `priceAmount` (which corresponds with the database field). Name that API uses is `price` and this PR manually adds a validation rule, which checks if variant price is provided in mutation input. Otherwise, it returns an error for the `price` field.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
