### PR TITLE
Raise an error for an empty key in metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix for failing finalising draft order - #6133 by @korycins
 - Remove corresponding draft order lines when variant is removing - #6119 by @IKarbowiak
 - Update required perms for apps management - #6173 by @IKarbowiak
+- Raise an error for an empty key in metadata - #6176 by @IKarbowiak
 
 ## 2.10.2
 

--- a/saleor/core/error_codes.py
+++ b/saleor/core/error_codes.py
@@ -15,6 +15,7 @@ class MetadataErrorCode(Enum):
     GRAPHQL_ERROR = "graphql_error"
     INVALID = "invalid"
     NOT_FOUND = "not_found"
+    REQUIRED = "required"
 
 
 class TranslationErrorCode(Enum):

--- a/saleor/graphql/core/utils/error_codes.py
+++ b/saleor/graphql/core/utils/error_codes.py
@@ -3,7 +3,7 @@ from enum import Enum
 from ....account.error_codes import AccountErrorCode, PermissionGroupErrorCode
 from ....app.error_codes import AppErrorCode
 from ....checkout.error_codes import CheckoutErrorCode
-from ....core.error_codes import ShopErrorCode
+from ....core.error_codes import MetadataErrorCode, ShopErrorCode, TranslationErrorCode
 from ....csv.error_codes import ExportErrorCode
 from ....discount.error_codes import DiscountErrorCode
 from ....giftcard.error_codes import GiftCardErrorCode
@@ -53,12 +53,14 @@ SALEOR_ERROR_CODE_ENUMS = [
     GiftCardErrorCode,
     InvoiceErrorCode,
     MenuErrorCode,
+    MetadataErrorCode,
     OrderErrorCode,
     PaymentErrorCode,
     PermissionGroupErrorCode,
     ProductErrorCode,
     ShippingErrorCode,
     ShopErrorCode,
+    TranslationErrorCode,
 ]
 
 saleor_error_codes = []

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -1282,6 +1282,35 @@ def test_add_private_metadata_for_myself_as_customer_no_permission(user_api_clie
     assert_no_permission(response)
 
 
+@pytest.mark.parametrize(
+    "input", [{"key": " ", "value": "test"}, {"key": "   ", "value": ""}],
+)
+def test_staff_update_private_metadata_empty_key(
+    input, staff_api_client, permission_manage_staff, admin_user
+):
+    # given
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+
+    # when
+    response = response = execute_update_private_metadata_for_item(
+        staff_api_client,
+        permission_manage_staff,
+        admin_id,
+        "User",
+        input["key"],
+        input["value"],
+    )
+
+    # then
+    data = response["data"]["updatePrivateMetadata"]
+    errors = data["metadataErrors"]
+
+    assert not data["item"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "input"
+
+
 def test_add_private_metadata_for_myself_as_staff(staff_api_client):
     # given
     staff = staff_api_client.user

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -3,6 +3,7 @@ import uuid
 from unittest.mock import patch
 
 import graphene
+import pytest
 
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
@@ -27,6 +28,7 @@ mutation UpdatePublicMetadata($id: ID!, $input: [MetadataInput!]!) {
         metadataErrors{
             field
             code
+            message
         }
         item {
             metadata{
@@ -201,6 +203,35 @@ def test_add_public_metadata_for_staff_as_app_no_permission(
 
     # then
     assert_no_permission(response)
+
+
+@pytest.mark.parametrize(
+    "input", [{"key": " ", "value": "test"}, {"key": "   ", "value": ""}],
+)
+def test_staff_update_metadata_empty_key(
+    input, staff_api_client, permission_manage_staff, admin_user
+):
+    # given
+    admin_id = graphene.Node.to_global_id("User", admin_user.pk)
+
+    # when
+    response = execute_update_public_metadata_for_item(
+        staff_api_client,
+        permission_manage_staff,
+        admin_id,
+        "User",
+        input["key"],
+        input["value"],
+    )
+
+    # then
+    data = response["data"]["updateMetadata"]
+    errors = data["metadataErrors"]
+
+    assert not data["item"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == MetadataErrorCode.REQUIRED.name
+    assert errors[0]["field"] == "input"
 
 
 def test_add_public_metadata_for_myself_as_customer(user_api_client):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2532,6 +2532,7 @@ enum MetadataErrorCode {
   GRAPHQL_ERROR
   INVALID
   NOT_FOUND
+  REQUIRED
 }
 
 input MetadataInput {


### PR DESCRIPTION
Raise an error when an empty key for metadata is provided.

[SALEOR-983](https://app.clickup.com/t/2549495/SALEOR-983)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
