### PR TITLE
Update AttributeCreate mutation permissions

### DIFF
--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -518,6 +518,42 @@ def test_create_attribute_and_attribute_values(
 
     # Check if the attribute values were correctly created
     assert len(data["attribute"]["values"]) == 1
+    assert data["attribute"]["type"] == AttributeTypeEnum.PRODUCT_TYPE.name
+    assert data["attribute"]["values"][0]["name"] == name
+    assert data["attribute"]["values"][0]["slug"] == slugify(name)
+
+
+def test_create_page_attribute_and_attribute_values(
+    staff_api_client, permission_manage_page_types_and_attributes
+):
+    query = CREATE_ATTRIBUTES_QUERY
+
+    attribute_name = "Example name"
+    name = "Value name"
+    variables = {
+        "name": attribute_name,
+        "values": [{"name": name}],
+        "type": AttributeTypeEnum.PAGE_TYPE.name,
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_page_types_and_attributes]
+    )
+    content = get_graphql_content(response)
+    assert not content["data"]["attributeCreate"]["errors"]
+    data = content["data"]["attributeCreate"]
+
+    # Check if the attribute was correctly created
+    assert data["attribute"]["name"] == attribute_name
+    assert data["attribute"]["slug"] == slugify(
+        attribute_name
+    ), "The default slug should be the slugified name"
+    assert (
+        data["attribute"]["productTypes"]["edges"] == []
+    ), "The attribute should not have been assigned to a product type"
+
+    # Check if the attribute values were correctly created
+    assert len(data["attribute"]["values"]) == 1
+    assert data["attribute"]["type"] == AttributeTypeEnum.PAGE_TYPE.name
     assert data["attribute"]["values"][0]["name"] == name
     assert data["attribute"]["values"][0]["slug"] == slugify(name)
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -460,7 +460,7 @@ input AttributeCreateInput {
   inputType: AttributeInputTypeEnum
   name: String!
   slug: String
-  type: AttributeTypeEnum
+  type: AttributeTypeEnum!
   values: [AttributeValueCreateInput]
   valueRequired: Boolean
   isVariantOnly: Boolean


### PR DESCRIPTION
Update `AttributeCreeate` mutation:
* set `type` input field as required,
*  check permissions based on attribute type.

Task linked: [SALEOR-1316](https://app.clickup.com/t/2549495/SALEOR-1316)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
