### PR TITLE
Allow associating attribute values with pages

### DIFF
--- a/saleor/graphql/page/dataloaders.py
+++ b/saleor/graphql/page/dataloaders.py
@@ -1,5 +1,15 @@
+from collections import defaultdict
+
+from promise import Promise
+
+from ...core.permissions import PagePermissions
 from ...page.models import Page, PageType
+from ...product.models import AssignedPageAttribute, AttributePage, AttributeValue
 from ..core.dataloaders import DataLoader
+from ..product.dataloaders.attributes import (
+    AttributesByAttributeId,
+    AttributeValueByIdLoader,
+)
 
 
 class PageByIdLoader(DataLoader):
@@ -16,3 +26,187 @@ class PageTypeByIdLoader(DataLoader):
     def batch_load(self, keys):
         page_types = PageType.objects.in_bulk(keys)
         return [page_types.get(page_type_id) for page_type_id in keys]
+
+
+class PageAttributesByPageTypeIdLoader(DataLoader):
+    """Loads page attributes by page type ID."""
+
+    context_key = "page_attributes_by_pagetype"
+
+    def batch_load(self, keys):
+        user = self.user
+        if user.is_active and user.has_perm(PagePermissions.MANAGE_PAGES):
+            qs = AttributePage.objects.all()
+        else:
+            qs = AttributePage.objects.filter(attribute__visible_in_storefront=True)
+
+        page_type_attribute_pairs = qs.filter(page_type_id__in=keys).values_list(
+            "page_type_id", "attribute_id"
+        )
+
+        page_type_to_attributes_map = defaultdict(list)
+        for page_type_id, attr_id in page_type_attribute_pairs:
+            page_type_to_attributes_map[page_type_id].append(attr_id)
+
+        def map_attributes(attributes):
+            attributes_map = {attr.id: attr for attr in attributes}
+            return [
+                [
+                    attributes_map[attr_id]
+                    for attr_id in page_type_to_attributes_map[page_type_id]
+                ]
+                for page_type_id in keys
+            ]
+
+        return (
+            AttributesByAttributeId(self.context)
+            .load_many(set(attr_id for _, attr_id in page_type_attribute_pairs))
+            .then(map_attributes)
+        )
+
+
+class AttributePagesByPageTypeIdLoader(DataLoader):
+    """Loads AttributePage objects by page type ID."""
+
+    context_key = "attributepages_by_pagetype"
+
+    def batch_load(self, keys):
+        user = self.user
+        if user.is_active and user.has_perm(PagePermissions.MANAGE_PAGES):
+            qs = AttributePage.objects.all()
+        else:
+            qs = AttributePage.objects.filter(attribute__visible_in_storefront=True)
+        attribute_pages = qs.filter(page_type_id__in=keys)
+        pagetype_to_attributepages = defaultdict(list)
+        for attribute_page in attribute_pages:
+            pagetype_to_attributepages[attribute_page.page_type_id].append(
+                attribute_page
+            )
+        return [pagetype_to_attributepages[key] for key in keys]
+
+
+class AssignedPageAttributesByPageIdLoader(DataLoader):
+    context_key = "assignedpageattributes_by_page"
+
+    def batch_load(self, keys):
+        user = self.user
+        if user.is_active and user.has_perm(PagePermissions.MANAGE_PAGES):
+            qs = AssignedPageAttribute.objects.all()
+        else:
+            qs = AssignedPageAttribute.objects.filter(
+                assignment__attribute__visible_in_storefront=True
+            )
+        assigned_page_attributes = qs.filter(page_id__in=keys)
+        page_to_assignedattributes = defaultdict(list)
+        for assigned_page_attribute in assigned_page_attributes:
+            page_to_assignedattributes[assigned_page_attribute.page_id].append(
+                assigned_page_attribute
+            )
+        return [page_to_assignedattributes[page_id] for page_id in keys]
+
+
+class AttributeValuesByAssignedPageAttributeIdLoader(DataLoader):
+    context_key = "attributevalues_by_assigned_pageattribute"
+
+    def batch_load(self, keys):
+        AttributeAssignment = AttributeValue.assignedpageattribute_set.through
+        attribute_values = AttributeAssignment.objects.filter(
+            assignedpageattribute_id__in=keys
+        )
+        value_ids = [a.attributevalue_id for a in attribute_values]
+
+        def map_assignment_to_values(values):
+            value_map = dict(zip(value_ids, values))
+            assigned_page_map = defaultdict(list)
+            for attribute_value in attribute_values:
+                assigned_page_map[attribute_value.assignedpageattribute_id].append(
+                    value_map.get(attribute_value.attributevalue_id)
+                )
+            return [
+                sorted(assigned_page_map[key], key=lambda v: (v.sort_order, v.id))
+                for key in keys
+            ]
+
+        return (
+            AttributeValueByIdLoader(self.context)
+            .load_many(value_ids)
+            .then(map_assignment_to_values)
+        )
+
+
+class SelectedAttributesByPageIdLoader(DataLoader):
+    context_key = "selectedattributes_by_page"
+
+    def batch_load(self, keys):
+        def with_pages_and_assigned_attributes(result):
+            pages, page_attributes = result
+            assigned_page_attributes_ids = list(
+                {attr.id for attrs in page_attributes for attr in attrs}
+            )
+            page_type_ids = [page.page_type_id for page in pages]
+            page_attributes = dict(zip(keys, page_attributes))
+
+            def with_attribute_pages_and_values(result):
+                attribute_pages, attribute_values = result
+                attribute_ids = list(
+                    {ap.attribute_id for aps in attribute_pages for ap in aps}
+                )
+                attribute_pages = dict(zip(page_type_ids, attribute_pages))
+                attribute_values = dict(
+                    zip(assigned_page_attributes_ids, attribute_values)
+                )
+
+                def with_attributes(attributes):
+                    id_to_attribute = dict(zip(attribute_ids, attributes))
+                    selected_attributes_map = defaultdict(list)
+                    for key, page in zip(keys, pages):
+                        assigned_pagetype_attributes = attribute_pages[
+                            page.page_type_id
+                        ]
+                        assigned_page_attributes = page_attributes[key]
+                        for assigned_pagetype_attribute in assigned_pagetype_attributes:
+                            page_assignment = next(
+                                (
+                                    apa
+                                    for apa in assigned_page_attributes
+                                    if apa.assignment_id
+                                    == assigned_pagetype_attribute.id
+                                ),
+                                None,
+                            )
+                            attribute = id_to_attribute[
+                                assigned_pagetype_attribute.attribute_id
+                            ]
+                            if page_assignment:
+                                values = attribute_values[page_assignment.id]
+                            else:
+                                values = []
+                            selected_attributes_map[key].append(
+                                {"values": values, "attribute": attribute}
+                            )
+                    return [selected_attributes_map[key] for key in keys]
+
+                return (
+                    AttributesByAttributeId(self.context)
+                    .load_many(attribute_ids)
+                    .then(with_attributes)
+                )
+
+            attribute_pages = AttributePagesByPageTypeIdLoader(self.context).load_many(
+                page_type_ids
+            )
+            attribute_values = AttributeValuesByAssignedPageAttributeIdLoader(
+                self.context
+            ).load_many(assigned_page_attributes_ids)
+            return Promise.all([attribute_pages, attribute_values]).then(
+                with_attribute_pages_and_values
+            )
+
+        pages = PageByIdLoader(self.context).load_many(keys)
+        assigned_attributes = AssignedPageAttributesByPageIdLoader(
+            self.context
+        ).load_many(keys)
+
+        return Promise.all([pages, assigned_attributes]).then(
+            with_pages_and_assigned_attributes
+        )

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -9,16 +9,25 @@ from ..core.fields import FilterInputConnectionField
 from ..decorators import permission_required
 from ..meta.deprecated.resolvers import resolve_meta, resolve_private_meta
 from ..meta.types import ObjectWithMetadata
-from ..product.dataloaders.attributes import PageAttributesByPageTypeIdLoader
 from ..product.filters import AttributeFilterInput
 from ..product.types import Attribute
+from ..product.types.attributes import SelectedAttribute
 from ..translations.fields import TranslationField
 from ..translations.types import PageTranslation
-from .dataloaders import PageTypeByIdLoader
+from .dataloaders import (
+    PageAttributesByPageTypeIdLoader,
+    PageTypeByIdLoader,
+    SelectedAttributesByPageIdLoader,
+)
 
 
 class Page(CountableDjangoObjectType):
     translation = TranslationField(PageTranslation, type_name="page")
+    attributes = graphene.List(
+        graphene.NonNull(SelectedAttribute),
+        required=True,
+        description="List of attributes assigned to this product.",
+    )
 
     class Meta:
         description = (
@@ -52,6 +61,10 @@ class Page(CountableDjangoObjectType):
     @staticmethod
     def resolve_page_type(root: models.Page, info):
         return PageTypeByIdLoader(info.context).load(root.page_type_id)
+
+    @staticmethod
+    def resolve_attributes(root: models.Page, info):
+        return SelectedAttributesByPageIdLoader(info.context).load(root.id)
 
 
 @key(fields="id")

--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -2,12 +2,11 @@ from collections import defaultdict
 
 from promise import Promise
 
-from ....core.permissions import PagePermissions, ProductPermissions
+from ....core.permissions import ProductPermissions
 from ....product.models import (
     AssignedProductAttribute,
     AssignedVariantAttribute,
     Attribute,
-    AttributePage,
     AttributeProduct,
     AttributeValue,
     AttributeVariant,
@@ -93,43 +92,6 @@ class VariantAttributesByProductTypeIdLoader(
 
     context_key = "variant_attributes_by_producttype"
     model_name = AttributeVariant
-
-
-class PageAttributesByPageTypeIdLoader(DataLoader):
-    """Loads page attributes by page type ID."""
-
-    context_key = "page_attributes_by_pagetype"
-
-    def batch_load(self, keys):
-        user = self.user
-        if user.is_active and user.has_perm(PagePermissions.MANAGE_PAGES):
-            qs = AttributePage.objects.all()
-        else:
-            qs = AttributePage.objects.filter(attribute__visible_in_storefront=True)
-
-        page_type_attribute_pairs = qs.filter(page_type_id__in=keys).values_list(
-            "page_type_id", "attribute_id"
-        )
-
-        page_type_to_attributes_map = defaultdict(list)
-        for page_type_id, attr_id in page_type_attribute_pairs:
-            page_type_to_attributes_map[page_type_id].append(attr_id)
-
-        def map_attributes(attributes):
-            attributes_map = {attr.id: attr for attr in attributes}
-            return [
-                [
-                    attributes_map[attr_id]
-                    for attr_id in page_type_to_attributes_map[page_type_id]
-                ]
-                for page_type_id in keys
-            ]
-
-        return (
-            AttributesByAttributeId(self.context)
-            .load_many(set(attr_id for _, attr_id in page_type_attribute_pairs))
-            .then(map_attributes)
-        )
 
 
 class AttributeProductsByProductTypeIdLoader(DataLoader):

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -59,8 +59,7 @@ from ..utils import (
     create_stocks,
     get_used_attribute_values_for_variant,
     get_used_variants_attribute_values,
-    validate_attributes_input_for_page,
-    validate_attributes_input_for_product,
+    validate_attributes_input_for_product_and_page,
     validate_attributes_input_for_variant,
 )
 from .common import ReorderInput
@@ -691,7 +690,9 @@ class AttributeAssignmentMixin:
         - ensure all required attributes are passed
         - ensure the values are correct for a product
         """
-        errors = validate_attributes_input_for_product(cleaned_input)
+        errors = validate_attributes_input_for_product_and_page(
+            cleaned_input, ProductErrorCode
+        )
 
         supplied_attribute_pk = [attribute.pk for attribute, _ in cleaned_input]
 
@@ -754,7 +755,9 @@ class AttributeAssignmentMixin:
 
         :raises ValidationError: when an invalid operation was found.
         """
-        errors = validate_attributes_input_for_page(cleaned_input)
+        errors = validate_attributes_input_for_product_and_page(
+            cleaned_input, PageErrorCode
+        )
 
         supplied_attribute_pk = [attribute.pk for attribute, _ in cleaned_input]
 

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.utils import IntegrityError
 
+from ...page.error_codes import PageErrorCode
 from ...product import AttributeInputType
 from ...product.error_codes import ProductErrorCode
 from ...warehouse.models import Stock
@@ -80,6 +81,43 @@ def validate_attributes_input_for_variant(
 
         if values[0] is None or not values[0].strip():
             attribute_errors[error_blank_value].append(attribute_id)
+
+    return prepare_error_list_from_error_attribute_mapping(attribute_errors)
+
+
+def validate_attributes_input_for_page(
+    input_data: List[Tuple["Attribute", List[str]]],
+):
+    error_no_value_given = ValidationError(
+        "Attribute expects a value but none were given",
+        code=PageErrorCode.REQUIRED.value,
+    )
+    error_dropdown_get_more_than_one_value = ValidationError(
+        "Attribute attribute must take only one value",
+        code=PageErrorCode.INVALID.value,
+    )
+    error_blank_value = ValidationError(
+        "Attribute values cannot be blank", code=PageErrorCode.REQUIRED.value,
+    )
+
+    attribute_errors: Dict[ValidationError, List[str]] = defaultdict(list)
+    for attribute, values in input_data:
+        attribute_id = graphene.Node.to_global_id("Attribute", attribute.pk)
+        if not values:
+            if attribute.value_required:
+                attribute_errors[error_no_value_given].append(attribute_id)
+            continue
+
+        if attribute.input_type != AttributeInputType.MULTISELECT and len(values) != 1:
+            attribute_errors[error_dropdown_get_more_than_one_value].append(
+                attribute_id
+            )
+            continue
+
+        for value in values:
+            if value is None or not value.strip():
+                attribute_errors[error_blank_value].append(attribute_id)
+                continue
 
     return prepare_error_list_from_error_attribute_mapping(attribute_errors)
 

--- a/saleor/graphql/product/utils.py
+++ b/saleor/graphql/product/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple
 import graphene
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Q
 from django.db.utils import IntegrityError
 
 from ...product import AttributeInputType
@@ -16,8 +17,16 @@ if TYPE_CHECKING:
 
 
 def validate_attributes_input_for_product_and_page(
-    input_data: List[Tuple["Attribute", List[str]]], error_code_enum,
+    input_data: List[Tuple["Attribute", List[str]]],
+    attribute_qs: "QuerySet",
+    error_code_enum,
 ):
+    """Validate attribute input.
+
+    - ensure all required attributes are passed
+    - ensure the values are correct for a products or a page
+    """
+
     error_no_value_given = ValidationError(
         "Attribute expects a value but none were given",
         code=error_code_enum.REQUIRED.value,
@@ -49,7 +58,41 @@ def validate_attributes_input_for_product_and_page(
                 attribute_errors[error_blank_value].append(attribute_id)
                 continue
 
-    return prepare_error_list_from_error_attribute_mapping(attribute_errors)
+    errors = prepare_error_list_from_error_attribute_mapping(attribute_errors)
+    errors = validate_required_attributes(
+        input_data, attribute_qs, errors, error_code_enum
+    )
+
+    return errors
+
+
+def validate_required_attributes(
+    input_data: List[Tuple["Attribute", List[str]]],
+    attribute_qs: "QuerySet",
+    errors: List[ValidationError],
+    error_code_enum,
+):
+    """Ensure all required attributes are supplied."""
+
+    supplied_attribute_pk = [attribute.pk for attribute, _ in input_data]
+
+    missing_required_attributes = attribute_qs.filter(
+        Q(value_required=True) & ~Q(pk__in=supplied_attribute_pk)
+    )
+
+    if missing_required_attributes:
+        ids = [
+            graphene.Node.to_global_id("Attribute", attr.pk)
+            for attr in missing_required_attributes
+        ]
+        error = ValidationError(
+            "All attributes flagged as having a value required must be supplied.",
+            code=error_code_enum.REQUIRED.value,
+            params={"attributes": ids},
+        )
+        errors.append(error)
+
+    return errors
 
 
 def validate_attributes_input_for_variant(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3258,6 +3258,7 @@ type Page implements Node & ObjectWithMetadata {
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
+  attributes: [SelectedAttribute!]!
 }
 
 type PageAttributeAssign {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3307,6 +3307,7 @@ input PageCreateInput {
   title: String
   content: String
   contentJson: JSONString
+  attributes: [AttributeValueInput!]
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput
@@ -3352,6 +3353,7 @@ input PageInput {
   title: String
   content: String
   contentJson: JSONString
+  attributes: [AttributeValueInput!]
   isPublished: Boolean
   publicationDate: String
   seo: SeoInput

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1881,6 +1881,13 @@ def page(db, page_type):
         "page_type": page_type,
     }
     page = Page.objects.create(**data)
+
+    # associate attribute value
+    page_attr = page_type.page_attributes.first()
+    page_attr_value = page_attr.values.first()
+
+    associate_attribute_values_to_instance(page, page_attr, page_attr_value)
+
     return page
 
 


### PR DESCRIPTION
* Add `Page.attributes` field to return page attributes and their values
* Allow setting attribute values for a page instance - update `pageCreate` and `pageUpdate` mutations

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
