### PR TITLE
Default variant improvements

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -249,7 +249,12 @@ def create_product_variants(variants_data):
         defaults["product_id"] = product_id
         set_field_as_money(defaults, "price_override")
         set_field_as_money(defaults, "cost_price")
+        is_default_variant = defaults.pop("default", False)
         variant, _ = ProductVariant.objects.update_or_create(pk=pk, defaults=defaults)
+        if is_default_variant:
+            product = variant.product
+            product.default_variant = variant
+            product.save(update_fields=["default_variant", "updated_at"])
         quantity = random.randint(100, 500)
         create_stocks(variant, quantity=quantity)
 

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -308,13 +308,16 @@ class ProductVariantBulkCreate(BaseMutation):
 
     @classmethod
     @transaction.atomic
-    def save_variants(cls, info, instances, cleaned_inputs):
+    def save_variants(cls, info, instances, product, cleaned_inputs):
         assert len(instances) == len(
             cleaned_inputs
         ), "There should be the same number of instances and cleaned inputs."
         for instance, cleaned_input in zip(instances, cleaned_inputs):
             cls.save(info, instance, cleaned_input)
             cls.create_variant_stocks(instance, cleaned_input)
+        if not product.default_variant:
+            product.default_variant = instances[0]
+            product.save(update_fields=["default_variant", "updated_at"])
 
     @classmethod
     def create_variant_stocks(cls, variant, cleaned_input):
@@ -336,7 +339,7 @@ class ProductVariantBulkCreate(BaseMutation):
         instances = cls.create_variants(info, cleaned_inputs, product, errors)
         if errors:
             raise ValidationError(errors)
-        cls.save_variants(info, instances, cleaned_inputs)
+        cls.save_variants(info, instances, product, cleaned_inputs)
 
         # Recalculate the "minimal variant price" for the parent product
         update_product_minimal_variant_price_task.delay(product.pk)

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -1527,6 +1527,8 @@ def test_product_variant_bulk_create_by_attribute_id(
     assert attribute_value_count == size_attribute.values.count()
     product_variant = ProductVariant.objects.get(sku=sku)
     assert not product_variant.cost_price
+    product.refresh_from_db()
+    assert product.default_variant == product_variant
 
 
 @pytest.mark.parametrize(

--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -2042,7 +2042,8 @@
       "product": 61,
       "track_inventory": true,
       "cost_price_amount": "5.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2090,7 +2091,8 @@
       "product": 62,
       "track_inventory": true,
       "cost_price_amount": "5.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2138,7 +2140,8 @@
       "product": 63,
       "track_inventory": true,
       "cost_price_amount": "5.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2186,7 +2189,8 @@
       "product": 64,
       "track_inventory": true,
       "cost_price_amount": "5.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2234,7 +2238,8 @@
       "product": 65,
       "track_inventory": true,
       "cost_price_amount": "5.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2282,7 +2287,8 @@
       "product": 71,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2330,7 +2336,8 @@
       "product": 81,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2346,7 +2353,8 @@
       "product": 82,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2362,7 +2370,8 @@
       "product": 83,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2378,7 +2387,8 @@
       "product": 84,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2394,7 +2404,8 @@
       "product": 85,
       "track_inventory": true,
       "cost_price_amount": "11.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2426,7 +2437,8 @@
       "product": 86,
       "track_inventory": true,
       "cost_price_amount": "13.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2458,7 +2470,8 @@
       "product": 72,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2506,7 +2519,8 @@
       "product": 73,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2554,7 +2568,8 @@
       "product": 74,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2602,7 +2617,8 @@
       "product": 75,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2650,7 +2666,8 @@
       "product": 76,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2698,7 +2715,8 @@
       "product": 77,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2746,7 +2764,8 @@
       "product": 78,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2794,7 +2813,8 @@
       "product": 79,
       "track_inventory": true,
       "cost_price_amount": "1.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2842,7 +2862,8 @@
       "product": 87,
       "track_inventory": true,
       "cost_price_amount": "20.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -2922,7 +2943,8 @@
       "product": 88,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "default": true
     }
   },
   {
@@ -2986,7 +3008,8 @@
       "product": 89,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3066,7 +3089,8 @@
       "product": 107,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3146,7 +3170,8 @@
       "product": 108,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3226,7 +3251,8 @@
       "product": 109,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3306,7 +3332,8 @@
       "product": 110,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3386,7 +3413,8 @@
       "product": 111,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3466,7 +3494,8 @@
       "product": 112,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3546,7 +3575,8 @@
       "product": 113,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3626,7 +3656,8 @@
       "product": 114,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3706,7 +3737,8 @@
       "product": 115,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3786,7 +3818,8 @@
       "product": 116,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3866,7 +3899,8 @@
       "product": 117,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -3946,7 +3980,8 @@
       "product": 118,
       "track_inventory": true,
       "cost_price_amount": "10.00",
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "default": true
     }
   },
   {
@@ -4026,7 +4061,8 @@
       "product": 119,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {
@@ -4042,7 +4078,8 @@
       "product": 120,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {
@@ -4058,7 +4095,8 @@
       "product": 121,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {
@@ -4074,7 +4112,8 @@
       "product": 122,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {
@@ -4090,7 +4129,8 @@
       "product": 123,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {
@@ -4106,7 +4146,8 @@
       "product": 124,
       "track_inventory": true,
       "cost_price_amount": null,
-      "weight": null
+      "weight": null,
+      "default": true
     }
   },
   {


### PR DESCRIPTION
[Already merged](https://github.com/mirumee/saleor/pull/6335)
**This is the same improvement already merged to 2.11 but it should also get merged to master.**

I want to merge this change because it introduces default product variant in populatedb script and ProductVariantBulkCreate mutation.

Related ticket: [SALEOR-1469](https://app.clickup.com/t/2549495/SALEOR-1469)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
