### PR TITLE
Fix is_visible when publication_date==today

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix get unpublished products, product variants and collection as app - #6194 by @fowczarek
 - Set OrderFulfillStockInput fields as required - #6196 by @IKarbowiak
 - Fix attribute filtering by categories and collections - #6214 by @fowczarek
-
+- Fix is_visible when publication_date==today - #6225 by @korycins
 ## 2.10.2
 
 - Add command to change currencies in the database - #5906 by @d-wysocki

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -71,7 +71,7 @@ class PublishableModel(models.Model):
     def is_visible(self):
         return self.is_published and (
             self.publication_date is None
-            or self.publication_date < datetime.date.today()
+            or self.publication_date <= datetime.date.today()
         )
 
 

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -2,6 +2,7 @@ import datetime
 from decimal import Decimal
 from unittest.mock import Mock
 
+from freezegun import freeze_time
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...plugins.manager import PluginsManager
@@ -124,6 +125,13 @@ def test_available_products_only_available(product_list):
     available_products = models.Product.objects.published()
     assert available_products.count() == 2
     assert all([product.is_visible for product in available_products])
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_product_is_visible_from_today(product):
+    product.publication_date = datetime.date.today()
+    product.save()
+    assert product.is_visible
 
 
 def test_available_products_with_variants(product_list):


### PR DESCRIPTION
The issue happens when publication_date is the same as date.today()
If you set `publication_date` to 2020-10-29 then is_visible will return true when date.today() >= 2020-10-30.
This fix changes condition form `<` to `<=`