### PR TITLE
Make TIME_ZONE and LANGUAGE_CODE configurable via env vars

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -69,7 +69,7 @@ from ...shipping.models import ShippingMethod, ShippingMethodType, ShippingZone
 from ...warehouse.management import increase_stock
 from ...warehouse.models import Stock, Warehouse
 
-fake = Factory.create()
+fake = Factory.create(settings.LANGUAGE_CODE)
 PRODUCTS_LIST_DIR = "products-list/"
 
 IMAGES_MAPPING = {

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -68,8 +68,8 @@ DATABASES = {
 }
 
 
-TIME_ZONE = "UTC"
-LANGUAGE_CODE = "en"
+TIME_ZONE = os.environ.get("TIME_ZONE", "UTC")
+LANGUAGE_CODE = os.environ.get("LANGUAGE_CODE", "en")
 LANGUAGES = [
     ("ar", "Arabic"),
     ("az", "Azerbaijani"),


### PR DESCRIPTION
I want to merge this change because...

In order to make the settings more configurable, I would like to merge the following changes:

* TIME_ZONE and LANGUAGE_CODE are configurable via env vars
* Faker uses the specified language code so the dummy data are more accurate to the developers location

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
