### PR TITLE
Add multiple origins in access control headers

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import traceback
-from urllib.parse import urlparse
 from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import urlparse
 
 import opentracing
 import opentracing.tags
@@ -99,10 +99,15 @@ class GraphQLView(View):
             return response
         url = urlparse(origin)
         origins = [urlparse(o) for o in settings.ALLOWED_GRAPHQL_ORIGINS]
-        if any(origin.scheme == url.scheme and origin.netloc == url.netloc for origin in origins):
+        if any(
+            origin.scheme == url.scheme and origin.netloc == url.netloc
+            for origin in origins
+        ):
             response["Access-Control-Allow-Origin"] = origin
         else:
-            response["Access-Control-Allow-Origin"] = settings.ALLOWED_GRAPHQL_ORIGINS[0]
+            response["Access-Control-Allow-Origin"] = settings.ALLOWED_GRAPHQL_ORIGINS[
+                0
+            ]
         response["Access-Control-Allow-Methods"] = "POST, OPTIONS"
         response[
             "Access-Control-Allow-Headers"

--- a/saleor/plugins/invoicing/tests/test_invoicing.py
+++ b/saleor/plugins/invoicing/tests/test_invoicing.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+import pytz
+
 from ....plugins.invoicing.utils import (
     chunk_products,
     generate_invoice_number,
@@ -40,7 +42,7 @@ def test_generate_invoice_pdf_for_order(
     get_template_mock.return_value.render.assert_called_once_with(
         {
             "invoice": fulfilled_order.invoices.first(),
-            "creation_date": datetime.today().strftime("%d %b %Y"),
+            "creation_date": datetime.now(tz=pytz.utc).strftime("%d %b %Y"),
             "order": fulfilled_order,
             "font_path": "file://test",
             "products_first_page": list(fulfilled_order.lines.all()),

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -390,7 +390,7 @@ TEST_RUNNER = "saleor.tests.runner.PytestTestRunner"
 PLAYGROUND_ENABLED = get_bool_from_env("PLAYGROUND_ENABLED", True)
 
 ALLOWED_HOSTS = get_list(os.environ.get("ALLOWED_HOSTS", "localhost,127.0.0.1"))
-ALLOWED_GRAPHQL_ORIGINS = os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*")
+ALLOWED_GRAPHQL_ORIGINS = get_list(os.environ.get("ALLOWED_GRAPHQL_ORIGINS", "*"))
 
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 


### PR DESCRIPTION
I want to merge this change because... it allows setting multiple values for `Access-Control-Allow-Origin` header.
I needed to set different origins for storefront and dashboard.
Also since recent dashboard changes, even local development with the header set to "*" is problematic because of this CORS error:
```
The value of the 'Access-Control-Allow-Origin' header in the response must not be the wildcard '*' when the request's credentials mode is 'include'.
```
This is my proposition to fix this problem. It is loosely based on [django-cors-headers](https://github.com/adamchainz/django-cors-headers) middleware.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
