### PR TITLE
Fix failing export products to xlsx

### DIFF
--- a/saleor/csv/utils/export.py
+++ b/saleor/csv/utils/export.py
@@ -123,15 +123,14 @@ def export_products_in_batches(
         append_to_file(export_data, headers, temporary_file, file_type, delimiter)
 
 
-def create_file_with_headers(
-    file_headers: List[str], delimiter: str, file_type: str,
-):
+def create_file_with_headers(file_headers: List[str], delimiter: str, file_type: str):
     table = etl.wrap([file_headers])
 
-    temp_file = NamedTemporaryFile("ab+")
     if file_type == FileTypes.CSV:
+        temp_file = NamedTemporaryFile("ab+", suffix=".csv")
         etl.tocsv(table, temp_file.name, delimiter=delimiter)
     else:
+        temp_file = NamedTemporaryFile("ab+", suffix=".xlsx")
         etl.io.xlsx.toxlsx(table, temp_file.name)
 
     return temp_file


### PR DESCRIPTION
Fix failing export products to xlsx.

Checked with S3 by @tomaszszymanski129 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
