### PR TITLE
In prepare_order_data we should use lines instead of iterating on checkout.

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -665,8 +665,7 @@ def prepare_order_data(
     )
 
     order_data["lines"] = [
-        create_line_for_order(checkout_line=line, discounts=discounts)
-        for line in checkout
+        create_line_for_order(checkout_line=line, discounts=discounts) for line in lines
     ]
 
     # validate checkout gift cards
@@ -678,7 +677,7 @@ def prepare_order_data(
     # assign gift cards to the order
 
     order_data["total_price_left"] = (
-        manager.calculate_checkout_subtotal(checkout, list(checkout), discounts)
+        manager.calculate_checkout_subtotal(checkout, lines, discounts)
         + shipping_total
         - checkout.discount
     ).gross


### PR DESCRIPTION
I want to merge this change because in prepare_order_data we should use lines instead of iterating on checkout.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
