### PR TITLE
Add TotalPrice to OrderLine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Adyen drop-in integration - #5914 by @korycins, @IKarbowiak
 - Add `change_currency` command - #6016 by @maarcingebala
 - Send a confirmation email when the order is canceled or refunded - #6017
+- Add `TotalPrice` to `OrderLine` - #6068 @fowczarek
 
 ### Breaking Changes
 

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -100,6 +100,19 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
                             variant {
                                 id
                             }
+                            quantity
+                            unitPrice {
+                                currency
+                                gross {
+                                    amount
+                                }
+                            }
+                            totalPrice {
+                                currency
+                                gross {
+                                    amount
+                                }
+                            }
                         }
                     }
                 }
@@ -116,6 +129,19 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
     assert order_data["lines"][0]["thumbnail"] is None
     variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
     assert order_data["lines"][0]["variant"]["id"] == variant_id
+    assert order_data["lines"][0]["quantity"] == line.quantity
+    assert order_data["lines"][0]["unitPrice"]["currency"] == line.unit_price.currency
+    expected_unit_price = Money(
+        amount=str(order_data["lines"][0]["unitPrice"]["gross"]["amount"]),
+        currency="USD",
+    )
+    assert order_data["lines"][0]["totalPrice"]["currency"] == line.unit_price.currency
+    assert expected_unit_price == line.unit_price.gross
+    expected_total_price = Money(
+        amount=str(order_data["lines"][0]["totalPrice"]["gross"]["amount"]),
+        currency="USD",
+    )
+    assert expected_total_price == line.unit_price.gross * line.quantity
 
 
 def test_order_query(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -240,6 +240,7 @@ class OrderLine(CountableDjangoObjectType):
     unit_price = graphene.Field(
         TaxedMoney, description="Price of the single item in the order line."
     )
+    total_price = graphene.Field(TaxedMoney, description="Price of the order line.",)
     variant = graphene.Field(
         ProductVariant,
         required=False,
@@ -285,6 +286,10 @@ class OrderLine(CountableDjangoObjectType):
     @staticmethod
     def resolve_unit_price(root: models.OrderLine, _info):
         return root.unit_price
+
+    @staticmethod
+    def resolve_total_price(root: models.OrderLine, _info):
+        return root.unit_price * root.quantity
 
     @staticmethod
     def resolve_translated_product_name(root: models.OrderLine, _info):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3123,6 +3123,7 @@ type OrderLine implements Node {
   digitalContentUrl: DigitalContentUrl
   thumbnail(size: Int): Image
   unitPrice: TaxedMoney
+  totalPrice: TaxedMoney
   variant: ProductVariant
   translatedProductName: String!
   translatedVariantName: String!


### PR DESCRIPTION
I want to merge this change because adding `total_price` to `order_line` in GraphQL API.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
