### PR TITLE
Fix empty plugin object result after PluginUpdate mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add missing OrderEvents during checkout flow - #5684 by @koradon
 - Update google merchant to get tax rate based by plugin manager - #5823 by @gabmartinez
 - Allow unicode in slug fields - #5877 by @IKarbowiak
+- Fix empty plugin object result after PluginUpdate mutation - #5968 by @gabmartinez
 
 ## 2.10.2
 

--- a/saleor/graphql/plugins/resolvers.py
+++ b/saleor/graphql/plugins/resolvers.py
@@ -12,6 +12,7 @@ def resolve_plugin(info, plugin_id):
         return None
     return PluginConfiguration(
         id=plugin.PLUGIN_ID,
+        identifier=plugin.PLUGIN_ID,
         active=plugin.active,
         configuration=plugin.configuration,
         description=plugin.PLUGIN_DESCRIPTION,
@@ -36,6 +37,7 @@ def resolve_plugins(sort_by=None, **kwargs):
     return [
         PluginConfiguration(
             id=plugin.PLUGIN_ID,
+            identifier=plugin.PLUGIN_ID,
             active=plugin.active,
             configuration=plugin.configuration,
             description=plugin.PLUGIN_DESCRIPTION,

--- a/saleor/graphql/plugins/tests/test_plugins.py
+++ b/saleor/graphql/plugins/tests/test_plugins.py
@@ -308,7 +308,7 @@ def test_plugin_configuration_update(
     response = staff_api_client_can_manage_plugins.post_graphql(
         PLUGIN_UPDATE_MUTATION, variables
     )
-    get_graphql_content(response)
+    content = get_graphql_content(response)
 
     plugin = PluginConfiguration.objects.get(identifier=PluginSample.PLUGIN_ID)
     assert plugin.active == active
@@ -320,6 +320,11 @@ def test_plugin_configuration_update(
     second_configuration_item = plugin.configuration[1]
     assert second_configuration_item["name"] == old_configuration[1]["name"]
     assert second_configuration_item["value"] == old_configuration[1]["value"]
+
+    configuration = content["data"]["pluginUpdate"]["plugin"]["configuration"]
+    assert configuration is not None
+    assert configuration[0]["name"] == updated_configuration_item["name"]
+    assert configuration[0]["value"] == updated_configuration_item["value"]
 
 
 def test_plugin_configuration_update_containing_invalid_plugin_id(

--- a/saleor/graphql/plugins/types.py
+++ b/saleor/graphql/plugins/types.py
@@ -54,13 +54,13 @@ class Plugin(CountableDjangoObjectType):
         only_fields = ["id", "name", "description", "active", "configuration"]
 
     def resolve_id(self: models.PluginConfiguration, _info):
-        return self.id
+        return self.identifier
 
     @staticmethod
     def resolve_configuration(
         root: models.PluginConfiguration, _info
     ) -> Optional["PluginConfigurationType"]:
-        plugin = manager.get_plugins_manager().get_plugin(str(root.id))
+        plugin = manager.get_plugins_manager().get_plugin(root.identifier)
         if not plugin:
             return None
         configuration = plugin.configuration


### PR DESCRIPTION
I want to merge this change because it uses the identifier field to resolve the ID field on the Plugin GraphQL type and fixes an issue on the dashboard that was not reflecting the changes applied to the plugin configuration.

**Here is a screenshot of the issue:**

<img src="https://user-images.githubusercontent.com/24206382/89736159-70465200-da35-11ea-8a1b-2b38dd04b879.png" height="150">

**Here is a screenshot after applying the fix:**

<img src="https://user-images.githubusercontent.com/24206382/89736172-83592200-da35-11ea-8d68-c8b79ed472a7.png" height="150">

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
