### PR TITLE
Refactor after merge variant and shipping prices

### DIFF
--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -62,8 +62,6 @@ def validate_order_lines(order, country):
                 )
 
 
-# TODO: We should reuse this logic in DraftOrderCreate validation
-# `validate_product_is_published_in_channel` after merge #5975
 def validate_product_is_published(order):
     variant_ids = []
     for line in order:

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -101,6 +101,9 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
         ProductChannelListing.objects.filter(
             product=product, channel_id__in=remove_channels
         ).delete()
+        ProductVariantChannelListing.objects.filter(
+            variant__product_id=product.pk, channel_id__in=remove_channels
+        ).delete()
 
     @classmethod
     @transaction.atomic()
@@ -134,7 +137,6 @@ class ProductVariantChannelListingAddInput(graphene.InputObjectType):
     )
 
 
-# TODO: Use BaseChannelListingMutation after merge #5975.
 class ProductVaraintChannelListingUpdate(BaseMutation):
     variant = graphene.Field(
         ProductVariant, description="An updated product variant instance."

--- a/saleor/graphql/product/tests/test_product_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_product_channel_listing_update.py
@@ -420,9 +420,17 @@ def test_product_channel_listing_update_update_publication_data(
 
 
 def test_product_channel_listing_update_remove_channel(
-    staff_api_client, product, permission_manage_products, channel_USD
+    staff_api_client,
+    product_available_in_many_channels,
+    permission_manage_products,
+    channel_USD,
+    channel_PLN,
 ):
     # given
+    product = product_available_in_many_channels
+    product_channel_listing_pln = product.channel_listing.get(channel=channel_PLN)
+    variant = product.variants.get()
+    variant_channel_listing_pln = variant.channel_listing.get(channel=channel_PLN)
     product_id = graphene.Node.to_global_id("Product", product.pk)
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     variables = {
@@ -443,7 +451,9 @@ def test_product_channel_listing_update_remove_channel(
     product_data = data["product"]
     assert not data["productChannelListingErrors"]
     assert product_data["slug"] == product.slug
-    assert len(product_data["channelListing"]) == 0
+    assert len(product_data["channelListing"]) == 1
+    assert product.channel_listing.get() == product_channel_listing_pln
+    assert variant.channel_listing.get() == variant_channel_listing_pln
 
 
 def test_product_channel_listing_update_remove_not_assigned_channel(


### PR DESCRIPTION
Refactor validate_product_is_published_in_channel to use `not_published` on product queryset.
Remove variant prices when removing the product from the channel

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
