### PR TITLE
Fix order_updated not triggering on mutation orderupdate

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -171,6 +171,7 @@ class OrderUpdate(DraftOrderUpdate):
             user = User.objects.filter(email=instance.user_email).first()
             instance.user = user
         instance.save()
+        info.context.plugins.order_updated(instance)
 
 
 class OrderUpdateShippingInput(graphene.InputObjectType):

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1649,8 +1649,13 @@ def test_require_draft_order_when_removing_lines(
     assert data["errors"]
 
 
+@patch("saleor.plugins.base_plugin.BasePlugin.order_updated")
 def test_order_update(
-    staff_api_client, permission_manage_orders, order_with_lines, graphql_address_data
+    plugin_mock,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    graphql_address_data,
 ):
     order = order_with_lines
     order.user = None
@@ -1695,6 +1700,7 @@ def test_order_update(
     assert order.user_email == email
     assert order.user is None
     assert order.status == OrderStatus.UNFULFILLED
+    assert plugin_mock.called is True
 
 
 def test_order_update_anonymous_user_no_user_email(


### PR DESCRIPTION
I want to merge this change because it fixes order_updated not triggering on mutation orderupdate

Related ticket: [SALEOR-1453](https://app.clickup.com/t/2549495/SALEOR-1453)

There should be more adjustments made to the order mutations but this will be handled in [separate PR](https://github.com/mirumee/saleor/pull/6324), this PR solves issue from ticket and can be merged before the other one to have the bug fixed quicker.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
