### PR TITLE
Replaced 'domain' with 'site_name' in email templates.

### DIFF
--- a/templates/templated_email/account/account_delete.email
+++ b/templates/templated_email/account/account_delete.email
@@ -7,7 +7,7 @@
 {% block plain %}
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Account delete reset e-mail text" %}
-You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ domain }}.
+You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.
 Click the link below to delete your account.
 
 Please note that this action is permanent and cannot be reversed.

--- a/templates/templated_email/account/confirm.email
+++ b/templates/templated_email/account/confirm.email
@@ -7,7 +7,7 @@
 {% block plain %}
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Account confirmation e-mail text" %}
-In order to log into {{ domain }}, you have to confirm your email address first.
+In order to log into {{ site_name }}, you have to confirm your email address first.
 Please click the link below to do so and log into your account.
 {% endblocktrans %}
 

--- a/templates/templated_email/account/email_changed_notification.email
+++ b/templates/templated_email/account/email_changed_notification.email
@@ -8,7 +8,7 @@
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Email change e-mail text" %}
 
-You're receiving this e-mail because you or someone else has changed email for your user account at {{ domain }}.
+You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.
 If you didn't request this change, please contact the administrator.
 {% endblocktrans %}
 

--- a/templates/templated_email/account/password_reset.email
+++ b/templates/templated_email/account/password_reset.email
@@ -7,7 +7,7 @@
 {% block plain %}
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Password reset e-mail text" %}
-You're receiving this e-mail because you or someone else has requested a password for your user account at {{ domain }}.
+You're receiving this e-mail because you or someone else has requested a password for your user account at {{ site_name }}.
 It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
 {% endblocktrans %}
 

--- a/templates/templated_email/account/request_email_change.email
+++ b/templates/templated_email/account/request_email_change.email
@@ -8,7 +8,7 @@
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Email change e-mail text" %}
 
-You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ domain }}.
+You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ site_name }}.
 It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.
 {% endblocktrans %}
 

--- a/templates/templated_email/compiled/account_delete.html
+++ b/templates/templated_email/compiled/account_delete.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Account delete e-mail text" %}
-            You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ domain }}.<br>
+            You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.<br>
             Click the link below to delete your account.
 
             Please note that this action is permanent and cannot be reversed.

--- a/templates/templated_email/compiled/confirm.html
+++ b/templates/templated_email/compiled/confirm.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Account confirmation e-mail text" %}
-            In order to log into {{ domain }}, you have to confirm your email address first.
+            In order to log into {{ site_name }}, you have to confirm your email address first.
             Please click the link below to do so and log into your account.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/compiled/email_changed_notification.html
+++ b/templates/templated_email/compiled/email_changed_notification.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Email change e-mail text" %}
-          You're receiving this e-mail because you or someone else has changed email for your user account at {{ domain }}.<br>
+          You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.<br>
           If you didn't request this change, please contact the administrator.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/compiled/password_reset.html
+++ b/templates/templated_email/compiled/password_reset.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Password reset e-mail text" %}
-            You're receiving this e-mail because you or someone else has requested a password for your user account at {{ domain }}.<br>
+            You're receiving this e-mail because you or someone else has requested a password for your user account at {{ site_name }}.<br>
             It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/compiled/request_email_change.html
+++ b/templates/templated_email/compiled/request_email_change.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Email change e-mail text" %}
-          You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ domain }}.<br>
+          You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ site_name }}.<br>
           It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/compiled/set_customer_password.html
+++ b/templates/templated_email/compiled/set_customer_password.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Set password for customer e-mail text" %}
-            You're receiving this e-mail because you have to set password for your customer account at {{ domain }}.<br>
+            You're receiving this e-mail because you have to set password for your customer account at {{ site_name }}.<br>
             Click the link below to set up your password.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/compiled/set_password.html
+++ b/templates/templated_email/compiled/set_password.html
@@ -104,7 +104,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Set password for staff member e-mail text" %}
-            You're receiving this e-mail because you have to set password for your staff member account at {{ domain }}.<br>
+            You're receiving this e-mail because you have to set password for your staff member account at {{ site_name }}.<br>
             Click the link below to set up your password.
           {% endblocktrans %}</div>
     

--- a/templates/templated_email/dashboard/customer/set_password.email
+++ b/templates/templated_email/dashboard/customer/set_password.email
@@ -4,7 +4,7 @@
 {% block plain %}
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Set password for customer e-mail text" %}
-You're receiving this e-mail because you have to set a password for your customer account at {{ domain }}.
+You're receiving this e-mail because you have to set a password for your customer account at {{ site_name }}.
 Click the link below to reset your password.
 {% endblocktrans %}
 

--- a/templates/templated_email/dashboard/staff/set_password.email
+++ b/templates/templated_email/dashboard/staff/set_password.email
@@ -4,7 +4,7 @@
 {% block plain %}
 {% include 'templated_email/shared/_header.email' %}
 {% blocktrans context "Set password for staff member e-mail text" %}
-You're receiving this e-mail because you have to set a password for your staff member account at {{ domain }}.
+You're receiving this e-mail because you have to set a password for your staff member account at {{ site_name }}.
 Click the link below to reset your password.
 {% endblocktrans %}
 

--- a/templates/templated_email/source/account_delete.mjml
+++ b/templates/templated_email/source/account_delete.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Account delete e-mail text" %}
-            You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ domain }}.<br/>
+            You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.<br/>
             Click the link below to delete your account.
 
             Please note that this action is permanent and cannot be reversed.

--- a/templates/templated_email/source/confirm.mjml
+++ b/templates/templated_email/source/confirm.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Account confirmation e-mail text" %}
-            In order to log into {{ domain }}, you have to confirm your email address first.
+            In order to log into {{ site_name }}, you have to confirm your email address first.
             Please click the link below to do so and log into your account.
           {% endblocktrans %}
         </mj-text>

--- a/templates/templated_email/source/email_changed_notification.mjml
+++ b/templates/templated_email/source/email_changed_notification.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Email change e-mail text" %}
-          You're receiving this e-mail because you or someone else has changed email for your user account at {{ domain }}.<br />
+          You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.<br />
           If you didn't request this change, please contact the administrator.
           {% endblocktrans %}
         </mj-text>

--- a/templates/templated_email/source/password_reset.mjml
+++ b/templates/templated_email/source/password_reset.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Password reset e-mail text" %}
-            You're receiving this e-mail because you or someone else has requested a password for your user account at {{ domain }}.<br/>
+            You're receiving this e-mail because you or someone else has requested a password for your user account at {{ site_name }}.<br/>
             It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
           {% endblocktrans %}
         </mj-text>

--- a/templates/templated_email/source/request_email_change.mjml
+++ b/templates/templated_email/source/request_email_change.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Email change e-mail text" %}
-          You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ domain }}.<br />
+          You're receiving this e-mail because you or someone else has requested an email change for your user account at {{ site_name }}.<br />
           It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.
           {% endblocktrans %}
         </mj-text>

--- a/templates/templated_email/source/set_customer_password.mjml
+++ b/templates/templated_email/source/set_customer_password.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Set password for customer e-mail text" %}
-            You're receiving this e-mail because you have to set password for your customer account at {{ domain }}.<br/>
+            You're receiving this e-mail because you have to set password for your customer account at {{ site_name }}.<br/>
             Click the link below to set up your password.
           {% endblocktrans %}
         </mj-text>

--- a/templates/templated_email/source/set_password.mjml
+++ b/templates/templated_email/source/set_password.mjml
@@ -14,7 +14,7 @@
         </mj-text>
         <mj-text>
           {% blocktrans trimmed context "Set password for staff member e-mail text" %}
-            You're receiving this e-mail because you have to set password for your staff member account at {{ domain }}.<br/>
+            You're receiving this e-mail because you have to set password for your staff member account at {{ site_name }}.<br/>
             Click the link below to set up your password.
           {% endblocktrans %}
         </mj-text>


### PR DESCRIPTION
I've replaced `domain` with `site_name` in the email templates.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
