### PR TITLE
Drop 'money_spent' filter from customers query

### DIFF
--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -1,20 +1,15 @@
 import django_filters
-from django.db.models import Count, Sum
+from django.db.models import Count
 
 from ...account.models import User
 from ..core.filters import EnumFilter, ObjectTypeFilter
-from ..core.types.common import DateRangeInput, IntRangeInput, PriceRangeInput
+from ..core.types.common import DateRangeInput, IntRangeInput
 from ..utils.filters import filter_by_query_param, filter_range_field
 from .enums import StaffMemberStatus
 
 
 def filter_date_joined(qs, _, value):
     return filter_range_field(qs, "date_joined__date", value)
-
-
-def filter_money_spent(qs, _, value):
-    qs = qs.annotate(money_spent=Sum("orders__total_gross_amount"))
-    return filter_range_field(qs, "money_spent", value)
 
 
 def filter_number_of_orders(qs, _, value):
@@ -60,9 +55,6 @@ class CustomerFilter(django_filters.FilterSet):
     date_joined = ObjectTypeFilter(
         input_class=DateRangeInput, method=filter_date_joined
     )
-    money_spent = ObjectTypeFilter(
-        input_class=PriceRangeInput, method=filter_money_spent
-    )
     number_of_orders = ObjectTypeFilter(
         input_class=IntRangeInput, method=filter_number_of_orders
     )
@@ -75,7 +67,6 @@ class CustomerFilter(django_filters.FilterSet):
         model = User
         fields = [
             "date_joined",
-            "money_spent",
             "number_of_orders",
             "placed_orders",
             "search",

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -13,7 +13,6 @@ from django.core.files import File
 from django.core.validators import URLValidator
 from django.test import override_settings
 from freezegun import freeze_time
-from prices import Money
 
 from ....account import events as account_events
 from ....account.error_codes import AccountErrorCode
@@ -3532,52 +3531,6 @@ def test_query_customers_with_filter_placed_orders_(
     second_customer = User.objects.create(email="second_example@example.com")
     with freeze_time("2012-01-14 11:00:00"):
         Order.objects.create(user=second_customer, channel=channel_USD)
-    variables = {"filter": customer_filter}
-    response = staff_api_client.post_graphql(
-        query_customer_with_filter, variables, permissions=[permission_manage_users]
-    )
-    content = get_graphql_content(response)
-    users = content["data"]["customers"]["edges"]
-
-    assert len(users) == count
-
-
-@pytest.mark.parametrize(
-    "customer_filter, count",
-    [
-        ({"moneySpent": {"gte": 16, "lte": 25}}, 1),
-        ({"moneySpent": {"gte": 15, "lte": 26}}, 2),
-        ({"moneySpent": {"gte": 0}}, 2),
-        ({"moneySpent": {"lte": 16}}, 1),
-    ],
-)
-def test_query_customers_with_filter_placed_orders__(
-    customer_filter,
-    count,
-    query_customer_with_filter,
-    staff_api_client,
-    permission_manage_users,
-    customer_user,
-    channel_USD,
-):
-    second_customer = User.objects.create(email="second_example@example.com")
-    Order.objects.bulk_create(
-        [
-            Order(
-                user=customer_user,
-                token=str(uuid.uuid4()),
-                total_gross=Money(15, "USD"),
-                channel=channel_USD,
-            ),
-            Order(
-                user=second_customer,
-                token=str(uuid.uuid4()),
-                total_gross=Money(25, "USD"),
-                channel=channel_USD,
-            ),
-        ]
-    )
-
     variables = {"filter": customer_filter}
     response = staff_api_client.post_graphql(
         query_customer_with_filter, variables, permissions=[permission_manage_users]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1709,7 +1709,6 @@ enum CustomerEventsEnum {
 
 input CustomerFilterInput {
   dateJoined: DateRangeInput
-  moneySpent: PriceRangeInput
   numberOfOrders: IntRangeInput
   placedOrders: DateRangeInput
   search: String


### PR DESCRIPTION
I want to merge this change because...I want to Drop 'money_spent' filter from customers query

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
