### PR TITLE
Add auto capture flags for Adyen and Saleor

### DIFF
--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -122,7 +122,7 @@ def capture(
     response, error = _fetch_gateway_response(
         plugin_manager.capture_payment, payment.gateway, payment_data
     )
-    if response.card_info:
+    if response and response.card_info:
         update_card_details(payment, response)
     return create_transaction(
         payment=payment,

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -314,7 +314,7 @@ class AdyenGatewayPlugin(BasePlugin):
     ) -> "GatewayResponse":
 
         _type, payment_id = from_global_id(payment_information.payment_id)
-        # we take Auth kind because it contains the transaction it that we need
+        # we take Auth kind because it contains the transaction id that we need
         transaction = (
             Transaction.objects.filter(
                 payment__id=payment_id, kind=TransactionKind.AUTH

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_handle_authorization_with_auto_capture.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_handle_authorization_with_auto_capture.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: '{"merchantAccount": "SaleorECOM", "modificationAmount": {"value": "123400",
+      "currency": "USD"}, "originalReference": "853596537720508F", "reference": "UGF5bWVudDoxMA==",
+      "applicationInfo": {"adyenLibrary": {"name": "adyen-python-api-library", "version":
+      "3.0.0"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '264'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - adyen-python-api-library/3.0.0
+      x-api-key:
+        - test_key
+    method: POST
+    uri: https://pal-test.adyen.com/pal/servlet/Payment/v49/capture
+  response:
+    body:
+      string: '{"pspReference":"853596621736884E","response":"[capture-received]"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Aug 2020 10:02:16 GMT
+      Keep-Alive:
+      - timeout=15, max=100
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=DE99DF461A79A101442FF0B7820C68D1.test4e; Path=/pal; Secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      pspReference:
+      - 853596621736884E
+    status:
+      code: 200
+      message: '200'
+version: 1

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment_with_adyen_auto_capture.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment_with_adyen_auto_capture.yaml
@@ -1,0 +1,48 @@
+interactions:
+- request:
+    body: '{"amount": {"value": "123400", "currency": "USD"}, "reference": "UGF5bWVudDo3",
+                "paymentMethod": {"paymentdata": ""}, "returnUrl": "http://127.0.0.1:3000/",
+                "merchantAccount": "SaleorECOM", "applicationInfo": {"adyenLibrary": {"name":
+                "adyen-python-api-library", "version": "3.0.0"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '4444'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - adyen-python-api-library/3.0.0
+      x-api-key:
+      - test_key
+    method: POST
+    uri: https://checkout-test.adyen.com/v49/payments
+  response:
+    body:
+      string: '{"pspReference":"882595494831959A","resultCode":"Authorised","merchantReference":"UGF5bWVudDoz"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jul 2020 09:00:31 GMT
+      Keep-Alive:
+      - timeout=15, max=100
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=16B2B5BA678472CFD5D8FEE7C6EB1227.test103e; Path=/checkout; Secure;
+        HttpOnly
+      Transfer-Encoding:
+      - chunked
+      pspReference:
+      - 881595494831497D
+    status:
+      code: 200
+      message: '200'
+version: 1

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment_with_auto_capture.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment_with_auto_capture.yaml
@@ -1,9 +1,17 @@
 interactions:
 - request:
-    body: '{"amount": {"value": "123400", "currency": "USD"}, "reference": "UGF5bWVudDo3",
-                "paymentMethod": {"paymentdata": ""}, "returnUrl": "http://127.0.0.1:3000/",
-                "merchantAccount": "SaleorECOM", "applicationInfo": {"adyenLibrary": {"name":
-                "adyen-python-api-library", "version": "3.0.0"}}}'
+    body: '{"amount": {"value": "123400", "currency": "USD"}, "reference": "UGF5bWVudDoxNw==",
+      "paymentMethod": {"type": "scheme", "holderName": "John Doe", "encryptedCardNumber":
+      "adyenjs_0_1_25$I4hADbyBrUvNV2Zv+lQcRZdBtj0pYYjRHweEJ7NgT+Lk91H77GhomGxuSuyQKE71qyOdloMBI/dB9AhYLzM3WkkpOdO903XHQfceMHrbfrMw7yYOcLg99bSYx3E0kgr1jgG0bNSnwG6SHW7bZO+ZC+FJ96juHFwjLIIsWVtZ0SCvhXdMdsvQwIGAQ6ry+J7AdVaAcLRWYQRwVl05CaXOTqoSIiwWgrj9nucbQfKVGaoi/eldsFzbs0Ou72ap9piKo0+1wtj4SMjJUPX8WO37uWZUgH2RjKRDCVAZgc7V2DbaZKmU5o9LHyFxEnjn37zTxf+XiEQWxYpfMFJc0+66WA==$rdYYJn4cYOlzPDauDrb5WW7x6RQzzyJrk8RuipaqxsUeGbmkJRh+JKogznXcLoRDltUcFITY2+hsYlfmCMq0Xii8mpBUJfHNJSwz/23/DPykr5uYPDWJctrsxnvl3/eNziPrymrXSW39gDAV50gG6xsce5gSybXoya8iJG5FGKIQi+0yrp6H4+c/dCMOXi7zj2tZl7WJg+Mm9KoCy0QuN9OzVjfNdWMUDlnNic08/8+jZlhKhk2iDby0IEIKcKtjm9/PkBKlJ6G7iGM/ka1cmL1SF1DRB1Ilv5nK6PqutfgrwgxKjtBHejFbqhI4S3raDgelJycz3yyvhj3ofKv8dcrR1hJuQcslolv2UFwRE37gDjXwT4xL1W37tZen5NqGOf51GIn62Wd03rFbFFmVuiI0MsLLuVVyoT/pzi6SVHlE+h76w6Sg8b/MvDaUwaBDTvGISP1IPFz9ViWlSbb4EXo2yLaw7KVjqmQMZAy1WVWt4cHQKD6nUH6Q0t6WRH/7L/MbwJqVAxBzikEbS0FuolvhQ1Hn04BbI+bo4shgplA7GviJ8hverCoZ7528kWxiUfo4oSIrC0MjXtEBdABdC0SS1pd1qYXg0aot+0sPqULVPXcDi5Zpk7L4fb1koxOlUT7FBZLqY18bmBMxU8khfL5boHRy402aRyZEZuOYbLw+/l7Mp8M85w4Y+APC1kKO0YmJrq2YHXyN2OzDR68vbLLXpvSw6XNdskZew7pwqg8HWR8s2QElZz3EQJ3dOtB659opAhYHwVc80Bid/lK4QuE3GZjf3NjU8T5R8dDyC5mCk9YCJyA0jC4vrSdrkqQ7ZGZz4NEgH8kJVSFCAJ+pINLoZfIUOgO8dTE=",
+      "encryptedExpiryMonth": "adyenjs_0_1_25$URPx4sYijaWTYxf+tDJjZWXvssRHxU8JYkfSpLSTf7AUU9JAraa+FPagzbQSICaaEE7cvuxwqtsV/39nHioHT0VCbTAhMxaUtpd5bMR6IM8IZK0qP8RAPNpBGWp/P4WAqNw9IJ+6YYTm8hR5vvloihQFZjzCELQGTUrzq6eWOscmM43Bl3oBDrKdkh48D6EjNXZIGbWV6xPC0xdIhLlkXR6El/ew/zdwpNpmxOdJOVHwN2/7EkYvZWbvx1UdSmTOR8pJRB4gA+1OL7YrfJ17mkW9O4TjQZwP3ASY/k1GFXZ1uQX5dm6eja9ynHJ/kSxkPOutfTP2Bdc7Wa/gNjtoPg==$7sGsVjqQAN242J0J8sUGJ+STsHl/Zq29fd+mMDjT3CT7duMEajMVm90ia3yccXW4xeRI1Pm7Q0GnKxruoA2ma2p4djT6obZ1YgE6ay8/vhEEEvqL8fjMQIgNxijVGiX2aHLKtithWJnAYOyJcoCdM+OXlC1k4X/lpS4cBiq4PLml9/LPs/i5z5YGjnwZg1lu1I3o0WWtx43+YZk7g/J8S8yVRv+kYx1dIzpr3Z0POnwjE8VAfXBeBw0oc3PN3PzRgy70zdYEdSffjtjtP2wtuwMW2UW1NqFsQRdvX3CAD8EEC19w98Hn3f3PDSCM9LZqS9wwF0Tzu2/Hd4IhJlMRZr5IrLexbUfTN7fmOZVSw5TusUHS1G3gOy6OoXA/VLV9VVct3zNkpiOt4LqmpME8lEJfy/NMxePV7IjVbZmzHybHoClS4wmC++N+3jS5VQ+aR1TNv61f+AWNynV4hrq4",
+      "encryptedExpiryYear": "adyenjs_0_1_25$Tf2w4PYP2iBE3VySwxVKQWRWbiGkH76FajWdRyK58ZX5bJSBykJOF4QjlvwU494hdTEYc8lfMaqvenDtyudv2/2jTSWWnLAMOkrOm4iXiQncPo1iUCMvQ1XMxM0hPmMknEjtNHniQWSUhTo9ENNseYZFeSJvIBt6zXeszifHjar7JrfniHjWVq3jp1OehlnnTCKdfv8SldC5hv4PCyhXbrM+Y6AuK+JaTQkbS5qmL0BFHXZzxhj8LvEVAM8rkqHEOGBHjyTBBG7Hx5ZFoqShmwqy+XLTEzZt9hjhLoB1a5qFIfmrrtsTRjviJOFZ0kTYbSvmITuTyzARtvkzD0HNlw==$C2y5QW7nFc98rCPMi4YqVxl77tqHsS5V4qWyIk/PiDPWd0EfQFGDmMGjxgxwfQlKO1RMzBmtnwHB3eRtI25fVBAciCMAnGC80YaKU+eDAgk3HedOZOTr24hzIO7UJcuNRWWjpbT0/UFCGoqYvBZNJPqXFUy3YTtV48sMtEqVXHUms1aIG1C0u+Yg1f89q30WkWNm24VuQl7/UOd0e6VsAvvBnNsXLQGZZpJXVpAndrDEOnw8ynWyxmk0jto6FiZfjlGlXg7dWDmgwOv5n62rCwna+gcM5OsaGjYHzNCjh4RGb793P/JDpciX2m1mMafGt9dgl/wqq1S0zNkGMVVLjOwUItATaIIvgdLU16znuU2i1N1CKLq7D++5KNMdMtajjd+S/0dcz9XBAtd9UsZq2RHXlb3pVGQ9+sNZsGCcm5KaEDDO0NqqyKig/hnIcX0tZd8G/6quilxOcsTHKvgE+g==",
+      "encryptedSecurityCode": "adyenjs_0_1_25$zmPMMRliaba9CMhviVvVl4hH6gYNK5RErn5ZZWa2tqh9uXi3s69AZCT5ZkpWJrQzIc5W06Ep4VL90QFsiUzdIjYHYaJkJGxC05yjEp985fLo75c8cwhV9AC5oCb+37rSVfQEU1KeacHxqsFNChUSH/TKofGZG7zOn0vMFJmoMwxDtSCNaLhvXSJUEVubMWD6A9NFQQ6yyT9XDrGuy3fmgyGoGwmfmbWZAWkwJhQ0J9DNpw51TGDxy4/QgSqxPaqhyk7XvkBRzv5nGOyJNIJWk7nuNx2aWabl36LVGsfYUPhHjIGfS8GZwNruUQ5M4qoV7feCZzwdtHFM5oiqDWszvg==$TxqgWYengy/dlzkfFejQmcaIfS1nWnvXVLb7EdLdPIBDBcKv9jlO9wRgz7MjkBeLwd0u0+av3VFd2jrt4sQIA/JNCcTCK+RIYxAY0FxstzhnY/tgFEbCKh6vM95s5txpt1AYg3dJgQvtksiklngnEqyyWWbKkn3mPF7pmVXZNz848nsu+eXXGmZ5vFF1A7nf2AOoSv504u8d4B/xOapkymESrPoc9Fi/Su4DgVvMRt1OE6et7pYLlAGVfJzdJGu2ZebN9MFhQEiIuZgtd+eKNzwOoZF6AiVQBBD3vyjeXbZN7Sz0NAafDGnJBQ/yfT63TroZ8otkE5IJa9Vja+IGUy3m3HfGI0zZ+KsBI8bjI9ILgrycbktJfYZKSGRKf+ftQ0FF4ClKN9rblQDTshVU+XZ6CUj77Z9tZmeUxYAZxr4LKH/ELUoRZjaF5W/bO5XBawRLsh+JfaE="},
+      "returnUrl": "http://127.0.0.1:3000/", "merchantAccount": "SaleorECOM", "browserInfo":
+      {"acceptHeader": "*/*", "colorDepth": 24, "language": "en-gb", "javaEnabled":
+      true, "screenHeight": 1440, "screenWidth": 2560, "userAgent": "Mozilla/5.0 (Macintosh;
+      Intel Mac OS X 10_15_4) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1
+      Safari/605.1.15", "timeZoneOffset": -120}, "applicationInfo": {"adyenLibrary":
+      {"name": "adyen-python-api-library", "version": "3.0.0"}}}'
     headers:
       Accept:
       - '*/*'
@@ -12,36 +20,81 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '4444'
+      - '4433'
       Content-Type:
       - application/json
       User-Agent:
       - adyen-python-api-library/3.0.0
       x-api-key:
-      - test_key
+        - test_key
     method: POST
     uri: https://checkout-test.adyen.com/v49/payments
   response:
     body:
-      string: '{"pspReference":"882595494831959A","resultCode":"Authorised","merchantReference":"UGF5bWVudDoz"}'
+      string: '{"pspReference":"883596624248178D","resultCode":"Authorised","merchantReference":"UGF5bWVudDoxNw=="}'
     headers:
       Connection:
       - Keep-Alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 23 Jul 2020 09:00:31 GMT
+      - Wed, 05 Aug 2020 10:44:08 GMT
       Keep-Alive:
       - timeout=15, max=100
       Server:
       - Apache
       Set-Cookie:
-      - JSESSIONID=16B2B5BA678472CFD5D8FEE7C6EB1227.test103e; Path=/checkout; Secure;
+      - JSESSIONID=7C62498C2A031656D45B70E9A2F50F69.test3e; Path=/checkout; Secure;
         HttpOnly
       Transfer-Encoding:
       - chunked
       pspReference:
-      - 881595494831497D
+      - 851596624248090H
+    status:
+      code: 200
+      message: '200'
+- request:
+    body: '{"merchantAccount": "SaleorECOM", "modificationAmount": {"value": "123400",
+      "currency": "USD"}, "originalReference": "883596624248178D", "reference": "UGF5bWVudDoxNw==",
+      "applicationInfo": {"adyenLibrary": {"name": "adyen-python-api-library", "version":
+      "3.0.0"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '264'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - adyen-python-api-library/3.0.0
+      x-api-key:
+      - AQEhhmfuXNWTK0Qc+iSDk2g9qPaBhkT1nbWV8YkFf5Sl/5+mEMFdWw2+5HzctViMSCJMYAc=-4yzUVXf8vxvefP8rRR8UOK/fHR34XP+tZmVZZFWntAs=-?[Cv%4@EEx:C5b6f
+    method: POST
+    uri: https://pal-test.adyen.com/pal/servlet/Payment/v49/capture
+  response:
+    body:
+      string: '{"pspReference":"853596624248395G","response":"[capture-received]"}'
+    headers:
+      Connection:
+      - Keep-Alive
+      Content-Type:
+      - application/json;charset=utf-8
+      Date:
+      - Wed, 05 Aug 2020 10:44:08 GMT
+      Keep-Alive:
+      - timeout=15, max=100
+      Server:
+      - Apache
+      Set-Cookie:
+      - JSESSIONID=109BFB126438537FBB7852C4C592655E.test3e; Path=/pal; Secure; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      pspReference:
+      - 853596624248395G
     status:
       code: 200
       message: '200'

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -15,6 +15,7 @@ def adyen_plugin(settings):
         return_url=None,
         origin_key=None,
         origin_url=None,
+        adyen_auto_capture=None,
         auto_capture=None,
     ):
         api_key = api_key or "test_key"
@@ -22,6 +23,7 @@ def adyen_plugin(settings):
         return_url = return_url or "http://127.0.0.1:3000/"
         origin_key = origin_key or "test_origin_key"
         origin_url = origin_url or "http://127.0.0.1:3000"
+        adyen_auto_capture = adyen_auto_capture or False
         auto_capture = auto_capture or False
         settings.PLUGINS = ["saleor.payment.gateways.adyen.plugin.AdyenGatewayPlugin"]
         manager = get_plugins_manager()
@@ -37,8 +39,9 @@ def adyen_plugin(settings):
                     {"name": "Origin Url", "value": origin_url},
                     {
                         "name": "Automatically mark payment as a capture",
-                        "value": auto_capture,
+                        "value": adyen_auto_capture,
                     },
+                    {"name": "Automatic payment capture", "value": auto_capture},
                     {"name": "Supported currencies", "value": "USD"},
                 ],
             },

--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -28,7 +28,7 @@ def test_get_payment_gateway_for_checkout(
     }
     assert config[1]["field"] == "config"
     config = json.loads(config[1]["value"])
-    assert isinstance(config, list)
+    assert isinstance(config, dict)
 
 
 @pytest.mark.vcr
@@ -42,6 +42,25 @@ def test_process_payment(payment_adyen_for_checkout, checkout_with_items, adyen_
     assert response.is_success is True
     assert response.action_required is False
     assert response.kind == TransactionKind.AUTH
+    assert response.amount == Decimal("1234")
+    assert response.currency == checkout_with_items.currency
+    assert response.transaction_id == "882595494831959A"  # ID returned by Adyen
+    assert response.error is None
+
+
+@pytest.mark.vcr
+def test_process_payment_with_adyen_auto_capture(
+    payment_adyen_for_checkout, checkout_with_items, adyen_plugin
+):
+    payment_info = create_payment_information(
+        payment_adyen_for_checkout,
+        additional_data={"paymentMethod": {"paymentdata": ""}},
+    )
+    adyen_plugin = adyen_plugin(adyen_auto_capture=True)
+    response = adyen_plugin.process_payment(payment_info, None)
+    assert response.is_success is True
+    assert response.action_required is False
+    assert response.kind == TransactionKind.CAPTURE
     assert response.amount == Decimal("1234")
     assert response.currency == checkout_with_items.currency
     assert response.transaction_id == "882595494831959A"  # ID returned by Adyen
@@ -63,7 +82,7 @@ def test_process_payment_with_auto_capture(
     assert response.kind == TransactionKind.CAPTURE
     assert response.amount == Decimal("1234")
     assert response.currency == checkout_with_items.currency
-    assert response.transaction_id == "882595494831959A"  # ID returned by Adyen
+    assert response.transaction_id == "853596624248395G"  # ID returned by Adyen
     assert response.error is None
 
 

--- a/saleor/payment/gateways/adyen/tests/test_webhook.py
+++ b/saleor/payment/gateways/adyen/tests/test_webhook.py
@@ -71,7 +71,7 @@ def test_handle_authorization(notification, adyen_plugin, payment_adyen_for_orde
     assert transaction.kind == TransactionKind.AUTH
 
 
-def test_handle_authorization_with_autocapture(
+def test_handle_authorization_with_adyen_auto_capture(
     notification, adyen_plugin, payment_adyen_for_order
 ):
     payment = payment_adyen_for_order
@@ -81,24 +81,50 @@ def test_handle_authorization_with_autocapture(
         value=get_price_amount(payment.total, payment.currency),
     )
     config = adyen_plugin().config
-    config.auto_capture = True
+    config.connection_params["adyen_auto_capture"] = True
     handle_authorization(notification, config)
 
-    assert payment.transactions.count() == 0
+    assert payment.transactions.count() == 1
+    assert payment.transactions.get().kind == TransactionKind.CAPTURE
 
 
-def test_handle_authorization_with_autocapture_and_payment_charged(
+@pytest.mark.vcr
+def test_handle_authorization_with_auto_capture(
+    notification, adyen_plugin, payment_adyen_for_order
+):
+    payment = payment_adyen_for_order
+    payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+    notification = notification(
+        psp_reference="853596537720508F",
+        merchant_reference=payment_id,
+        value=get_price_amount(payment.total, payment.currency),
+    )
+    config = adyen_plugin().config
+    config.auto_capture = True
+    config.connection_params["adyen_auto_capture"] = False
+
+    handle_authorization(notification, config)
+
+    payment.refresh_from_db()
+    assert payment.transactions.count() == 2
+    assert payment.transactions.first().kind == TransactionKind.AUTH
+    assert payment.transactions.last().kind == TransactionKind.CAPTURE
+    assert payment.charge_status == ChargeStatus.FULLY_CHARGED
+
+
+def test_handle_authorization_with_adyen_auto_capture_and_payment_charged(
     notification, adyen_plugin, payment_adyen_for_order
 ):
     payment = payment_adyen_for_order
     payment.charge_status = ChargeStatus.FULLY_CHARGED
+    payment.save()
     payment_id = graphene.Node.to_global_id("Payment", payment.pk)
     notification = notification(
         merchant_reference=payment_id,
         value=get_price_amount(payment.total, payment.currency),
     )
     config = adyen_plugin().config
-    config.auto_capture = True
+    config.connection_params["adyen_auto_capture"] = True
     handle_authorization(notification, config)
 
     # payment already has a charge status no need to handle auth action
@@ -259,7 +285,7 @@ def test_handle_pending(notification, adyen_plugin, payment_adyen_for_order):
     assert payment.charge_status == ChargeStatus.PENDING
 
 
-def test_handle_pending_with_autocapture(
+def test_handle_pending_with_adyen_auto_capture(
     notification, adyen_plugin, payment_adyen_for_order
 ):
     payment = payment_adyen_for_order
@@ -269,15 +295,16 @@ def test_handle_pending_with_autocapture(
         value=get_price_amount(payment.total, payment.currency),
     )
     config = adyen_plugin().config
-    config.auto_capture = True
+    config.connection_params["adyen_auto_capture"] = True
 
     handle_pending(notification, config)
 
     # in case of autocapture we don't want to store the pending status as all payments
     # by default get capture status.
-    assert payment.transactions.count() == 0
+    assert payment.transactions.count() == 1
+    assert payment.transactions.get().kind == TransactionKind.PENDING
     payment.refresh_from_db()
-    assert payment.charge_status != ChargeStatus.PENDING
+    assert payment.charge_status == ChargeStatus.PENDING
 
 
 def test_handle_pending_already_pending(

--- a/saleor/payment/gateways/adyen/utils.py
+++ b/saleor/payment/gateways/adyen/utils.py
@@ -170,7 +170,7 @@ def request_for_payment_refund(
 
 
 def request_for_payment_capture(
-    payment_information: "PaymentData", merchant_account, token
+    payment_information: "PaymentData", merchant_account: str, token: str
 ) -> Dict[str, Any]:
     return {
         "merchantAccount": merchant_account,
@@ -183,3 +183,17 @@ def request_for_payment_capture(
         "originalReference": token,
         "reference": payment_information.payment_id,
     }
+
+
+def call_capture(
+    payment_information: "PaymentData",
+    merchant_account: str,
+    token: str,
+    adyen_client: Adyen.Adyen,
+):
+    request = request_for_payment_capture(
+        payment_information=payment_information,
+        merchant_account=merchant_account,
+        token=token,
+    )
+    return api_call(request, adyen_client.payment.capture)

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -20,6 +20,7 @@ from ....order.actions import (
 from ....order.events import external_notification_event
 from ....payment.models import Payment, Transaction
 from ... import ChargeStatus, TransactionKind
+from ...gateway import capture
 from ...interface import GatewayConfig, GatewayResponse
 from ...utils import create_transaction, gateway_postprocess
 from .utils import convert_adyen_price_format
@@ -90,18 +91,22 @@ def handle_authorization(notification: Dict[str, Any], gateway_config: GatewayCo
         ChargeStatus.PARTIALLY_CHARGED,
     }:
         return
-    mark_capture = gateway_config.auto_capture
-    if mark_capture:
-        # If we mark order as a capture by default we don't need to handle auth actions
-        return
+
+    kind = TransactionKind.AUTH
+    adyen_auto_capture = gateway_config.connection_params["adyen_auto_capture"]
+    if adyen_auto_capture:
+        kind = TransactionKind.CAPTURE
 
     transaction_id = notification.get("pspReference")
-    transaction = get_transaction(payment, transaction_id, TransactionKind.AUTH)
-    if transaction:
-        # We already marked it as Auth
+    transaction = payment.transactions.filter(
+        token=transaction_id, kind__in=[TransactionKind.AUTH, TransactionKind.CAPTURE]
+    ).first()
+
+    if transaction and transaction.is_success:
+        # We already have this transaction
         return
 
-    transaction = create_new_transaction(notification, payment, TransactionKind.AUTH)
+    transaction = create_new_transaction(notification, payment, kind)
     reason = notification.get("reason", "-")
 
     success_msg = f"Adyen: The payment  {transaction_id} request  was successful."
@@ -109,8 +114,17 @@ def handle_authorization(notification: Dict[str, Any], gateway_config: GatewayCo
     create_payment_notification_for_order(
         payment, success_msg, failed_msg, transaction.is_success
     )
-    if payment.order:
+    if not payment.order:
+        return
+
+    # If saleor has enabled auto capture we need to proceed the capture action.
+    if gateway_config.auto_capture:
+        capture(payment, amount=transaction.amount)
+
+    if kind == TransactionKind.AUTH:
         order_authorized(payment.order, None, transaction.amount, payment)
+    elif kind == TransactionKind.CAPTURE:
+        order_captured(payment.order, None, transaction.amount, payment)
 
 
 def handle_cancellation(notification: Dict[str, Any], _gateway_config: GatewayConfig):
@@ -207,10 +221,6 @@ def handle_failed_capture(notification: Dict[str, Any], _gateway_config: Gateway
 def handle_pending(notification: Dict[str, Any], gateway_config: GatewayConfig):
     # https://docs.adyen.com/development-resources/webhooks/understand-notifications#
     # event-codes"
-    mark_capture = gateway_config.auto_capture
-    if mark_capture:
-        # If we mark order as a capture by default we don't need to handle this action
-        return
     payment = get_payment(notification.get("merchantReference"))
     if not payment:
         return


### PR DESCRIPTION
Add two auto_capture flags to handle the cases where:
- Immediately auto-capture is enabled on the Adyen side
- auto-capture on the Adyen side is disabled and Saleor uses own auto-capture logic 