### PR TITLE
Add credit card field to payment type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - New logging setup will now output JSON logs in production mode for ease of feeding them into log collection systems like Logstash or CloudWatch Logs - #5699 by @patrys
 - Deprecate `WebhookEventType.CHECKOUT_QUANTITY_CHANGED`. It will be removed in Saleor 3.0 - #5837 by @korycins
 - Add dummy credit card payment - #5822 by @IKarbowiak
-- Anonymize and update order and payment fields; drop PaymentSecureConfirm mutation, drop Payment type fields: extraData, billingAddress, billingEmail, creditCard, drop gatewayResponse from Transaction type - #5926 by @IKarbowiak
+- Anonymize and update order and payment fields; drop PaymentSecureConfirm mutation, drop Payment type fields: extraData, billingAddress, billingEmail, drop gatewayResponse from Transaction type - #5926 by @IKarbowiak
 
 ### Fixes
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -33,7 +33,7 @@ class Transaction(CountableDjangoObjectType):
 class CreditCard(graphene.ObjectType):
     brand = graphene.String(description="Card brand.", required=True)
     first_digits = graphene.String(
-        description="The host name of the domain.", required=False
+        description="First 4 digits of the card number.", required=False
     )
     last_digits = graphene.String(
         description="Last 4 digits of the card number.", required=True

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -33,18 +33,18 @@ class Transaction(CountableDjangoObjectType):
 class CreditCard(graphene.ObjectType):
     brand = graphene.String(description="Card brand.", required=True)
     first_digits = graphene.String(
-        description="The host name of the domain.", required=True
+        description="The host name of the domain.", required=False
     )
     last_digits = graphene.String(
         description="Last 4 digits of the card number.", required=True
     )
     exp_month = graphene.Int(
         description=("Two-digit number representing the card’s expiration month."),
-        required=True,
+        required=False,
     )
     exp_year = graphene.Int(
         description=("Four-digit number representing the card’s expiration year."),
-        required=True,
+        required=False,
     )
 
 
@@ -84,6 +84,9 @@ class Payment(CountableDjangoObjectType):
     )
     available_refund_amount = graphene.Field(
         Money, description="Maximum amount of money that can be refunded."
+    )
+    credit_card = graphene.Field(
+        CreditCard, description="The details of the card used for this payment."
     )
 
     class Meta:
@@ -139,3 +142,13 @@ class Payment(CountableDjangoObjectType):
         if not root.can_capture():
             return None
         return root.get_charge_amount()
+
+    @staticmethod
+    def resolve_credit_card(root: models.Payment, _info):
+        data = {
+            "last_digits": root.cc_last_digits,
+            "brand": root.cc_brand,
+        }
+        if not any(data.values()):
+            return None
+        return CreditCard(**data)

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1533,10 +1533,10 @@ type CreateToken {
 
 type CreditCard {
   brand: String!
-  firstDigits: String!
+  firstDigits: String
   lastDigits: String!
-  expMonth: Int!
-  expYear: Int!
+  expMonth: Int
+  expYear: Int
 }
 
 type CustomerBulkDelete {
@@ -3375,6 +3375,7 @@ type Payment implements Node {
   transactions: [Transaction]
   availableCaptureAmount: Money
   availableRefundAmount: Money
+  creditCard: CreditCard
 }
 
 type PaymentCapture {


### PR DESCRIPTION
Add credit card field to payment type.
Change `CrediCard` type: make only `brand` and `last_digits` required fields.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
