### PR TITLE
Fix for fulfilling an order when product quantity equals allocated quantity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add metadata to page model - #6292 by @dominik-zeglen
 - Fix for unnecesary attributes validation while updating simple product - #6300 by @GrzegorzDerdak
 - Include order line total price to webhook payload - #6354 by @korycins
+- Fix for fulfilling an order when product quantity equals allocated quantity - #6333 by @GrzegorzDerdak
 
 ## 2.10.2
 

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -8,14 +8,10 @@ class AllocationsByOrderLineIdLoader(DataLoader):
     context_key = "allocations_by_orderline_id"
 
     def batch_load(self, keys):
-        allocations = Allocation.objects.filter(order_line__pk__in=keys).select_related(
-            "order_line", "stock"
-        )
+        allocations = Allocation.objects.filter(order_line__pk__in=keys)
         order_lines_to_allocations = defaultdict(list)
 
         for allocation in allocations:
-            for order_line_id in keys:
-                if allocation.order_line_id == order_line_id:
-                    order_lines_to_allocations[order_line_id].append(allocation)
+            order_lines_to_allocations[allocation.order_line_id].append(allocation)
 
         return [order_lines_to_allocations[order_line_id] for order_line_id in keys]

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -1,0 +1,21 @@
+from collections import defaultdict
+
+from ...warehouse.models import Allocation
+from ..core.dataloaders import DataLoader
+
+
+class AllocationsByOrderLineIdLoader(DataLoader):
+    context_key = "allocations_by_orderline_id"
+
+    def batch_load(self, keys):
+        allocations = Allocation.objects.filter(order_line__pk__in=keys).select_related(
+            "order_line", "stock"
+        )
+        order_lines_to_allocations = defaultdict(list)
+
+        for allocation in allocations:
+            for order_line_id in keys:
+                if allocation.order_line_id == order_line_id:
+                    order_lines_to_allocations[order_line_id].append(allocation)
+
+        return [order_lines_to_allocations[order_line_id] for order_line_id in keys]

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -103,7 +103,7 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
                             quantity
                             allocations {
                                 id
-                                quantityAllocated
+                                quantity
                                 warehouse {
                                     id
                                 }
@@ -160,11 +160,7 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
         "Warehouse", allocation.stock.warehouse.pk
     )
     assert first_order_data_line["allocations"] == [
-        {
-            "id": allocation_id,
-            "quantityAllocated": 0,
-            "warehouse": {"id": warehouse_id},
-        }
+        {"id": allocation_id, "quantity": 0, "warehouse": {"id": warehouse_id}}
     ]
 
 
@@ -182,7 +178,7 @@ def test_order_line_with_allocations(
                             id
                             allocations {
                                 id
-                                quantityAllocated
+                                quantity
                                 warehouse {
                                     id
                                 }
@@ -206,7 +202,7 @@ def test_order_line_with_allocations(
         _, _id = graphene.Node.from_global_id(line["id"])
         order_line = order.lines.get(pk=_id)
         allocations_from_query = {
-            allocation["quantityAllocated"] for allocation in line["allocations"]
+            allocation["quantity"] for allocation in line["allocations"]
         }
         allocations_from_db = set(
             order_line.allocations.values_list("quantity_allocated", flat=True)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -101,6 +101,13 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
                                 id
                             }
                             quantity
+                            allocations {
+                                id
+                                quantity
+                                warehouse {
+                                    id
+                                }
+                            }
                             unitPrice {
                                 currency
                                 gross {
@@ -126,22 +133,35 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
     response = staff_api_client.post_graphql(query)
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
-    assert order_data["lines"][0]["thumbnail"] is None
+    first_order_data_line = order_data["lines"][0]
     variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
-    assert order_data["lines"][0]["variant"]["id"] == variant_id
-    assert order_data["lines"][0]["quantity"] == line.quantity
-    assert order_data["lines"][0]["unitPrice"]["currency"] == line.unit_price.currency
+
+    assert first_order_data_line["thumbnail"] is None
+    assert first_order_data_line["variant"]["id"] == variant_id
+    assert first_order_data_line["quantity"] == line.quantity
+    assert first_order_data_line["unitPrice"]["currency"] == line.unit_price.currency
+
     expected_unit_price = Money(
-        amount=str(order_data["lines"][0]["unitPrice"]["gross"]["amount"]),
+        amount=str(first_order_data_line["unitPrice"]["gross"]["amount"]),
         currency="USD",
     )
-    assert order_data["lines"][0]["totalPrice"]["currency"] == line.unit_price.currency
+    assert first_order_data_line["totalPrice"]["currency"] == line.unit_price.currency
     assert expected_unit_price == line.unit_price.gross
+
     expected_total_price = Money(
-        amount=str(order_data["lines"][0]["totalPrice"]["gross"]["amount"]),
+        amount=str(first_order_data_line["totalPrice"]["gross"]["amount"]),
         currency="USD",
     )
     assert expected_total_price == line.unit_price.gross * line.quantity
+
+    allocation = line.allocations.first()
+    allocation_id = graphene.Node.to_global_id("Allocation", allocation.pk)
+    warehouse_id = graphene.Node.to_global_id(
+        "Warehouse", allocation.stock.warehouse.pk
+    )
+    assert first_order_data_line["allocations"] == [
+        {"id": allocation_id, "quantity": 2, "warehouse": {"id": warehouse_id}}
+    ]
 
 
 def test_order_query(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -308,8 +308,8 @@ class OrderLine(CountableDjangoObjectType):
     @one_of_permissions_required(
         [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
     )
-    def resolve_allocations(root: models.OrderLine, _info):
-        return AllocationsByOrderLineIdLoader(_info.context).load(root.id)
+    def resolve_allocations(root: models.OrderLine, info):
+        return AllocationsByOrderLineIdLoader(info.context).load(root.id)
 
 
 class Order(CountableDjangoObjectType):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -26,7 +26,7 @@ from ..meta.types import ObjectWithMetadata
 from ..payment.types import OrderAction, Payment, PaymentChargeStatusEnum
 from ..product.types import ProductVariant
 from ..shipping.types import ShippingMethod
-from ..warehouse.types import Warehouse
+from ..warehouse.types import Allocation, Warehouse
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum
 from .utils import validate_draft_order
 
@@ -255,6 +255,9 @@ class OrderLine(CountableDjangoObjectType):
     translated_variant_name = graphene.String(
         required=True, description="Variant name in the customer's language"
     )
+    allocations = graphene.List(
+        Allocation, description="List of allocations across warehouses.",
+    )
 
     class Meta:
         description = "Represents order line of particular order."
@@ -298,6 +301,10 @@ class OrderLine(CountableDjangoObjectType):
     @staticmethod
     def resolve_translated_variant_name(root: models.OrderLine, _info):
         return root.translated_variant_name
+
+    @staticmethod
+    def resolve_allocations(root: models.OrderLine, _info):
+        return root.allocations.all()
 
 
 class Order(CountableDjangoObjectType):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -195,6 +195,12 @@ type AddressValidationData {
   postalCodePrefix: String
 }
 
+type Allocation implements Node {
+  id: ID!
+  quantity: Int!
+  warehouse: Warehouse
+}
+
 type App implements Node & ObjectWithMetadata {
   id: ID!
   name: String
@@ -3142,6 +3148,7 @@ type OrderLine implements Node {
   variant: ProductVariant
   translatedProductName: String!
   translatedVariantName: String!
+  allocations: [Allocation]
 }
 
 input OrderLineCreateInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -197,7 +197,7 @@ type AddressValidationData {
 
 type Allocation implements Node {
   id: ID!
-  quantityAllocated: Int!
+  quantity: Int!
   warehouse: Warehouse!
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3148,7 +3148,7 @@ type OrderLine implements Node {
   variant: ProductVariant
   translatedProductName: String!
   translatedVariantName: String!
-  allocations: [Allocation]
+  allocations: [Allocation!]
 }
 
 input OrderLineCreateInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -197,8 +197,8 @@ type AddressValidationData {
 
 type Allocation implements Node {
   id: ID!
-  quantity: Int!
-  warehouse: Warehouse
+  quantityAllocated: Int!
+  warehouse: Warehouse!
 }
 
 type App implements Node & ObjectWithMetadata {

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -93,11 +93,7 @@ class Stock(CountableDjangoObjectType):
 
 
 class Allocation(CountableDjangoObjectType):
-    quantity_allocated = graphene.Int(
-        required=True,
-        description="Quantity of a product in the warehouse's possession, "
-        "including the allocated stock that is waiting for shipment.",
-    )
+    quantity = graphene.Int(required=True, description="Quantity allocated for orders.")
     warehouse = graphene.Field(
         Warehouse, required=True, description="The warehouse were items were allocated."
     )
@@ -119,7 +115,7 @@ class Allocation(CountableDjangoObjectType):
     @one_of_permissions_required(
         [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
     )
-    def resolve_quantity_allocated(root, *_args):
+    def resolve_quantity(root, *_args):
         return root.stock.allocations.aggregate(
             quantity_allocated=Coalesce(Sum("quantity_allocated"), 0)
         )["quantity_allocated"]

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -90,3 +90,26 @@ class Stock(CountableDjangoObjectType):
         return root.allocations.aggregate(
             quantity_allocated=Coalesce(Sum("quantity_allocated"), 0)
         )["quantity_allocated"]
+
+
+class Allocation(CountableDjangoObjectType):
+    quantity = graphene.Int(
+        required=True,
+        description="Quantity of a product in the warehouse's possession, "
+        "including the allocated stock that is waiting for shipment.",
+    )
+    warehouse = graphene.Field(
+        Warehouse, description="The warehouse were items were allocated."
+    )
+
+    class Meta:
+        description = "Represets allocation."
+        model = models.Allocation
+        interfaces = [graphene.relay.Node]
+        only_fields = ["id"]
+
+    def resolve_warehouse(root, *_args):
+        return root.stock.warehouse
+
+    def resolve_quantity(root, *_args):
+        return root.stock.quantity


### PR DESCRIPTION
Fix for fulfilling an order when product quantity equals allocated quantity

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog

# Related frontend Pull Request

https://github.com/mirumee/saleor-dashboard/pull/788