### PR TITLE
Fix price productVariantUpdate mutation when price is not passed in input

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1194,7 +1194,7 @@ class ProductVariantCreate(ModelMutation):
             cleaned_input["cost_price_amount"] = cost_price
 
         price = cleaned_input.get("price")
-        if price is None:
+        if price is None and instance.price is None:
             raise ValidationError(
                 {
                     "price": ValidationError(


### PR DESCRIPTION
Mutation `productVariantUpdate` returns an error code "REQUIRED" when the price is not passed in the input. We shouldn't raise this error when the price is already set in the instance.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
