### PR TITLE
Add searching customers by phone number

### DIFF
--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -43,6 +43,7 @@ def filter_staff_search(qs, _, value):
         "default_shipping_address__last_name",
         "default_shipping_address__city",
         "default_shipping_address__country",
+        "default_shipping_address__phone",
     )
     if value:
         qs = filter_by_query_param(qs, value, search_fields)

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4,8 +4,9 @@ from collections import defaultdict
 from datetime import timedelta
 from unittest.mock import ANY, MagicMock, Mock, patch
 
+
 import graphene
-import pytest
+import pytest 
 from django.contrib.auth.models import Group
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
@@ -3644,6 +3645,9 @@ def test_query_customers_with_sort(
         ({"search": "Doe"}, 1),  # default_shipping_address__last_name
         ({"search": "wroc"}, 1),  # default_shipping_address__city
         ({"search": "pl"}, 2),  # default_shipping_address__country, email
+        ({"search": "+48713988102"}, 1),
+        ({"search": "7139881"}, 1),
+        ({"search": "+48713"}, 1),
     ],
 )
 def test_query_customer_members_with_filter_search(
@@ -3656,6 +3660,8 @@ def test_query_customer_members_with_filter_search(
     staff_user,
 ):
 
+    # print("Address is: " + str(address)
+    print("test ==== ")
     User.objects.bulk_create(
         [
             User(

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4,9 +4,8 @@ from collections import defaultdict
 from datetime import timedelta
 from unittest.mock import ANY, MagicMock, Mock, patch
 
-
 import graphene
-import pytest 
+import pytest
 from django.contrib.auth.models import Group
 from django.contrib.auth.tokens import default_token_generator
 from django.core.exceptions import ValidationError
@@ -3660,8 +3659,6 @@ def test_query_customer_members_with_filter_search(
     staff_user,
 ):
 
-    # print("Address is: " + str(address)
-    print("test ==== ")
     User.objects.bulk_create(
         [
             User(


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] Added option to filter staff by phone number as well - many customers don't remember their order number and saying their email through the phone can be tricky, so searching by phone number (for example in the dashboard 'Orders' section) can be useful.

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
