### PR TITLE
Bump graphene-django

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -964,10 +964,6 @@ version = "1.52.0"
 [package.dependencies]
 protobuf = ">=3.6.0"
 
-[package.dependencies.grpcio]
-optional = true
-version = ">=1.0.0"
-
 [package.extras]
 grpc = ["grpcio (>=1.0.0)"]
 
@@ -996,7 +992,7 @@ description = "Graphene Django integration"
 name = "graphene-django"
 optional = false
 python-versions = "*"
-version = "2.12.1"
+version = "2.13.0"
 
 [package.dependencies]
 Django = ">=1.11"
@@ -2808,8 +2804,8 @@ graphene = [
     {file = "graphene-2.1.8.tar.gz", hash = "sha256:2cbe6d4ef15cfc7b7805e0760a0e5b80747161ce1b0f990dfdc0d2cf497c12f9"},
 ]
 graphene-django = [
-    {file = "graphene-django-2.12.1.tar.gz", hash = "sha256:3d92bf2c43834f3e1caa1c24b79cc5f7c5974670d7d92fd3a4f28c2fd7680c5b"},
-    {file = "graphene_django-2.12.1-py2.py3-none-any.whl", hash = "sha256:03dfe2081c256e56d94d90b33b0bf6fa46ec274186023ccffb9c3aa46a856587"},
+    {file = "graphene-django-2.13.0.tar.gz", hash = "sha256:8a4efc7bf954ba0b5a28d3cdb090b36941aca6b83d211e3cd3ab29cf53ac6154"},
+    {file = "graphene_django-2.13.0-py2.py3-none-any.whl", hash = "sha256:0e33cdec0774284175c387c2af1e0ef4eb0f4e10a56a3a1b2d39bc3a74d9a538"},
 ]
 graphene-federation = [
     {file = "graphene-federation-0.1.0.tar.gz", hash = "sha256:e44e8e354d0c8eeb03547d5c262d01c868d4ea7d1458512c994176eed80fd2bf"},
@@ -3398,7 +3394,7 @@ requests = [
     {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
 ]
 rsa = [
-    {file = "rsa-4.6-py2.py3-none-any.whl", hash = "sha256:23778f5523461cf86ae075f9482a99317f362bca752ae57cb118044066f4026f"},
+    {file = "rsa-4.6-py3-none-any.whl", hash = "sha256:6166864e23d6b5195a5cfed6cd9fed0fe774e226d8f854fcb23b7bbef0350233"},
     {file = "rsa-4.6.tar.gz", hash = "sha256:109ea5a66744dd859bf16fe904b8d8b627adafb9408753161e766a92e7d681fa"},
 ]
 rx = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ google-measurement-protocol==1.0.0
 google-resumable-media==0.7.1
 googleapis-common-protos==1.52.0
 graphene==2.1.8
-graphene-django==2.12.1
+graphene-django==2.13.0
 graphene-federation==0.1.0
 graphql-core==2.3.2
 graphql-relay==2.0.1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -76,7 +76,7 @@ google-measurement-protocol==1.0.0
 google-resumable-media==0.7.1
 googleapis-common-protos==1.52.0
 graphene==2.1.8
-graphene-django==2.12.1
+graphene-django==2.13.0
 graphene-federation==0.1.0
 graphql-core==2.3.2
 graphql-relay==2.0.1

--- a/saleor/graphql/core/types/converter.py
+++ b/saleor/graphql/core/types/converter.py
@@ -1,8 +1,6 @@
 import graphene
-from django.db.models import JSONField  # type: ignore
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField, TaxedMoneyField
-from graphene.types.json import JSONString
 from graphene_django.converter import convert_django_field
 from graphene_django.forms.converter import convert_form_field
 
@@ -30,13 +28,6 @@ def convert_field_money(*_args):
 @convert_django_field.register(MeasurementField)
 def convert_field_measurements(*_args):
     return graphene.Field(Weight)
-
-
-# This converter can be removed when the following changes are released
-# in graphene-django https://github.com/graphql-python/graphene-django/pull/1017/.
-@convert_django_field.register(JSONField)
-def convert_json_field(field, registry=None):
-    return JSONString(description=field.help_text, required=not field.null)
 
 
 @convert_form_field.register(ObjectTypeFilter)


### PR DESCRIPTION
Bump graphene-django to the newest version and remove custom JSONField converter which is now provided by the package.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
