### PR TITLE
Add channel id to draftOrder

### DIFF
--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -142,10 +142,7 @@ class OrderError(Error):
     )
     variants = graphene.List(
         graphene.NonNull(graphene.ID),
-        description=(
-            "List of product variants product variant that are not published "
-            "in the channel associated with this order."
-        ),
+        description="List of product variants that are associated with the error",
         required=False,
     )
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -140,6 +140,14 @@ class OrderError(Error):
     order_line = graphene.ID(
         description="Order line ID which causes the error.", required=False,
     )
+    variants = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description=(
+            "List of product variants product variant that are not published "
+            "in the channel associated with this order."
+        ),
+        required=False,
+    )
 
 
 class InvoiceError(Error):

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -103,13 +103,18 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
                 Q(is_published=False),
             ).values_list("product__variants__id", flat=True)
             if unpublished_variants:
+                unpublished_variants_global_ids = [
+                    graphene.Node.to_global_id("ProductVariant", unpublished_variant)
+                    for unpublished_variant in unpublished_variants
+                ]
+
                 raise ValidationError(
                     {
                         "lines": ValidationError(
                             "Can't add product variant that are not published in "
                             "the channel associated with this order.",
                             code=OrderErrorCode.PRODUCT_NOT_PUBLISHED,
-                            params={"variants": unpublished_variants},
+                            params={"variants": unpublished_variants_global_ids},
                         )
                     }
                 )

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -645,9 +645,19 @@ def test_draft_order_update(
     assert not order.voucher
     assert not order.customer_note
     query = """
-        mutation draftUpdate($id: ID!, $voucher: ID!, $customerNote: String) {
-            draftOrderUpdate(id: $id,
-                             input: {voucher: $voucher, customerNote: $customerNote}) {
+        mutation draftUpdate(
+        $id: ID!,
+        $voucher: ID!,
+        $channel: ID,
+        $customerNote: String
+        ) {
+            draftOrderUpdate(
+                id: $id,
+                input: {
+                    voucher: $voucher,
+                    customerNote: $customerNote
+                    channel: $channel
+                }) {
                 errors {
                     field
                     message
@@ -661,7 +671,12 @@ def test_draft_order_update(
     order_id = graphene.Node.to_global_id("Order", order.id)
     voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
     customer_note = "Test customer note"
-    variables = {"id": order_id, "voucher": voucher_id, "customerNote": customer_note}
+    variables = {
+        "id": order_id,
+        "voucher": voucher_id,
+        "customerNote": customer_note,
+    }
+
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_orders]
     )

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -551,6 +551,7 @@ DRAFT_ORDER_CREATE_MUTATION = """
                     orderErrors {
                         field
                         code
+                        variants
                         message
                     }
                     order {
@@ -692,13 +693,16 @@ def test_draft_order_create_with_channel_with_unpublished_product(
         "voucher": voucher_id,
         "customerNote": customer_note,
     }
+
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_orders]
     )
     content = get_graphql_content(response)
     error = content["data"]["draftOrderCreate"]["orderErrors"][0]
+
     assert error["field"] == "lines"
     assert error["code"] == "PRODUCT_NOT_PUBLISHED"
+    assert error["variants"] == [str(variant_1.id)]
 
 
 def test_draft_order_create_with_channel(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -702,7 +702,7 @@ def test_draft_order_create_with_channel_with_unpublished_product(
 
     assert error["field"] == "lines"
     assert error["code"] == "PRODUCT_NOT_PUBLISHED"
-    assert error["variants"] == [str(variant_1.id)]
+    assert error["variants"] == [variant_1_id]
 
 
 def test_draft_order_create_with_channel(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1837,6 +1837,7 @@ input DraftOrderCreateInput {
   shippingMethod: ID
   voucher: ID
   customerNote: String
+  channel: ID
   lines: [OrderLineCreateInput]
 }
 
@@ -1855,6 +1856,7 @@ input DraftOrderInput {
   shippingMethod: ID
   voucher: ID
   customerNote: String
+  channel: ID
 }
 
 type DraftOrderLineDelete {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3036,6 +3036,7 @@ type OrderError {
   code: OrderErrorCode!
   warehouse: ID
   orderLine: ID
+  variants: [ID!]
 }
 
 enum OrderErrorCode {


### PR DESCRIPTION
I want to merge this change because...I want to add channel id to draftORder mutations

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
