### PR TITLE
No secure cookie in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `change_currency` command - #6016 by @maarcingebala
 - Send a confirmation email when the order is canceled or refunded - #6017
 - Add `TotalPrice` to `OrderLine` - #6068 @fowczarek
+- No secure cookie in debug mode - #6082 by @patrys, @orzechdev
 
 ### Breaking Changes
 

--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -135,7 +135,7 @@ def jwt_refresh_token_middleware(get_response):
                 jwt_refresh_token,
                 expires=expires,
                 httponly=True,  # protects token from leaking
-                secure=True,
+                secure=not settings.DEBUG,
             )
         return response
 


### PR DESCRIPTION
I want to merge this change because... it removes setting secure flag in `set-cookie` header in debug mode for easier testing.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
