### PR TITLE
Fix for variant false with inventory tracking.  Issue #6001

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "2.11.0-a.0",
+  "version": "2.11.0-rc.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "2.11.0-rc.1",
+  "version": "2.11.0-rc.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "2.11.0-a.0",
+  "version": "2.11.0-rc.1",
   "repository": {
     "type": "git",
     "url": "git://github.com/mirumee/saleor.git"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "saleor",
-  "version": "2.11.0-rc.1",
+  "version": "2.11.0-rc.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/mirumee/saleor.git"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saleor"
-version = "2.11.0-a.0"
+version = "2.11.0-rc.1"
 description = "A modular, high performance e-commerce storefront built with GraphQL, Django, and ReactJS."
 authors = ["Mirumee Software <hello@mirumee.com>"]
 license = "BSD-3-Clause"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "saleor"
-version = "2.11.0-rc.1"
+version = "2.11.0-rc.2"
 description = "A modular, high performance e-commerce storefront built with GraphQL, Django, and ReactJS."
 authors = ["Mirumee Software <hello@mirumee.com>"]
 license = "BSD-3-Clause"

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1491,3 +1491,25 @@ def test_cancel_active_payments(checkout_with_payments):
 
     # then
     assert checkout.payments.filter(is_active=True).count() == 0
+
+def test_create_order_with_variant_tracking_false(
+        checkout, customer_user, variant_without_inventory_tracking
+):
+    variant = variant_without_inventory_tracking
+    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
+    checkout.user = customer_user
+    checkout.billing_address = customer_user.default_billing_address
+    checkout.shipping_address = customer_user.default_billing_address
+    checkout.save()
+
+    order_data = prepare_order_data(
+        checkout=checkout, lines=list(checkout), tracking_code="", discounts=None
+    )
+
+    order_1 = create_order(
+        checkout=checkout,
+        order_data=order_data,
+        user=customer_user,
+        redirect_url="https://www.example.com",
+    )
+    assert order_1.checkout_token == checkout.token

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -35,12 +35,13 @@ def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity:
     If so - returns None. If there is less stock then required raise InsufficientStock
     exception.
     """
-    stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
-    if not stocks:
-        raise InsufficientStock(variant)
+    if variant.track_inventory:
+        stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
+        if not stocks:
+            raise InsufficientStock(variant)
 
-    if variant.track_inventory and quantity > _get_available_quantity(stocks):
-        raise InsufficientStock(variant)
+        if variant.track_inventory and quantity > _get_available_quantity(stocks):
+            raise InsufficientStock(variant)
 
 
 def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -40,7 +40,7 @@ def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity:
         if not stocks:
             raise InsufficientStock(variant)
 
-        if variant.track_inventory and quantity > _get_available_quantity(stocks):
+        if quantity > _get_available_quantity(stocks):
             raise InsufficientStock(variant)
 
 


### PR DESCRIPTION
I want to merge this change because...
Fix for variant without inventory tracking should be able to create order without throwing InsufficientStock exception.
Currently Exception is thrown when we add a variant with tracking_ventory set as False

<!-- Please mention all relevant issue numbers. -->
Issue: #6001 
# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
