### PR TITLE
Add attributes validation while creating/updating a product's variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix attribute filtering by categories and collections - #6214 by @fowczarek
 - Fix is_visible when publication_date==today - #6225 by @korycins
 - Fix filtering products by multiple attributes - #6215 by @GrzegorzDerdak
+- Add attributes validation while creating/updating a product's variant - #6269 by @GrzegorzDerdak
 
 ## 2.10.2
 

--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -130,30 +130,47 @@ def test_total_count_query(api_client, product):
 
 
 def test_mutation_positive_decimal_input(
-    staff_api_client, variant, stock, permission_manage_products
+    staff_api_client, variant, size_attribute, stock, permission_manage_products
 ):
     query = """
     mutation PositiveDecimalInput(
-        $id: ID!, $cost: PositiveDecimal, $price: PositiveDecimal
+        $id: ID!,
+        $cost: PositiveDecimal,
+        $price: PositiveDecimal,
+        $attributes: [AttributeValueInput],
     ) {
-        productVariantUpdate(id: $id, input: {costPrice: $cost, price: $price}) {
+        productVariantUpdate(
+            id: $id,
+            input: {
+                costPrice: $cost,
+                price: $price,
+                attributes: $attributes
+            }
+        ) {
             errors {
                 field
                 message
             }
             productVariant {
-                costPrice{
+                costPrice {
                     amount
                 }
             }
         }
     }
     """
+
     variables = {
         "id": graphene.Node.to_global_id("ProductVariant", variant.id),
         "price": 15,
         "cost": 12.12,
         "quantity": 17,
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", size_attribute.pk),
+                "values": ["S"],
+            }
+        ],
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]
@@ -164,13 +181,23 @@ def test_mutation_positive_decimal_input(
 
 
 def test_mutation_positive_decimal_input_without_arguments(
-    staff_api_client, variant, permission_manage_products
+    staff_api_client, variant, size_attribute, permission_manage_products
 ):
     query = """
     mutation ProductVariantUpdate(
-        $id: ID!, $price: PositiveDecimal, $costPrice: PositiveDecimal
+        $id: ID!,
+        $price: PositiveDecimal,
+        $costPrice: PositiveDecimal,
+        $attributes: [AttributeValueInput],
     ) {
-        productVariantUpdate(id: $id, input: {costPrice: $costPrice, price: $price}) {
+        productVariantUpdate(
+            id: $id,
+            input: {
+                costPrice: $costPrice,
+                price: $price,
+                attributes: $attributes,
+            }
+        ) {
             errors {
                 field
                 message
@@ -187,6 +214,12 @@ def test_mutation_positive_decimal_input_without_arguments(
         "id": graphene.Node.to_global_id("ProductVariant", variant.id),
         "cost": 12.12,
         "price": 15,
+        "attributes": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", size_attribute.pk),
+                "values": ["S"],
+            }
+        ],
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -1206,6 +1206,11 @@ class ProductVariantCreate(ModelMutation):
     def clean_attributes(
         cls, attributes: dict, product_type: models.ProductType
     ) -> T_INPUT_MAP:
+        if not attributes:
+            raise ValidationError(
+                "All attributes must take a value.", ProductErrorCode.REQUIRED.value
+            )
+
         attributes_qs = product_type.variant_attributes
         attributes = AttributeAssignmentMixin.clean_input(
             attributes, attributes_qs, is_variant=True

--- a/saleor/graphql/product/tests/test_product_minimal_variant_price.py
+++ b/saleor/graphql/product/tests/test_product_minimal_variant_price.py
@@ -78,17 +78,20 @@ def test_product_variant_update_updates_minimal_variant_price(
     mock_update_product_minimal_variant_price_task,
     staff_api_client,
     product,
+    size_attribute,
     permission_manage_products,
 ):
     query = """
         mutation ProductVariantUpdate(
             $id: ID!,
             $price: PositiveDecimal,
+            $attributes: [AttributeValueInput],
         ) {
             productVariantUpdate(
                 id: $id,
                 input: {
                     price: $price,
+                    attributes: $attributes
                 }
             ) {
                 productVariant {
@@ -103,8 +106,13 @@ def test_product_variant_update_updates_minimal_variant_price(
     """
     variant = product.variants.first()
     variant_id = to_global_id("ProductVariant", variant.pk)
+    attribute_id = to_global_id("Attribute", size_attribute.pk)
     price = "1.99"
-    variables = {"id": variant_id, "price": price}
+    variables = {
+        "id": variant_id,
+        "price": price,
+        "attributes": [{"id": attribute_id, "values": ["S"]}],
+    }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]
     )

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -686,18 +686,24 @@ def test_update_product_variant_unset_cost_price(
 
 
 def test_update_product_variant_invalid_price(
-    staff_api_client, product, permission_manage_products
+    staff_api_client, product, size_attribute, permission_manage_products
 ):
     query = """
         mutation updateVariant(
             $id: ID!
             $sku: String!
             $price: PositiveDecimal
-            $costPrice: PositiveDecimal
+            $costPrice: PositiveDecimal,
+            $attributes: [AttributeValueInput],
         ) {
             productVariantUpdate(
                 id: $id
-                input: { sku: $sku, price: $price, costPrice: $costPrice }
+                input: {
+                    sku: $sku,
+                    price: $price,
+                    costPrice: $costPrice,
+                    attributes: $attributes,
+                }
             ) {
                 productErrors {
                     field
@@ -709,12 +715,14 @@ def test_update_product_variant_invalid_price(
     """
     variant = product.variants.first()
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    attribute_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
 
     variables = {
         "id": variant_id,
         "sku": variant.sku,
         "costPrice": 15,
         "price": 1234567891234,
+        "attributes": [{"id": attribute_id, "values": ["S"]}],
     }
 
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -262,6 +262,33 @@ def test_create_product_variant_with_negative_weight(
     assert error["code"] == ProductErrorCode.INVALID.name
 
 
+def test_create_product_variant_without_attributes(
+    staff_api_client, product, permission_manage_products
+):
+    # given
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variables = {
+        "productId": product_id,
+        "sku": "test-sku",
+        "price": 0,
+        "attributes": [],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantCreate"]
+    error = data["productErrors"][0]
+
+    assert error["field"] == "attributes"
+    assert error["code"] == ProductErrorCode.REQUIRED.name
+
+
 def test_create_product_variant_not_all_attributes(
     staff_api_client, product, product_type, color_attribute, permission_manage_products
 ):


### PR DESCRIPTION
Add attributes validation while creating or updating a product's variant. Previously it was possible to create or update a variant without providing any attributes.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
