### PR TITLE
Fix get unpublished products and collection as app

### DIFF
--- a/saleor/graphql/core/tests/test_base_mutation.py
+++ b/saleor/graphql/core/tests/test_base_mutation.py
@@ -21,6 +21,9 @@ class Mutation(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, product_id):
+        # Need to mock `app_middleware`
+        info.context.app = None
+
         product = cls.get_node_or_error(
             info, product_id, field="product_id", only_type=product_types.Product
         )

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -153,6 +153,27 @@ def test_product_query_by_id(
     assert product_data["visibleInListings"] is True
 
 
+def test_product_unpublished_query_by_id_as_app(
+    app_api_client, unavailable_product, permission_manage_products
+):
+    # given
+    variables = {"id": graphene.Node.to_global_id("Product", unavailable_product.pk)}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_PRODUCT,
+        variables=variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    product_data = content["data"]["product"]
+    assert product_data is not None
+    assert product_data["name"] == unavailable_product.name
+
+
 def test_product_query_by_id_weight_returned_in_default_unit(
     user_api_client, product, site_settings
 ):

--- a/saleor/graphql/product/tests/test_variant_query.py
+++ b/saleor/graphql/product/tests/test_variant_query.py
@@ -1,5 +1,4 @@
 import graphene
-import pytest
 
 from ...tests.utils import assert_graphql_error_with_message, get_graphql_content
 
@@ -68,7 +67,6 @@ def test_get_unpublished_variant_by_id_as_staff(
     assert data["sku"] == variant.sku
 
 
-@pytest.mark.skip(reason="Issue #5845")
 def test_get_unpublished_variant_by_id_as_app(
     app_api_client, permission_manage_products, unavailable_product_with_variant
 ):
@@ -220,7 +218,6 @@ def test_get_unpublished_variant_by_sku_as_staff(
     assert data["sku"] == variant.sku
 
 
-@pytest.mark.skip(reason="Issue #5845")
 def test_get_unpublished_variant_by_sku_as_app(
     app_api_client, permission_manage_products, unavailable_product_with_variant
 ):

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -412,10 +412,10 @@ class ProductVariant(CountableDjangoObjectType):
 
     @classmethod
     def get_node(cls, info, pk):
-        user = info.context.user
-        visible_products = models.Product.objects.visible_to_user(user).values_list(
-            "pk", flat=True
-        )
+        requestor = get_user_or_app_from_context(info.context)
+        visible_products = models.Product.objects.visible_to_user(
+            requestor
+        ).values_list("pk", flat=True)
         qs = cls._meta.model.objects.filter(product__id__in=visible_products)
         return qs.filter(pk=pk).first()
 
@@ -631,7 +631,8 @@ class Product(CountableDjangoObjectType):
     @classmethod
     def get_node(cls, info, pk):
         if info.context:
-            qs = cls._meta.model.objects.visible_to_user(info.context.user)
+            requestor = get_user_or_app_from_context(info.context)
+            qs = cls._meta.model.objects.visible_to_user(requestor)
             return qs.filter(pk=pk).first()
         return None
 
@@ -793,8 +794,8 @@ class Collection(CountableDjangoObjectType):
     @classmethod
     def get_node(cls, info, id):
         if info.context:
-            user = info.context.user
-            qs = cls._meta.model.objects.visible_to_user(user)
+            requestor = get_user_or_app_from_context(info.context)
+            qs = cls._meta.model.objects.visible_to_user(requestor)
             return qs.filter(id=id).first()
         return None
 


### PR DESCRIPTION
I want to merge this change because fix #5845.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
