### PR TITLE
Allow REDIS_URL as CELERY_BROKER_URL

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -470,7 +470,10 @@ AUTHENTICATION_BACKENDS = [
 # CELERY SETTINGS
 CELERY_TIMEZONE = TIME_ZONE
 CELERY_BROKER_URL = (
-    os.environ.get("CELERY_BROKER_URL", os.environ.get("CLOUDAMQP_URL")) or ""
+    os.environ.get(
+        "CELERY_BROKER_URL", 
+        os.environ.get("CLOUDAMQP_URL", os.environ.get("REDIS_URL"))
+    ) or ""
 )
 CELERY_TASK_ALWAYS_EAGER = not CELERY_BROKER_URL
 CELERY_ACCEPT_CONTENT = ["json"]


### PR DESCRIPTION
I want to merge this change because in Heroku we can use only one REDIS_URL variable. And I don't want to create 2 Redis instances. I want to use one Redis for Celery broker and fo Cache. 

Is it a good fix?
