### PR TITLE
Fix validation error when publishing a product without a category

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -861,8 +861,9 @@ class ProductCreate(ModelMutation):
         if not category and is_published:
             raise ValidationError(
                 {
-                    "isPublished": ValidationError(
-                        "You must select a category to be able to publish"
+                    "category": ValidationError(
+                        "You must select a category to be able to publish",
+                        code=ProductErrorCode.REQUIRED,
                     )
                 }
             )

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -1590,8 +1590,8 @@ def test_product_create_without_category_and_true_is_published_value(
             product {
                 id
             }
-            errors {
-                message
+            productErrors {
+                code
                 field
             }
         }
@@ -1604,10 +1604,9 @@ def test_product_create_without_category_and_true_is_published_value(
         {"productTypeId": product_type_id},
         permissions=[permission_manage_products],
     )
-    errors = get_graphql_content(response)["data"]["productCreate"]["errors"]
-
-    assert errors[0]["field"] == "isPublished"
-    assert errors[0]["message"] == "You must select a category to be able to publish"
+    errors = get_graphql_content(response)["data"]["productCreate"]["productErrors"]
+    assert errors[0]["field"] == "category"
+    assert errors[0]["code"] == ProductErrorCode.REQUIRED.name
 
 
 def test_product_create_with_collections_webhook(
@@ -2265,8 +2264,8 @@ def test_update_product_without_category_and_true_is_published_value(
             product {
                 id
             }
-            errors {
-                message
+            productErrors {
+                code
                 field
             }
         }
@@ -2283,12 +2282,9 @@ def test_update_product_without_category_and_true_is_published_value(
     )
 
     data = get_graphql_content(response)["data"]["productUpdate"]
-    assert data["errors"]
-    assert data["errors"][0]["field"] == "isPublished"
-    assert (
-        data["errors"][0]["message"]
-        == "You must select a category to be able to publish"
-    )
+    assert data["productErrors"]
+    assert data["productErrors"][0]["field"] == "category"
+    assert data["productErrors"][0]["code"] == ProductErrorCode.REQUIRED.name
 
 
 UPDATE_PRODUCT = """


### PR DESCRIPTION
Category is required to publish a product. The error returned by API in `productCreate` mutation used the `isPublished` field with `INVALID` code, but the dashboard didn't render this error. I changed the error to use field `category` and code `REQUIRED` which our dashboard can easily handle without any frontend changes:

![image](https://user-images.githubusercontent.com/5421321/88387677-46ddc300-cdb3-11ea-94d4-053d240bd467.png)


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
