### PR TITLE
Drop channel middleware

### DIFF
--- a/saleor/channel/exceptions.py
+++ b/saleor/channel/exceptions.py
@@ -1,12 +1,12 @@
-class ChannelSlugNotPassedException(Exception):
+class ChannelNotDefined(Exception):
     def __init__(self, msg=None):
         if msg is None:
-            msg = "Channel slug not passed."
+            msg = "More than one channel exists. Specify which channel to use."
         super().__init__(msg)
 
 
-class NoChannelException(Exception):
+class NoDefaultChannel(Exception):
     def __init__(self, msg=None):
         if msg is None:
-            msg = "There's no channel."
+            msg = "A default channel does not exist."
         super().__init__(msg)

--- a/saleor/channel/models.py
+++ b/saleor/channel/models.py
@@ -15,3 +15,6 @@ class Channel(models.Model):
         permissions = (
             (ChannelPermissions.MANAGE_CHANNELS.codename, "Manage channels.",),
         )
+
+    def __str__(self):
+        return self.slug

--- a/saleor/channel/tests/test_utils.py
+++ b/saleor/channel/tests/test_utils.py
@@ -2,25 +2,23 @@ import warnings
 
 import pytest
 
-from ..exceptions import ChannelSlugNotPassedException, NoChannelException
-from ..utils import DEPRECATION_WARNING_MESSAGE, get_default_channel_slug_if_available
+from ..exceptions import ChannelNotDefined, NoDefaultChannel
+from ..utils import DEPRECATION_WARNING_MESSAGE, get_default_channel
 
 
-def test_get_default_channel_slug_if_available_without_channels():
-    with pytest.raises(NoChannelException):
-        get_default_channel_slug_if_available()
+def test_get_default_channel_without_channels():
+    with pytest.raises(NoDefaultChannel):
+        get_default_channel()
 
 
-def test_get_default_channel_slug_if_available_with_one_channels(channel_USD):
+def test_get_default_channel_with_one_channels(channel_USD):
     with warnings.catch_warnings(record=True) as warns:
-        get_default_channel_slug_if_available()
+        get_default_channel()
         assert any(
             [str(warning.message) == DEPRECATION_WARNING_MESSAGE for warning in warns]
         )
 
 
-def test_get_default_channel_slug_if_available_with_many_channels(
-    channel_USD, channel_PLN
-):
-    with pytest.raises(ChannelSlugNotPassedException):
-        get_default_channel_slug_if_available()
+def test_get_default_channel_with_many_channels(channel_USD, channel_PLN):
+    with pytest.raises(ChannelNotDefined):
+        get_default_channel()

--- a/saleor/channel/utils.py
+++ b/saleor/channel/utils.py
@@ -1,21 +1,34 @@
 import warnings
 
-from .exceptions import ChannelSlugNotPassedException, NoChannelException
+from .exceptions import ChannelNotDefined, NoDefaultChannel
 from .models import Channel
 
-# TODO: Add message with deprecation date.
 DEPRECATION_WARNING_MESSAGE = (
-    "DEPRECATED: Channel slug not passed. Query working only if exists one channel."
-    "This behavior will be removed after XXXX-XX-XX."
+    "Default channel used in a query. Please make sure that channel is explicitly "
+    "provided. This behavior works only when a one channel exists and will be removed "
+    "after 2020-12-31."
 )
 
 
-def get_default_channel_slug_if_available() -> str:
+def get_default_channel() -> Channel:
+    """Return a default channel.
+
+    Returns a channel only when exactly one channel exists in the system. If there are
+    more channels, you need to ensure that the channel is explicitly specified. This
+    function is intended to use throughout the full migration to the multi-channel
+    approach in Saleor and will be removed after 2020-12-31. Since then, the API and
+    all functions will require specifying the channel.
+
+    :raises ChannelNotDefined: When there is more than one channel.
+    :raises NoDefaultChannel: When there are no channels.
+    """
+
     try:
         channel = Channel.objects.get()
     except Channel.MultipleObjectsReturned:
-        raise ChannelSlugNotPassedException()
+        raise ChannelNotDefined()
     except Channel.DoesNotExist:
-        raise NoChannelException()
-    warnings.warn(DEPRECATION_WARNING_MESSAGE)
-    return channel.slug
+        raise NoDefaultChannel()
+    else:
+        warnings.warn(DEPRECATION_WARNING_MESSAGE)
+        return channel

--- a/saleor/graphql/channel/__init__.py
+++ b/saleor/graphql/channel/__init__.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import Any, Optional
+
+from django.db.models import QuerySet
+
+
+@dataclass
+class ChannelContext:
+    node: Any
+    channel_slug: Optional[str] = None
+
+
+@dataclass
+class ChannelQsContext:
+    qs: QuerySet
+    channel_slug: str

--- a/saleor/graphql/channel/__init__.py
+++ b/saleor/graphql/channel/__init__.py
@@ -7,10 +7,10 @@ from django.db.models import QuerySet
 @dataclass
 class ChannelContext:
     node: Any
-    channel_slug: Optional[str] = None
+    channel_slug: Optional[str]
 
 
 @dataclass
 class ChannelQsContext:
     qs: QuerySet
-    channel_slug: Optional[str] = None
+    channel_slug: Optional[str]

--- a/saleor/graphql/channel/__init__.py
+++ b/saleor/graphql/channel/__init__.py
@@ -13,4 +13,4 @@ class ChannelContext:
 @dataclass
 class ChannelQsContext:
     qs: QuerySet
-    channel_slug: str
+    channel_slug: Optional[str] = None

--- a/saleor/graphql/channel/__init__.py
+++ b/saleor/graphql/channel/__init__.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Generic, Optional, TypeVar
 
 from django.db.models import QuerySet
 
+N = TypeVar("N")
+
 
 @dataclass
-class ChannelContext:
-    node: Any
+class ChannelContext(Generic[N]):
+    node: N
     channel_slug: Optional[str]
 
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -31,6 +31,22 @@ class ChannelContextType(DjangoObjectType):
         return super().is_type_of(root.node, info)
 
     @staticmethod
+    def resolve_translation(root: ChannelContext, info, language_code):
+        # Resolver for TranslationField; needs to be manually specified.
+        return resolve_translation(root.node, info, language_code)
+
+
+class ChannelContextTypeWithMetadata(ChannelContextType):
+    """A Graphene type for that uses ChannelContext as root in resolvers.
+
+    Same as ChannelContextType, but for types that implement ObjectWithMetadata
+    interface.
+    """
+
+    class Meta:
+        abstract = True
+
+    @staticmethod
     def resolve_metadata(root: ChannelContext, info):
         # Used in metadata API to resolve metadata fields from an instance.
         return ObjectWithMetadata.resolve_metadata(root.node, info)
@@ -39,11 +55,6 @@ class ChannelContextType(DjangoObjectType):
     def resolve_private_metadata(root: ChannelContext, info):
         # Used in metadata API to resolve private metadata fields from an instance.
         return ObjectWithMetadata.resolve_private_metadata(root.node, info)
-
-    @staticmethod
-    def resolve_translation(root: ChannelContext, info, language_code):
-        # Resolver for TranslationField; needs to be manually specified.
-        return resolve_translation(root.node, info, language_code)
 
 
 class Channel(CountableDjangoObjectType):

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -1,7 +1,49 @@
 from graphene import relay
+from graphene.types.resolver import get_default_resolver
+from graphene_django import DjangoObjectType
 
 from ...channel import models
 from ..core.connection import CountableDjangoObjectType
+from ..meta.types import ObjectWithMetadata
+from ..translations.resolvers import resolve_translation
+from . import ChannelContext
+
+
+class ChannelContextType(DjangoObjectType):
+    """A Graphene type that supports resolvers' root as ChannelContext objects."""
+
+    class Meta:
+        abstract = True
+
+    @staticmethod
+    def resolver_with_context(
+        attname, default_value, root: ChannelContext, info, **args
+    ):
+        resolver = get_default_resolver()
+        return resolver(attname, default_value, root.node, info, **args)
+
+    @staticmethod
+    def resolve_id(root: ChannelContext, _info):
+        return root.node.pk
+
+    @classmethod
+    def is_type_of(cls, root: ChannelContext, info):
+        return super().is_type_of(root.node, info)
+
+    @staticmethod
+    def resolve_metadata(root: ChannelContext, info):
+        # Used in metadata API to resolve metadata fields from an instance.
+        return ObjectWithMetadata.resolve_metadata(root.node, info)
+
+    @staticmethod
+    def resolve_private_metadata(root: ChannelContext, info):
+        # Used in metadata API to resolve private metadata fields from an instance.
+        return ObjectWithMetadata.resolve_private_metadata(root.node, info)
+
+    @staticmethod
+    def resolve_translation(root: ChannelContext, info, language_code):
+        # Resolver for TranslationField; needs to be manually specified.
+        return resolve_translation(root.node, info, language_code)
 
 
 class Channel(CountableDjangoObjectType):

--- a/saleor/graphql/channel/utils.py
+++ b/saleor/graphql/channel/utils.py
@@ -1,0 +1,18 @@
+from graphql.error import GraphQLError
+
+from ...channel.exceptions import ChannelNotDefined, NoDefaultChannel
+from ...channel.models import Channel
+from ...channel.utils import get_default_channel
+
+
+def get_default_channel_or_graphql_error() -> Channel:
+    """Return a default channel or a GraphQL error.
+
+    Utility to get the default channel in GraphQL query resolvers.
+    """
+    try:
+        channel = get_default_channel()
+    except (ChannelNotDefined, NoDefaultChannel) as e:
+        raise GraphQLError(str(e))
+    else:
+        return channel

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -8,6 +8,7 @@ from ...core.permissions import AccountPermissions, CheckoutPermissions
 from ...core.taxes import display_gross_prices, zero_taxed_money
 from ...plugins.manager import get_plugins_manager
 from ..account.utils import requestor_has_access
+from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
 from ..core.scalars import UUID
 from ..core.types.money import TaxedMoney
@@ -67,10 +68,16 @@ class CheckoutLine(CountableDjangoObjectType):
         filter_fields = ["id"]
 
     @staticmethod
-    def resolve_total_price(self, info):
+    def resolve_variant(root, _info):
+        # FIXME: Consider whether here we should use checkout's channel or None
+        channel_slug = root.checkout.channel.slug
+        return ChannelContext(node=root.variant, channel_slug=channel_slug)
+
+    @staticmethod
+    def resolve_total_price(root, info):
         def calculate_total_price(discounts):
             return info.context.plugins.calculate_checkout_line_total(
-                checkout_line=self, discounts=discounts
+                checkout_line=root, discounts=discounts
             )
 
         return (

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -69,7 +69,6 @@ class CheckoutLine(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_variant(root, _info):
-        # FIXME: Consider whether here we should use checkout's channel or None
         channel_slug = root.checkout.channel.slug
         return ChannelContext(node=root.variant, channel_slug=channel_slug)
 

--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -92,18 +92,6 @@ def convert_field_measurements(*_args):
 
 
 class PrefetchingConnectionField(BaseDjangoConnectionField):
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault(
-            "channel",
-            graphene.Argument(
-                graphene.String,
-                description=(
-                    "Slug of the channel for which the data should be returned."
-                ),
-            ),
-        )
-        super().__init__(*args, **kwargs)
-
     @classmethod
     def connection_resolver(
         cls,

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -21,8 +21,7 @@ class Mutation(BaseMutation):
         description = "Base mutation"
 
     @classmethod
-    def perform_mutation(cls, _root, info, product_id, channel):
-        info.context.channel_slug = channel
+    def perform_mutation(cls, _root, info, product_id):
         product = cls.get_node_or_error(
             info, product_id, field="product_id", only_type=product_types.Product
         )

--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -21,7 +21,7 @@ class Mutation(BaseMutation):
         description = "Base mutation"
 
     @classmethod
-    def perform_mutation(cls, _root, info, product_id):
+    def perform_mutation(cls, _root, info, product_id, channel):
         product = cls.get_node_or_error(
             info, product_id, field="product_id", only_type=product_types.Product
         )

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -81,7 +81,7 @@ def test_real_query(user_api_client, product, channel_USD):
     query Root($categoryId: ID!, $sortBy: ProductOrder, $first: Int,
             $attributesFilter: [AttributeInput], $channel: String) {
 
-        category(id: $categoryId, channel: $channel) {
+        category(id: $categoryId) {
             ...CategoryPageFragmentQuery
             __typename
         }

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -5,7 +5,7 @@ import pytest
 from django.test import override_settings
 
 from ....demo.views import EXAMPLE_QUERY
-from ...product.types import Product
+from ...product.types import Collection
 from ...tests.fixtures import API_PATH
 from ...tests.utils import _get_graphql_content_from_response, get_graphql_content
 
@@ -191,12 +191,13 @@ def test_validation_errors_query_do_not_get_logged(
     assert graphql_log_handler.messages == []
 
 
-@mock.patch.object(Product, "get_node")
+@mock.patch.object(Collection, "get_node")
 def test_unexpected_exceptions_are_logged_in_their_own_logger(
     mocked_get_node,
     staff_api_client,
     graphql_log_handler,
     permission_manage_products,
+    collection,
     channel_USD,
 ):
     def bad_get_node(info, pk):
@@ -205,8 +206,9 @@ def test_unexpected_exceptions_are_logged_in_their_own_logger(
     mocked_get_node.side_effect = bad_get_node
 
     staff_api_client.user.user_permissions.add(permission_manage_products)
+    variables = {"id": graphene.Node.to_global_id("Collection", collection.pk)}
     response = staff_api_client.post_graphql(
-        '{ product(id: "UHJvZHVjdDoxMg==") { name } }'
+        "query($id: ID!) { collection(id: $id) { name } }", variables=variables,
     )
 
     assert response.status_code == 200

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -19,8 +19,8 @@ def test_batch_queries(category, product, api_client, channel_USD):
         }
     """
     query_category = """
-        query GetCategory($id: ID!, $channel: String) {
-            category(id: $id, channel: $channel) {
+        query GetCategory($id: ID!) {
+            category(id: $id) {
                 name
             }
         }
@@ -193,7 +193,11 @@ def test_validation_errors_query_do_not_get_logged(
 
 @mock.patch.object(Product, "get_node")
 def test_unexpected_exceptions_are_logged_in_their_own_logger(
-    mocked_get_node, staff_api_client, graphql_log_handler, permission_manage_products
+    mocked_get_node,
+    staff_api_client,
+    graphql_log_handler,
+    permission_manage_products,
+    channel_USD,
 ):
     def bad_get_node(info, pk):
         raise NotImplementedError(info, pk)

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -4,6 +4,8 @@ from django.core.exceptions import ValidationError
 from ...core import models
 from ...core.error_codes import MetadataErrorCode
 from ...core.exceptions import PermissionDenied
+from ...product import models as product_models
+from ..channel import ChannelContext
 from ..core.mutations import BaseMutation
 from ..core.types.common import MetadataError
 from .permissions import PRIVATE_META_PERMISSION_MAP, PUBLIC_META_PERMISSION_MAP
@@ -85,6 +87,15 @@ class BaseMetadataMutation(BaseMutation):
     @classmethod
     def success_response(cls, instance):
         """Return a success response."""
+        # Wrap the instance with ChannelContext for models that use it.
+        use_channel_context = any(
+            [
+                isinstance(instance, Model)
+                for Model in [product_models.Product, product_models.ProductVariant]
+            ]
+        )
+        if use_channel_context:
+            instance = ChannelContext(node=instance, channel_slug=None)
         return cls(**{"item": instance, "errors": []})
 
 

--- a/saleor/graphql/meta/types.py
+++ b/saleor/graphql/meta/types.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.models import ModelWithMetadata
+from ..channel import ChannelContext
 from .resolvers import (
     resolve_metadata,
     resolve_object_with_metadata_type,
@@ -59,4 +60,7 @@ class ObjectWithMetadata(graphene.Interface):
 
     @classmethod
     def resolve_type(cls, instance: ModelWithMetadata, _info):
+        if isinstance(instance, ChannelContext):
+            # Return instance for types that use ChannelContext
+            instance = instance.node
         return resolve_object_with_metadata_type(instance)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -15,6 +15,7 @@ from ...product.templatetags.product_images import get_product_image_thumbnail
 from ...warehouse import models as warehouse_models
 from ..account.types import User
 from ..account.utils import requestor_has_access
+from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
 from ..core.types.common import Image
 from ..core.types.money import Money, TaxedMoney
@@ -293,6 +294,11 @@ class OrderLine(CountableDjangoObjectType):
     @staticmethod
     def resolve_translated_variant_name(root: models.OrderLine, _info):
         return root.translated_variant_name
+
+    @staticmethod
+    def resolve_variant(root: models.OrderLine, _info):
+        channel_slug = root.order.channel.slug if root.order.channel else None
+        return ChannelContext(node=root, channel_slug=channel_slug)
 
 
 class Order(CountableDjangoObjectType):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -298,7 +298,7 @@ class OrderLine(CountableDjangoObjectType):
     @staticmethod
     def resolve_variant(root: models.OrderLine, _info):
         channel_slug = root.order.channel.slug if root.order.channel else None
-        return ChannelContext(node=root, channel_slug=channel_slug)
+        return ChannelContext(node=root.variant, channel_slug=channel_slug)
 
 
 class Order(CountableDjangoObjectType):

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -10,7 +10,6 @@ from ....product.models import (
     ProductImage,
     ProductVariant,
 )
-from ...channel.utils import get_default_channel_or_graphql_error
 from ...core.dataloaders import DataLoader
 
 ProductIdAndChannelSlug = Tuple[int, str]
@@ -28,11 +27,9 @@ class ProductByIdLoader(DataLoader):
     context_key = "product_by_id"
 
     def batch_load(self, keys):
-        # FIXME: add param to pass the channel slug from outside
-        channel = get_default_channel_or_graphql_error()
-        products = Product.objects.visible_to_user(self.user, channel.slug).in_bulk(
-            keys
-        )
+        # FIXME: check if we need to use visible_for_user queryset here or we can
+        # ensure the right access to visible products at some higher level.
+        products = Product.objects.all().in_bulk(keys)
         return [products.get(product_id) for product_id in keys]
 
 

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -8,6 +8,7 @@ from django.db import transaction
 from ....core.permissions import ProductPermissions
 from ....product.error_codes import ProductErrorCode
 from ....product.models import ProductChannelListing
+from ...channel import ChannelContext
 from ...channel.types import Channel
 from ...core.mutations import BaseMutation
 from ...core.types.common import ProductChannelListingError
@@ -179,5 +180,6 @@ class ProductChannelListingUpdate(BaseMutation):
             raise ValidationError(errors)
 
         cls.save(info, product, cleaned_input)
-
-        return ProductChannelListingUpdate(product=product)
+        return ProductChannelListingUpdate(
+            product=ChannelContext(node=product, channel_slug=None)
+        )

--- a/saleor/graphql/product/mutations/digital_contents.py
+++ b/saleor/graphql/product/mutations/digital_contents.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from ....core.permissions import ProductPermissions
 from ....product import models
 from ....product.error_codes import ProductErrorCode
+from ...channel import ChannelContext
 from ...core.mutations import BaseMutation, ModelMutation
 from ...core.types import Upload
 from ...core.types.common import ProductError
@@ -113,7 +114,9 @@ class DigitalContentCreate(BaseMutation):
 
         variant.digital_content = digital_content
         variant.digital_content.save()
-        return DigitalContentCreate(content=digital_content)
+
+        variant = ChannelContext(node=variant, channel_slug=None)
+        return DigitalContentCreate(content=digital_content, variant=variant)
 
 
 class DigitalContentDelete(BaseMutation):
@@ -140,6 +143,7 @@ class DigitalContentDelete(BaseMutation):
         if hasattr(variant, "digital_content"):
             variant.digital_content.delete()
 
+        variant = ChannelContext(node=variant, channel_slug=None)
         return DigitalContentDelete(variant=variant)
 
 
@@ -218,6 +222,7 @@ class DigitalContentUpdate(BaseMutation):
         variant.digital_content = digital_content
         variant.digital_content.save()
 
+        variant = ChannelContext(node=variant, channel_slug=None)
         return DigitalContentUpdate(content=digital_content, variant=variant)
 
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -49,24 +49,20 @@ def resolve_digital_contents(info):
     return models.DigitalContent.objects.all()
 
 
-def resolve_product_by_slug(info, slug):
+def resolve_product_by_slug(info, product_slug, channel_slug):
     user = info.context.user
-    channel_slug = info.context.channel_slug
     return (
-        models.Product.objects.visible_to_user(user, channel_slug)
-        .filter(slug=slug)
+        models.Product.objects.visible_to_user(user, channel_slug=channel_slug)
+        .filter(slug=product_slug)
         .first()
     )
 
 
-def resolve_products(info, stock_availability=None, **_kwargs):
+def resolve_products(info, stock_availability=None, channel_slug=None, **_kwargs):
     user = get_user_or_app_from_context(info.context)
-    channel_slug = info.context.channel_slug
     qs = models.Product.objects.visible_to_user(user, channel_slug)
-
     if stock_availability:
         qs = filter_products_by_stock_availability(qs, stock_availability)
-
     return qs.distinct()
 
 
@@ -74,9 +70,8 @@ def resolve_product_types(info, **_kwargs):
     return models.ProductType.objects.all()
 
 
-def resolve_product_variants(info, ids=None):
+def resolve_product_variants(info, ids=None, channel_slug=None):
     user = info.context.user
-    channel_slug = info.context.channel_slug
     visible_products = models.Product.objects.visible_to_user(
         user, channel_slug
     ).values_list("pk", flat=True)

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -78,6 +78,15 @@ def resolve_products(
     return ChannelQsContext(qs=qs.distinct(), channel_slug=channel_slug)
 
 
+def resolve_variant_by_id(info, id, channel_slug):
+    user = info.context.user
+    visible_products = models.Product.objects.visible_to_user(
+        user, channel_slug
+    ).values_list("pk", flat=True)
+    qs = models.ProductVariant.objects.filter(product__id__in=visible_products)
+    return qs.filter(pk=id).first()
+
+
 def resolve_product_types(info, **_kwargs):
     return models.ProductType.objects.all()
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -46,8 +46,17 @@ def resolve_collections(info, **_kwargs):
     return models.Collection.objects.visible_to_user(user)
 
 
-def resolve_digital_contents(info):
+def resolve_digital_contents(_info):
     return models.DigitalContent.objects.all()
+
+
+def resolve_product_by_id(info, id, channel_slug):
+    user = info.context.user
+    return (
+        models.Product.objects.visible_to_user(user, channel_slug=channel_slug)
+        .filter(id=id)
+        .first()
+    )
 
 
 def resolve_product_by_slug(info, product_slug, channel_slug):
@@ -85,7 +94,7 @@ def resolve_product_variants(info, ids=None, channel_slug=None) -> ChannelQsCont
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 
 
-def resolve_report_product_sales(period):
+def resolve_report_product_sales(period, channel_slug=None) -> ChannelQsContext:
     qs = models.ProductVariant.objects.all()
 
     # exclude draft and canceled orders
@@ -97,4 +106,5 @@ def resolve_report_product_sales(period):
 
     qs = qs.annotate(quantity_ordered=Sum("order_lines__quantity"))
     qs = qs.filter(quantity_ordered__isnull=False)
-    return qs.order_by("-quantity_ordered")
+    qs = qs.order_by("-quantity_ordered")
+    return ChannelQsContext(qs=qs, channel_slug=channel_slug)

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -244,7 +244,7 @@ class ProductQueries(graphene.ObjectType):
         ),
         description="Look up a product variant by ID.",
     )
-    product_variants = PrefetchingConnectionField(
+    product_variants = ChannelContextFilterConnectionField(
         ProductVariant,
         ids=graphene.List(
             graphene.ID, description="Filter product variants by given IDs."

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -124,6 +124,7 @@ from .resolvers import (
     resolve_product_variants,
     resolve_products,
     resolve_report_product_sales,
+    resolve_variant_by_id,
 )
 from .sorters import (
     AttributeSortingInput,
@@ -327,7 +328,8 @@ class ProductQueries(graphene.ObjectType):
     def resolve_product_variant(self, info, id, channel=None, **_kwargs):
         if channel is None:
             channel = get_default_channel_or_graphql_error().slug
-        variant = graphene.Node.get_node_from_global_id(info, id, ProductVariant)
+        _, id = graphene.Node.from_global_id(id)
+        variant = resolve_variant_by_id(info, id, channel_slug=channel)
         return ChannelContext(node=variant, channel_slug=channel) if variant else None
 
     def resolve_product_variants(self, info, ids=None, channel=None, **_kwargs):

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -192,10 +192,11 @@ def test_retrieve_channel_listings(
     staff_api_client,
     count_queries,
     permission_manage_products,
+    channel_USD,
 ):
     query = """
-        query {
-          products(first: 10) {
+        query($channel: String) {
+          products(first: 10, channel: $channel) {
             edges {
               node {
                 id
@@ -211,7 +212,7 @@ def test_retrieve_channel_listings(
         }
     """
 
-    variables = {}
+    variables = {"channel": channel_USD.slug}
     get_graphql_content(
         staff_api_client.post_graphql(
             query,

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -121,14 +121,14 @@ def test_collections_query(
 ):
     query = """
         query Collections ($channel: String) {
-            collections(first: 2, channel: $channel) {
+            collections(first: 2) {
                 edges {
                     node {
                         isPublished
                         name
                         slug
                         description
-                        products {
+                        products(channel: $channel) {
                             totalCount
                         }
                     }
@@ -159,7 +159,7 @@ def test_collections_query_as_staff(
     channel_USD,
 ):
     query = """
-        query Collections {
+        query Collections($channel: String) {
             collections(first: 2) {
                 edges {
                     node {
@@ -167,7 +167,7 @@ def test_collections_query_as_staff(
                         name
                         slug
                         description
-                        products {
+                        products(channel: $channel) {
                             totalCount
                         }
                     }
@@ -176,8 +176,9 @@ def test_collections_query_as_staff(
         }
     """
     # query all collections only as a staff user with proper permissions
+    variables = {"channel": channel_USD.slug}
     staff_api_client.user.user_permissions.add(permission_manage_products)
-    response = staff_api_client.post_graphql(query)
+    response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     edges = content["data"]["collections"]["edges"]
     assert len(edges) == 2
@@ -306,7 +307,7 @@ def test_create_collection_without_background_image(
     ),
 )
 def test_create_collection_with_given_slug(
-    staff_api_client, permission_manage_products, input_slug, expected_slug
+    staff_api_client, permission_manage_products, input_slug, expected_slug, channel_USD
 ):
     query = CREATE_COLLECTION_MUTATION
     name = "Test collection"
@@ -321,7 +322,7 @@ def test_create_collection_with_given_slug(
 
 
 def test_create_collection_name_with_unicode(
-    staff_api_client, permission_manage_products
+    staff_api_client, permission_manage_products, channel_USD
 ):
     query = CREATE_COLLECTION_MUTATION
     name = "わたし わ にっぽん です"

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -833,7 +833,7 @@ def test_fetch_product_from_category_query(
     product = category.products.first()
     query = """
     query {
-        category(id: "%(category_id)s", channel: "%(channel_slug)s") {
+        category(id: "%(category_id)s") {
             products(first: 20) {
                 edges {
                     node {
@@ -888,7 +888,6 @@ def test_fetch_product_from_category_query(
     }
     """ % {
         "category_id": graphene.Node.to_global_id("Category", category.id),
-        "channel_slug": channel_USD.slug,
     }
     staff_api_client.user.user_permissions.add(permission_manage_products)
     response = staff_api_client.post_graphql(query)
@@ -2598,13 +2597,13 @@ def test_delete_product(staff_api_client, product, permission_manage_products):
 def test_product_type(user_api_client, product_type, channel_USD):
     query = """
     query ($channel: String){
-        productTypes(first: 20, channel: $channel) {
+        productTypes(first: 20) {
             totalCount
             edges {
                 node {
                     id
                     name
-                    products(first: 1) {
+                    products(first: 1, channel: $channel) {
                         edges {
                             node {
                                 id
@@ -2640,9 +2639,9 @@ def test_product_type_query(
     )
     query = """
             query getProductType($id: ID!, $channel: String) {
-                productType(id: $id,  channel:$channel) {
+                productType(id: $id) {
                     name
-                    products(first: 20) {
+                    products(first: 20, channel:$channel) {
                         totalCount
                         edges {
                             node {
@@ -3595,10 +3594,11 @@ def test_report_product_sales(
     order_with_lines,
     permission_manage_products,
     permission_manage_orders,
+    channel_USD,
 ):
     query = """
-    query TopProducts($period: ReportingPeriod!) {
-        reportProductSales(period: $period, first: 20) {
+    query TopProducts($period: ReportingPeriod!, $channel: String) {
+        reportProductSales(period: $period, first: 20, channel: $channel) {
             edges {
                 node {
                     revenue(period: $period) {
@@ -3613,7 +3613,7 @@ def test_report_product_sales(
         }
     }
     """
-    variables = {"period": ReportingPeriod.TODAY.name}
+    variables = {"period": ReportingPeriod.TODAY.name, "channel": channel_USD.slug}
     permissions = [permission_manage_orders, permission_manage_products]
     response = staff_api_client.post_graphql(query, variables, permissions)
     content = get_graphql_content(response)

--- a/saleor/graphql/product/tests/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_product_channel_listing_update.py
@@ -495,7 +495,6 @@ def test_product_channel_listing_update_publish_product_without_category(
 
     # then
     data = content["data"]["productChannelListingUpdate"]
-    print(data)
     errors = data["productsErrors"]
     assert errors[0]["field"] == "isPublished"
     assert errors[0]["code"] == ProductErrorCode.PRODUCT_WITHOUT_CATEGORY.name

--- a/saleor/graphql/product/tests/test_product_pagination.py
+++ b/saleor/graphql/product/tests/test_product_pagination.py
@@ -419,6 +419,7 @@ def test_products_pagination_with_sorting(
     staff_api_client,
     permission_manage_products,
     products_for_pagination,
+    channel_USD,
 ):
     page_size = 3
 
@@ -442,6 +443,7 @@ def test_products_pagination_with_sorting_by_attribute(
     permission_manage_products,
     products_for_pagination,
     color_attribute,
+    channel_USD,
 ):
     page_size = 3
     products_order = ["Product2", "ProductProduct1", "Product1"]
@@ -464,7 +466,7 @@ def test_products_pagination_with_sorting_by_attribute(
 
 
 def test_products_pagination_for_products_with_the_same_names_two_pages(
-    staff_api_client, permission_manage_products, category, product_type
+    staff_api_client, permission_manage_products, category, product_type, channel_USD
 ):
     products = Product.objects.bulk_create(
         [
@@ -526,7 +528,7 @@ def test_products_pagination_for_products_with_the_same_names_two_pages(
 
 
 def test_products_pagination_for_products_with_the_same_names_one_page(
-    staff_api_client, permission_manage_products, category, product_type
+    staff_api_client, permission_manage_products, category, product_type, channel_USD
 ):
     products = Product.objects.bulk_create(
         [
@@ -586,6 +588,7 @@ def test_products_pagination_with_filtering(
     staff_api_client,
     permission_manage_products,
     products_for_pagination,
+    channel_USD,
 ):
     page_size = 2
 
@@ -604,7 +607,7 @@ def test_products_pagination_with_filtering(
 
 
 def test_products_pagination_with_filtering_by_attribute(
-    staff_api_client, permission_manage_products, products_for_pagination,
+    staff_api_client, permission_manage_products, products_for_pagination, channel_USD
 ):
     page_size = 2
     products_order = ["Product2", "ProductProduct1"]
@@ -625,7 +628,11 @@ def test_products_pagination_with_filtering_by_attribute(
 
 
 def test_products_pagination_with_filtering_by_product_types(
-    staff_api_client, permission_manage_products, products_for_pagination, product_type
+    staff_api_client,
+    permission_manage_products,
+    products_for_pagination,
+    product_type,
+    channel_USD,
 ):
     page_size = 2
     products_order = ["Product2", "ProductProduct1"]
@@ -647,7 +654,11 @@ def test_products_pagination_with_filtering_by_product_types(
 
 
 def test_products_pagination_with_filtering_by_stocks(
-    staff_api_client, permission_manage_products, products_for_pagination, warehouse
+    staff_api_client,
+    permission_manage_products,
+    products_for_pagination,
+    warehouse,
+    channel_USD,
 ):
     page_size = 2
     products_order = ["ProductProduct1", "ProductProduct2"]

--- a/saleor/graphql/product/types/__init__.py
+++ b/saleor/graphql/product/types/__init__.py
@@ -5,6 +5,7 @@ from .products import (
     Category,
     Collection,
     Product,
+    ProductContext,
     ProductImage,
     ProductType,
     ProductVariant,

--- a/saleor/graphql/product/types/__init__.py
+++ b/saleor/graphql/product/types/__init__.py
@@ -5,7 +5,6 @@ from .products import (
     Category,
     Collection,
     Product,
-    ProductContext,
     ProductImage,
     ProductType,
     ProductVariant,

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -127,6 +127,8 @@ class ProductPricingInfo(BasePricingInfo):
 
 
 class ChannelContextType(DjangoObjectType):
+    """A Graphene type used with resolvers root objects wrapped with ChannelContext."""
+
     class Meta:
         abstract = True
 
@@ -342,7 +344,9 @@ class ProductVariant(ChannelContextType, CountableDjangoObjectType):
 
     @staticmethod
     def resolve_product(root: ChannelContext, info):
-        return ProductByIdLoader(info.context).load(root.node.product_id)
+        # FIXME: use dataloader
+        # product = ProductByIdLoader(info.context).load(root.node.product_id)
+        return ChannelContext(node=root.node.product, channel_slug=root.channel_slug)
 
     @staticmethod
     def resolve_is_available(root: ChannelContext, info):
@@ -651,6 +655,9 @@ class ProductType(CountableDjangoObjectType):
             description="Slug of a channel for which the data should be returned."
         ),
         description="List of products of this type.",
+        deprecation_reason=(
+            "Use the top-level `products` query with the `productTypes` filter."
+        ),
     )
     tax_rate = TaxRateType(description="A type of tax rate.")
     tax_type = graphene.Field(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -344,9 +344,10 @@ class ProductVariant(ChannelContextType, CountableDjangoObjectType):
 
     @staticmethod
     def resolve_product(root: ChannelContext, info):
-        # FIXME: use dataloader
-        # product = ProductByIdLoader(info.context).load(root.node.product_id)
-        return ChannelContext(node=root.node.product, channel_slug=root.channel_slug)
+        product = ProductByIdLoader(info.context).load(root.node.product_id)
+        return product.then(
+            lambda product: ChannelContext(node=product, channel_slug=root.channel_slug)
+        )
 
     @staticmethod
     def resolve_is_available(root: ChannelContext, info):

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -26,7 +26,7 @@ from ....warehouse.availability import (
 )
 from ...account.enums import CountryCodeEnum
 from ...channel import ChannelContext, ChannelQsContext
-from ...channel.types import ChannelContextType
+from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
 from ...channel.utils import get_default_channel_or_graphql_error
 from ...core.connection import CountableDjangoObjectType
 from ...core.enums import ReportingPeriod, TaxRateType
@@ -126,7 +126,7 @@ class ProductPricingInfo(BasePricingInfo):
 
 
 @key(fields="id")
-class ProductVariant(ChannelContextType, CountableDjangoObjectType):
+class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     quantity = graphene.Int(
         required=True,
         description="Quantity of a product available for sale.",
@@ -395,7 +395,7 @@ class ProductVariant(ChannelContextType, CountableDjangoObjectType):
 
 
 @key(fields="id")
-class Product(ChannelContextType, CountableDjangoObjectType):
+class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     url = graphene.String(
         description="The storefront URL for the product.",
         required=True,

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -127,7 +127,7 @@ class ProductPricingInfo(BasePricingInfo):
 
 
 class ChannelContextType(DjangoObjectType):
-    """A Graphene type used with resolvers root objects wrapped with ChannelContext."""
+    """A Graphene type that supports resolvers' root as ChannelContext objects."""
 
     class Meta:
         abstract = True
@@ -146,6 +146,16 @@ class ChannelContextType(DjangoObjectType):
     @classmethod
     def is_type_of(cls, root: ChannelContext, info):
         return super().is_type_of(root.node, info)
+
+    @staticmethod
+    def resolve_metadata(root: ChannelContext, info):
+        # Used in metadata API to resolve metadata fields from an instance.
+        return ObjectWithMetadata.resolve_metadata(root.node, info)
+
+    @staticmethod
+    def resolve_private_metadata(root: ChannelContext, info):
+        # Used in metadata API to resolve private metadata fields from an instance.
+        return ObjectWithMetadata.resolve_private_metadata(root.node, info)
 
 
 @key(fields="id")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -609,7 +609,16 @@ class Product(ChannelContextType, CountableDjangoObjectType):
 
     @staticmethod
     def resolve_variants(root: ChannelContext, info, **_kwargs):
-        return ProductVariantsByProductIdLoader(info.context).load(root.node.id)
+        return (
+            ProductVariantsByProductIdLoader(info.context)
+            .load(root.node.id)
+            .then(
+                lambda variants: [
+                    ChannelContext(node=variant, channel_slug=root.channel_slug)
+                    for variant in variants
+                ]
+            )
+        )
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -409,17 +409,6 @@ class ProductVariant(ChannelContextType, CountableDjangoObjectType):
     def resolve_images(root: ChannelContext, *_args):
         return root.node.images.all()
 
-    # FIXME: Implement access to node at resolver level if possible
-    # @classmethod
-    # def get_node(cls, info, pk):
-    #     user = info.context.user
-    #     channel = get_default_channel_or_graphql_error()
-    #     visible_products = models.Product.objects.visible_to_user(
-    #         user, channel.slug
-    #     ).values_list("pk", flat=True)
-    #     qs = cls._meta.model.objects.filter(product__id__in=visible_products)
-    #     return qs.filter(pk=pk).first()
-
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_private_meta(root: ChannelContext, _info):
@@ -650,16 +639,6 @@ class Product(ChannelContextType, CountableDjangoObjectType):
     @staticmethod
     def resolve_collections(root: ChannelContext, *_args):
         return root.node.collections.all()
-
-    # FIXME: Implement access to node at resolver level if possible
-    # @classmethod
-    # def get_node(cls, info, pk):
-    #     if info.context:
-    #         user = info.context.user
-    #         channel = get_default_channel_or_graphql_error()
-    #         qs = cls._meta.model.objects.visible_to_user(user, channel.slug)
-    #         return qs.filter(pk=pk).first()
-    #     return None
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -3,8 +3,6 @@ from dataclasses import asdict
 import graphene
 from django.conf import settings
 from graphene import relay
-from graphene.types.resolver import get_default_resolver
-from graphene_django.types import DjangoObjectType
 from graphene_federation import key
 from graphql.error import GraphQLError
 
@@ -28,6 +26,7 @@ from ....warehouse.availability import (
 )
 from ...account.enums import CountryCodeEnum
 from ...channel import ChannelContext, ChannelQsContext
+from ...channel.types import ChannelContextType
 from ...channel.utils import get_default_channel_or_graphql_error
 from ...core.connection import CountableDjangoObjectType
 from ...core.enums import ReportingPeriod, TaxRateType
@@ -42,7 +41,6 @@ from ...discount.dataloaders import DiscountsByDateTimeLoader
 from ...meta.deprecated.resolvers import resolve_meta, resolve_private_meta
 from ...meta.types import ObjectWithMetadata
 from ...translations.fields import TranslationField
-from ...translations.resolvers import resolve_translation
 from ...translations.types import (
     CategoryTranslation,
     CollectionTranslation,
@@ -125,43 +123,6 @@ class ProductPricingInfo(BasePricingInfo):
 
     class Meta:
         description = "Represents availability of a product in the storefront."
-
-
-class ChannelContextType(DjangoObjectType):
-    """A Graphene type that supports resolvers' root as ChannelContext objects."""
-
-    class Meta:
-        abstract = True
-
-    @staticmethod
-    def resolver_with_context(
-        attname, default_value, root: ChannelContext, info, **args
-    ):
-        resolver = get_default_resolver()
-        return resolver(attname, default_value, root.node, info, **args)
-
-    @staticmethod
-    def resolve_id(root: ChannelContext, _info):
-        return root.node.pk
-
-    @classmethod
-    def is_type_of(cls, root: ChannelContext, info):
-        return super().is_type_of(root.node, info)
-
-    @staticmethod
-    def resolve_metadata(root: ChannelContext, info):
-        # Used in metadata API to resolve metadata fields from an instance.
-        return ObjectWithMetadata.resolve_metadata(root.node, info)
-
-    @staticmethod
-    def resolve_private_metadata(root: ChannelContext, info):
-        # Used in metadata API to resolve private metadata fields from an instance.
-        return ObjectWithMetadata.resolve_private_metadata(root.node, info)
-
-    @staticmethod
-    def resolve_translation(root: ChannelContext, info, language_code):
-        # Resolver for TranslationField; needs to be manually specified.
-        return resolve_translation(root.node, info, language_code)
 
 
 @key(fields="id")

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -719,10 +719,10 @@ type Category implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  ancestors(channel: String, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
-  children(channel: String, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
 }
@@ -1128,7 +1128,7 @@ type Collection implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
 }
@@ -4006,12 +4006,12 @@ type ProductType implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   taxRate: TaxRateType
   taxType: TaxType
   variantAttributes: [Attribute]
   productAttributes: [Attribute]
-  availableAttributes(filter: AttributeFilterInput, channel: String, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
+  availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
 }
 
 type ProductTypeBulkDelete {
@@ -4301,75 +4301,75 @@ type ProductVariantUpdatePrivateMeta {
 
 type Query {
   webhook(id: ID!): Webhook
-  webhooks(sortBy: WebhookSortingInput, filter: WebhookFilterInput, channel: String, before: String, after: String, first: Int, last: Int): WebhookCountableConnection @deprecated(reason: "Use webhooks field on app(s) query instead. This field will be removed after 2020-07-31.")
+  webhooks(sortBy: WebhookSortingInput, filter: WebhookFilterInput, before: String, after: String, first: Int, last: Int): WebhookCountableConnection @deprecated(reason: "Use webhooks field on app(s) query instead. This field will be removed after 2020-07-31.")
   webhookEvents: [WebhookEvent]
   webhookSamplePayload(eventType: WebhookSampleEventTypeEnum!): JSONString
   warehouse(id: ID!): Warehouse
-  warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, channel: String, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
+  warehouses(filter: WarehouseFilterInput, sortBy: WarehouseSortingInput, before: String, after: String, first: Int, last: Int): WarehouseCountableConnection
   translations(kind: TranslatableKinds!, before: String, after: String, first: Int, last: Int): TranslatableItemConnection
-  translation(id: ID!, kind: TranslatableKinds!, channel: String): TranslatableItem
+  translation(id: ID!, kind: TranslatableKinds!): TranslatableItem
   stock(id: ID!): Stock
-  stocks(filter: StockFilterInput, channel: String, before: String, after: String, first: Int, last: Int): StockCountableConnection
+  stocks(filter: StockFilterInput, before: String, after: String, first: Int, last: Int): StockCountableConnection
   shop: Shop!
   shippingZone(id: ID!): ShippingZone
-  shippingZones(channel: String, before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
+  shippingZones(before: String, after: String, first: Int, last: Int): ShippingZoneCountableConnection
   digitalContent(id: ID!): DigitalContent
-  digitalContents(channel: String, before: String, after: String, first: Int, last: Int): DigitalContentCountableConnection
-  attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, channel: String, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
+  digitalContents(before: String, after: String, first: Int, last: Int): DigitalContentCountableConnection
+  attributes(filter: AttributeFilterInput, sortBy: AttributeSortingInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
   attribute(id: ID!): Attribute
-  categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, channel: String, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  category(id: ID, slug: String, channel: String): Category
+  categories(filter: CategoryFilterInput, sortBy: CategorySortingInput, level: Int, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  category(id: ID, slug: String): Category
   collection(id: ID, slug: String): Collection
-  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, channel: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  collections(filter: CollectionFilterInput, sortBy: CollectionSortingInput, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
   product(id: ID, slug: String, channel: String): Product
   products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  productType(id: ID!, channel: String): ProductType
-  productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, channel: String, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
-  productVariant(id: ID!, channel: String): ProductVariant
+  productType(id: ID!): ProductType
+  productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
+  productVariant(id: ID!): ProductVariant
   productVariants(ids: [ID], channel: String, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
-  reportProductSales(period: ReportingPeriod!, channel: String, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
+  reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment
-  payments(channel: String, before: String, after: String, first: Int, last: Int): PaymentCountableConnection
+  payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection
   page(id: ID, slug: String): Page
-  pages(sortBy: PageSortingInput, filter: PageFilterInput, channel: String, before: String, after: String, first: Int, last: Int): PageCountableConnection
-  homepageEvents(channel: String, before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
+  pages(sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
+  homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
-  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
-  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  draftOrders(sortBy: OrderSortingInput, filter: OrderDraftFilterInput, created: ReportingPeriod, before: String, after: String, first: Int, last: Int): OrderCountableConnection
   ordersTotal(period: ReportingPeriod): TaxedMoney
   orderByToken(token: UUID!): Order
   menu(id: ID, name: String): Menu
-  menus(sortBy: MenuSortingInput, filter: MenuFilterInput, channel: String, before: String, after: String, first: Int, last: Int): MenuCountableConnection
+  menus(sortBy: MenuSortingInput, filter: MenuFilterInput, before: String, after: String, first: Int, last: Int): MenuCountableConnection
   menuItem(id: ID!): MenuItem
-  menuItems(sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, channel: String, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
+  menuItems(sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
   giftCard(id: ID!): GiftCard
-  giftCards(channel: String, before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
+  giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   plugin(id: ID!): Plugin
   plugins(filter: PluginFilterInput, sortBy: PluginSortingInput, before: String, after: String, first: Int, last: Int): PluginCountableConnection
   sale(id: ID!): Sale
-  sales(filter: SaleFilterInput, sortBy: SaleSortingInput, query: String, channel: String, before: String, after: String, first: Int, last: Int): SaleCountableConnection
+  sales(filter: SaleFilterInput, sortBy: SaleSortingInput, query: String, before: String, after: String, first: Int, last: Int): SaleCountableConnection
   voucher(id: ID!): Voucher
-  vouchers(filter: VoucherFilterInput, sortBy: VoucherSortingInput, query: String, channel: String, before: String, after: String, first: Int, last: Int): VoucherCountableConnection
+  vouchers(filter: VoucherFilterInput, sortBy: VoucherSortingInput, query: String, before: String, after: String, first: Int, last: Int): VoucherCountableConnection
   exportFile(id: ID!): ExportFile
-  exportFiles(filter: ExportFileFilterInput, sortBy: ExportFileSortingInput, channel: String, before: String, after: String, first: Int, last: Int): ExportFileCountableConnection
+  exportFiles(filter: ExportFileFilterInput, sortBy: ExportFileSortingInput, before: String, after: String, first: Int, last: Int): ExportFileCountableConnection
   taxTypes: [TaxType]
   checkout(token: UUID, channel: String): Checkout
   checkouts(before: String, after: String, first: Int, last: Int): CheckoutCountableConnection
   checkoutLine(id: ID): CheckoutLine
-  checkoutLines(channel: String, before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
+  checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
   channel(id: ID): Channel
   channels: [Channel!]
   appsInstallations: [AppInstallation!]!
-  apps(filter: AppFilterInput, sortBy: AppSortingInput, channel: String, before: String, after: String, first: Int, last: Int): AppCountableConnection
+  apps(filter: AppFilterInput, sortBy: AppSortingInput, before: String, after: String, first: Int, last: Int): AppCountableConnection
   app(id: ID!): App
   addressValidationRules(countryCode: CountryCode!, countryArea: String, city: String, cityArea: String): AddressValidationData
   address(id: ID!): Address
-  customers(filter: CustomerFilterInput, sortBy: UserSortingInput, channel: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
-  permissionGroups(filter: PermissionGroupFilterInput, sortBy: PermissionGroupSortingInput, channel: String, before: String, after: String, first: Int, last: Int): GroupCountableConnection
+  customers(filter: CustomerFilterInput, sortBy: UserSortingInput, before: String, after: String, first: Int, last: Int): UserCountableConnection
+  permissionGroups(filter: PermissionGroupFilterInput, sortBy: PermissionGroupSortingInput, before: String, after: String, first: Int, last: Int): GroupCountableConnection
   permissionGroup(id: ID!): Group
   me: User
-  staffUsers(filter: StaffUserInput, sortBy: UserSortingInput, channel: String, before: String, after: String, first: Int, last: Int): UserCountableConnection
-  serviceAccounts(filter: ServiceAccountFilterInput, sortBy: ServiceAccountSortingInput, channel: String, before: String, after: String, first: Int, last: Int): ServiceAccountCountableConnection @deprecated(reason: "Use the `apps` query instead. This field will be removed after 2020-07-31.")
+  staffUsers(filter: StaffUserInput, sortBy: UserSortingInput, before: String, after: String, first: Int, last: Int): UserCountableConnection
+  serviceAccounts(filter: ServiceAccountFilterInput, sortBy: ServiceAccountSortingInput, before: String, after: String, first: Int, last: Int): ServiceAccountCountableConnection @deprecated(reason: "Use the `apps` query instead. This field will be removed after 2020-07-31.")
   serviceAccount(id: ID!): ServiceAccount @deprecated(reason: "Use the `app` query instead. This field will be removed after 2020-07-31.")
   user(id: ID!): User
   _entities(representations: [_Any]): [_Entity]
@@ -4416,9 +4416,9 @@ type Sale implements Node {
   value: Float!
   startDate: DateTime!
   endDate: DateTime
-  categories(channel: String, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  collections(channel: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
 }
 
@@ -5213,8 +5213,8 @@ type User implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   addresses: [Address]
   checkout: Checkout
-  giftCards(channel: String, before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
-  orders(channel: String, before: String, after: String, first: Int, last: Int): OrderCountableConnection
+  giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
+  orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
   permissions: [Permission] @deprecated(reason: "Will be removed in Saleor 2.11.Use the `userPermissions` instead.")
   userPermissions: [UserPermission]
   permissionGroups: [Group]
@@ -5358,9 +5358,9 @@ type Voucher implements Node {
   discountValue: Float!
   minSpent: Money
   minCheckoutItemsQuantity: Int
-  categories(channel: String, before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  collections(channel: String, before: String, after: String, first: Int, last: Int): CollectionCountableConnection
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  categories(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
+  collections(before: String, after: String, first: Int, last: Int): CollectionCountableConnection
+  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   countries: [CountryDisplay]
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -720,7 +720,7 @@ type Category implements Node & ObjectWithMetadata {
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
@@ -1128,7 +1128,7 @@ type Collection implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4327,7 +4327,7 @@ type Query {
   productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
   productVariant(id: ID!, channel: String): ProductVariant
   productVariants(ids: [ID], channel: String, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
-  reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
+  reportProductSales(period: ReportingPeriod!, channel: String, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment
   payments(before: String, after: String, first: Int, last: Int): PaymentCountableConnection
   page(id: ID, slug: String): Page

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4006,7 +4006,7 @@ type ProductType implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "Use the top-level `products` query with the `productTypes` filter.")
   taxRate: TaxRateType
   taxType: TaxType
   variantAttributes: [Attribute]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4006,7 +4006,7 @@ type ProductType implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   taxRate: TaxRateType
   taxType: TaxType
   variantAttributes: [Attribute]
@@ -4325,7 +4325,7 @@ type Query {
   products(filter: ProductFilterInput, sortBy: ProductOrder, stockAvailability: StockAvailability, channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   productType(id: ID!): ProductType
   productTypes(filter: ProductTypeFilterInput, sortBy: ProductTypeSortingInput, before: String, after: String, first: Int, last: Int): ProductTypeCountableConnection
-  productVariant(id: ID!): ProductVariant
+  productVariant(id: ID!, channel: String): ProductVariant
   productVariants(ids: [ID], channel: String, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   reportProductSales(period: ReportingPeriod!, before: String, after: String, first: Int, last: Int): ProductVariantCountableConnection
   payment(id: ID!): Payment

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -7,6 +7,7 @@ from ...menu import models as menu_models
 from ...page import models as page_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
+from ..channel import ChannelContext
 from ..core.mutations import BaseMutation, ModelMutation, registry
 from ..core.types.common import TranslationError
 from ..core.utils import from_global_id_strict_type
@@ -96,6 +97,7 @@ class ProductTranslate(BaseTranslateMutation):
         product.translations.update_or_create(
             language_code=data["language_code"], defaults=data["input"]
         )
+        product = ChannelContext(node=product, channel_slug=None)
         return cls(**{cls._meta.return_field_name: product})
 
 
@@ -140,6 +142,7 @@ class ProductVariantTranslate(BaseTranslateMutation):
         variant.translations.update_or_create(
             language_code=data["language_code"], defaults=data["input"]
         )
+        variant = ChannelContext(node=variant, channel_slug=None)
         return cls(**{cls._meta.return_field_name: variant})
 
 

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -14,7 +14,7 @@ from ...product.models import (
 )
 from ...shipping.models import ShippingMethod
 from ..core.connection import CountableConnection
-from ..core.fields import BaseConnectionField, FieldWithChannel
+from ..core.fields import BaseConnectionField
 from ..decorators import permission_required
 from ..discount.resolvers import resolve_sales, resolve_vouchers
 from ..menu.resolvers import resolve_menu_items
@@ -77,7 +77,7 @@ class TranslationQueries(graphene.ObjectType):
             TranslatableKinds, required=True, description="Kind of objects to retrieve."
         ),
     )
-    translation = FieldWithChannel(
+    translation = graphene.Field(
         TranslatableItem,
         id=graphene.Argument(
             graphene.ID, description="ID of the object to retrieve.", required=True

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -8,6 +8,7 @@ from ...page import models as page_models
 from ...product import models as product_models
 from ...shipping import models as shipping_models
 from ...site import models as site_models
+from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import LanguageDisplay
 from ..core.utils import str_to_enum
@@ -124,7 +125,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_product_variant(root: product_models.ProductVariant, info):
-        return root
+        return ChannelContext(node=root, channel_slug=None)
 
 
 class ProductTranslation(BaseTranslationType):
@@ -148,7 +149,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_product(root: product_models.Product, info):
-        return root
+        return ChannelContext(node=root, channel_slug=None)
 
 
 class CollectionTranslation(BaseTranslationType):

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -5,6 +5,7 @@ from django.db.models.functions import Coalesce
 from ...core.permissions import ProductPermissions
 from ...warehouse import models
 from ..account.enums import CountryCodeEnum
+from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
 from ..decorators import permission_required
 
@@ -86,3 +87,7 @@ class Stock(CountableDjangoObjectType):
         return root.allocations.aggregate(
             quantity_allocated=Coalesce(Sum("quantity_allocated"), 0)
         )["quantity_allocated"]
+
+    @staticmethod
+    def resolve_product_variant(root, *_args):
+        return ChannelContext(node=root.product_variant, channel_slug=None)

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -113,9 +113,6 @@ class ProductType(ModelWithMetadata):
 
 
 class ProductsQueryset(models.QuerySet):
-    def in_channel(self, channel_slug):
-        return self.filter(channel_listing__channel__slug=channel_slug)
-
     def collection_sorted(self, user: "User", channel_slug: str):
         qs = self.visible_to_user(user, channel_slug)
         qs = qs.order_by(
@@ -126,10 +123,10 @@ class ProductsQueryset(models.QuerySet):
 
     def published(self, channel_slug: str):
         today = datetime.date.today()
-        qs = self.in_channel(channel_slug)
-        return qs.filter(
+        return self.filter(
             Q(channel_listing__publication_date__lte=today)
             | Q(channel_listing__publication_date__isnull=True),
+            channel_listing__channel__slug=channel_slug,
             channel_listing__is_published=True,
         )
 
@@ -139,7 +136,7 @@ class ProductsQueryset(models.QuerySet):
 
     def visible_to_user(self, user: "User", channel_slug: str):
         if self.user_has_access_to_all(user):
-            return self.in_channel(channel_slug)
+            return self.all()
         return self.published_with_variants(channel_slug)
 
     @staticmethod

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -9,7 +9,6 @@ from django.db import models
 from django.db.models import Case, Count, F, FilteredRelation, Q, Value, When
 from django.urls import reverse
 from django.utils.encoding import smart_text
-from django.utils.functional import SimpleLazyObject
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField
 from draftjs_sanitizer import clean_draft_js

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -488,7 +488,7 @@ OPENTRACING_MAX_QUERY_LENGTH_LOG = 2000
 DEFAULT_MENUS = {"top_menu_name": "navbar", "bottom_menu_name": "footer"}
 
 # Slug for channel precreated in Django migrations
-DEFAULT_CHANNEL_SLUG = os.environ.get("DEFAULT_CHANNEL_SLUG", "saleor-default-channel")
+DEFAULT_CHANNEL_SLUG = os.environ.get("DEFAULT_CHANNEL_SLUG", "default-channel")
 
 
 #  Sentry
@@ -504,7 +504,6 @@ GRAPHENE = {
     "MIDDLEWARE": [
         "saleor.graphql.middleware.OpentracingGrapheneMiddleware",
         "saleor.graphql.middleware.JWTMiddleware",
-        "saleor.graphql.middleware.ChannelMiddleware",
         "saleor.graphql.middleware.app_middleware",
     ],
 }


### PR DESCRIPTION
Drop channel middleware and replace it with explicitly passed context objects that store the channel that was passed in the top-level resolver and the resolved object.

Some product mutations may still not work but I think we should merge it to not use channel middleware anymore in other PRs and in the meantime I'll be fixing other things that do not work.

Other changes:
- Removed implicit channel arg from `PrefetchingConnectionField` - I think we should use it explicitly and make sure that it's properly resolved, instead of automatically adding it to all connections. Also, it's not needed in all of them now. The same applies to `FieldWithChannel` field, for now, I removed its usages and will keep adding channel arg where it's needed.
- added some docstrings to utility functions
- renamed custom exceptions

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
