### PR TITLE
Fix attribute filtering by categories and collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix deleting product when default variant is deleted - #6186 by @IKarbowiak
 - Fix get unpublished products, product variants and collection as app - #6194 by @fowczarek
 - Set OrderFulfillStockInput fields as required - #6196 by @IKarbowiak
+- Fix attribute filtering by categories and collections - #6214 by @fowczarek
 
 ## 2.10.2
 

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -214,6 +214,8 @@ def filter_attributes_by_product_types(qs, field, value, requestor):
     if not value:
         return qs
 
+    product_qs = Product.objects.visible_to_user(requestor)
+
     if field == "in_category":
         category_id = from_global_id_strict_type(
             value, only_type="Category", field=field
@@ -224,7 +226,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor):
             return qs.none()
 
         tree = category.get_descendants(include_self=True)
-        product_qs = Product.objects.filter(category__in=tree)
+        product_qs = product_qs.filter(category__in=tree)
 
         if not product_qs.user_has_access_to_all(requestor):
             product_qs = product_qs.exclude(visible_in_listings=False)
@@ -233,7 +235,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor):
         collection_id = from_global_id_strict_type(
             value, only_type="Collection", field=field
         )
-        product_qs = Product.objects.filter(collections__id=collection_id)
+        product_qs = product_qs.filter(collections__id=collection_id)
 
     else:
         raise NotImplementedError(f"Filtering by {field} is unsupported")

--- a/saleor/graphql/product/tests/test_attribute_pagination.py
+++ b/saleor/graphql/product/tests/test_attribute_pagination.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 import graphene
 import pytest
 
@@ -7,6 +9,7 @@ from ....product.models import (
     AttributeVariant,
     Product,
     ProductType,
+    ProductVariant,
 )
 from ...tests.utils import get_graphql_content
 
@@ -53,7 +56,11 @@ def attributes_for_pagination(collection, category):
         name="Test product",
         product_type=product_type,
         category=category,
+        is_published=True,
         visible_in_listings=True,
+    )
+    ProductVariant.objects.create(
+        product=product, sku="testVariant", price_amount=Decimal(10)
     )
     collection.products.add(product)
     AttributeVariant.objects.bulk_create(

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -1984,7 +1984,7 @@ def test_filter_attributes_by_global_id_list(api_client, attribute_list):
     assert received_slugs == expected_slugs
 
 
-def test_filter_attributes_in_category_by_customer(
+def test_filter_attributes_in_category_not_visible_in_listings_by_customer(
     user_api_client, product_list, weight_attribute
 ):
     # given
@@ -2024,7 +2024,7 @@ def test_filter_attributes_in_category_by_customer(
     }
 
 
-def test_filter_attributes_in_category_by_staff_with_perm(
+def test_filter_attributes_in_category_not_visible_in_listings_by_staff_with_perm(
     staff_api_client, product_list, weight_attribute, permission_manage_products
 ):
     # given
@@ -2063,7 +2063,7 @@ def test_filter_attributes_in_category_by_staff_with_perm(
     assert len(attributes) == attribute_count
 
 
-def test_filter_attributes_in_category_by_staff_without_perm(
+def test_filter_attributes_in_category_not_visible_in_listings_by_staff_without_perm(
     staff_api_client, product_list, weight_attribute, permission_manage_products
 ):
     # given
@@ -2103,7 +2103,7 @@ def test_filter_attributes_in_category_by_staff_without_perm(
     }
 
 
-def test_filter_attributes_in_category_by_app_with_perm(
+def test_filter_attributes_in_category_not_visible_in_listings_by_app_with_perm(
     app_api_client, product_list, weight_attribute, permission_manage_products
 ):
     # given
@@ -2142,7 +2142,7 @@ def test_filter_attributes_in_category_by_app_with_perm(
     assert len(attributes) == attribute_count
 
 
-def test_filter_attributes_in_category_by_app_without_perm(
+def test_filter_attributes_in_category_not_visible_in_listings_by_app_without_perm(
     app_api_client, product_list, weight_attribute, permission_manage_products
 ):
     # given
@@ -2182,7 +2182,205 @@ def test_filter_attributes_in_category_by_app_without_perm(
     }
 
 
-def test_filter_attributes_in_collection_by_customer(
+def test_filter_attributes_in_category_not_published_by_customer(
+    user_api_client, product_list, weight_attribute
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    category = last_product.category
+    variables = {
+        "filters": {"inCategory": graphene.Node.to_global_id("Category", category.pk)}
+    }
+
+    # when
+    attributes = get_graphql_content(
+        user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
+
+
+def test_filter_attributes_in_category_not_published_by_staff_with_perm(
+    staff_api_client, product_list, weight_attribute, permission_manage_products
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    category = last_product.category
+    variables = {
+        "filters": {"inCategory": graphene.Node.to_global_id("Category", category.pk)}
+    }
+
+    # when
+    attributes = get_graphql_content(
+        staff_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count
+
+
+def test_filter_attributes_in_category_not_published_by_staff_without_perm(
+    staff_api_client, product_list, weight_attribute, permission_manage_products
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    category = last_product.category
+    variables = {
+        "filters": {"inCategory": graphene.Node.to_global_id("Category", category.pk)}
+    }
+
+    # when
+    attributes = get_graphql_content(
+        staff_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
+
+
+def test_filter_attributes_in_category_not_published_by_app_with_perm(
+    app_api_client, product_list, weight_attribute, permission_manage_products
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_products)
+
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    category = last_product.category
+    variables = {
+        "filters": {"inCategory": graphene.Node.to_global_id("Category", category.pk)}
+    }
+
+    # when
+    attributes = get_graphql_content(
+        app_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count
+
+
+def test_filter_attributes_in_category_not_published_by_app_without_perm(
+    app_api_client, product_list, weight_attribute, permission_manage_products
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    category = last_product.category
+    variables = {
+        "filters": {"inCategory": graphene.Node.to_global_id("Category", category.pk)}
+    }
+
+    # when
+    attributes = get_graphql_content(
+        app_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
+
+
+def test_filter_attributes_in_collection_not_visible_in_listings_by_customer(
     user_api_client, product_list, weight_attribute, collection
 ):
     # given
@@ -2221,6 +2419,240 @@ def test_filter_attributes_in_collection_by_customer(
 
     # then
     assert len(attributes) == attribute_count
+
+
+def test_filter_in_collection_not_published_by_customer(
+    user_api_client, product_list, weight_attribute, collection
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Collection", collection.pk)
+        }
+    }
+
+    # when
+    attributes = get_graphql_content(
+        user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
+
+
+def test_filter_in_collection_not_published_by_staff_with_perm(
+    staff_api_client,
+    product_list,
+    weight_attribute,
+    permission_manage_products,
+    collection,
+):
+    # given
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Collection", collection.pk)
+        }
+    }
+
+    # when
+    attributes = get_graphql_content(
+        staff_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count
+
+
+def test_filter_in_collection_not_published_by_staff_without_perm(
+    staff_api_client,
+    product_list,
+    weight_attribute,
+    permission_manage_products,
+    collection,
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Collection", collection.pk)
+        }
+    }
+
+    # when
+    attributes = get_graphql_content(
+        staff_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
+
+
+def test_filter_in_collection_not_published_by_app_with_perm(
+    app_api_client,
+    product_list,
+    weight_attribute,
+    permission_manage_products,
+    collection,
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_products)
+
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Collection", collection.pk)
+        }
+    }
+
+    # when
+    attributes = get_graphql_content(
+        app_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count
+
+
+def test_filter_in_collection_not_published_by_app_without_perm(
+    app_api_client,
+    product_list,
+    weight_attribute,
+    permission_manage_products,
+    collection,
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.is_published = False
+    last_product.save(update_fields=["is_published", "product_type"])
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    attribute_count = Attribute.objects.count()
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Collection", collection.pk)
+        }
+    }
+
+    # when
+    attributes = get_graphql_content(
+        app_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+    )["data"]["attributes"]["edges"]
+
+    # then
+    assert len(attributes) == attribute_count - 1
+    assert weight_attribute.slug not in {
+        attribute["node"]["slug"] for attribute in attributes
+    }
 
 
 ATTRIBUTES_SORT_QUERY = """


### PR DESCRIPTION
I want to merge this change because fix attribute filtering by categories and collections. 

If a user tries to get all attributes assigned to the category he shouldn't get attribute assigned only to not published products.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
