### PR TITLE
Fix performance of product type and attributes fields

### DIFF
--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -10,6 +10,7 @@ from .products import (
     ImagesByProductIdLoader,
     ImagesByProductVariantIdLoader,
     ProductByIdLoader,
+    ProductTypeByIdLoader,
     ProductVariantByIdLoader,
     ProductVariantsByProductIdLoader,
 )
@@ -21,6 +22,7 @@ __all__ = [
     "CollectionsByProductIdLoader",
     "ImagesByProductIdLoader",
     "ProductByIdLoader",
+    "ProductTypeByIdLoader",
     "ProductVariantByIdLoader",
     "ProductVariantsByProductIdLoader",
     "ImagesByProductVariantIdLoader",

--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -1,7 +1,9 @@
 from .attributes import (
     AttributeValuesByAttributeIdLoader,
+    ProductAttributesByProductTypeIdLoader,
     SelectedAttributesByProductIdLoader,
     SelectedAttributesByProductVariantIdLoader,
+    VariantAttributesByProductTypeIdLoader,
 )
 from .products import (
     CategoryByIdLoader,
@@ -21,6 +23,7 @@ __all__ = [
     "CollectionByIdLoader",
     "CollectionsByProductIdLoader",
     "ImagesByProductIdLoader",
+    "ProductAttributesByProductTypeIdLoader",
     "ProductByIdLoader",
     "ProductTypeByIdLoader",
     "ProductVariantByIdLoader",
@@ -28,4 +31,5 @@ __all__ = [
     "ImagesByProductVariantIdLoader",
     "SelectedAttributesByProductIdLoader",
     "SelectedAttributesByProductVariantIdLoader",
+    "VariantAttributesByProductTypeIdLoader",
 ]

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -6,6 +6,7 @@ from ....product.models import (
     CollectionProduct,
     Product,
     ProductImage,
+    ProductType,
     ProductVariant,
     VariantImage,
 )
@@ -26,6 +27,14 @@ class ProductByIdLoader(DataLoader):
     def batch_load(self, keys):
         products = Product.objects.visible_to_user(self.user).in_bulk(keys)
         return [products.get(product_id) for product_id in keys]
+
+
+class ProductTypeByIdLoader(DataLoader):
+    context_key = "product_type_by_id"
+
+    def batch_load(self, keys):
+        product_types = ProductType.objects.in_bulk(keys)
+        return [product_types.get(product_type_id) for product_type_id in keys]
 
 
 class ImagesByProductIdLoader(DataLoader):

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -178,3 +178,32 @@ def test_retrieve_product_attributes(product_list, api_client, count_queries):
 
     variables = {}
     get_graphql_content(api_client.post_graphql(query, variables))
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_retrive_products_with_product_types_and_attributes(
+    product_list, api_client, count_queries
+):
+    query = """
+        {
+          products(first: 10) {
+            edges {
+              node {
+                id
+                  productType {
+                    name
+                  productAttributes {
+                    name
+                  }
+                  variantAttributes {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        }
+    """
+    variables = {}
+    get_graphql_content(api_client.post_graphql(query, variables))

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -53,6 +53,7 @@ from ..dataloaders import (
     ImagesByProductIdLoader,
     ImagesByProductVariantIdLoader,
     ProductByIdLoader,
+    ProductTypeByIdLoader,
     ProductVariantByIdLoader,
     ProductVariantsByProductIdLoader,
     SelectedAttributesByProductIdLoader,
@@ -652,6 +653,10 @@ class Product(CountableDjangoObjectType):
     @staticmethod
     def resolve_is_available_for_purchase(root: models.Product, _info):
         return root.is_available_for_purchase()
+
+    @staticmethod
+    def resolve_product_type(root: models.Product, info):
+        return ProductTypeByIdLoader(info.context).load(root.product_type_id)
 
 
 @key(fields="id")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -52,12 +52,14 @@ from ..dataloaders import (
     CollectionsByProductIdLoader,
     ImagesByProductIdLoader,
     ImagesByProductVariantIdLoader,
+    ProductAttributesByProductTypeIdLoader,
     ProductByIdLoader,
     ProductTypeByIdLoader,
     ProductVariantByIdLoader,
     ProductVariantsByProductIdLoader,
     SelectedAttributesByProductIdLoader,
     SelectedAttributesByProductVariantIdLoader,
+    VariantAttributesByProductTypeIdLoader,
 )
 from ..filters import AttributeFilterInput, ProductFilterInput
 from ..resolvers import resolve_attributes
@@ -709,12 +711,12 @@ class ProductType(CountableDjangoObjectType):
         return root.get_value_from_metadata("vatlayer.code")
 
     @staticmethod
-    def resolve_product_attributes(root: models.ProductType, *_args, **_kwargs):
-        return root.product_attributes.product_attributes_sorted().all()
+    def resolve_product_attributes(root: models.ProductType, info):
+        return ProductAttributesByProductTypeIdLoader(info.context).load(root.pk)
 
     @staticmethod
-    def resolve_variant_attributes(root: models.ProductType, *_args, **_kwargs):
-        return root.variant_attributes.variant_attributes_sorted().all()
+    def resolve_variant_attributes(root: models.ProductType, info):
+        return VariantAttributesByProductTypeIdLoader(info.context).load(root.pk)
 
     @staticmethod
     def resolve_products(root: models.ProductType, info, **_kwargs):


### PR DESCRIPTION
Adds data loaders for:
- `Product.productType`
- `ProductType.productAttributes`
- `ProductType.variantAttributes`

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
