### PR TITLE
Use auth refrence as a searchable key

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -277,7 +277,7 @@ class AdyenGatewayPlugin(BasePlugin):
             kind = TransactionKind.PENDING
         elif adyen_auto_capture:
             kind = TransactionKind.CAPTURE
-
+        searchable_key = result.message.get("pspReference", "")
         action = result.message.get("action")
         error_message = result.message.get("refusalReason")
         if action:
@@ -307,7 +307,7 @@ class AdyenGatewayPlugin(BasePlugin):
             raw_response=result.message,
             action_required_data=action,
             payment_method_info=payment_method_info,
-            searchable_key=result.message.get("pspReference", ""),
+            searchable_key=searchable_key,
         )
 
     @classmethod


### PR DESCRIPTION
When Saleor makes capture action we save capture's psp refrence as a searchable_key.
Adyen uses Auth PSP refrence on their dashboard. This PR changes the assigment of searchable key. It will always be a Auth reference.  