### PR TITLE
Switch to Django 3.1, add support for ASGI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
     - SECRET_KEY="irrelevant"
     - QUERIES_RESULTS_PATH=/tmp/queries-results.json
   matrix:
-    - DJANGO="3.0"
+    - DJANGO="3.1"
     - DJANGO="master"
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Deprecate `WebhookEventType.CHECKOUT_QUANTITY_CHANGED`. It will be removed in Saleor 3.0 - #5837 by @korycins
 - Add dummy credit card payment - #5822 by @IKarbowiak
 - Anonymize and update order and payment fields; drop PaymentSecureConfirm mutation, drop Payment type fields: extraData, billingAddress, billingEmail, drop gatewayResponse from Transaction type - #5926 by @IKarbowiak
+- Switch the HTTP stack from WSGI to ASGI based on Uvicorn - #5960 by @patrys
 
 ### Fixes
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,14 +19,14 @@ RUN groupadd -r saleor && useradd -r -g saleor saleor
 
 RUN apt-get update \
   && apt-get install -y \
-    libxml2 \
-    libssl1.1 \
-    libcairo2 \
-    libpango-1.0-0 \
-    libpangocairo-1.0-0 \
-    libgdk-pixbuf2.0-0 \
-    shared-mime-info \
-    mime-support \
+  libxml2 \
+  libssl1.1 \
+  libcairo2 \
+  libpango-1.0-0 \
+  libpangocairo-1.0-0 \
+  libgdk-pixbuf2.0-0 \
+  shared-mime-info \
+  mime-support \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -43,8 +43,6 @@ ENV STATIC_URL ${STATIC_URL:-/static/}
 RUN SECRET_KEY=dummy STATIC_URL=${STATIC_URL} python3 manage.py collectstatic --no-input
 
 EXPOSE 8000
-ENV PORT 8000
 ENV PYTHONUNBUFFERED 1
-ENV PROCESSES 4
 
-CMD ["uwsgi", "--ini", "/app/saleor/wsgi/uwsgi.ini"]
+CMD ["gunicorn", "--bind", ":8000", "--workers", "4", "--worker-class", "uvicorn.workers.UvicornWorker", "saleor.asgi:application"]

--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 release: python manage.py migrate --no-input
-web: uwsgi saleor/wsgi/uwsgi.ini
+web: gunicorn --bind :$PORT --workers 4 --worker-class uvicorn.workers.UvicornWorker saleor.asgi:application
 celeryworker: celery worker -A saleor.celeryconf:app --loglevel=info -E

--- a/poetry.lock
+++ b/poetry.lock
@@ -416,10 +416,10 @@ description = "A high-level Python Web framework that encourages rapid developme
 name = "django"
 optional = false
 python-versions = ">=3.6"
-version = "3.0.8"
+version = "3.1"
 
 [package.dependencies]
-asgiref = ">=3.2,<4.0"
+asgiref = ">=3.2.10,<3.3.0"
 pytz = "*"
 sqlparse = ">=0.2.2"
 
@@ -2309,6 +2309,7 @@ multidict = ">=4.0"
 
 [metadata]
 content-hash = "2c29f431ea93ee7ee63e10a7bf479b983b00e2979557e643e4e2e08cabca71f3"
+lock-version = "1.0"
 python-versions = "~3.8"
 
 [metadata.files]
@@ -2507,8 +2508,8 @@ dj-email-url = [
     {file = "dj_email_url-1.0.1-py2.py3-none-any.whl", hash = "sha256:557c07b3039befdc1c561c4038b155d659c09f996d5e33c91189c2e23969da90"},
 ]
 django = [
-    {file = "Django-3.0.8-py3-none-any.whl", hash = "sha256:5457fc953ec560c5521b41fad9e6734a4668b7ba205832191bbdff40ec61073c"},
-    {file = "Django-3.0.8.tar.gz", hash = "sha256:31a5fbbea5fc71c99e288ec0b2f00302a0a92c44b13ede80b73a6a4d6d205582"},
+    {file = "Django-3.1-py3-none-any.whl", hash = "sha256:1a63f5bb6ff4d7c42f62a519edc2adbb37f9b78068a5a862beff858b68e3dc8b"},
+    {file = "Django-3.1.tar.gz", hash = "sha256:2d390268a13c655c97e0e2ede9d117007996db692c1bb93eabebd4fb7ea7012b"},
 ]
 django-appconf = [
     {file = "django-appconf-1.0.4.tar.gz", hash = "sha256:be58deb54a43d77d2e1621fe59f787681376d3cd0b8bd8e4758ef6c3a6453380"},
@@ -2838,11 +2839,6 @@ markupsafe = [
     {file = "MarkupSafe-1.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win32.whl", hash = "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2"},
     {file = "MarkupSafe-1.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:6788b695d50a51edb699cb55e35487e430fa21f1ed838122d722e0ff0ac5ba15"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:cdb132fc825c38e1aeec2c8aa9338310d29d337bebbd7baa06889d09a60a1fa2"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:13d3144e1e340870b25e7b10b98d779608c02016d5184cfb9927a9f10c689f42"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win32.whl", hash = "sha256:596510de112c685489095da617b5bcbbac7dd6384aeebeda4df6025d0256a81b"},
-    {file = "MarkupSafe-1.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:e8313f01ba26fbbe36c7be1966a7b7424942f670f38e666995b88d012765b9be"},
     {file = "MarkupSafe-1.1.1.tar.gz", hash = "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b"},
 ]
 maxminddb = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -323,7 +323,7 @@ python-versions = "*"
 version = "3.0.4"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
@@ -1035,6 +1035,31 @@ six = ">=1.12"
 
 [[package]]
 category = "main"
+description = "WSGI HTTP Server for UNIX"
+name = "gunicorn"
+optional = false
+python-versions = ">=3.4"
+version = "20.0.4"
+
+[package.dependencies]
+setuptools = ">=3.0"
+
+[package.extras]
+eventlet = ["eventlet (>=0.9.7)"]
+gevent = ["gevent (>=0.13)"]
+setproctitle = ["setproctitle"]
+tornado = ["tornado (>=0.2)"]
+
+[[package]]
+category = "main"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+name = "h11"
+optional = false
+python-versions = "*"
+version = "0.9.0"
+
+[[package]]
+category = "main"
 description = "Convert basic HTML into DraftJS JSON format."
 name = "html-to-draftjs"
 optional = false
@@ -1065,6 +1090,18 @@ all = ["genshi", "chardet (>=2.2)", "lxml"]
 chardet = ["chardet (>=2.2)"]
 genshi = ["genshi"]
 lxml = ["lxml"]
+
+[[package]]
+category = "main"
+description = "A collection of framework independent HTTP protocol utils."
+marker = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
+name = "httptools"
+optional = false
+python-versions = "*"
+version = "0.1.1"
+
+[package.extras]
+test = ["Cython (0.29.14)"]
 
 [[package]]
 category = "dev"
@@ -2206,12 +2243,30 @@ socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
 category = "main"
-description = "The uWSGI server"
-marker = "sys_platform != \"win32\""
-name = "uwsgi"
+description = "The lightning-fast ASGI server."
+name = "uvicorn"
 optional = false
 python-versions = "*"
-version = "2.0.19.1"
+version = "0.11.8"
+
+[package.dependencies]
+click = ">=7.0.0,<8.0.0"
+h11 = ">=0.8,<0.10"
+httptools = ">=0.1.0,<0.2.0"
+uvloop = ">=0.14.0"
+websockets = ">=8.0.0,<9.0.0"
+
+[package.extras]
+watchgodreload = ["watchgod (>=0.6,<0.7)"]
+
+[[package]]
+category = "main"
+description = "Fast implementation of asyncio event loop on top of libuv"
+marker = "sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\""
+name = "uvloop"
+optional = false
+python-versions = "*"
+version = "0.14.0"
 
 [[package]]
 category = "dev"
@@ -2287,6 +2342,14 @@ python-versions = "*"
 version = "0.5.1"
 
 [[package]]
+category = "main"
+description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
+name = "websockets"
+optional = false
+python-versions = ">=3.6.1"
+version = "8.1"
+
+[[package]]
 category = "dev"
 description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
@@ -2308,7 +2371,7 @@ idna = ">=2.0"
 multidict = ">=4.0"
 
 [metadata]
-content-hash = "2c29f431ea93ee7ee63e10a7bf479b983b00e2979557e643e4e2e08cabca71f3"
+content-hash = "ddb74ac22ffa44ee49fde593d8887471f82eb357c9e3ee059ccf6447de4e1f6e"
 lock-version = "1.0"
 python-versions = "~3.8"
 
@@ -2705,12 +2768,34 @@ graphql-relay = [
     {file = "graphql-relay-2.0.1.tar.gz", hash = "sha256:870b6b5304123a38a0b215a79eace021acce5a466bf40cd39fa18cb8528afabb"},
     {file = "graphql_relay-2.0.1-py3-none-any.whl", hash = "sha256:ac514cb86db9a43014d7e73511d521137ac12cf0101b2eaa5f0a3da2e10d913d"},
 ]
+gunicorn = [
+    {file = "gunicorn-20.0.4-py2.py3-none-any.whl", hash = "sha256:cd4a810dd51bf497552cf3f863b575dabd73d6ad6a91075b65936b151cbf4f9c"},
+    {file = "gunicorn-20.0.4.tar.gz", hash = "sha256:1904bb2b8a43658807108d59c3f3d56c2b6121a701161de0ddf9ad140073c626"},
+]
+h11 = [
+    {file = "h11-0.9.0-py2.py3-none-any.whl", hash = "sha256:4bc6d6a1238b7615b266ada57e0618568066f57dd6fa967d1290ec9309b2f2f1"},
+    {file = "h11-0.9.0.tar.gz", hash = "sha256:33d4bca7be0fa039f4e84d50ab00531047e53d6ee8ffbc83501ea602c169cae1"},
+]
 html-to-draftjs = [
     {file = "html-to-draftjs-1.0.1.tar.gz", hash = "sha256:2212acf3b063c17b6dc91875f474159e1f730c1a4e5fbf74f9a66250f7040e9a"},
 ]
 html5lib = [
     {file = "html5lib-1.1-py2.py3-none-any.whl", hash = "sha256:0d78f8fde1c230e99fe37986a60526d7049ed4bf8a9fadbad5f00e22e58e041d"},
     {file = "html5lib-1.1.tar.gz", hash = "sha256:b2e5b40261e20f354d198eae92afc10d750afb487ed5e50f9c4eaf07c184146f"},
+]
+httptools = [
+    {file = "httptools-0.1.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:a2719e1d7a84bb131c4f1e0cb79705034b48de6ae486eb5297a139d6a3296dce"},
+    {file = "httptools-0.1.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:fa3cd71e31436911a44620473e873a256851e1f53dee56669dae403ba41756a4"},
+    {file = "httptools-0.1.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:86c6acd66765a934e8730bf0e9dfaac6fdcf2a4334212bd4a0a1c78f16475ca6"},
+    {file = "httptools-0.1.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bc3114b9edbca5a1eb7ae7db698c669eb53eb8afbbebdde116c174925260849c"},
+    {file = "httptools-0.1.1-cp36-cp36m-win_amd64.whl", hash = "sha256:ac0aa11e99454b6a66989aa2d44bca41d4e0f968e395a0a8f164b401fefe359a"},
+    {file = "httptools-0.1.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:96da81e1992be8ac2fd5597bf0283d832287e20cb3cfde8996d2b00356d4e17f"},
+    {file = "httptools-0.1.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:56b6393c6ac7abe632f2294da53f30d279130a92e8ae39d8d14ee2e1b05ad1f2"},
+    {file = "httptools-0.1.1-cp37-cp37m-win_amd64.whl", hash = "sha256:96eb359252aeed57ea5c7b3d79839aaa0382c9d3149f7d24dd7172b1bcecb009"},
+    {file = "httptools-0.1.1-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:fea04e126014169384dee76a153d4573d90d0cbd1d12185da089f73c78390437"},
+    {file = "httptools-0.1.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:3592e854424ec94bd17dc3e0c96a64e459ec4147e6d53c0a42d0ebcef9cb9c5d"},
+    {file = "httptools-0.1.1-cp38-cp38-win_amd64.whl", hash = "sha256:0a4b1b2012b28e68306575ad14ad5e9120b34fccd02a81eb08838d7e3bbb48be"},
+    {file = "httptools-0.1.1.tar.gz", hash = "sha256:41b573cf33f64a8f8f3400d0a7faf48e1888582b6f6e02b82b9bd4f0bf7497ce"},
 ]
 identify = [
     {file = "identify-1.4.23-py2.py3-none-any.whl", hash = "sha256:882c4b08b4569517b5f2257ecca180e01f38400a17f429f5d0edff55530c41c7"},
@@ -3342,8 +3427,20 @@ urllib3 = [
     {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
-uwsgi = [
-    {file = "uWSGI-2.0.19.1.tar.gz", hash = "sha256:faa85e053c0b1be4d5585b0858d3a511d2cd10201802e8676060fd0a109e5869"},
+uvicorn = [
+    {file = "uvicorn-0.11.8-py3-none-any.whl", hash = "sha256:4b70ddb4c1946e39db9f3082d53e323dfd50634b95fd83625d778729ef1730ef"},
+    {file = "uvicorn-0.11.8.tar.gz", hash = "sha256:46a83e371f37ea7ff29577d00015f02c942410288fb57def6440f2653fff1d26"},
+]
+uvloop = [
+    {file = "uvloop-0.14.0-cp35-cp35m-macosx_10_11_x86_64.whl", hash = "sha256:08b109f0213af392150e2fe6f81d33261bb5ce968a288eb698aad4f46eb711bd"},
+    {file = "uvloop-0.14.0-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:4544dcf77d74f3a84f03dd6278174575c44c67d7165d4c42c71db3fdc3860726"},
+    {file = "uvloop-0.14.0-cp36-cp36m-macosx_10_11_x86_64.whl", hash = "sha256:b4f591aa4b3fa7f32fb51e2ee9fea1b495eb75b0b3c8d0ca52514ad675ae63f7"},
+    {file = "uvloop-0.14.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:f07909cd9fc08c52d294b1570bba92186181ca01fe3dc9ffba68955273dd7362"},
+    {file = "uvloop-0.14.0-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:afd5513c0ae414ec71d24f6f123614a80f3d27ca655a4fcf6cabe50994cc1891"},
+    {file = "uvloop-0.14.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:e7514d7a48c063226b7d06617cbb12a14278d4323a065a8d46a7962686ce2e95"},
+    {file = "uvloop-0.14.0-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:bcac356d62edd330080aed082e78d4b580ff260a677508718f88016333e2c9c5"},
+    {file = "uvloop-0.14.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4315d2ec3ca393dd5bc0b0089d23101276778c304d42faff5dc4579cb6caef09"},
+    {file = "uvloop-0.14.0.tar.gz", hash = "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e"},
 ]
 vcrpy = [
     {file = "vcrpy-4.0.2-py2.py3-none-any.whl", hash = "sha256:c4ddf1b92c8a431901c56a1738a2c797d965165a96348a26f4b2bbc5fa6d36d9"},
@@ -3364,6 +3461,30 @@ weasyprint = [
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+websockets = [
+    {file = "websockets-8.1-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:3762791ab8b38948f0c4d281c8b2ddfa99b7e510e46bd8dfa942a5fff621068c"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:3db87421956f1b0779a7564915875ba774295cc86e81bc671631379371af1170"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4f9f7d28ce1d8f1295717c2c25b732c2bc0645db3215cf757551c392177d7cb8"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:295359a2cc78736737dd88c343cd0747546b2174b5e1adc223824bcaf3e164cb"},
+    {file = "websockets-8.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1d3f1bf059d04a4e0eb4985a887d49195e15ebabc42364f4eb564b1d065793f5"},
+    {file = "websockets-8.1-cp36-cp36m-win32.whl", hash = "sha256:2db62a9142e88535038a6bcfea70ef9447696ea77891aebb730a333a51ed559a"},
+    {file = "websockets-8.1-cp36-cp36m-win_amd64.whl", hash = "sha256:0e4fb4de42701340bd2353bb2eee45314651caa6ccee80dbd5f5d5978888fed5"},
+    {file = "websockets-8.1-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:9b248ba3dd8a03b1a10b19efe7d4f7fa41d158fdaa95e2cf65af5a7b95a4f989"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ce85b06a10fc65e6143518b96d3dca27b081a740bae261c2fb20375801a9d56d"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:965889d9f0e2a75edd81a07592d0ced54daa5b0785f57dc429c378edbcffe779"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:751a556205d8245ff94aeef23546a1113b1dd4f6e4d102ded66c39b99c2ce6c8"},
+    {file = "websockets-8.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3ef56fcc7b1ff90de46ccd5a687bbd13a3180132268c4254fc0fa44ecf4fc422"},
+    {file = "websockets-8.1-cp37-cp37m-win32.whl", hash = "sha256:7ff46d441db78241f4c6c27b3868c9ae71473fe03341340d2dfdbe8d79310acc"},
+    {file = "websockets-8.1-cp37-cp37m-win_amd64.whl", hash = "sha256:20891f0dddade307ffddf593c733a3fdb6b83e6f9eef85908113e628fa5a8308"},
+    {file = "websockets-8.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c1ec8db4fac31850286b7cd3b9c0e1b944204668b8eb721674916d4e28744092"},
+    {file = "websockets-8.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5c01fd846263a75bc8a2b9542606927cfad57e7282965d96b93c387622487485"},
+    {file = "websockets-8.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9bef37ee224e104a413f0780e29adb3e514a5b698aabe0d969a6ba426b8435d1"},
+    {file = "websockets-8.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d705f8aeecdf3262379644e4b55107a3b55860eb812b673b28d0fbc347a60c55"},
+    {file = "websockets-8.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:c8a116feafdb1f84607cb3b14aa1418424ae71fee131642fc568d21423b51824"},
+    {file = "websockets-8.1-cp38-cp38-win32.whl", hash = "sha256:e898a0863421650f0bebac8ba40840fc02258ef4714cb7e1fd76b6a6354bda36"},
+    {file = "websockets-8.1-cp38-cp38-win_amd64.whl", hash = "sha256:f8a7bff6e8664afc4e6c28b983845c5bc14965030e3fb98789734d416af77c4b"},
+    {file = "websockets-8.1.tar.gz", hash = "sha256:5c65d2da8c6bce0fca2528f69f44b2f977e06954c8512a952222cea50dad430f"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,6 @@ sentry-sdk = "^0"
 stripe = "^2.47.0"
 text-unidecode = "^1.2"
 tqdm = "^4.47"
-uwsgi = {version = "^2.0.19", platform = "!=win32"}
 weasyprint = ">=48"
 oauthlib = "^3.0"
 jaeger-client = "^4.3.0"
@@ -67,6 +66,8 @@ python-json-logger = "^0.1.11"
 pytimeparse = "^1.1.8"
 django-redis = "^4.12.1"
 Adyen = "^3.0.0"
+uvicorn = "^0.11.8"
+gunicorn = "^20.0.4"
 
 [tool.poetry.dev-dependencies]
 black = "19.10b0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,7 @@ celery==4.4.7
 certifi==2020.6.20
 cffi==1.14.0
 chardet==3.0.4
+click==7.1.2
 cssselect2==0.3.0
 defusedxml==0.6.0
 dj-database-url==0.5.0
@@ -56,8 +57,11 @@ graphene-django==2.12.1
 graphene-federation==0.1.0
 graphql-core==2.3.2
 graphql-relay==2.0.1
+gunicorn==20.0.4
+h11==0.9.0
 html-to-draftjs==1.0.1
 html5lib==1.1
+httptools==0.1.1; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
 idna==2.10
 jaeger-client==4.3.0
 jdcal==1.4.1
@@ -114,7 +118,9 @@ tqdm==4.48.1
 typing==3.7.4.3
 unidecode==1.1.1
 urllib3==1.25.9
-uwsgi==2.0.19.1; sys_platform != "win32"
+uvicorn==0.11.8
+uvloop==0.14.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
 vine==1.3.0
 weasyprint==51
 webencodings==0.5.1
+websockets==8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ asgiref==3.2.10
 babel==2.8.0
 beautifulsoup4==4.7.1
 billiard==3.6.3.0
-boto3==1.14.28
-botocore==1.17.28
-braintree==4.2.0
+boto3==1.14.35
+botocore==1.17.35
+braintree==4.3.0
 cachetools==4.1.1
 cairocffi==1.1.0
 cairosvg==2.4.2
-celery==4.4.6
+celery==4.4.7
 certifi==2020.6.20
 cffi==1.14.0
 chardet==3.0.4
@@ -19,7 +19,7 @@ cssselect2==0.3.0
 defusedxml==0.6.0
 dj-database-url==0.5.0
 dj-email-url==1.0.1
-django==3.0.8
+django==3.1
 django-appconf==1.0.4
 django-cache-url==3.1.2
 django-countries==6.1.2
@@ -42,7 +42,6 @@ enmerkar==0.7.1
 et-xmlfile==1.0.1
 faker==4.1.1
 freezegun==0.3.15
-future==0.18.2
 google-api-core==1.21.0
 google-auth==1.19.1
 google-cloud-core==1.3.0
@@ -67,7 +66,7 @@ jsonfield==3.1.0
 kombu==4.6.11
 lxml==4.5.2
 markdown==3.2.2
-maxminddb==2.0.1
+maxminddb==2.0.2
 maxminddb-geolite2==2018.703
 measurement==3.2.0
 mpmath==1.1.0
@@ -111,7 +110,7 @@ threadloop==1.0.2
 thrift==0.13.0
 tinycss2==1.0.2
 tornado==6.0.4
-tqdm==4.48.0
+tqdm==4.48.1
 typing==3.7.4.3
 unidecode==1.1.1
 urllib3==1.25.9

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -79,8 +79,11 @@ graphene-django==2.12.1
 graphene-federation==0.1.0
 graphql-core==2.3.2
 graphql-relay==2.0.1
+gunicorn==20.0.4
+h11==0.9.0
 html-to-draftjs==1.0.1
 html5lib==1.1
+httptools==0.1.1; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
 identify==1.4.23
 idna==2.10
 iniconfig==1.0.1
@@ -181,11 +184,13 @@ typing==3.7.4.3
 typing-extensions==3.7.4.2
 unidecode==1.1.1
 urllib3==1.25.9
-uwsgi==2.0.19.1; sys_platform != "win32"
+uvicorn==0.11.8
+uvloop==0.14.0; sys_platform != "win32" and sys_platform != "cygwin" and platform_python_implementation != "PyPy"
 vcrpy==4.0.2
 vine==1.3.0
 virtualenv==20.0.27
 weasyprint==51
 webencodings==0.5.1
+websockets==8.1
 wrapt==1.12.1
 yarl==1.4.2; python_version >= "3.6"

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -12,13 +12,13 @@ beautifulsoup4==4.7.1
 beautifultable==0.7.0
 billiard==3.6.3.0
 black==19.10b0
-boto3==1.14.28
-botocore==1.17.28
-braintree==4.2.0
+boto3==1.14.35
+botocore==1.17.35
+braintree==4.3.0
 cachetools==4.1.1
 cairocffi==1.1.0
 cairosvg==2.4.2
-celery==4.4.6
+celery==4.4.7
 certifi==2020.6.20
 cffi==1.14.0
 cfgv==3.1.0
@@ -32,7 +32,7 @@ defusedxml==0.6.0
 distlib==0.3.1
 dj-database-url==0.5.0
 dj-email-url==1.0.1
-django==3.0.8
+django==3.1
 django-appconf==1.0.4
 django-cache-url==3.1.2
 django-countries==6.1.2
@@ -63,7 +63,6 @@ faker==4.1.1
 filelock==3.0.12
 flake8==3.8.3
 freezegun==0.3.15
-future==0.18.2
 gitdb==4.0.5
 gitpython==3.1.7
 google-api-core==1.21.0
@@ -84,6 +83,7 @@ html-to-draftjs==1.0.1
 html5lib==1.1
 identify==1.4.23
 idna==2.10
+iniconfig==1.0.1
 isort==4.3.21
 jaeger-client==4.3.0
 jdcal==1.4.1
@@ -95,7 +95,7 @@ lazy-object-proxy==1.4.3
 lxml==4.5.2
 markdown==3.2.2
 markupsafe==1.1.1
-maxminddb==2.0.1
+maxminddb==2.0.2
 maxminddb-geolite2==2018.703
 mccabe==0.6.1
 measurement==3.2.0
@@ -134,14 +134,14 @@ pylint-django==2.2.0
 pylint-plugin-utils==0.6
 pyparsing==2.4.7
 pyphen==0.9.5
-pytest==5.4.3
+pytest==6.0.1
 pytest-cov==2.10.0
 pytest-django==3.9.0
 pytest-django-queries==1.1.0
 pytest-forked==1.2.0
 pytest-mock==3.2.0
 pytest-vcr==1.0.2
-pytest-xdist==1.33.0
+pytest-xdist==1.34.0
 python-dateutil==2.8.1
 python-json-logger==0.1.11
 python-magic==0.4.18
@@ -173,8 +173,8 @@ thrift==0.13.0
 tinycss2==1.0.2
 toml==0.10.1
 tornado==6.0.4
-tox==3.18.0
-tqdm==4.48.0
+tox==3.18.1
+tqdm==4.48.1
 transifex-client==0.13.11
 typed-ast==1.4.1
 typing==3.7.4.3
@@ -185,7 +185,6 @@ uwsgi==2.0.19.1; sys_platform != "win32"
 vcrpy==4.0.2
 vine==1.3.0
 virtualenv==20.0.27
-wcwidth==0.2.5
 weasyprint==51
 webencodings==0.5.1
 wrapt==1.12.1

--- a/saleor/account/i18n.py
+++ b/saleor/account/i18n.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 import i18naddress
 from django import forms
 from django.core.exceptions import ValidationError
-from django.forms.forms import BoundField  # type: ignore
+from django.forms import BoundField  # type: ignore
 from django_countries import countries
 
 from .models import Address

--- a/saleor/asgi/__init__.py
+++ b/saleor/asgi/__init__.py
@@ -1,4 +1,4 @@
-"""ASGI config for saleor project.
+"""ASGI config for Saleor project.
 
 It exposes the ASGI callable as a module-level variable named ``application``.
 

--- a/saleor/asgi/__init__.py
+++ b/saleor/asgi/__init__.py
@@ -1,0 +1,18 @@
+"""ASGI config for saleor project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/3.1/howto/deployment/asgi/
+"""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+from saleor.asgi.health_check import health_check
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
+
+application = get_asgi_application()
+application = health_check(application, "/health/")

--- a/saleor/asgi/health_check.py
+++ b/saleor/asgi/health_check.py
@@ -1,0 +1,15 @@
+def health_check(application, health_url):
+    async def health_check_wrapper(scope, receive, send):
+        if scope.get("path") != health_url:
+            await application(scope, receive, send)
+            return
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [(b"content-type", b"text/plain")],
+            }
+        )
+        await send({"type": "http.response.body"})
+
+    return health_check_wrapper

--- a/saleor/graphql/account/mutations/jwt.py
+++ b/saleor/graphql/account/mutations/jwt.py
@@ -3,7 +3,10 @@ from typing import Optional
 import graphene
 import jwt
 from django.core.exceptions import ValidationError
-from django.middleware.csrf import _compare_salted_tokens, _get_new_csrf_token
+from django.middleware.csrf import (  # type: ignore
+    _compare_masked_tokens,
+    _get_new_csrf_token,
+)
 from django.utils import timezone
 from django.utils.crypto import get_random_string
 from graphene.types.generic import GenericScalar
@@ -180,7 +183,7 @@ class RefreshToken(BaseMutation):
 
     @classmethod
     def clean_csrf_token(cls, csrf_token, payload):
-        is_valid = _compare_salted_tokens(csrf_token, payload["csrfToken"])
+        is_valid = _compare_masked_tokens(csrf_token, payload["csrfToken"])
         if not is_valid:
             raise ValidationError(
                 {

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -1,4 +1,4 @@
-"""WSGI config for saleor project.
+"""WSGI config for Saleor project.
 
 This module contains the WSGI application used by Django's development server
 and any production WSGI deployments. It should expose a module-level variable

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -27,13 +27,7 @@ def get_allowed_host_lazy():
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
 
-# This application object is used by any WSGI server configured to use this
-# file. This includes Django's development server, if the WSGI_APPLICATION
-# setting points here.
 application = get_wsgi_application()
-# Apply WSGI middleware here.
-# from helloworld.wsgi import HelloWorldApplication
-# application = HelloWorldApplication(application)
 application = health_check(application, "/health/")
 
 # Warm-up the django application instead of letting it lazy-load

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{30,_master}
+envlist = py38-django{31,_master}
 skipsdist = True
 
 [testenv]
@@ -10,7 +10,6 @@ deps =
     -rrequirements.txt
     -rrequirements_dev.txt
 commands =
-    ; django30: pip install "django>=3.0a1,<3.1" --upgrade --pre
     django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput --verbosity=0
     pytest --cov --cov-report= --django-db-bench={env:QUERIES_RESULTS_PATH}
@@ -68,5 +67,5 @@ unignore_outcomes = True
 
 [travis:env]
 DJANGO =
-    3.0: django30
+    3.1: django31
     master: django_master


### PR DESCRIPTION
To test ASGI support:

```
pip install uvicorn
uvicorn saleor.asgi:application --reload
```

(`--reload` flag monitors local files for changes during development)

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
