### PR TITLE
Fix empty name and description in updatePlugin mutation response

### DIFF
--- a/saleor/graphql/plugins/tests/test_plugins.py
+++ b/saleor/graphql/plugins/tests/test_plugins.py
@@ -252,36 +252,38 @@ def test_query_plugin_configuration_as_customer_user(user_api_client, settings):
 
 
 PLUGIN_UPDATE_MUTATION = """
-        mutation pluginUpdate(
-            $id: ID!,
-            $active: Boolean,
-            $configuration: [ConfigurationItemInput]
-        ){pluginUpdate(
-            id:$id,
-            input:{active: $active, configuration: $configuration}
-        ){
-            plugin{
-              name
-              active
-              configuration{
+    mutation pluginUpdate(
+        $id: ID!
+        $active: Boolean
+        $configuration: [ConfigurationItemInput]
+    ) {
+        pluginUpdate(
+            id: $id
+            input: { active: $active, configuration: $configuration }
+        ) {
+            plugin {
                 name
-                value
-                type
-                helpText
-                label
-              }
+                description
+                active
+                configuration {
+                    name
+                    value
+                    type
+                    helpText
+                    label
+                }
             }
-            errors{
-              field
-              message
+            errors {
+                field
+                message
             }
             pluginsErrors {
-              field
-              code
+                field
+                code
             }
-          }
         }
-    """
+    }
+"""
 
 
 @pytest.mark.parametrize(
@@ -310,6 +312,11 @@ def test_plugin_configuration_update(
     )
     content = get_graphql_content(response)
 
+    plugin_data = content["data"]["pluginUpdate"]["plugin"]
+
+    assert plugin_data["name"] == plugin.PLUGIN_NAME
+    assert plugin_data["description"] == plugin.PLUGIN_DESCRIPTION
+
     plugin = PluginConfiguration.objects.get(identifier=PluginSample.PLUGIN_ID)
     assert plugin.active == active
 
@@ -321,7 +328,7 @@ def test_plugin_configuration_update(
     assert second_configuration_item["name"] == old_configuration[1]["name"]
     assert second_configuration_item["value"] == old_configuration[1]["value"]
 
-    configuration = content["data"]["pluginUpdate"]["plugin"]["configuration"]
+    configuration = plugin_data["configuration"]
     assert configuration is not None
     assert configuration[0]["name"] == updated_configuration_item["name"]
     assert configuration[0]["value"] == updated_configuration_item["value"]

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -485,9 +485,12 @@ class PluginsManager(PaymentInterface):
                     identifier=plugin_id,
                     defaults={"configuration": plugin.configuration},
                 )
-                return plugin.save_plugin_configuration(
+                configuration = plugin.save_plugin_configuration(
                     plugin_configuration, cleaned_data
                 )
+                configuration.name = plugin.PLUGIN_NAME
+                configuration.description = plugin.PLUGIN_DESCRIPTION
+                return configuration
 
     def get_plugin(self, plugin_id: str) -> Optional["BasePlugin"]:
         for plugin in self.plugins:


### PR DESCRIPTION
I want to merge this change because it fixes #6009 

Related ticket: [SALEOR-1395](https://app.clickup.com/t/2549495/SALEOR-1395)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
