### PR TITLE
deprecate homepage collection

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4757,7 +4757,7 @@ type Shop {
   defaultMailSenderAddress: String
   description: String
   domain: Domain!
-  homepageCollection: Collection
+  homepageCollection: Collection @deprecated(reason: "Use the collection query with slug. This field will be removed in SALEOR 3.0")
   languages: [LanguageDisplay]!
   name: String!
   navigation: Navigation

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4757,7 +4757,7 @@ type Shop {
   defaultMailSenderAddress: String
   description: String
   domain: Domain!
-  homepageCollection: Collection @deprecated(reason: "Use the collection query with slug. This field will be removed in SALEOR 3.0")
+  homepageCollection: Collection @deprecated(reason: "Use the `collection` query with the `slug` parameter. This field will be removed in Saleor 3.0")
   languages: [LanguageDisplay]!
   name: String!
   navigation: Navigation

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -114,8 +114,14 @@ class Shop(graphene.ObjectType):
     description = graphene.String(description="Shop's description.")
     domain = graphene.Field(Domain, required=True, description="Shop's domain data.")
     homepage_collection = graphene.Field(
-        Collection, description="Collection displayed on homepage."
+        Collection,
+        description="Collection displayed on homepage.",
+        deprecation_reason=(
+            "Use the collection query with slug. "
+            "This field will be removed in SALEOR 3.0"
+        ),
     )
+
     languages = graphene.List(
         LanguageDisplay,
         description="List of the shops's supported languages.",

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -117,8 +117,8 @@ class Shop(graphene.ObjectType):
         Collection,
         description="Collection displayed on homepage.",
         deprecation_reason=(
-            "Use the collection query with slug. "
-            "This field will be removed in SALEOR 3.0"
+            "Use the `collection` query with the `slug` parameter. "
+            "This field will be removed in Saleor 3.0"
         ),
     )
     languages = graphene.List(

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -121,7 +121,6 @@ class Shop(graphene.ObjectType):
             "This field will be removed in SALEOR 3.0"
         ),
     )
-
     languages = graphene.List(
         LanguageDisplay,
         description="List of the shops's supported languages.",


### PR DESCRIPTION
I want to merge this change because...homepage collection will be removed in SALEOR 3.0

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
