### PR TITLE
Use product and variant names for klarna product description

### DIFF
--- a/saleor/payment/gateways/adyen/tests/test_utils.py
+++ b/saleor/payment/gateways/adyen/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_append_klarna_data(dummy_payment_data, payment_dummy, checkout_with_ite
         "shopperEmail": dummy_payment_data.customer_email,
         "lineItems": [
             {
-                "description": f"{line.variant.product.name} - {line.variant.name}",
+                "description": f"{line.variant.product.name}, {line.variant.name}",
                 "quantity": line.quantity,
                 "id": line.variant.sku,
                 "taxAmount": "0",
@@ -94,7 +94,7 @@ def test_append_klarna_data_tax_included(
         "shopperEmail": dummy_payment_data.customer_email,
         "lineItems": [
             {
-                "description": f"{line.variant.product.name} - {line.variant.name}",
+                "description": f"{line.variant.product.name}, {line.variant.name}",
                 "quantity": line.quantity,
                 "id": line.variant.sku,
                 "taxAmount": to_adyen_price((gross - net).amount, "USD"),

--- a/saleor/payment/gateways/adyen/tests/test_utils.py
+++ b/saleor/payment/gateways/adyen/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_append_klarna_data(dummy_payment_data, payment_dummy, checkout_with_ite
         "shopperEmail": dummy_payment_data.customer_email,
         "lineItems": [
             {
-                "description": line.variant.product.description,
+                "description": f"{line.variant.product.name} - {line.variant.name}",
                 "quantity": line.quantity,
                 "id": line.variant.sku,
                 "taxAmount": "0",
@@ -94,7 +94,7 @@ def test_append_klarna_data_tax_included(
         "shopperEmail": dummy_payment_data.customer_email,
         "lineItems": [
             {
-                "description": line.variant.product.description,
+                "description": f"{line.variant.product.name} - {line.variant.name}",
                 "quantity": line.quantity,
                 "id": line.variant.sku,
                 "taxAmount": to_adyen_price((gross - net).amount, "USD"),

--- a/saleor/payment/gateways/adyen/utils.py
+++ b/saleor/payment/gateways/adyen/utils.py
@@ -129,7 +129,7 @@ def append_klarna_data(payment_information: "PaymentData", payment_data: dict):
             "quantity": line.quantity,
             "amountExcludingTax": to_adyen_price(total_net, currency),
             "taxPercentage": round(tax_amount / total_gross * 100),
-            "description": line.variant.product.description,
+            "description": f"{line.variant.product.name} - {line.variant.name}",
             "id": line.variant.sku,
             "taxAmount": to_adyen_price(tax_amount, currency),
             "amountIncludingTax": to_adyen_price(total_gross, currency),

--- a/saleor/payment/gateways/adyen/utils.py
+++ b/saleor/payment/gateways/adyen/utils.py
@@ -129,7 +129,7 @@ def append_klarna_data(payment_information: "PaymentData", payment_data: dict):
             "quantity": line.quantity,
             "amountExcludingTax": to_adyen_price(total_net, currency),
             "taxPercentage": round(tax_amount / total_gross * 100),
-            "description": f"{line.variant.product.name} - {line.variant.name}",
+            "description": f"{line.variant.product.name}, {line.variant.name}",
             "id": line.variant.sku,
             "taxAmount": to_adyen_price(tax_amount, currency),
             "amountIncludingTax": to_adyen_price(total_gross, currency),


### PR DESCRIPTION
Instead of description on the klarna side like:
![image](https://user-images.githubusercontent.com/23282005/90037412-79008780-dcc4-11ea-88f8-c57621e45487.png)
We use product and variant names:
![image](https://user-images.githubusercontent.com/23282005/90037452-8584e000-dcc4-11ea-9a12-6db89dbeca78.png)
