### PR TITLE
Fix for updating product variant without providing an attributes

### DIFF
--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -130,21 +130,19 @@ def test_total_count_query(api_client, product):
 
 
 def test_mutation_positive_decimal_input(
-    staff_api_client, variant, size_attribute, stock, permission_manage_products
+    staff_api_client, variant, stock, permission_manage_products
 ):
     query = """
     mutation PositiveDecimalInput(
         $id: ID!,
         $cost: PositiveDecimal,
         $price: PositiveDecimal,
-        $attributes: [AttributeValueInput],
     ) {
         productVariantUpdate(
             id: $id,
             input: {
                 costPrice: $cost,
                 price: $price,
-                attributes: $attributes
             }
         ) {
             errors {
@@ -165,12 +163,6 @@ def test_mutation_positive_decimal_input(
         "price": 15,
         "cost": 12.12,
         "quantity": 17,
-        "attributes": [
-            {
-                "id": graphene.Node.to_global_id("Attribute", size_attribute.pk),
-                "values": ["S"],
-            }
-        ],
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]
@@ -181,21 +173,19 @@ def test_mutation_positive_decimal_input(
 
 
 def test_mutation_positive_decimal_input_without_arguments(
-    staff_api_client, variant, size_attribute, permission_manage_products
+    staff_api_client, variant, permission_manage_products
 ):
     query = """
     mutation ProductVariantUpdate(
         $id: ID!,
         $price: PositiveDecimal,
         $costPrice: PositiveDecimal,
-        $attributes: [AttributeValueInput],
     ) {
         productVariantUpdate(
             id: $id,
             input: {
                 costPrice: $costPrice,
                 price: $price,
-                attributes: $attributes,
             }
         ) {
             errors {
@@ -214,12 +204,6 @@ def test_mutation_positive_decimal_input_without_arguments(
         "id": graphene.Node.to_global_id("ProductVariant", variant.id),
         "cost": 12.12,
         "price": 15,
-        "attributes": [
-            {
-                "id": graphene.Node.to_global_id("Attribute", size_attribute.pk),
-                "values": ["S"],
-            }
-        ],
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]

--- a/saleor/graphql/product/tests/test_product_minimal_variant_price.py
+++ b/saleor/graphql/product/tests/test_product_minimal_variant_price.py
@@ -78,20 +78,17 @@ def test_product_variant_update_updates_minimal_variant_price(
     mock_update_product_minimal_variant_price_task,
     staff_api_client,
     product,
-    size_attribute,
     permission_manage_products,
 ):
     query = """
         mutation ProductVariantUpdate(
             $id: ID!,
             $price: PositiveDecimal,
-            $attributes: [AttributeValueInput],
         ) {
             productVariantUpdate(
                 id: $id,
                 input: {
                     price: $price,
-                    attributes: $attributes
                 }
             ) {
                 productVariant {
@@ -106,12 +103,10 @@ def test_product_variant_update_updates_minimal_variant_price(
     """
     variant = product.variants.first()
     variant_id = to_global_id("ProductVariant", variant.pk)
-    attribute_id = to_global_id("Attribute", size_attribute.pk)
     price = "1.99"
     variables = {
         "id": variant_id,
         "price": price,
-        "attributes": [{"id": attribute_id, "values": ["S"]}],
     }
     response = staff_api_client.post_graphql(
         query, variables, permissions=[permission_manage_products]


### PR DESCRIPTION
This PR allows updating a product variant without providing attributes.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
