### PR TITLE
Fix for inccorect calculating taxes for orders in Avalara

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -268,6 +268,9 @@ def get_order_lines_data(
             tax_code=tax_code,
             item_code=line.variant.sku,
             name=line.variant.product.name,
+            # The orders created from checkout have already assigned taxes,
+            # orders from draft doesn't have.
+            tax_included=line.unit_price_gross_amount != line.unit_price_net_amount,
         )
     if order.discount_amount:
         append_line_to_data(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -19,6 +19,7 @@ from .. import (
     api_post_request,
     generate_request_data_from_checkout,
     get_cached_tax_codes_or_fetch,
+    get_order_request_data,
     taxes_need_new_fetch,
 )
 from ..plugin import AvataxPlugin
@@ -652,3 +653,33 @@ def test_api_post_request_handles_json_errors(product, monkeypatch):
 
     assert mocked_response.called
     assert response == {}
+
+
+def test_get_order_request_data_checks_if_taxes_are_included_to_price(
+    order_with_lines, shipping_zone, site_settings, address_usa
+):
+    method = shipping_zone.shipping_methods.get()
+    line = order_with_lines.lines.first()
+    line.unit_price_gross_amount = line.unit_price_net_amount
+    line.save()
+
+    order_with_lines.shipping_address = order_with_lines.billing_address.get_copy()
+    order_with_lines.shipping_method_name = method.name
+    order_with_lines.shipping_method = method
+    order_with_lines.save()
+
+    site_settings.company_address = address_usa
+    site_settings.save()
+
+    config = AvataxConfiguration(
+        username_or_account="", password_or_license="", use_sandbox=False,
+    )
+    request_data = get_order_request_data(order_with_lines, config)
+    lines_data = request_data["createTransactionModel"]["lines"]
+    line_without_taxes = [line for line in lines_data if line["taxIncluded"] is False]
+    lines_with_taxes = [line for line in lines_data if line["taxIncluded"] is True]
+
+    assert len(line_without_taxes) == 1
+    assert len(lines_with_taxes) == 2
+
+    assert line_without_taxes[0]["itemCode"] == line.product_sku


### PR DESCRIPTION
For the orders created form checkout, the logic was assigning the taxes one more time. 
