### PR TITLE
Add pageTypeReorderAttributes mutation

### DIFF
--- a/saleor/graphql/page/mutations/attributes.py
+++ b/saleor/graphql/page/mutations/attributes.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING, Dict, List
+from typing import Dict, List
 
 import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -14,12 +14,10 @@ from ...core.types.common import PageError
 from ...core.utils import from_global_id_strict_type
 from ...core.utils.reordering import perform_reordering
 from ...page.types import PageType
+from ...product.mutations.attributes import BaseReorderAttributesMutation
 from ...product.mutations.common import ReorderInput
 from ...product.types import Attribute
 from ...utils import resolve_global_ids_to_primary_keys
-
-if TYPE_CHECKING:
-    from django.db.models import QuerySet
 
 
 class PageAttributeAssign(BaseMutation):
@@ -146,7 +144,7 @@ class PageAttributeUnassign(BaseMutation):
         return cls(page_type=page_type)
 
 
-class PageTypeReorderAttributes(BaseMutation):
+class PageTypeReorderAttributes(BaseReorderAttributesMutation):
     page_type = graphene.Field(
         PageType, description="Page type from which attributes are reordered."
     )
@@ -166,43 +164,6 @@ class PageTypeReorderAttributes(BaseMutation):
         permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
         error_type_class = PageError
         error_type_field = "page_errors"
-
-    @classmethod
-    def prepare_operations(cls, moves: ReorderInput, page_attributes: "QuerySet"):
-        """Prepare operations dict for reordering attributes.
-
-        Operation dict format:
-            key: page attribute pk,
-            value: sort_order value - relative sorting position of the attribute
-        """
-        operations = {}
-        invalid_attributes = []
-
-        # resolve attribute moves
-        for move_info in moves:
-            attribute_pk = from_global_id_strict_type(
-                move_info.id, only_type=Attribute, field="pk"
-            )
-
-            try:
-                page_attribute = page_attributes.get(attribute_id=int(attribute_pk))
-            except ObjectDoesNotExist:
-                invalid_attributes.append(move_info.id)
-            else:
-                operations[page_attribute.pk] = move_info.sort_order
-
-        if invalid_attributes:
-            raise ValidationError(
-                {
-                    "moves": ValidationError(
-                        "Couldn't resolve to an attribute.",
-                        code=PageErrorCode.NOT_FOUND.value,
-                        params={"attributes": invalid_attributes},
-                    )
-                }
-            )
-
-        return operations
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -226,7 +187,11 @@ class PageTypeReorderAttributes(BaseMutation):
         page_attributes = page_type.attributepage.all()
         moves = data["moves"]
 
-        operations = cls.prepare_operations(moves, page_attributes)
+        try:
+            operations = cls.prepare_operations(moves, page_attributes)
+        except ValidationError as error:
+            error.code = PageErrorCode.NOT_FOUND.value
+            raise ValidationError({"moves": error})
 
         with transaction.atomic():
             perform_reordering(page_attributes, operations)

--- a/saleor/graphql/page/mutations/attributes.py
+++ b/saleor/graphql/page/mutations/attributes.py
@@ -2,19 +2,24 @@ from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, List
 
 import graphene
-from django.core.exceptions import ValidationError
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.db import transaction
 
 from ....core.permissions import PageTypePermissions
+from ....page import models as page_models
 from ....page.error_codes import PageErrorCode
 from ....product import AttributeType, models
 from ...core.mutations import BaseMutation
 from ...core.types.common import PageError
+from ...core.utils import from_global_id_strict_type
+from ...core.utils.reordering import perform_reordering
 from ...page.types import PageType
+from ...product.mutations.common import ReorderInput
 from ...product.types import Attribute
 from ...utils import resolve_global_ids_to_primary_keys
 
 if TYPE_CHECKING:
-    from ....page import models as page_models
+    from django.db.models import QuerySet
 
 
 class PageAttributeAssign(BaseMutation):
@@ -139,3 +144,91 @@ class PageAttributeUnassign(BaseMutation):
         page_type.page_attributes.remove(*attr_pks)
 
         return cls(page_type=page_type)
+
+
+class PageTypeReorderAttributes(BaseMutation):
+    page_type = graphene.Field(
+        PageType, description="Page type from which attributes are reordered."
+    )
+
+    class Arguments:
+        page_type_id = graphene.Argument(
+            graphene.ID, required=True, description="ID of a page type."
+        )
+        moves = graphene.List(
+            graphene.NonNull(ReorderInput),
+            required=True,
+            description="The list of attribute reordering operations.",
+        )
+
+    class Meta:
+        description = "Reorder the attributes of a page type."
+        permissions = (PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,)
+        error_type_class = PageError
+        error_type_field = "page_errors"
+
+    @classmethod
+    def prepare_operations(cls, moves: ReorderInput, page_attributes: "QuerySet"):
+        """Prepare operations dict for reordering attributes.
+
+        Operation dict format:
+            key: page attribute pk,
+            value: sort_order value - relative sorting position of the attribute
+        """
+        operations = {}
+        invalid_attributes = []
+
+        # resolve attribute moves
+        for move_info in moves:
+            attribute_pk = from_global_id_strict_type(
+                move_info.id, only_type=Attribute, field="pk"
+            )
+
+            try:
+                page_attribute = page_attributes.get(attribute_id=int(attribute_pk))
+            except ObjectDoesNotExist:
+                invalid_attributes.append(move_info.id)
+            else:
+                operations[page_attribute.pk] = move_info.sort_order
+
+        if invalid_attributes:
+            raise ValidationError(
+                {
+                    "moves": ValidationError(
+                        "Couldn't resolve to an attribute.",
+                        code=PageErrorCode.NOT_FOUND.value,
+                        params={"attributes": invalid_attributes},
+                    )
+                }
+            )
+
+        return operations
+
+    @classmethod
+    def perform_mutation(cls, _root, info, **data):
+        page_type_id = data["page_type_id"]
+        pk = from_global_id_strict_type(page_type_id, only_type=PageType, field="pk")
+
+        try:
+            page_type = page_models.PageType.objects.prefetch_related(
+                "attributepage"
+            ).get(pk=pk)
+        except ObjectDoesNotExist:
+            raise ValidationError(
+                {
+                    "page_type_id": ValidationError(
+                        f"Couldn't resolve to a page type: {page_type_id}",
+                        code=PageErrorCode.NOT_FOUND.value,
+                    )
+                }
+            )
+
+        page_attributes = page_type.attributepage.all()
+        moves = data["moves"]
+
+        operations = cls.prepare_operations(moves, page_attributes)
+
+        with transaction.atomic():
+            perform_reordering(page_attributes, operations)
+
+        return PageTypeReorderAttributes(page_type=page_type)

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -4,7 +4,11 @@ from ..core.fields import FilterInputConnectionField
 from ..translations.mutations import PageTranslate
 from .bulk_mutations import PageBulkDelete, PageBulkPublish, PageTypeBulkDelete
 from .filters import PageFilterInput, PageTypeFilterInput
-from .mutations.attributes import PageAttributeAssign, PageAttributeUnassign
+from .mutations.attributes import (
+    PageAttributeAssign,
+    PageAttributeUnassign,
+    PageTypeReorderAttributes,
+)
 from .mutations.pages import (
     PageCreate,
     PageDelete,
@@ -79,3 +83,4 @@ class PageMutations(graphene.ObjectType):
     # attributes mutations
     page_attribute_assign = PageAttributeAssign.Field()
     page_attribute_unassign = PageAttributeUnassign.Field()
+    page_type_reorder_attributes = PageTypeReorderAttributes.Field()

--- a/saleor/graphql/page/tests/test_page_type_reorder_attributes.py
+++ b/saleor/graphql/page/tests/test_page_type_reorder_attributes.py
@@ -1,0 +1,306 @@
+import graphene
+
+from ....page.error_codes import PageErrorCode
+from ....page.models import PageType
+from ...tests.utils import assert_no_permission, get_graphql_content
+
+PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION = """
+    mutation PageTypeReorderAttributes(
+        $pageTypeId: ID!
+        $moves: [ReorderInput!]!
+    ) {
+        pageTypeReorderAttributes(
+            pageTypeId: $pageTypeId
+            moves: $moves
+        ) {
+            pageType {
+                id
+                attributes {
+                    id
+                    slug
+                }
+            }
+            pageErrors {
+                code
+                field
+                message
+                attributes
+            }
+        }
+    }
+"""
+
+
+def test_reorder_page_type_attributes_by_staff(
+    staff_api_client,
+    permission_manage_page_types_and_attributes,
+    page_type_attribute_list,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_page_types_and_attributes
+    )
+
+    attributes = page_type_attribute_list
+    assert len(attributes) == 3
+
+    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type.page_attributes.set(attributes)
+
+    sorted_attributes = list(page_type.page_attributes.order_by())
+
+    assert len(sorted_attributes) == 3
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[0].pk),
+                "sortOrder": 2,
+            },
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[2].pk),
+                "sortOrder": -1,
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeReorderAttributes"]
+    errors = data["pageErrors"]
+    page_type_data = data["pageType"]
+
+    assert not errors
+    assert len(page_type_data["attributes"]) == len(sorted_attributes)
+
+    expected_order = [
+        sorted_attributes[2].pk,
+        sorted_attributes[1].pk,
+        sorted_attributes[0].pk,
+    ]
+
+    for attr, expected_pk in zip(page_type_data["attributes"], expected_order):
+        gql_type, gql_attr_id = graphene.Node.from_global_id(attr["id"])
+        assert gql_type == "Attribute"
+        assert int(gql_attr_id) == expected_pk
+
+
+def test_reorder_page_type_attributes_by_staff_no_perm(
+    staff_api_client, page_type_attribute_list
+):
+    # given
+    attributes = page_type_attribute_list
+    assert len(attributes) == 3
+
+    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type.page_attributes.set(attributes)
+
+    sorted_attributes = list(page_type.page_attributes.order_by())
+
+    assert len(sorted_attributes) == 3
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[0].pk),
+                "sortOrder": 1,
+            },
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[2].pk),
+                "sortOrder": -1,
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_reorder_page_type_attributes_by_app(
+    app_api_client,
+    permission_manage_page_types_and_attributes,
+    page_type_attribute_list,
+):
+    # given
+    app_api_client.app.permissions.add(permission_manage_page_types_and_attributes)
+
+    attributes = page_type_attribute_list
+    assert len(attributes) == 3
+
+    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type.page_attributes.set(attributes)
+
+    sorted_attributes = list(page_type.page_attributes.order_by())
+
+    assert len(sorted_attributes) == 3
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[2].pk),
+                "sortOrder": -2,
+            },
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[0].pk),
+                "sortOrder": 1,
+            },
+        ],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeReorderAttributes"]
+    errors = data["pageErrors"]
+    page_type_data = data["pageType"]
+
+    assert not errors
+    assert len(page_type_data["attributes"]) == len(sorted_attributes)
+
+    expected_order = [
+        sorted_attributes[2].pk,
+        sorted_attributes[1].pk,
+        sorted_attributes[0].pk,
+    ]
+
+    for attr, expected_pk in zip(page_type_data["attributes"], expected_order):
+        gql_type, gql_attr_id = graphene.Node.from_global_id(attr["id"])
+        assert gql_type == "Attribute"
+        assert int(gql_attr_id) == expected_pk
+
+
+def test_reorder_page_type_attributes_by_app_no_perm(
+    app_api_client, page_type_attribute_list
+):
+    # given
+    attributes = page_type_attribute_list
+    assert len(attributes) == 3
+
+    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type.page_attributes.set(attributes)
+
+    sorted_attributes = list(page_type.page_attributes.order_by())
+
+    assert len(sorted_attributes) == 3
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[2].pk),
+                "sortOrder": -2,
+            },
+            {
+                "id": graphene.Node.to_global_id("Attribute", attributes[0].pk),
+                "sortOrder": 1,
+            },
+        ],
+    }
+
+    # when
+    response = app_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_reorder_page_type_attributes_invalid_page_type(
+    staff_api_client, permission_manage_page_types_and_attributes, page_type
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_page_types_and_attributes
+    )
+
+    attribute = page_type.page_attributes.first()
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", -1),
+        "moves": [
+            {
+                "id": graphene.Node.to_global_id("Attribute", attribute.pk),
+                "sortOrder": 1,
+            },
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeReorderAttributes"]
+    errors = data["pageErrors"]
+    page_type_data = data["pageType"]
+
+    assert not page_type_data
+    assert len(errors) == 1
+    assert errors[0]["field"] == "pageTypeId"
+    assert errors[0]["code"] == PageErrorCode.NOT_FOUND.name
+
+
+def test_reorder_page_type_attributes_invalid_attribute_id(
+    staff_api_client,
+    permission_manage_page_types_and_attributes,
+    page_type,
+    color_attribute,
+    size_attribute,
+):
+    # given
+    staff_api_client.user.user_permissions.add(
+        permission_manage_page_types_and_attributes
+    )
+
+    page_type_attribute = page_type.page_attributes.first()
+    color_attribute_id = graphene.Node.to_global_id("Attribute", color_attribute.pk)
+    size_attribute_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
+
+    variables = {
+        "pageTypeId": graphene.Node.to_global_id("PageType", page_type.pk),
+        "moves": [
+            {"id": color_attribute_id, "sortOrder": 1},
+            {
+                "id": graphene.Node.to_global_id("Attribute", page_type_attribute.pk),
+                "sortOrder": 1,
+            },
+            {"id": size_attribute_id, "sortOrder": 1},
+        ],
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        PAGE_TYPE_REORDER_ATTRIBUTES_MUTATION, variables
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["pageTypeReorderAttributes"]
+    errors = data["pageErrors"]
+    page_type_data = data["pageType"]
+
+    assert not page_type_data
+    assert len(errors) == 1
+    assert errors[0]["field"] == "moves"
+    assert errors[0]["code"] == PageErrorCode.NOT_FOUND.name
+    assert set(errors[0]["attributes"]) == {color_attribute_id, size_attribute_id}

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import List
+from typing import TYPE_CHECKING, List
 
 import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -24,10 +24,14 @@ from ...core.utils import (
 from ...core.utils.reordering import perform_reordering
 from ...meta.deprecated.mutations import ClearMetaBaseMutation, UpdateMetaBaseMutation
 from ...product.types import ProductType
+from ...utils import resolve_global_ids_to_primary_keys
 from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
 from ..enums import AttributeInputTypeEnum, AttributeTypeEnum, ProductAttributeType
 from ..types import Attribute, AttributeValue
 from .common import ReorderInput
+
+if TYPE_CHECKING:
+    from django.db.models import QuerySet
 
 
 class AttributeValueCreateInput(graphene.InputObjectType):
@@ -717,7 +721,57 @@ class AttributeValueDelete(ModelDeleteMutation):
         return response
 
 
-class ProductTypeReorderAttributes(BaseMutation):
+class BaseReorderAttributesMutation(BaseMutation):
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def prepare_operations(cls, moves: ReorderInput, attributes: "QuerySet"):
+        """Prepare operations dict for reordering attributes.
+
+        Operation dict format:
+            key: attribute pk,
+            value: sort_order value - relative sorting position of the attribute
+        """
+        attribute_ids = []
+        sort_orders = []
+
+        # resolve attribute moves
+        for move_info in moves:
+            attribute_ids.append(move_info.id)
+            sort_orders.append(move_info.sort_order)
+
+        _, attr_pks = resolve_global_ids_to_primary_keys(attribute_ids, Attribute)
+        attr_pks = [int(pk) for pk in attr_pks]
+
+        attributes_m2m = attributes.filter(attribute_id__in=attr_pks)
+
+        if attributes_m2m.count() != len(attr_pks):
+            attribute_pks = attributes_m2m.values_list("attribute_id", flat=True)
+            invalid_attrs = set(attr_pks) - set(attribute_pks)
+            invalid_attr_ids = [
+                graphene.Node.to_global_id("Attribute", attr_pk)
+                for attr_pk in invalid_attrs
+            ]
+            raise ValidationError(
+                "Couldn't resolve to an attribute.",
+                params={"attributes": invalid_attr_ids},
+            )
+
+        attributes_m2m = list(attributes_m2m)
+        attributes_m2m.sort(
+            key=lambda e: attr_pks.index(e.attribute.pk)
+        )  # preserve order in pks
+
+        operations = {
+            attribute.pk: sort_order
+            for attribute, sort_order in zip(attributes_m2m, sort_orders)
+        }
+
+        return operations
+
+
+class ProductTypeReorderAttributes(BaseReorderAttributesMutation):
     product_type = graphene.Field(
         ProductType, description="Product type from which attributes are reordered."
     )
@@ -767,29 +821,16 @@ class ProductTypeReorderAttributes(BaseMutation):
             )
 
         attributes_m2m = getattr(product_type, m2m_field)
-        operations = {}
 
-        # Resolve the attributes
-        for move_info in moves:
-            attribute_pk = from_global_id_strict_type(
-                move_info.id, only_type=Attribute, field="moves"
-            )
-
-            try:
-                m2m_info = attributes_m2m.get(attribute_id=int(attribute_pk))
-            except ObjectDoesNotExist:
-                raise ValidationError(
-                    {
-                        "moves": ValidationError(
-                            f"Couldn't resolve to an attribute: {move_info.id}",
-                            code=ProductErrorCode.NOT_FOUND,
-                        )
-                    }
-                )
-            operations[m2m_info.pk] = move_info.sort_order
+        try:
+            operations = cls.prepare_operations(moves, attributes_m2m)
+        except ValidationError as error:
+            error.code = ProductErrorCode.NOT_FOUND.value
+            raise ValidationError({"moves": error})
 
         with transaction.atomic():
             perform_reordering(attributes_m2m, operations)
+
         return ProductTypeReorderAttributes(product_type=product_type)
 
 

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -1864,9 +1864,11 @@ ATTRIBUTES_RESORT_QUERY = """
           }
         }
 
-        errors {
+        productErrors {
           field
           message
+          code
+          attributes
         }
       }
     }
@@ -1895,10 +1897,12 @@ def test_sort_attributes_within_product_type_invalid_product_type(
         )
     )["data"]["productTypeReorderAttributes"]
 
-    assert content["errors"] == [
+    assert content["productErrors"] == [
         {
             "field": "productTypeId",
+            "code": ProductErrorCode.NOT_FOUND.name,
             "message": f"Couldn't resolve to a product type: {product_type_id}",
+            "attributes": None,
         }
     ]
 
@@ -1927,10 +1931,12 @@ def test_sort_attributes_within_product_type_invalid_id(
         )
     )["data"]["productTypeReorderAttributes"]
 
-    assert content["errors"] == [
+    assert content["productErrors"] == [
         {
             "field": "moves",
-            "message": f"Couldn't resolve to an attribute: {attribute_id}",
+            "message": "Couldn't resolve to an attribute.",
+            "attributes": [attribute_id],
+            "code": ProductErrorCode.NOT_FOUND.name,
         }
     ]
 
@@ -1987,7 +1993,7 @@ def test_sort_attributes_within_product_type(
     content = get_graphql_content(
         staff_api_client.post_graphql(ATTRIBUTES_RESORT_QUERY, variables)
     )["data"]["productTypeReorderAttributes"]
-    assert not content["errors"]
+    assert not content["productErrors"]
 
     assert (
         content["productType"]["id"] == product_type_id

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2683,6 +2683,7 @@ type Mutation {
   pageTypeBulkDelete(ids: [ID!]!): PageTypeBulkDelete
   pageAttributeAssign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeAssign
   pageAttributeUnassign(attributeIds: [ID!]!, pageTypeId: ID!): PageAttributeUnassign
+  pageTypeReorderAttributes(moves: [ReorderInput!]!, pageTypeId: ID!): PageTypeReorderAttributes
   draftOrderComplete(id: ID!): DraftOrderComplete
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
@@ -3438,6 +3439,12 @@ type PageTypeDelete {
 
 input PageTypeFilterInput {
   search: String
+}
+
+type PageTypeReorderAttributes {
+  errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  pageType: PageType
+  pageErrors: [PageError!]!
 }
 
 enum PageTypeSortField {


### PR DESCRIPTION
Allow reordering page type attributes.

Linked task: [SALEOR-1176](https://app.clickup.com/t/2549495/SALEOR-1176)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
