### PR TITLE
Use full HTTP mode and enable threads by default

### DIFF
--- a/saleor/wsgi/uwsgi.ini
+++ b/saleor/wsgi/uwsgi.ini
@@ -1,6 +1,7 @@
 [uwsgi]
 die-on-term = true
-http-socket = :$(PORT)
+enable-threads = true
+http = :$(PORT)
 log-format = UWSGI uwsgi "%(method) %(uri) %(proto)" %(status) %(size) %(msecs)ms [PID:%(pid):Worker-%(wid)] [RSS:%(rssM)MB]
 master = true
 max-requests = 100


### PR DESCRIPTION
This makes UWSGI use full HTTP mode by default which makes it suitable for use without a proxy in front of the Docker image. It also enables threads to make sure async tools like Sentry work.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
