### PR TITLE
Fix invoice layout

### DIFF
--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: master\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-11 12:15+0000\n"
+"POT-Creation-Date: 2020-10-23 07:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -32,52 +32,57 @@ msgid ""
 "%(street_address_2)s"
 msgstr ""
 
-#: templates/invoices/invoice.html:218
+#: templates/invoices/invoice.html:210
 msgctxt "Invoice PDF header"
 msgid "INVOICE INFORMATION"
 msgstr ""
 
-#: templates/invoices/invoice.html:221
+#: templates/invoices/invoice.html:213
 msgctxt "Invoice PDF header: Invoice number"
 msgid "Invoice number:"
 msgstr ""
 
-#: templates/invoices/invoice.html:227
+#: templates/invoices/invoice.html:219
 msgctxt "Invoice PDF header: order number"
 msgid "Order:"
 msgstr ""
 
-#: templates/invoices/invoice.html:233
+#: templates/invoices/invoice.html:225
 msgctxt "Invoice PDF header"
 msgid "Date:"
 msgstr ""
 
-#: templates/invoices/invoice.html:239
+#: templates/invoices/invoice.html:231
 msgctxt "Invoice PDF amount (price)"
 msgid "Amount:"
 msgstr ""
 
-#: templates/invoices/invoice.html:248
+#: templates/invoices/invoice.html:240
 msgctxt "Invoice PDF"
 msgid "BILLING ADDRESS"
 msgstr ""
 
-#: templates/invoices/invoice.html:277
+#: templates/invoices/invoice.html:269
 msgctxt "Invoice PDF"
 msgid "SHIPMENT ADDRESS"
 msgstr ""
 
-#: templates/invoices/invoice.html:308
+#: templates/invoices/invoice.html:300
 msgctxt "Invoice PDF"
 msgid "PAYMENT METHOD"
 msgstr ""
 
-#: templates/invoices/invoice.html:316
+#: templates/invoices/invoice.html:306
+msgctxt "Invoice PDF: Payment method value"
+msgid "Unpaid"
+msgstr ""
+
+#: templates/invoices/invoice.html:314
 msgctxt "Invoice PDF"
 msgid "SHIPMENT METHOD"
 msgstr ""
 
-#: templates/invoices/invoice.html:326
+#: templates/invoices/invoice.html:324
 msgctxt "Invoice PDF table header"
 msgid "ITEMS ORDERED"
 msgstr ""

--- a/templates/invoices/invoice.html
+++ b/templates/invoices/invoice.html
@@ -29,7 +29,7 @@
         .section-header,
         .section-invoice-info {
             background-color: #EFF5F8;
-            height: 235px;
+            height: 255px;
         }
 
         .section-left {
@@ -105,12 +105,6 @@
 
         .summary-row {
             line-height: normal;
-        }
-
-        .logo-placeholder {
-            height: 30px;
-            width: 78px;
-            padding-bottom: 20px;
         }
 
         .padded-font {
@@ -190,8 +184,6 @@
 <body>
     <div class="section-header section-left">
         <div class="content-padded">
-            <div class="logo-placeholder"></div>
-            <br />
             <span class="normal-text">{{ order.billing_address.company_name }}</span>
             <br />
             <span class="normal-text">{{ order.billing_address.street_address_1 }}</span>
@@ -307,7 +299,11 @@
         <div class="content-tight-padded padded-top">
             <span class="header-title">{% trans "PAYMENT METHOD" context "Invoice PDF" %}</span>
             <br />
-            <span class="normal-text">{{ order.get_last_payment.gateway }}</span>
+            {% if order.get_last_payment %}
+                <span class="normal-text">{{ order.get_last_payment.gateway }}</span>
+            {% else %}
+                <span class="normal-text">Unpaid</span>
+            {% endif %}
             <br />
         </div>
     </div>

--- a/templates/invoices/invoice.html
+++ b/templates/invoices/invoice.html
@@ -302,7 +302,9 @@
             {% if order.get_last_payment %}
                 <span class="normal-text">{{ order.get_last_payment.gateway }}</span>
             {% else %}
-                <span class="normal-text">Unpaid</span>
+                <span class="normal-text">
+                    {% trans "Unpaid" context "Invoice PDF: Payment method value" %}
+                </span>
             {% endif %}
             <br />
         </div>


### PR DESCRIPTION
I want to merge this change because it fixes two issues with the invoice
- fix the layout (padding where the logo was in the past), now the header looks like:
![image](https://user-images.githubusercontent.com/12252472/96852431-6a1f1980-1459-11eb-9d19-e2ec550ef854.png)

- if the order was unpaid and invoice got generated it mas missing the gateway variable and ended up with:
![image](https://user-images.githubusercontent.com/12252472/96851932-d8afa780-1458-11eb-9b2b-86b9b51f8001.png)

It has been fixed to:

![image](https://user-images.githubusercontent.com/12252472/96852027-f41ab280-1458-11eb-9685-a51be967ab84.png)

Related ticket: [SALEOR-1306](https://app.clickup.com/t/2549495/SALEOR-1306)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
