### PR TITLE
Do not allow negative product price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix incorrect tax calculation for Avatax - #6035 by @korycins
 - Fix incorrect calculation of subtotal with active Avatax - #6035 by @korycins
 - Fix incorrect assigment of tax_code for Avatax - #6035 by @korycins
+- Do not allow negative product price - #6091 by @IKarbowiak
 
 ## 2.10.2
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -823,6 +823,17 @@ class ProductCreate(ModelMutation):
                 }
             )
 
+        base_price = cleaned_input.get("base_price")
+        if base_price is not None and base_price < 0:
+            raise ValidationError(
+                {
+                    "base_price": ValidationError(
+                        "Product price cannot be lower than 0.",
+                        code=ProductErrorCode.INVALID.value,
+                    )
+                }
+            )
+
         # Attributes are provided as list of `AttributeValueInput` objects.
         # We need to transform them into the format they're stored in the
         # `Product` model, which is HStore field that maps attribute's PK to


### PR DESCRIPTION
Do not allow negative product price - right now there is a possibility to provide negative `basePrice` in `productUpdate` and `productCreate` mutation. If a variant for the product doesn't exists, the `basePrice` is used as variant price.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
