### PR TITLE
Remove corresponding draft order lines when variant is removing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update default decimal places - #6098 by @IKarbowiak
 - Avoid assigning the same pictures twice to a variant - #6112 by @IKarbowiak
 - Fix crashing system when avalara is improperly configured - #6117 by @IKarbowiak
+- Remove corresponding draft order lines when variant is removing - #6119 by @IKarbowiak
 
 ## 2.10.2
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -36,7 +36,7 @@ from ..mutations.products import (
     ProductVariantInput,
     StockInput,
 )
-from ..types import ProductVariant
+from ..types import Product, ProductVariant
 from ..utils import create_stocks, get_used_variants_attribute_values
 
 
@@ -108,6 +108,24 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+
+    @classmethod
+    def perform_mutation(cls, _root, info, ids, **data):
+        nodes_type, pks = resolve_global_ids_to_primary_keys(ids, Product)
+        variants = models.ProductVariant.objects.filter(product__pk__in=pks)
+        # get draft order lines for products
+        order_line_pks = list(
+            order_models.OrderLine.objects.filter(
+                variant__in=variants, order__status=OrderStatus.DRAFT
+            ).values_list("pk", flat=True)
+        )
+
+        response = super().perform_mutation(_root, info, ids, **data)
+
+        # delete order lines for deleted variants
+        order_models.OrderLine.objects.filter(pk__in=order_line_pks).delete()
+
+        return response
 
 
 class ProductVariantBulkCreateInput(ProductVariantInput):

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -111,7 +111,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, ids, **data):
-        nodes_type, pks = resolve_global_ids_to_primary_keys(ids, Product)
+        _, pks = resolve_global_ids_to_primary_keys(ids, Product)
         variants = models.ProductVariant.objects.filter(product__pk__in=pks)
         # get draft order lines for products
         order_line_pks = list(
@@ -363,11 +363,11 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, ids, **data):
-        instances = cls.get_nodes_or_error(ids, "id", ProductVariant)
+        _, pks = resolve_global_ids_to_primary_keys(ids, ProductVariant)
         # get draft order lines for variants
         order_line_pks = list(
             order_models.OrderLine.objects.filter(
-                variant__in=instances, order__status=OrderStatus.DRAFT
+                variant__pk__in=pks, order__status=OrderStatus.DRAFT
             ).values_list("pk", flat=True)
         )
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1402,12 +1402,12 @@ class ProductVariantDelete(ModelDeleteMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         node_id = data.get("id")
-        instance = cls.get_node_or_error(info, node_id, only_type=ProductVariant)
+        variant_pk = from_global_id_strict_type(node_id, ProductVariant, field="pk")
 
         # get draft order lines for variant
         line_pks = list(
             order_models.OrderLine.objects.filter(
-                variant=instance, order__status=OrderStatus.DRAFT
+                variant__pk=variant_pk, order__status=OrderStatus.DRAFT
             ).values_list("pk", flat=True)
         )
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -2909,8 +2909,6 @@ def test_delete_product_variant_in_draft_order(
         product.refresh_from_db()
     assert node_id == data["product"]["id"]
 
-    with pytest.raises(order_line._meta.model.DoesNotExist):
-        order_line.refresh_from_db()
     assert not OrderLine.objects.filter(pk__in=draft_order_lines_pks).exists()
 
     assert OrderLine.objects.filter(pk__in=not_draft_order_lines_pks).exists()

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -4,8 +4,11 @@ from uuid import uuid4
 import graphene
 import pytest
 from measurement.measures import Weight
+from prices import Money, TaxedMoney
 
 from ....core.weight import WeightUnits
+from ....order import OrderStatus
+from ....order.models import OrderLine
 from ....product.error_codes import ProductErrorCode
 from ....product.models import Product, ProductVariant
 from ....product.utils.attributes import associate_attribute_values_to_instance
@@ -999,17 +1002,20 @@ def test_update_product_variant_with_price_does_not_raise_price_validation_error
     )
 
 
-def test_delete_variant(staff_api_client, product, permission_manage_products):
-    query = """
-        mutation variantDelete($id: ID!) {
-            productVariantDelete(id: $id) {
-                productVariant {
-                    sku
-                    id
-                }
-              }
+DELETE_VARIANT_MUTATION = """
+    mutation variantDelete($id: ID!) {
+        productVariantDelete(id: $id) {
+            productVariant {
+                sku
+                id
             }
-    """
+            }
+        }
+"""
+
+
+def test_delete_variant(staff_api_client, product, permission_manage_products):
+    query = DELETE_VARIANT_MUTATION
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
     variables = {"id": variant_id}
@@ -1021,6 +1027,47 @@ def test_delete_variant(staff_api_client, product, permission_manage_products):
     assert data["productVariant"]["sku"] == variant.sku
     with pytest.raises(variant._meta.model.DoesNotExist):
         variant.refresh_from_db()
+
+
+def test_delete_variant_in_draft_order(
+    staff_api_client, order_line, permission_manage_products, order_list
+):
+    query = DELETE_VARIANT_MUTATION
+
+    draft_order = order_line.order
+    draft_order.status = OrderStatus.DRAFT
+    draft_order.save(update_fields=["status"])
+
+    variant = order_line.variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {"id": variant_id}
+
+    net = variant.get_price()
+    gross = Money(amount=net.amount, currency=net.currency)
+    order_not_draft = order_list[-1]
+    order_line_not_in_draft = OrderLine.objects.create(
+        variant=variant,
+        order=order_not_draft,
+        product_name=str(variant.product),
+        variant_name=str(variant),
+        product_sku=variant.sku,
+        is_shipping_required=variant.is_shipping_required(),
+        unit_price=TaxedMoney(net=net, gross=gross),
+        quantity=3,
+    )
+    order_line_not_in_draft_pk = order_line_not_in_draft.pk
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantDelete"]
+    assert data["productVariant"]["sku"] == variant.sku
+    with pytest.raises(order_line._meta.model.DoesNotExist):
+        order_line.refresh_from_db()
+
+    assert OrderLine.objects.filter(pk=order_line_not_in_draft_pk).exists()
 
 
 def _fetch_all_variants(client, permissions=None):


### PR DESCRIPTION
When the variant is removing, the corresponding draft order lines too.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
