### PR TITLE
use logger.exception for avatax' api requests

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -87,7 +87,7 @@ def api_post_request(
             logger.exception("Avatax response contains errors %s", json_response)
             return json_response
     except requests.exceptions.RequestException:
-        logger.error("Fetching taxes failed %s", url)
+        logger.exception("Fetching taxes failed %s", url)
         return {}
     except json.JSONDecodeError:
         content = response.content if response else "Unable to find the response"
@@ -111,7 +111,7 @@ def api_get_request(
             logger.error("Avatax response contains errors %s", json_response)
         return json_response
     except requests.exceptions.RequestException:
-        logger.error("Failed to fetch data from %s", url)
+        logger.exception("Failed to fetch data from %s", url)
         return {}
     except json.JSONDecodeError:
         content = response.content if response else "Unable to find the response"


### PR DESCRIPTION
The error msg didn't have enough information. This PR replaces the logger.error to a logger.exception which will capture exception also.