### PR TITLE
Fix incorrectly returned tax codes

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -870,9 +870,10 @@ class ProductCreate(ModelMutation):
         if tax_rate:
             info.context.plugins.assign_tax_code_to_object_meta(instance, tax_rate)
 
-        tax_code = cleaned_input.pop("tax_code", "")
-        if tax_code:
-            info.context.plugins.assign_tax_code_to_object_meta(instance, tax_code)
+        if "tax_code" in cleaned_input:
+            info.context.plugins.assign_tax_code_to_object_meta(
+                instance, cleaned_input["tax_code"]
+            )
 
         if attributes and product_type:
             try:

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -39,6 +39,7 @@ COMMON_DISCOUNT_VOUCHER_CODE = "OD010000"
 
 # Temporary Unmapped Other SKU - taxable default
 DEFAULT_TAX_CODE = "O9999999"
+DEFAULT_TAX_DESCRIPTION = "Unmapped Other SKU - taxable default"
 
 
 @dataclass

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -398,8 +398,13 @@ class AvataxPlugin(BasePlugin):
         if not self.active:
             return previous_value
 
+        if tax_code is None and obj.pk:
+            obj.delete_value_from_metadata(META_CODE_KEY)
+            obj.delete_value_from_metadata(META_DESCRIPTION_KEY)
+            return
+
         codes = get_cached_tax_codes_or_fetch(self.config)
-        if tax_code and tax_code not in codes:
+        if tax_code not in codes:
             return
 
         tax_description = codes.get(tax_code)

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -401,15 +401,16 @@ class AvataxPlugin(BasePlugin):
         if tax_code is None and obj.pk:
             obj.delete_value_from_metadata(META_CODE_KEY)
             obj.delete_value_from_metadata(META_DESCRIPTION_KEY)
-            return
+            return previous_value
 
         codes = get_cached_tax_codes_or_fetch(self.config)
         if tax_code not in codes:
-            return
+            return previous_value
 
         tax_description = codes.get(tax_code)
         tax_item = {META_CODE_KEY: tax_code, META_DESCRIPTION_KEY: tax_description}
         obj.store_value_in_metadata(items=tax_item)
+        return previous_value
 
     def get_tax_code_from_object_meta(
         self, obj: Union["Product", "ProductType"], previous_value: Any

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -90,7 +90,7 @@ def test_calculate_checkout_line_total(
     site_settings.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, None)
+    product.metadata = {}
     manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
     product.product_type.save()
@@ -147,7 +147,7 @@ def test_calculate_checkout_total_uses_default_calculation(
     checkout_with_item.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, None)
+    product.metadata = {}
     manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
     product.product_type.save()
@@ -216,7 +216,7 @@ def test_calculate_checkout_total(
     checkout_with_item.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, None)
+    product.metadata = {}
     manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
     product.product_type.save()

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -90,8 +90,10 @@ def test_calculate_checkout_line_total(
     site_settings.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, "PC040156")
+    manager.assign_tax_code_to_object_meta(product, None)
+    manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
+    product.product_type.save()
     discounts = [discount_info] if with_discount else None
     total = manager.calculate_checkout_line_total(line, discounts)
     total = quantize_price(total, total.currency)
@@ -145,9 +147,10 @@ def test_calculate_checkout_total_uses_default_calculation(
     checkout_with_item.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, "PC040156")
+    manager.assign_tax_code_to_object_meta(product, None)
+    manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
-
+    product.product_type.save()
     product_with_single_variant.charge_taxes = False
     product_with_single_variant.category = non_default_category
     product_with_single_variant.save()
@@ -213,9 +216,10 @@ def test_calculate_checkout_total(
     checkout_with_item.save()
     line = checkout_with_item.lines.first()
     product = line.variant.product
-    manager.assign_tax_code_to_object_meta(product, "PC040156")
+    manager.assign_tax_code_to_object_meta(product, None)
+    manager.assign_tax_code_to_object_meta(product.product_type, "PC040156")
     product.save()
-
+    product.product_type.save()
     product_with_single_variant.charge_taxes = False
     product_with_single_variant.category = non_default_category
     product_with_single_variant.save()

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -253,7 +253,10 @@ class BasePlugin:
         return NotImplemented
 
     def assign_tax_code_to_object_meta(
-        self, obj: Union["Product", "ProductType"], tax_code: str, previous_value: Any
+        self,
+        obj: Union["Product", "ProductType"],
+        tax_code: Optional[str],
+        previous_value: Any,
     ):
         """Assign tax code dedicated to plugin."""
         return NotImplemented

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -455,7 +455,7 @@ class PluginsManager(PaymentInterface):
     # FIXME these methods should be more generic
 
     def assign_tax_code_to_object_meta(
-        self, obj: Union["Product", "ProductType"], tax_code: str
+        self, obj: Union["Product", "ProductType"], tax_code: Optional[str]
     ):
         default_value = None
         return self.__run_method_on_plugins(

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -247,7 +247,7 @@ class VatlayerPlugin(BasePlugin):
         if tax_code is None and obj.pk:
             obj.delete_value_from_metadata(self.META_CODE_KEY)
             obj.delete_value_from_metadata(self.META_DESCRIPTION_KEY)
-            return
+            return previous_value
 
         if tax_code not in dict(TaxRateType.CHOICES):
             return previous_value

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -244,7 +244,12 @@ class VatlayerPlugin(BasePlugin):
         if not self.active:
             return previous_value
 
-        if tax_code and tax_code not in dict(TaxRateType.CHOICES):
+        if tax_code is None and obj.pk:
+            obj.delete_value_from_metadata(self.META_CODE_KEY)
+            obj.delete_value_from_metadata(self.META_DESCRIPTION_KEY)
+            return
+
+        if tax_code not in dict(TaxRateType.CHOICES):
             return previous_value
 
         tax_item = {self.META_CODE_KEY: tax_code, self.META_DESCRIPTION_KEY: tax_code}

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -442,10 +442,7 @@ def test_apply_taxes_to_product_uses_taxes_from_product_type(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     country = Country("PL")
     manager = get_plugins_manager()
-    variant.product.metadata = {
-        "vatlayer.code": None,
-        "vatlayer.description": None,
-    }
+    variant.product.metadata = {}
     variant.product.product_type.metadata = {
         "vatlayer.code": "standard",
         "vatlayer.description": "standard",

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -436,6 +436,26 @@ def test_apply_taxes_to_product(vatlayer, settings, variant, discount_info):
     assert price == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5.00", "USD"))
 
 
+def test_apply_taxes_to_product_uses_taxes_from_product_type(
+    vatlayer, settings, variant, discount_info
+):
+    settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
+    country = Country("PL")
+    manager = get_plugins_manager()
+    variant.product.metadata = {
+        "vatlayer.code": None,
+        "vatlayer.description": None,
+    }
+    variant.product.product_type.metadata = {
+        "vatlayer.code": "standard",
+        "vatlayer.description": "standard",
+    }
+    price = manager.apply_taxes_to_product(
+        variant.product, variant.get_price([discount_info]), country
+    )
+    assert price == TaxedMoney(net=Money("4.07", "USD"), gross=Money("5.00", "USD"))
+
+
 def test_calculations_checkout_total_with_vatlayer(
     vatlayer, settings, checkout_with_item
 ):

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -455,7 +455,7 @@
         "taxes": {
           "vatlayer": {
             "code": "standard",
-            "description": ""
+            "description": "standard"
           }
         }
       },

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -301,7 +301,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Paint",
       "slug": "paint",
@@ -318,7 +318,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Music",
       "slug": "music",
@@ -335,7 +335,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Juice",
       "slug": "juice",
@@ -352,7 +352,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Wine",
       "slug": "wine",
@@ -369,7 +369,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Beer",
       "slug": "beer",
@@ -386,7 +386,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Cushion",
       "slug": "cushion",
@@ -403,7 +403,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Shoe",
       "slug": "shoe",
@@ -420,7 +420,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "name": "Top (clothing)",
       "slug": "top-clothing",
@@ -496,7 +496,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "The rich, deep hue of space dust. Vacuum packed and airlocked for long-lasting freshness of color.",
@@ -535,7 +535,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "",
@@ -574,7 +574,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "There is life in outer space. This vibrant light speed yellow paint brings life to any surface. Goes on easy and dries at light speed.",
@@ -613,7 +613,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Turquoise is the new black. No more gloomy night skies, brighten up your evenings with hyperspace paint.",
@@ -652,7 +652,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Fell from a tree straight into the bottle. No additives, no preservatives, just the refreshing taste of pure sun-kissed Californian oranges.",
@@ -691,7 +691,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Fell straight from the tree, on to Newton’s head, then into the bottle. The autumn taste of English apples. Brought to you by gravity.",
@@ -730,7 +730,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Improve your eyesight the natural way with 100% pure, squeezed carrot juice. The sweet, orange nectar of Mother Earth.",
@@ -769,7 +769,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Build your protein the natural way, with exotic banana juice made from ripe fruit and packed with all the goodness of the tropical sun.",
@@ -808,7 +808,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "I can’t stand pineapples, so this one is not for me. They have a weird, fluffy, tangy taste. But if it is your kind of thing, then knock yourself out.",
@@ -847,7 +847,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Did you know falling coconuts kill 150 people a year? But did you know that coconut juice is the new superfood? You win some, you lose some.",
@@ -886,7 +886,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Is it a bird? Is it a plane? No! It’s some jacked dude who just sucked down a bottle of our brand new power juice! Look at him go!",
@@ -925,7 +925,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Brussel sprouts, spinach, peas, kale, lettuce, cabbage, zucchini, more brussel sprouts. All the greens you’ll ever need in one delicious juice.",
@@ -964,7 +964,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Bean there, drunk that! The energy drink for the health-conscious. Brand new bean juice; from allotment to bottle in under 8 hours.",
@@ -1003,7 +1003,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "A fine, mature red with a hint of blackberry, an undertone of the alkaline Burgundy soil, a delicate aftertaste of burnt garlic, and a whole lot of grapes.",
@@ -1042,7 +1042,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Watch the slow setting sun of a wild summer evening sink into the horizon as you sip white wine that tastes like bittersweet memories of halcyon days.",
@@ -1081,7 +1081,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Find your sea legs and then lose the power to use them with extra strong seaman’s lager. Don’t drink and sail, me hearties!",
@@ -1120,7 +1120,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Best beer on the seven seas. A dark ale for when the dark clouds gather overhead. The nutty nautical taste that sailors love.",
@@ -1159,7 +1159,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Add a little color to your life with a Saleor parrot cushion. Turns any old sofa into a rainbow of classy interior design.",
@@ -1198,7 +1198,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Minimalist interiors need simple, sleek soft furnishings. Don’t parrot what others do, set your own monochrome trends with Saleor designs.",
@@ -1237,7 +1237,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Mellow yellow. Step into summer with Saleor. Every time your head goes down, you see these beauties, and your mood bounces right back up.",
@@ -1276,7 +1276,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "PE at school wouldn’t have been such a drag with these on your feet. Slip on the style and stride tall with Saleor branded plimsolls. PE now stands for pretty elegant.",
@@ -1315,7 +1315,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Pay homage to the music and art of Joy Division and Peter Saville, but with a Mirumee twist. Perfect live transmission apparel for dead souls.",
@@ -1354,7 +1354,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Ever have those days where you feel a bit geometric? Can't quite shape yourself up right? Show your different sides with a Saleor styles.",
@@ -1393,7 +1393,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Polo? Yolo… so don’t waste time on the wrong apparel. Choose a polo shirt that looks as good as you feel.",
@@ -1432,7 +1432,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Wondering if this will look as good on you as it does on the screen? The answer is yes. A quality polo with smart styling.",
@@ -1471,7 +1471,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "They say polo is the sport of kings. Or was that stamp collecting? Either way, this shirt is fit for a king of Saturday night.",
@@ -1510,7 +1510,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "One style fits all. Get a look that works even when you are taking it easy. Relaxed wear for the masses.",
@@ -1549,7 +1549,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "A classic tee for a timeless look, at a great price. Feel like a million bucks without breaking the bank.",
@@ -1588,7 +1588,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Want to look like you just fell out of bed? Sometimes style can be effortless. Throw it on get on with having a good day.",
@@ -1627,7 +1627,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Your t-shirt is your second skin. It’s the version of you that you show to the world. Wear one that flows with your movements and is built to last.",
@@ -1666,7 +1666,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Special offer. Buy a hood and get a free jet black sweater attached. Perfect for when you are up to no good.",
@@ -1705,7 +1705,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Special offer. Buy a superhero blue sweater and get a free hood attached. Ideal for when you are out saving the world.",
@@ -1744,7 +1744,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Who dunnit? It was Colonel Mustard, in the dining room, with the lead piping, wearing this hot as mustard hoodie.",
@@ -1783,7 +1783,7 @@
       "private_metadata": {},
       "metadata": {
         "vatlayer.code": "standard",
-        "vatlayer.description": ""
+        "vatlayer.description": "standard"
       },
       "seo_title": "",
       "seo_description": "Get your slouch on and be seen with a whiter than white hoodie straight from the streets. Relaxed stylin’ and profilin’ with flair.",


### PR DESCRIPTION
- Fix the missing description for vatlayer taxes in sample data.
- Possibility to erase the tax meta code for product
- return Null for objects without assigned tax code. (previously it was empty string)