### PR TITLE
Allow to add product variant with 0 price to draft order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Update required perms for apps management - #6173 by @IKarbowiak
 - Raise an error for an empty key in metadata - #6176 by @IKarbowiak
 - Add attributes to product error - #6181 by @IKarbowiak
+- Allow to add product variant with 0 price to draft order - #6189 by @IKarbowiak
 
 ## 2.10.2
 

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -70,6 +70,28 @@ def test_add_variant_to_draft_order_adds_line_for_new_variant(
     assert line.product_name == str(variant.product)
 
 
+def test_add_variant_to_draft_order_adds_line_for_variant_with_price_0(
+    order_with_lines, product, product_translation_fr, settings
+):
+    order = order_with_lines
+    variant = product.variants.get()
+    variant.price = Money(0, "USD")
+    variant.save(update_fields=["price"])
+
+    lines_before = order.lines.count()
+    settings.LANGUAGE_CODE = "fr"
+    add_variant_to_draft_order(order, variant, 1)
+
+    line = order.lines.last()
+    assert order.lines.count() == lines_before + 1
+    assert line.product_sku == variant.sku
+    assert line.quantity == 1
+    assert line.unit_price == TaxedMoney(net=Money(0, "USD"), gross=Money(0, "USD"))
+    assert line.translated_product_name == str(variant.product.translated)
+    assert line.variant_name == str(variant)
+    assert line.product_name == str(variant.product)
+
+
 def test_add_variant_to_draft_order_not_allocates_stock_for_new_variant(
     order_with_lines, product
 ):

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -204,7 +204,9 @@ def add_variant_to_draft_order(order, variant, quantity, discounts=None):
         manager = get_plugins_manager()
         unit_price = manager.calculate_order_line_unit(line)
         line.unit_price = unit_price
-        line.tax_rate = unit_price.tax / unit_price.net
+        line.tax_rate = (
+            unit_price.tax / unit_price.net if unit_price.net.amount != 0 else 0
+        )
         line.save(
             update_fields=[
                 "currency",


### PR DESCRIPTION
Allow creating a draft order for products with price 0.

[SALEOR-1232](https://app.clickup.com/t/2549495/SALEOR-1232)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
