### PR TITLE
Use checkout object with many lines in benchmark tests

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -14,17 +14,26 @@ def customer_checkout(customer_user, checkout_with_voucher_percentage_and_shippi
 
 
 @pytest.fixture()
-def checkout_with_variant(checkout, stock):
-    variant = stock.product_variant
-    add_variant_to_checkout(checkout, variant, 1)
+def checkout_with_variants(
+    checkout,
+    stock,
+    product_with_default_variant,
+    product_with_single_variant,
+    product_with_two_variants,
+):
+
+    add_variant_to_checkout(checkout, product_with_default_variant.variants.get(), 1)
+    add_variant_to_checkout(checkout, product_with_single_variant.variants.get(), 10)
+    add_variant_to_checkout(checkout, product_with_two_variants.variants.first(), 3)
+    add_variant_to_checkout(checkout, product_with_two_variants.variants.last(), 5)
 
     checkout.save()
     return checkout
 
 
 @pytest.fixture()
-def checkout_with_shipping_address(checkout_with_variant, address):
-    checkout = checkout_with_variant
+def checkout_with_shipping_address(checkout_with_variants, address):
+    checkout = checkout_with_variants
 
     checkout.shipping_address = address.get_copy()
     checkout.save()

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -297,7 +297,7 @@ def test_add_billing_address_to_checkout(
 @pytest.mark.count_queries(autouse=False)
 def test_update_checkout_lines(
     api_client,
-    checkout_with_variant,
+    checkout_with_items,
     stock,
     product_with_default_variant,
     product_with_single_variant,
@@ -331,7 +331,7 @@ def test_update_checkout_lines(
         """
     )
     variables = {
-        "checkoutId": Node.to_global_id("Checkout", checkout_with_variant.pk),
+        "checkoutId": Node.to_global_id("Checkout", checkout_with_items.pk),
         "lines": [
             {
                 "quantity": 1,
@@ -372,7 +372,7 @@ def test_update_checkout_lines(
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_checkout_shipping_address_update(
-    api_client, graphql_address_data, checkout_with_variant, count_queries
+    api_client, graphql_address_data, checkout_with_variants, count_queries
 ):
     query = (
         FRAGMENT_CHECKOUT
@@ -395,7 +395,7 @@ def test_checkout_shipping_address_update(
         """
     )
     variables = {
-        "checkoutId": Node.to_global_id("Checkout", checkout_with_variant.pk),
+        "checkoutId": Node.to_global_id("Checkout", checkout_with_variants.pk),
         "shippingAddress": graphql_address_data,
     }
     response = get_graphql_content(api_client.post_graphql(query, variables))
@@ -404,7 +404,7 @@ def test_checkout_shipping_address_update(
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_checkout_email_update(api_client, checkout_with_variant, count_queries):
+def test_checkout_email_update(api_client, checkout_with_variants, count_queries):
     query = (
         FRAGMENT_CHECKOUT
         + """
@@ -424,7 +424,7 @@ def test_checkout_email_update(api_client, checkout_with_variant, count_queries)
         """
     )
     variables = {
-        "checkoutId": Node.to_global_id("Checkout", checkout_with_variant.pk),
+        "checkoutId": Node.to_global_id("Checkout", checkout_with_variants.pk),
         "email": "newEmail@example.com",
     }
     response = get_graphql_content(api_client.post_graphql(query, variables))


### PR DESCRIPTION
Most of the benchmark tests for counting the queries for checkout use simple relation with only one line. As a result, we don't see the issues with missing prefetches or increasing DB counts. This PR changes the checkout object used in benchmark test.
An increased number of queries in `django-queries` is expected.