### PR TITLE
Restrict product attributes in product type mutations

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -13,7 +13,7 @@ from graphql_relay import from_global_id
 from ....core.exceptions import PermissionDenied
 from ....core.permissions import ProductPermissions
 from ....order import OrderStatus, models as order_models
-from ....product import models
+from ....product import AttributeType, models
 from ....product.error_codes import ProductErrorCode
 from ....product.tasks import (
     update_product_minimal_variant_price_task,
@@ -1559,7 +1559,30 @@ class ProductTypeCreate(ModelMutation):
         if tax_code:
             info.context.plugins.assign_tax_code_to_object_meta(instance, tax_code)
 
+        cls.validate_attributes(cleaned_input)
+
         return cleaned_input
+
+    @classmethod
+    def validate_attributes(cls, cleaned_data):
+        errors = {}
+        for field in ["product_attributes", "variant_attributes"]:
+            attributes = cleaned_data.get(field)
+            if not attributes:
+                continue
+            not_valid_attributes = [
+                graphene.Node.to_global_id("Attribute", attr.pk)
+                for attr in attributes
+                if attr.type != AttributeType.PRODUCT_TYPE
+            ]
+            if not_valid_attributes:
+                errors[field] = ValidationError(
+                    "Only Product type attributes are allowed.",
+                    code=ProductErrorCode.INVALID.value,
+                    params={"attributes": not_valid_attributes},
+                )
+        if errors:
+            raise ValidationError(errors)
 
     @classmethod
     def _save_m2m(cls, info, instance, cleaned_data):

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -282,6 +282,8 @@ def test_resolve_attribute_values(user_api_client, product, staff_user):
         variant_attributes[0]["attribute"]["type"]
         == AttributeTypeEnum.PRODUCT_TYPE.name
     )
+
+
 def test_resolve_attribute_values_non_assigned_to_node(
     user_api_client, product, staff_user
 ):

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -282,9 +282,6 @@ def test_resolve_attribute_values(user_api_client, product, staff_user):
         variant_attributes[0]["attribute"]["type"]
         == AttributeTypeEnum.PRODUCT_TYPE.name
     )
-    assert variant_attributes[0]["values"][0]["slug"] == variant_attribute_values[0]
-
-
 def test_resolve_attribute_values_non_assigned_to_node(
     user_api_client, product, staff_user
 ):

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -3369,6 +3369,7 @@ PRODUCT_TYPE_CREATE_MUTATION = """
                 field
                 message
                 code
+                attributes
             }
         }
 
@@ -3495,40 +3496,125 @@ def test_create_product_type_create_with_negative_weight(
     assert error["code"] == ProductErrorCode.INVALID.name
 
 
+def test_product_type_create_mutation_not_valid_attributes(
+    staff_api_client,
+    product_type,
+    permission_manage_products,
+    monkeypatch,
+    setup_vatlayer,
+):
+    # given
+    query = PRODUCT_TYPE_CREATE_MUTATION
+    product_type_name = "test type"
+    slug = "test-type"
+    has_variants = True
+    require_shipping = True
+
+    product_attributes = product_type.product_attributes.all()
+    product_page_attribute = product_attributes.last()
+    product_page_attribute.type = AttributeType.PAGE_TYPE
+    product_page_attribute.save(update_fields=["type"])
+
+    variant_attributes = product_type.variant_attributes.all()
+    variant_page_attribute = variant_attributes.last()
+    variant_page_attribute.type = AttributeType.PAGE_TYPE
+    variant_page_attribute.save(update_fields=["type"])
+
+    product_attributes_ids = [
+        graphene.Node.to_global_id("Attribute", att.id) for att in product_attributes
+    ]
+    variant_attributes_ids = [
+        graphene.Node.to_global_id("Attribute", att.id) for att in variant_attributes
+    ]
+
+    variables = {
+        "name": product_type_name,
+        "slug": slug,
+        "hasVariants": has_variants,
+        "taxCode": "wine",
+        "isShippingRequired": require_shipping,
+        "productAttributes": product_attributes_ids,
+        "variantAttributes": variant_attributes_ids,
+    }
+    initial_count = ProductType.objects.count()
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productTypeCreate"]
+    errors = data["productErrors"]
+
+    assert len(errors) == 2
+    expected_errors = [
+        {
+            "code": ProductErrorCode.INVALID.name,
+            "field": "productAttributes",
+            "message": ANY,
+            "attributes": [
+                graphene.Node.to_global_id("Attribute", product_page_attribute.pk)
+            ],
+        },
+        {
+            "code": ProductErrorCode.INVALID.name,
+            "field": "variantAttributes",
+            "message": ANY,
+            "attributes": [
+                graphene.Node.to_global_id("Attribute", variant_page_attribute.pk)
+            ],
+        },
+    ]
+    for error in errors:
+        assert error in expected_errors
+
+    assert initial_count == ProductType.objects.count()
+
+
+PRODUCT_TYPE_UPDATE_MUTATION = """
+mutation updateProductType(
+    $id: ID!,
+    $name: String!,
+    $hasVariants: Boolean!,
+    $isShippingRequired: Boolean!,
+    $productAttributes: [ID],
+    ) {
+        productTypeUpdate(
+        id: $id,
+        input: {
+            name: $name,
+            hasVariants: $hasVariants,
+            isShippingRequired: $isShippingRequired,
+            productAttributes: $productAttributes
+        }) {
+            productType {
+                name
+                slug
+                isShippingRequired
+                hasVariants
+                variantAttributes {
+                    id
+                }
+                productAttributes {
+                    id
+                }
+            }
+            productErrors {
+                code
+                field
+                attributes
+            }
+            }
+        }
+"""
+
+
 def test_product_type_update_mutation(
     staff_api_client, product_type, permission_manage_products
 ):
-    query = """
-    mutation updateProductType(
-        $id: ID!,
-        $name: String!,
-        $hasVariants: Boolean!,
-        $isShippingRequired: Boolean!,
-        $productAttributes: [ID],
-        ) {
-            productTypeUpdate(
-            id: $id,
-            input: {
-                name: $name,
-                hasVariants: $hasVariants,
-                isShippingRequired: $isShippingRequired,
-                productAttributes: $productAttributes
-            }) {
-                productType {
-                    name
-                    slug
-                    isShippingRequired
-                    hasVariants
-                    variantAttributes {
-                        id
-                    }
-                    productAttributes {
-                        id
-                    }
-                }
-              }
-            }
-    """
+    query = PRODUCT_TYPE_UPDATE_MUTATION
     product_type_name = "test type updated"
     slug = product_type.slug
     has_variants = True
@@ -3561,6 +3647,50 @@ def test_product_type_update_mutation(
     assert data["isShippingRequired"] == require_shipping
     assert not data["productAttributes"]
     assert len(data["variantAttributes"]) == (variant_attributes.count())
+
+
+def test_product_type_update_mutation_not_valid_attributes(
+    staff_api_client, product_type, permission_manage_products, size_page_attribute
+):
+    # given
+    query = PRODUCT_TYPE_UPDATE_MUTATION
+    product_type_name = "test type updated"
+    has_variants = True
+    require_shipping = False
+    product_type_id = graphene.Node.to_global_id("ProductType", product_type.id)
+
+    # Test scenario: adding page attribute raise error
+
+    page_attribute_id = graphene.Node.to_global_id("Attribute", size_page_attribute.id)
+    product_attributes_ids = [
+        page_attribute_id,
+        graphene.Node.to_global_id(
+            "Attribute", product_type.product_attributes.first().pk
+        ),
+    ]
+
+    variables = {
+        "id": product_type_id,
+        "name": product_type_name,
+        "hasVariants": has_variants,
+        "isShippingRequired": require_shipping,
+        "productAttributes": product_attributes_ids,
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productTypeUpdate"]
+    errors = data["productErrors"]
+
+    assert len(errors) == 1
+    assert errors[0]["field"] == "productAttributes"
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+    assert errors[0]["attributes"] == [page_attribute_id]
 
 
 UPDATE_PRODUCT_TYPE_SLUG_MUTATION = """

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -9,7 +9,7 @@ from graphql.error import GraphQLError
 
 from ....core.permissions import OrderPermissions, ProductPermissions
 from ....core.weight import convert_weight_to_default_weight_unit
-from ....product import models
+from ....product import AttributeType, models
 from ....product.templatetags.product_images import (
     get_product_image_thumbnail,
     get_thumbnail,

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -9,7 +9,7 @@ from graphql.error import GraphQLError
 
 from ....core.permissions import OrderPermissions, ProductPermissions
 from ....core.weight import convert_weight_to_default_weight_unit
-from ....product import AttributeType, models
+from ....product import models
 from ....product.templatetags.product_images import (
     get_product_image_thumbnail,
     get_thumbnail,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -641,6 +641,16 @@ def weight_attribute(db):
 
 
 @pytest.fixture
+def size_page_attribute(db):
+    attribute = Attribute.objects.create(
+        slug="page-size", name="Page size", type=AttributeType.PAGE_TYPE
+    )
+    AttributeValue.objects.create(attribute=attribute, name="10", slug="10")
+    AttributeValue.objects.create(attribute=attribute, name="15", slug="15")
+    return attribute
+
+
+@pytest.fixture
 def attribute_list() -> List[Attribute]:
     return list(
         Attribute.objects.bulk_create(


### PR DESCRIPTION
Allow adding only product attributes in Product Type mutations.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
