### PR TITLE
Fix products query on category type

### DIFF
--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -149,7 +149,7 @@ def test_query_category_product_only_visible_in_listings_as_staff_without_perm(
 
 
 def test_query_category_product_only_visible_in_listings_as_staff_with_perm(
-    staff_api_client, product_list, permission_manage_products, channel_USD
+    staff_api_client, product_list, permission_manage_products
 ):
     # given
     staff_api_client.user.user_permissions.add(permission_manage_products)
@@ -160,10 +160,7 @@ def test_query_category_product_only_visible_in_listings_as_staff_with_perm(
 
     product_count = Product.objects.count()
 
-    variables = {
-        "id": graphene.Node.to_global_id("Category", category.pk),
-        "channel": channel_USD.slug,
-    }
+    variables = {"id": graphene.Node.to_global_id("Category", category.pk)}
 
     # when
     response = staff_api_client.post_graphql(QUERY_CATEGORY, variables=variables)
@@ -197,7 +194,7 @@ def test_query_category_product_only_visible_in_listings_as_app_without_perm(
 
 
 def test_query_category_product_only_visible_in_listings_as_app_with_perm(
-    app_api_client, product_list, permission_manage_products, channel_USD
+    app_api_client, product_list, permission_manage_products
 ):
     # given
     app_api_client.app.permissions.add(permission_manage_products)
@@ -208,10 +205,7 @@ def test_query_category_product_only_visible_in_listings_as_app_with_perm(
 
     product_count = Product.objects.count()
 
-    variables = {
-        "id": graphene.Node.to_global_id("Category", category.pk),
-        "channel": channel_USD.slug,
-    }
+    variables = {"id": graphene.Node.to_global_id("Category", category.pk)}
 
     # when
     response = app_api_client.post_graphql(QUERY_CATEGORY, variables=variables)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -933,10 +933,12 @@ class Category(CountableDjangoObjectType):
         tree = root.get_descendants(include_self=True)
         if channel is None:
             channel = get_default_channel_slug_or_graphql_error()
-        qs = models.Product.objects.published(channel)
+        qs = models.Product.objects.all()
         if not qs.user_has_access_to_all(requestor):
-            qs = qs.annotate_visible_in_listings(channel).exclude(
-                visible_in_listings=False,
+            qs = (
+                qs.published(channel)
+                .annotate_visible_in_listings(channel)
+                .exclude(visible_in_listings=False,)
             )
         qs = qs.filter(category__in=tree)
         return ChannelQsContext(qs=qs, channel_slug=channel)


### PR DESCRIPTION
I want to merge this change because as staff users we should be able to get all products assigned to a category. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
