### PR TITLE
Adyen/use client key instead of origin key

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -55,7 +55,7 @@ class AdyenGatewayPlugin(BasePlugin):
         {"name": "Merchant Account", "value": None},
         {"name": "API key", "value": None},
         {"name": "Supported currencies", "value": ""},
-        {"name": "Origin Key", "value": ""},
+        {"name": "Client Key", "value": ""},
         {"name": "Origin Url", "value": ""},
         {"name": "Live", "value": ""},
         {"name": "Automatically mark payment as a capture", "value": True},
@@ -86,14 +86,26 @@ class AdyenGatewayPlugin(BasePlugin):
             " Please enter currency codes separated by a comma.",
             "label": "Supported currencies",
         },
-        "Origin Key": {
+        "Client Key": {
             "type": ConfigurationTypeField.STRING,
-            "help_text": "",  # FIXME define them as per channel
-            "label": "Origin Key",
+            "help_text": (
+                "The client key is a public key that uniquely identifies a web service "
+                "user. Each web service user has a list of allowed origins, or domains "
+                "from which we expect to get your requests. We make sure data cannot "
+                "be accessed by unknown parties by using Cross-Origin Resource Sharing."
+                "Not required for Android or iOS app."
+            ),
+            "label": "Client Key",
         },
         "Origin Url": {
             "type": ConfigurationTypeField.STRING,
-            "help_text": "",  # FIXME define them as per channel
+            "help_text": (
+                "The origin URL of the page where you are rendering the Drop-in. This "
+                "should not include subdirectories and a trailing slash. For example, "
+                "if you are rendering the Drop-in on "
+                "https://your-company.com/checkout/payment, specify here: "
+                "https://your-company.com. Not required for Android or iOS app."
+            ),
             "label": "Origin Url",
         },
         "Live": {
@@ -166,7 +178,7 @@ class AdyenGatewayPlugin(BasePlugin):
             connection_params={
                 "api_key": configuration["API key"],
                 "merchant_account": configuration["Merchant Account"],
-                "origin_key": configuration["Origin Key"],
+                "client_key": configuration["Client Key"],
                 "origin_url": configuration["Origin Url"],
                 "live": configuration["Live"],
                 "webhook_hmac": configuration["HMAC secret key"],
@@ -187,7 +199,6 @@ class AdyenGatewayPlugin(BasePlugin):
 
     def webhook(self, request: WSGIRequest, path: str, previous_value) -> HttpResponse:
         config = self._get_gateway_config()
-        self.config.connection_params["adyen_auto_capture"]
         if path.startswith(WEBHOOK_PATH):
             return handle_webhook(request, config)
         elif path.startswith(ADDITIONAL_ACTION_PATH):
@@ -221,8 +232,8 @@ class AdyenGatewayPlugin(BasePlugin):
             name=self.PLUGIN_NAME,
             config=[
                 {
-                    "field": "origin_key",
-                    "value": config.connection_params["origin_key"],
+                    "field": "client_key",
+                    "value": config.connection_params["client_key"],
                 },
                 {"field": "config", "value": json.dumps(response.message)},
             ],

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -108,16 +108,6 @@ class AdyenGatewayPlugin(BasePlugin):
             ),
             "label": "Live",
         },
-        "Enable notifications": {
-            "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": (
-                "Enable the support for processing the Adyen's webhooks. The Saleor "
-                "webhook url is "
-                "http(s)://<your-backend-url>/plugins/mirumee.payments.adyen/webhooks/ "
-                "https://docs.adyen.com/development-resources/webhooks"
-            ),
-            "label": "Enable notifications",
-        },
         "Automatically mark payment as a capture": {
             "type": ConfigurationTypeField.BOOLEAN,
             "help_text": (

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -13,7 +13,7 @@ def adyen_plugin(settings):
         api_key=None,
         merchant_account=None,
         return_url=None,
-        origin_key=None,
+        client_key=None,
         origin_url=None,
         adyen_auto_capture=None,
         auto_capture=None,
@@ -21,7 +21,7 @@ def adyen_plugin(settings):
         api_key = api_key or "test_key"
         merchant_account = merchant_account or "SaleorECOM"
         return_url = return_url or "http://127.0.0.1:3000/"
-        origin_key = origin_key or "test_origin_key"
+        client_key = client_key or "test_origin_key"
         origin_url = origin_url or "http://127.0.0.1:3000"
         adyen_auto_capture = adyen_auto_capture or False
         auto_capture = auto_capture or False
@@ -35,7 +35,7 @@ def adyen_plugin(settings):
                     {"name": "API key", "value": api_key},
                     {"name": "Merchant Account", "value": merchant_account},
                     {"name": "Return Url", "value": return_url},
-                    {"name": "Origin Key", "value": origin_key},
+                    {"name": "Client Key", "value": client_key},
                     {"name": "Origin Url", "value": origin_url},
                     {
                         "name": "Automatically mark payment as a capture",

--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -25,8 +25,8 @@ def test_get_payment_gateway_for_checkout(
     config = response.config
     assert len(config) == 2
     assert config[0] == {
-        "field": "origin_key",
-        "value": adyen_plugin.config.connection_params["origin_key"],
+        "field": "client_key",
+        "value": adyen_plugin.config.connection_params["client_key"],
     }
     assert config[1]["field"] == "config"
     config = json.loads(config[1]["value"])

--- a/saleor/payment/gateways/adyen/utils.py
+++ b/saleor/payment/gateways/adyen/utils.py
@@ -108,10 +108,8 @@ def request_data_for_payment(
     if (
         "browserInfo" in extra_request_params
         and "billingAddress" in extra_request_params
+        and origin_url
     ):
-        # Replace this assigment. Add note that customer_ip_address has incorrect name
-        # Add to dashboard config the flow to combine channel with url like:
-        # web1:https://shop.com, web2:https://shop1.com
         extra_request_params["origin"] = origin_url
 
     method = payment_data["paymentMethod"].get("type", [])


### PR DESCRIPTION
Replace origin_key with client_key
https://docs.adyen.com/user-management/client-side-authentication/migrate-from-origin-key-to-client-key