### PR TITLE
Fix CORS support for clients with credentials=include

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -1,3 +1,4 @@
+import fnmatch
 import json
 import logging
 import traceback
@@ -91,12 +92,18 @@ class GraphQLView(View):
         else:
             return HttpResponseNotAllowed(["GET", "OPTIONS", "POST"])
         # Add access control headers
-        response["Access-Control-Allow-Origin"] = settings.ALLOWED_GRAPHQL_ORIGINS
-        response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
-        response[
-            "Access-Control-Allow-Headers"
-        ] = "Origin, Content-Type, Accept, Authorization"
-        response["Access-Control-Allow-Credentials"] = "true"
+        if "HTTP_ORIGIN" in request.META:
+            for origin in settings.ALLOWED_GRAPHQL_ORIGINS:
+                if fnmatch.fnmatchcase(request.META["HTTP_ORIGIN"], origin):
+                    response["Access-Control-Allow-Origin"] = request.META[
+                        "HTTP_ORIGIN"
+                    ]
+                    response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
+                    response[
+                        "Access-Control-Allow-Headers"
+                    ] = "Origin, Content-Type, Accept, Authorization"
+                    response["Access-Control-Allow-Credentials"] = "true"
+                    break
         return response
 
     def render_playground(self, request):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -390,7 +390,7 @@ TEST_RUNNER = "saleor.tests.runner.PytestTestRunner"
 PLAYGROUND_ENABLED = get_bool_from_env("PLAYGROUND_ENABLED", True)
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1"))
-ALLOWED_GRAPHQL_ORIGINS = os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*")
+ALLOWED_GRAPHQL_ORIGINS = get_list(os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*"))
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 


### PR DESCRIPTION
Without this change, it's impossible to allow multiple storefront domains to work with the API as wildcard origins are explicitly rejected for security reasons.

⚠️ Looking for a volunteer to add unit tests for this.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
