### PR TITLE
Add payment method info to gateway response in adyen

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -22,6 +22,7 @@ from .utils import (
     PENDING_STATUSES,
     api_call,
     call_capture,
+    get_payment_method_info,
     request_data_for_gateway_config,
     request_data_for_payment,
     request_for_payment_cancel,
@@ -289,6 +290,9 @@ class AdyenGatewayPlugin(BasePlugin):
                 token=result.message.get("pspReference"),
                 adyen_client=self.adyen,
             )
+
+        payment_method_info = get_payment_method_info(payment_information, result)
+
         return GatewayResponse(
             is_success=is_success,
             action_required="action" in result.message,
@@ -299,6 +303,7 @@ class AdyenGatewayPlugin(BasePlugin):
             error=error_message,
             raw_response=result.message,
             action_required_data=action,
+            payment_method_info=payment_method_info,
         )
 
     @classmethod
@@ -469,6 +474,9 @@ class AdyenGatewayPlugin(BasePlugin):
             token=transaction.token,
             adyen_client=self.adyen,
         )
+
+        payment_method_info = get_payment_method_info(payment_information, result)
+
         return GatewayResponse(
             is_success=True,
             action_required=False,
@@ -478,6 +486,7 @@ class AdyenGatewayPlugin(BasePlugin):
             transaction_id=result.message.get("pspReference", ""),
             error="",
             raw_response=result.message,
+            payment_method_info=payment_method_info,
         )
 
     @require_active_plugin

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_capture_payment.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_capture_payment.yaml
@@ -23,7 +23,8 @@ interactions:
     uri: https://pal-test.adyen.com/pal/servlet/Payment/v49/capture
   response:
     body:
-      string: '{"pspReference":"852595499936560C","response":"[capture-received]"}'
+      string: '{"pspReference":"852595499936560C","response":"[capture-received]",
+        "additionalData":{"paymentMethod": "visa"}}'
     headers:
       Connection:
       - Keep-Alive

--- a/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment.yaml
+++ b/saleor/payment/gateways/adyen/tests/cassettes/test_process_payment.yaml
@@ -23,7 +23,8 @@ interactions:
     uri: https://checkout-test.adyen.com/v49/payments
   response:
     body:
-      string: '{"pspReference":"882595494831959A","resultCode":"Authorised","merchantReference":"UGF5bWVudDoz"}'
+      string: '{"pspReference":"882595494831959A","resultCode":"Authorised","merchantReference":"UGF5bWVudDoz",
+                  "additionalData":{"paymentMethod": "visa"}}'
     headers:
       Connection:
       - Keep-Alive


### PR DESCRIPTION
Extend `GatewayResponse` with `payment_method_info` for `capture_payment` and `process_payment` in adyen gateway.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
