### PR TITLE
Raise InvalidTokenError when invalid token is passed

### DIFF
--- a/saleor/core/tests/test_auth_backend.py
+++ b/saleor/core/tests/test_auth_backend.py
@@ -11,6 +11,7 @@ from ..jwt import (
     create_access_token,
     create_access_token_for_app,
     create_refresh_token,
+    get_user_from_access_token,
     jwt_encode,
     jwt_user_payload,
 )
@@ -175,3 +176,10 @@ def test_user_has_old_token_type(rf, staff_user, settings):
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
+
+
+def test_get_user_from_access_token_fails_on_incorrect_token():
+    token = "JWT null"
+    with pytest.raises(jwt.InvalidTokenError) as e:
+        get_user_from_access_token(token)
+    assert type(e.value) == jwt.InvalidTokenError

--- a/saleor/graphql/account/mutations/jwt.py
+++ b/saleor/graphql/account/mutations/jwt.py
@@ -44,10 +44,10 @@ def get_payload(token):
     return payload
 
 
-def get_user(payload):
+def get_user_or_error(payload):
     try:
         user = get_user_from_payload(payload)
-    except Exception:
+    except jwt.PyJWTError:
         user = None
     if not user:
         raise ValidationError(
@@ -197,7 +197,7 @@ class RefreshToken(BaseMutation):
     @classmethod
     def get_user(cls, payload):
         try:
-            user = get_user(payload)
+            user = get_user_or_error(payload)
         except ValidationError as e:
             raise ValidationError({"refreshToken": e})
         return user
@@ -212,7 +212,7 @@ class RefreshToken(BaseMutation):
             csrf_token = data.get("csrf_token")
             cls.clean_csrf_token(csrf_token, payload)
 
-        user = get_user(payload)
+        user = cls.get_user(payload)
         token = create_access_token(user)
         return cls(errors=[], user=user, token=token)
 
@@ -247,7 +247,7 @@ class VerifyToken(BaseMutation):
     @classmethod
     def get_user(cls, payload):
         try:
-            user = get_user(payload)
+            user = get_user_or_error(payload)
         except ValidationError as e:
             raise ValidationError({"token": e})
         return user


### PR DESCRIPTION
Raise `InvalidTokenError` when an invalid token is passed to `get_user_from_access_token`.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
