### PR TITLE
Fix: checking variant.track_inventory while checking for stock_quantity

### DIFF
--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -9,6 +9,19 @@ from django_countries.fields import Country
 from freezegun import freeze_time
 from prices import Money, TaxedMoney
 
+from ...account import CustomerEvents
+from ...account.models import Address, CustomerEvent, User
+from ...account.utils import store_user_address
+from ...core.exceptions import InsufficientStock
+from ...core.taxes import zero_money, zero_taxed_money
+from ...discount import DiscountValueType, VoucherType
+from ...discount.models import NotApplicable, Voucher
+from ...order import OrderEvents, OrderEventsEmails
+from ...order.models import OrderEvent
+from ...payment.models import Payment
+from ...plugins.manager import get_plugins_manager
+from ...shipping.models import ShippingZone
+from ...tests.utils import flush_post_commit_hooks
 from .. import AddressType, calculations
 from ..models import Checkout
 from ..utils import (
@@ -27,19 +40,6 @@ from ..utils import (
     recalculate_checkout_discount,
     remove_voucher_from_checkout,
 )
-from ...account import CustomerEvents
-from ...account.models import Address, CustomerEvent, User
-from ...account.utils import store_user_address
-from ...core.exceptions import InsufficientStock
-from ...core.taxes import zero_money, zero_taxed_money
-from ...discount import DiscountValueType, VoucherType
-from ...discount.models import NotApplicable, Voucher
-from ...order import OrderEvents, OrderEventsEmails
-from ...order.models import OrderEvent
-from ...payment.models import Payment
-from ...plugins.manager import get_plugins_manager
-from ...shipping.models import ShippingZone
-from ...tests.utils import flush_post_commit_hooks
 
 
 def test_is_valid_shipping_method(checkout_with_item, address, shipping_zone):

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1497,11 +1497,11 @@ def test_create_order_with_variant_tracking_false(
     checkout, customer_user, variant_without_inventory_tracking
 ):
     variant = variant_without_inventory_tracking
-    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
     checkout.save()
+    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
 
     order_data = prepare_order_data(
         checkout=checkout, lines=list(checkout), tracking_code="", discounts=None

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -35,12 +35,13 @@ def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity:
     If so - returns None. If there is less stock then required raise InsufficientStock
     exception.
     """
-    stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
-    if not stocks:
-        raise InsufficientStock(variant)
+    if variant.track_inventory:
+        stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
+        if not stocks:
+            raise InsufficientStock(variant)
 
-    if variant.track_inventory and quantity > _get_available_quantity(stocks):
-        raise InsufficientStock(variant)
+        if quantity > _get_available_quantity(stocks):
+            raise InsufficientStock(variant)
 
 
 def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:


### PR DESCRIPTION
I want to merge this change because...

Fix for variant without inventory tracking should be able to create order without throwing InsufficientStock exception.
Currently Exception is thrown when we add a variant with tracking_ventory set as False
<!-- Please mention all relevant issue numbers. -->
Issue: #6001 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
