### PR TITLE
Fix incorrect tax calculation for Avatax. Recalculate draft order prices

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -15,7 +15,7 @@ from ....order.actions import (
     order_voided,
 )
 from ....order.error_codes import OrderErrorCode
-from ....order.utils import get_valid_shipping_methods_for_order
+from ....order.utils import get_valid_shipping_methods_for_order, update_order_prices
 from ....payment import CustomPaymentChoices, PaymentError, TransactionKind, gateway
 from ...account.types import AddressInput
 from ...core.mutations import BaseMutation
@@ -249,6 +249,7 @@ class OrderUpdateShipping(BaseMutation):
                 "shipping_price_gross_amount",
             ]
         )
+        update_order_prices(order, info.context.discounts)
         # Post-process the results
         order_shipping_updated(order)
         return OrderUpdateShipping(order=order)

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -254,6 +254,7 @@ def get_order_lines_data(
         "variant__product__collections",
         "variant__product__product_type",
     ).filter(variant__product__charge_taxes=True)
+    system_tax_included = Site.objects.get_current().settings.include_taxes_in_prices
     for line in lines:
         if not line.variant:
             continue
@@ -261,6 +262,15 @@ def get_order_lines_data(
         product_type = line.variant.product.product_type
         tax_code = retrieve_tax_code_from_meta(product, default=None)
         tax_code = tax_code or retrieve_tax_code_from_meta(product_type)
+
+        # Confirm if line doesn't have included taxes in the price. If not then, we
+        # check if the current Saleor config doesn't assume that taxes are included in
+        # prices
+        line_has_included_taxes = (
+            line.unit_price_gross_amount != line.unit_price_net_amount
+        )
+        tax_included = line_has_included_taxes or system_tax_included
+
         append_line_to_data(
             data=data,
             quantity=line.quantity,
@@ -268,9 +278,7 @@ def get_order_lines_data(
             tax_code=tax_code,
             item_code=line.variant.sku,
             name=line.variant.product.name,
-            # The orders created from checkout have already assigned taxes,
-            # orders from draft doesn't have.
-            tax_included=line.unit_price_gross_amount != line.unit_price_net_amount,
+            tax_included=tax_included,
         )
     if order.discount_amount:
         append_line_to_data(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -677,7 +677,7 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
     request_data = get_order_request_data(order_with_lines, config)
     lines_data = request_data["createTransactionModel"]["lines"]
 
-    assert all([line for line in lines_data])
+    assert all([line for line in lines_data if line["taxIncluded"] is True])
 
 
 def test_get_order_request_data_checks_when_taxes_are_not_included_to_price(


### PR DESCRIPTION
- fix for re-calculating prices in the draft order
- fix for adding taxes to the gross price