### PR TITLE
Add page types query

### DIFF
--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -11,6 +11,13 @@ def filter_page_search(qs, _, value):
     return qs
 
 
+def filter_page_type_search(qs, _, value):
+    fields = ["name", "slug"]
+    if value:
+        qs = filter_by_query_param(qs, value, fields)
+    return qs
+
+
 class PageFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_page_search)
 
@@ -22,3 +29,12 @@ class PageFilter(django_filters.FilterSet):
 class PageFilterInput(FilterInputObjectType):
     class Meta:
         filterset_class = PageFilter
+
+
+class PageTypeFilter(django_filters.FilterSet):
+    search = django_filters.CharFilter(method=filter_page_type_search)
+
+
+class PageTypeFilterInput(FilterInputObjectType):
+    class Meta:
+        filterset_class = PageTypeFilter

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -23,3 +23,7 @@ def resolve_pages(info, **_kwargs):
 
 def resolve_page_type(info, global_page_type_id):
     return graphene.Node.get_node_from_global_id(info, global_page_type_id, PageType)
+
+
+def resolve_page_types(info, **_kwargs):
+    return models.PageType.objects.all()

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -3,7 +3,7 @@ import graphene
 from ..core.fields import FilterInputConnectionField
 from ..translations.mutations import PageTranslate
 from .bulk_mutations import PageBulkDelete, PageBulkPublish
-from .filters import PageFilterInput
+from .filters import PageFilterInput, PageTypeFilterInput
 from .mutations import (
     PageCreate,
     PageDelete,
@@ -11,8 +11,13 @@ from .mutations import (
     PageTypeUpdate,
     PageUpdate,
 )
-from .resolvers import resolve_page, resolve_page_type, resolve_pages
-from .sorters import PageSortingInput
+from .resolvers import (
+    resolve_page,
+    resolve_page_type,
+    resolve_page_types,
+    resolve_pages,
+)
+from .sorters import PageSortingInput, PageTypeSortingInput
 from .types import Page, PageType
 
 
@@ -34,6 +39,12 @@ class PageQueries(graphene.ObjectType):
         id=graphene.Argument(graphene.ID, description="ID of the page type."),
         description="Look up a page type by ID.",
     )
+    page_types = FilterInputConnectionField(
+        PageType,
+        sort_by=PageTypeSortingInput(description="Sort page types."),
+        filter=PageTypeFilterInput(description="Filtering options for page types."),
+        description="List of the page types.",
+    )
 
     def resolve_page(self, info, id=None, slug=None):
         return resolve_page(info, id, slug)
@@ -43,6 +54,9 @@ class PageQueries(graphene.ObjectType):
 
     def resolve_page_type(self, info, id):
         return resolve_page_type(info, id)
+
+    def resolve_page_types(self, info, **kwargs):
+        return resolve_page_types(info, **kwargs)
 
 
 class PageMutations(graphene.ObjectType):

--- a/saleor/graphql/page/sorters.py
+++ b/saleor/graphql/page/sorters.py
@@ -22,3 +22,21 @@ class PageSortingInput(SortInputObjectType):
     class Meta:
         sort_enum = PageSortField
         type_name = "pages"
+
+
+class PageTypeSortField(graphene.Enum):
+    NAME = ["name", "slug"]
+    SLUG = ["slug"]
+
+    @property
+    def description(self):
+        if self.name in PageTypeSortField.__enum__._member_names_:
+            sport_name = self.name.lower().replace("_", " ")
+            return f"Sort page types by {sport_name}."
+        raise ValueError(f"Unsupported enum value: {self.value}")
+
+
+class PageTypeSortingInput(SortInputObjectType):
+    class Meta:
+        sort_enum = PageTypeSortField
+        type_name = "page types"

--- a/saleor/graphql/page/tests/benchmark/test_page_type.py
+++ b/saleor/graphql/page/tests/benchmark/test_page_type.py
@@ -64,3 +64,66 @@ def test_query_page_type(
     content = get_graphql_content(response)
     data = content["data"]["pageType"]
     assert data
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=True)
+def test_query_page_types(
+    page_type,
+    staff_api_client,
+    author_page_attribute,
+    permission_manage_pages,
+    permission_manage_products,
+    count_queries,
+):
+    query = """
+        query {
+            pageTypes(first: 10) {
+                edges {
+                    node {
+                        id
+                        name
+                        slug
+                        attributes {
+                            slug
+                            name
+                            type
+                            inputType
+                            values {
+                                name
+                                slug
+                                type
+                            }
+                            valueRequired
+                            visibleInStorefront
+                            filterableInStorefront
+                        }
+                        availableAttributes(first: 10) {
+                            edges {
+                                node {
+                                    slug
+                                    name
+                                    type
+                                    inputType
+                                    values {
+                                        name
+                                        slug
+                                        type
+                                    }
+                                    valueRequired
+                                    visibleInStorefront
+                                    filterableInStorefront
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    response = staff_api_client.post_graphql(
+        query, {}, permissions=[permission_manage_products, permission_manage_pages],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypes"]
+    assert data

--- a/saleor/graphql/page/tests/test_page_types_sorting_and_filtering.py
+++ b/saleor/graphql/page/tests/test_page_types_sorting_and_filtering.py
@@ -1,0 +1,109 @@
+import graphene
+import pytest
+
+from ....page.models import PageType
+from ...tests.utils import get_graphql_content
+
+PAGE_TYPES_QUERY = """
+    query PageTypes($filter: PageTypeFilterInput, $sortBy: PageTypeSortingInput) {
+        pageTypes(first: 10, filter: $filter, sortBy: $sortBy) {
+            edges {
+                node {
+                    id
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "search_value, result_items",
+    [("test", [0]), ("page", [0, 1, 2]), ("Example page", [1, 2])],
+)
+def test_filter_page_types(
+    search_value, result_items, staff_api_client, page_type_list
+):
+    # given
+    variables = {"filter": {"search": search_value}}
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypes"]["edges"]
+
+    assert {node["node"]["id"] for node in data} == {
+        graphene.Node.to_global_id("PageType", page_type_list[i].pk)
+        for i in result_items
+    }
+
+
+@pytest.mark.parametrize(
+    "direction, order_direction", (("ASC", "name"), ("DESC", "-name")),
+)
+def test_sort_page_types_by_name(
+    direction, order_direction, staff_api_client, page_type_list
+):
+    # given
+    variables = {"sortBy": {"field": "NAME", "direction": direction}}
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypes"]["edges"]
+
+    assert [node["node"]["id"] for node in data] == [
+        graphene.Node.to_global_id("PageType", page_type.pk)
+        for page_type in PageType.objects.order_by(order_direction)
+    ]
+
+
+@pytest.mark.parametrize(
+    "direction, order_direction", (("ASC", "slug"), ("DESC", "-slug")),
+)
+def test_sort_page_types_by_slug(
+    direction, order_direction, staff_api_client, page_type_list
+):
+    # given
+    variables = {"sortBy": {"field": "SLUG", "direction": direction}}
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypes"]["edges"]
+
+    assert [node["node"]["id"] for node in data] == [
+        graphene.Node.to_global_id("PageType", page_type.pk)
+        for page_type in PageType.objects.order_by(order_direction)
+    ]
+
+
+@pytest.mark.parametrize(
+    "direction, result_items", (("ASC", [1, 2]), ("DESC", [2, 1])),
+)
+def test_filter_and_sort_by_slug_page_types(
+    direction, result_items, staff_api_client, page_type_list
+):
+    # given
+    variables = {
+        "filter": {"search": "Example"},
+        "sortBy": {"field": "SLUG", "direction": direction},
+    }
+
+    # when
+    response = staff_api_client.post_graphql(PAGE_TYPES_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypes"]["edges"]
+
+    assert [node["node"]["id"] for node in data] == [
+        graphene.Node.to_global_id("PageType", page_type_list[i].pk)
+        for i in result_items
+    ]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3381,6 +3381,17 @@ type PageType implements Node & ObjectWithMetadata {
   availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
 }
 
+type PageTypeCountableConnection {
+  pageInfo: PageInfo!
+  edges: [PageTypeCountableEdge!]!
+  totalCount: Int
+}
+
+type PageTypeCountableEdge {
+  node: PageType!
+  cursor: String!
+}
+
 type PageTypeCreate {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   pageErrors: [PageError!]!
@@ -3391,6 +3402,20 @@ input PageTypeCreateInput {
   name: String
   slug: String
   addAttributes: [ID!]
+}
+
+input PageTypeFilterInput {
+  search: String
+}
+
+enum PageTypeSortField {
+  NAME
+  SLUG
+}
+
+input PageTypeSortingInput {
+  direction: OrderDirection!
+  field: PageTypeSortField!
 }
 
 type PageTypeUpdate {
@@ -4336,6 +4361,7 @@ type Query {
   page(id: ID, slug: String): Page
   pages(sortBy: PageSortingInput, filter: PageFilterInput, before: String, after: String, first: Int, last: Int): PageCountableConnection
   pageType(id: ID): PageType
+  pageTypes(sortBy: PageTypeSortingInput, filter: PageTypeFilterInput, before: String, after: String, first: Int, last: Int): PageTypeCountableConnection
   homepageEvents(before: String, after: String, first: Int, last: Int): OrderEventCountableConnection
   order(id: ID!): Order
   orders(sortBy: OrderSortingInput, filter: OrderFilterInput, created: ReportingPeriod, status: OrderStatusFilter, before: String, after: String, first: Int, last: Int): OrderCountableConnection

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1920,6 +1920,22 @@ def page_type(db, size_page_attribute, tag_page_attribute):
 
 
 @pytest.fixture
+def page_type_list(db, tag_page_attribute):
+    page_types = list(
+        PageType.objects.bulk_create(
+            [
+                PageType(name="Test page type 1", slug="test-page-type-1"),
+                PageType(name="Example page type 2", slug="page-type-2"),
+                PageType(name="Example page type 3", slug="page-type-3"),
+            ]
+        )
+    )
+    for page_type in page_types:
+        page_type.page_attributes.add(tag_page_attribute)
+    return page_types
+
+
+@pytest.fixture
 def model_form_class():
     mocked_form_class = MagicMock(name="test", spec=ModelForm)
     mocked_form_class._meta = Mock(name="_meta")


### PR DESCRIPTION
Add page types query with sorting and filtering options.

Linked task: [SALEOR-1169](https://app.clickup.com/t/2549495/SALEOR-1169)
(Page Type query already exists.)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
