### PR TITLE
Fix invoicing test timezone

### DIFF
--- a/saleor/plugins/invoicing/tests/test_invoicing.py
+++ b/saleor/plugins/invoicing/tests/test_invoicing.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from unittest.mock import Mock, patch
 
+import pytz
+
 from ....plugins.invoicing.utils import (
     chunk_products,
     generate_invoice_number,
@@ -40,7 +42,7 @@ def test_generate_invoice_pdf_for_order(
     get_template_mock.return_value.render.assert_called_once_with(
         {
             "invoice": fulfilled_order.invoices.first(),
-            "creation_date": datetime.today().strftime("%d %b %Y"),
+            "creation_date": datetime.now(tz=pytz.utc).strftime("%d %b %Y"),
             "order": fulfilled_order,
             "font_path": "file://test",
             "products_first_page": list(fulfilled_order.lines.all()),


### PR DESCRIPTION
I want to merge this change because... it fixes the invoicing test not passing at a certain time of day depending on the timezone.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
