### PR TITLE
Set OrderFulfillStockInput fields as required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow to add product variant with 0 price to draft order - #6189 by @IKarbowiak
 - Fix deleting product when default variant is deleted - #6186 by @IKarbowiak
 - Fix get unpublished products, product variants and collection as app - #6194 by @fowczarek
+- Set OrderFulfillStockInput fields as required - #6196 by @IKarbowiak
 
 ## 2.10.2
 

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -25,10 +25,12 @@ from ..types import OrderLine
 
 class OrderFulfillStockInput(graphene.InputObjectType):
     quantity = graphene.Int(
-        description="The number of line items to be fulfilled from given warehouse."
+        description="The number of line items to be fulfilled from given warehouse.",
+        required=True,
     )
     warehouse = graphene.ID(
-        description="ID of the warehouse from which the item will be fulfilled."
+        description="ID of the warehouse from which the item will be fulfilled.",
+        required=True,
     )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3117,8 +3117,8 @@ input OrderFulfillLineInput {
 }
 
 input OrderFulfillStockInput {
-  quantity: Int
-  warehouse: ID
+  quantity: Int!
+  warehouse: ID!
 }
 
 type OrderLine implements Node {


### PR DESCRIPTION
Providing `None` as `quantity` in `OrderFulfillStockInput` was allowed and causing the error.

[SALEOR-1265](https://app.clickup.com/t/2549495/SALEOR-1265)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
