### PR TITLE
Add old meta to page type

### DIFF
--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -7,6 +7,7 @@ from ...product import models as product_models
 from ..core.connection import CountableDjangoObjectType
 from ..core.fields import FilterInputConnectionField
 from ..decorators import permission_required
+from ..meta.deprecated.resolvers import resolve_meta, resolve_private_meta
 from ..meta.types import ObjectWithMetadata
 from ..product.dataloaders.attributes import PageAttributesByPageTypeIdLoader
 from ..product.filters import AttributeFilterInput
@@ -69,3 +70,12 @@ class PageType(CountableDjangoObjectType):
         return product_models.Attribute.objects.get_unassigned_page_type_attributes(
             root.pk
         )
+
+    @staticmethod
+    @permission_required(PagePermissions.MANAGE_PAGES)
+    def resolve_private_meta(root: models.PageType, _info):
+        return resolve_private_meta(root, _info)
+
+    @staticmethod
+    def resolve_meta(root: models.PageType, _info):
+        return resolve_meta(root, _info)


### PR DESCRIPTION
To be compliant, add old meta to the page type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
