### PR TITLE
Fix shipping method resolver in order type

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -218,6 +218,9 @@ def test_order_query(
                         }
                         type
                     }
+                    shippingMethod{
+                        id
+                    }
                 }
             }
         }

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -302,7 +302,7 @@ class OrderLine(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_variant(root: models.OrderLine, _info):
-        # TODO: Add dataloader for channel_slug
+        # TODO: Add dataloader for variant and channel_slug
         channel_slug = root.order.channel.slug if root.order.channel else None
         return ChannelContext(node=root.variant, channel_slug=channel_slug)
 
@@ -517,6 +517,11 @@ class Order(CountableDjangoObjectType):
         if requestor_has_access(requester, root.user, AccountPermissions.MANAGE_USERS):
             return root.user
         raise PermissionDenied()
+
+    @staticmethod
+    def resolve_shipping_method(root: models.Order, info):
+        # TODO: Add dataloader for shipping_method and channelslug
+        return ChannelContext(node=root.shipping_method, channel_slug=root.channel.slug)
 
     @staticmethod
     def resolve_available_shipping_methods(root: models.Order, _info):


### PR DESCRIPTION
I want to merge this change because fixing the shipping method resolver in the order type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
