### PR TITLE
Fix margin resolver on varaint channel listing

### DIFF
--- a/saleor/graphql/product/tests/test_variant_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_variant_channel_listing_update.py
@@ -38,6 +38,7 @@ mutation UpdateProductVariantChannelListing(
                     amount
                     currency
                 }
+                margin
             }
         }
     }

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -3,7 +3,10 @@ import graphene
 from ....core.permissions import ProductPermissions
 from ....graphql.core.types import Money, MoneyRange
 from ....product import models
-from ....product.utils.costs import get_margin_for_variant, get_product_costs_data
+from ....product.utils.costs import (
+    get_margin_for_variant_channel_listing,
+    get_product_costs_data,
+)
 from ...channel.dataloaders import ChannelByIdLoader
 from ...core.connection import CountableDjangoObjectType
 from ...decorators import permission_required
@@ -141,12 +144,7 @@ class ProductVariantChannelListing(CountableDjangoObjectType):
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_margin(root: models.ProductVariantChannelListing, *_args):
-        variant_channel_listing = root.objects.filter(
-            channel_id=root.channel_id
-        ).first()
-        if not variant_channel_listing:
-            return None
-        return get_margin_for_variant(variant_channel_listing)
+        return get_margin_for_variant_channel_listing(root)
 
 
 class CollectionChannelListing(CountableDjangoObjectType):

--- a/saleor/product/tests/test_product.py
+++ b/saleor/product/tests/test_product.py
@@ -12,7 +12,7 @@ from ..filters import filter_products_by_attributes_values
 from ..models import DigitalContentUrl
 from ..thumbnails import create_product_thumbnails
 from ..utils.attributes import associate_attribute_values_to_instance
-from ..utils.costs import get_margin_for_variant
+from ..utils.costs import get_margin_for_variant_channel_listing
 from ..utils.digital_products import increment_download_count
 
 
@@ -242,13 +242,15 @@ def test_digital_product_view_url_expired(client, digital_content):
 @pytest.mark.parametrize(
     "price, cost", [(Money("0", "USD"), Money("1", "USD")), (Money("2", "USD"), None)]
 )
-def test_costs_get_margin_for_variant(variant, price, cost, channel_USD):
+def test_costs_get_margin_for_variant_channel_listing(
+    variant, price, cost, channel_USD
+):
     variant_channel_listing = variant.channel_listing.filter(
         channel_id=channel_USD.id
     ).first()
     variant_channel_listing.cost_price = cost
     variant_channel_listing.price = price
-    assert not get_margin_for_variant(variant_channel_listing)
+    assert not get_margin_for_variant_channel_listing(variant_channel_listing)
 
 
 @patch("saleor.product.thumbnails.create_thumbnails")

--- a/saleor/product/utils/costs.py
+++ b/saleor/product/utils/costs.py
@@ -60,7 +60,7 @@ def get_variant_costs_data(
     costs = []
     margins = []
     costs.append(get_cost_price(variant_channel_listing))
-    margin = get_margin_for_variant(variant_channel_listing)
+    margin = get_margin_for_variant_channel_listing(variant_channel_listing)
     if margin:
         margins.append(margin)
     return CostsData(costs, margins)
@@ -72,7 +72,7 @@ def get_cost_price(variant_channel_listing: "ProductVariantChannelListing") -> "
     return variant_channel_listing.cost_price
 
 
-def get_margin_for_variant(
+def get_margin_for_variant_channel_listing(
     variant_channel_listing: "ProductVariantChannelListing",
 ) -> Optional[float]:
     if variant_channel_listing.cost_price is None:


### PR DESCRIPTION
I want to merge this change because fixing margin resolver on variant channel listing.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
