### PR TITLE
Add deprecation to default currency field on shop query

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4760,7 +4760,7 @@ type Shop {
   authorizationKeys: [AuthorizationKey]!
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
   currencies: [String]! @deprecated(reason: "This field will be removed in Saleor 3.0")
-  defaultCurrency: String!
+  defaultCurrency: String! @deprecated(reason: "This field will be removed in Saleor 3.0")
   defaultCountry: CountryDisplay
   defaultMailSenderName: String
   defaultMailSenderAddress: String

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -103,7 +103,9 @@ class Shop(graphene.ObjectType):
         deprecation_reason="This field will be removed in Saleor 3.0",
     )
     default_currency = graphene.String(
-        description="Shop's default currency.", required=True
+        description="Shop's default currency.",
+        required=True,
+        deprecation_reason="This field will be removed in Saleor 3.0",
     )
     default_country = graphene.Field(
         CountryDisplay, description="Shop's default country."


### PR DESCRIPTION
Add deprecation to default currency field on shop query

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
