### PR TITLE
Trigger product update webhook

### DIFF
--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -315,6 +315,7 @@ class ProductVariantChannelListingUpdate(BaseMutation):
                 variant=variant, channel=channel, defaults=defaults,
             )
         update_product_discounted_price_task.delay(variant.product_id)
+        info.context.plugins.product_updated(variant.product)
 
     @classmethod
     def perform_mutation(cls, _root, info, id, input):


### PR DESCRIPTION
I want to merge this change because...I want to trigger product update webhook on Product and Variant channel listing mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
