### PR TITLE
Add filtering by Product IDs to `products` query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow product variants to be sortable - #6138 by @tomaszszymanski129
 - Staff with only manage_orders should be able to query all stock related date. - #6139 by @fowczarek
 - Add filtering to `ProductVariants` query and option to fetch variant by sku in `ProductVariant` query - #6190 by @fowczarek
+- Add filtering by Product IDs to `products` query - #6224 by @GrzegorzDerdak
 
 
 ### Breaking Changes

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -326,6 +326,7 @@ class ProductFilter(django_filters.FilterSet):
     product_types = GlobalIDMultipleChoiceFilter(field_name="product_type")
     stocks = ObjectTypeFilter(input_class=ProductStockFilterInput, method=filter_stocks)
     search = django_filters.CharFilter(method=filter_search)
+    ids = GlobalIDMultipleChoiceFilter(field_name="id")
 
     class Meta:
         model = Product

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -950,6 +950,21 @@ def test_products_query_with_filter_stocks(
     assert {node["node"]["id"] for node in products_data} == product_ids
 
 
+def test_query_products_query_with_filter_ids(
+    staff_api_client, product, query_products_with_filter
+):
+    product_global_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {"filter": {"ids": [product_global_id]}}
+    response = staff_api_client.post_graphql(
+        query_products_with_filter, variables, check_no_permissions=False
+    )
+    content = get_graphql_content(response)
+    products_data = content["data"]["products"]["edges"]
+
+    assert len(products_data) == 1
+    assert products_data[0]["node"]["id"] == product_global_id
+
+
 def test_query_product_image_by_id(user_api_client, product_with_image):
     image = product_with_image.images.first()
     query = """

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -950,19 +950,24 @@ def test_products_query_with_filter_stocks(
     assert {node["node"]["id"] for node in products_data} == product_ids
 
 
-def test_query_products_query_with_filter_ids(
-    staff_api_client, product, query_products_with_filter
+def test_query_products_with_filter_ids(
+    api_client, product_list, query_products_with_filter
 ):
-    product_global_id = graphene.Node.to_global_id("Product", product.id)
-    variables = {"filter": {"ids": [product_global_id]}}
-    response = staff_api_client.post_graphql(
-        query_products_with_filter, variables, check_no_permissions=False
-    )
+    # given
+    product_ids = [
+        graphene.Node.to_global_id("Product", product.id) for product in product_list
+    ][:2]
+    variables = {"filter": {"ids": product_ids}}
+
+    # when
+    response = api_client.post_graphql(query_products_with_filter, variables)
+
+    # then
     content = get_graphql_content(response)
     products_data = content["data"]["products"]["edges"]
 
-    assert len(products_data) == 1
-    assert products_data[0]["node"]["id"] == product_global_id
+    assert len(products_data) == 2
+    assert [node["node"]["id"] for node in products_data] == product_ids
 
 
 def test_query_product_image_by_id(user_api_client, product_with_image):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3791,6 +3791,7 @@ input ProductFilterInput {
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
   productTypes: [ID]
+  ids: [ID]
 }
 
 type ProductImage implements Node {


### PR DESCRIPTION
This PR adds filtering by Product IDs to products query.

Related ticket: [SALEOR-1290](https://app.clickup.com/t/2549495/SALEOR-1290)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
