### PR TITLE
Fix price error field name in mutation responses

### DIFF
--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -98,6 +98,7 @@ class BaseMutation(graphene.Mutation):
         _meta=None,
         error_type_class=None,
         error_type_field=None,
+        errors_mapping=None,
         **options,
     ):
         if not _meta:
@@ -117,6 +118,7 @@ class BaseMutation(graphene.Mutation):
         _meta.permissions = permissions
         _meta.error_type_class = error_type_class
         _meta.error_type_field = error_type_field
+        _meta.errors_mapping = errors_mapping
         super().__init_subclass_with_meta__(
             description=description, _meta=_meta, **options
         )
@@ -186,6 +188,20 @@ class BaseMutation(graphene.Mutation):
             )
         return instances
 
+    @staticmethod
+    def remap_error_fields(validation_error, field_map):
+        """Rename validation_error fields accoring to provided field_map.
+
+        Skips renaming fields from field_map that are not on validation_error.
+        """
+        for old_field, new_field in field_map.items():
+            try:
+                validation_error.error_dict[
+                    new_field
+                ] = validation_error.error_dict.pop(old_field)
+            except KeyError:
+                pass
+
     @classmethod
     def clean_instance(cls, info, instance):
         """Clean the instance that was created using the input data.
@@ -204,6 +220,9 @@ class BaseMutation(graphene.Mutation):
                     if field not in cls._meta.exclude:
                         new_error_dict[field] = errors
                 error.error_dict = new_error_dict
+
+            if cls._meta.errors_mapping:
+                cls.remap_error_fields(error, cls._meta.errors_mapping)
 
             if error.error_dict:
                 raise error
@@ -353,20 +372,6 @@ class ModelMutation(BaseMutation):
         fields = {return_field_name: graphene.Field(model_type)}
 
         cls._update_mutation_arguments_and_fields(arguments=arguments, fields=fields)
-
-    @staticmethod
-    def remap_error_fields(validation_error, field_map):
-        """Rename validation_error fields accoring to provided field_map.
-
-        Skips renaming fields from field_map that are not on validation_error.
-        """
-        for old_field, new_field in field_map.items():
-            try:
-                validation_error.error_dict[
-                    new_field
-                ] = validation_error.error_dict.pop(old_field)
-            except KeyError:
-                pass
 
     @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -354,6 +354,20 @@ class ModelMutation(BaseMutation):
 
         cls._update_mutation_arguments_and_fields(arguments=arguments, fields=fields)
 
+    @staticmethod
+    def remap_error_fields(validation_error, field_map):
+        """Rename validation_error fields accoring to provided field_map.
+
+        Skips renaming fields from field_map that are not on validation_error.
+        """
+        for old_field, new_field in field_map.items():
+            try:
+                validation_error.error_dict[
+                    new_field
+                ] = validation_error.error_dict.pop(old_field)
+            except KeyError:
+                pass
+
     @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):
         """Clean input data received from mutation arguments.

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1227,6 +1227,15 @@ class ProductVariantCreate(ModelMutation):
             used_attribute_values.append(attribute_values)
 
     @classmethod
+    def clean_instance(cls, info, instance):
+        try:
+            cleaned_instance = super().clean_instance(info, instance)
+        except ValidationError as validation_error:
+            cls.remap_error_fields(validation_error, {"price_amount": "price"})
+            raise validation_error
+        return cleaned_instance
+
+    @classmethod
     def clean_input(
         cls, info, instance: models.ProductVariant, data: dict, input_cls=None
     ):

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1200,6 +1200,7 @@ class ProductVariantCreate(ModelMutation):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        errors_mapping = {"price_amount": "price"}
 
     @classmethod
     def clean_attributes(
@@ -1225,15 +1226,6 @@ class ProductVariantCreate(ModelMutation):
             )
         else:
             used_attribute_values.append(attribute_values)
-
-    @classmethod
-    def clean_instance(cls, info, instance):
-        try:
-            cleaned_instance = super().clean_instance(info, instance)
-        except ValidationError as validation_error:
-            cls.remap_error_fields(validation_error, {"price_amount": "price"})
-            raise validation_error
-        return cleaned_instance
 
     @classmethod
     def clean_input(
@@ -1392,6 +1384,7 @@ class ProductVariantUpdate(ProductVariantCreate):
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
         error_type_class = ProductError
         error_type_field = "product_errors"
+        errors_mapping = {"price_amount": "price"}
 
     @classmethod
     def validate_duplicated_attribute_values(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -670,26 +670,23 @@ def test_update_product_variant_invalid_price(
     staff_api_client, product, permission_manage_products
 ):
     query = """
-        mutation updateVariant (
-            $id: ID!,
-            $sku: String!,
-            $price: PositiveDecimal,
-            $costPrice: PositiveDecimal) {
-                productVariantUpdate(
-                    id: $id,
-                    input: {
-                        sku: $sku,
-                        price: $price,
-                        costPrice: $costPrice,
-                    }) {
-                    productErrors {
-                        field
-                        message
-                        code
-                    }
+        mutation updateVariant(
+            $id: ID!
+            $sku: String!
+            $price: PositiveDecimal
+            $costPrice: PositiveDecimal
+        ) {
+            productVariantUpdate(
+                id: $id
+                input: { sku: $sku, price: $price, costPrice: $costPrice }
+            ) {
+                productErrors {
+                    field
+                    message
+                    code
                 }
             }
-
+        }
     """
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -666,6 +666,51 @@ def test_update_product_variant_unset_cost_price(
     assert data["costPrice"] is None
 
 
+def test_update_product_variant_invalid_price(
+    staff_api_client, product, permission_manage_products
+):
+    query = """
+        mutation updateVariant (
+            $id: ID!,
+            $sku: String!,
+            $price: PositiveDecimal,
+            $costPrice: PositiveDecimal) {
+                productVariantUpdate(
+                    id: $id,
+                    input: {
+                        sku: $sku,
+                        price: $price,
+                        costPrice: $costPrice,
+                    }) {
+                    productErrors {
+                        field
+                        message
+                        code
+                    }
+                }
+            }
+
+    """
+    variant = product.variants.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+
+    variables = {
+        "id": variant_id,
+        "sku": variant.sku,
+        "costPrice": 15,
+        "price": 1234567891234,
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+
+    errors = content["data"]["productVariantUpdate"]["productErrors"]
+    assert errors[0]["field"] == "price"
+    assert errors[0]["code"] == ProductErrorCode.INVALID.name
+
+
 QUERY_UPDATE_VARIANT_ATTRIBUTES = """
     mutation updateVariant (
         $id: ID!,

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -165,15 +165,6 @@ class ShippingZoneDelete(ModelDeleteMutation):
 
 class ShippingPriceMixin:
     @classmethod
-    def clean_instance(cls, info, instance):
-        try:
-            cleaned_instance = super().clean_instance(info, instance)
-        except ValidationError as validation_error:
-            cls.remap_error_fields(validation_error, {"price_amount": "price"})
-            raise validation_error
-        return cleaned_instance
-
-    @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):
         cleaned_input = super().clean_input(info, instance, data)
 
@@ -285,6 +276,7 @@ class ShippingPriceCreate(ShippingPriceMixin, ModelMutation):
         permissions = (ShippingPermissions.MANAGE_SHIPPING,)
         error_type_class = ShippingError
         error_type_field = "shipping_errors"
+        errors_mapping = {"price_amount": "price"}
 
     @classmethod
     def success_response(cls, instance):
@@ -311,6 +303,7 @@ class ShippingPriceUpdate(ShippingPriceMixin, ModelMutation):
         permissions = (ShippingPermissions.MANAGE_SHIPPING,)
         error_type_class = ShippingError
         error_type_field = "shipping_errors"
+        errors_mapping = {"price_amount": "price"}
 
     @classmethod
     def success_response(cls, instance):

--- a/saleor/graphql/shipping/mutations.py
+++ b/saleor/graphql/shipping/mutations.py
@@ -165,6 +165,15 @@ class ShippingZoneDelete(ModelDeleteMutation):
 
 class ShippingPriceMixin:
     @classmethod
+    def clean_instance(cls, info, instance):
+        try:
+            cleaned_instance = super().clean_instance(info, instance)
+        except ValidationError as validation_error:
+            cls.remap_error_fields(validation_error, {"price_amount": "price"})
+            raise validation_error
+        return cleaned_instance
+
+    @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):
         cleaned_input = super().clean_input(info, instance, data)
 


### PR DESCRIPTION
I want to merge this change because it fixes backend responding with `priceAmount` intead of `price` on mutations:
- `ShippingPriceCreate`
- `ShippingPriceUpdate`
- `ProductVariantCreate`
- `ProductVariantUpdate`

Input of both mutations accepts price and error of the same name should be returned. Checked on frontend to make sure it now marks the field red as it should.

Linked task: [SALEOR-1337](https://app.clickup.com/t/2549495/SALEOR-1337)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
