### PR TITLE
Update error codes in AttributeBulkDelete and AttributeValueBulkDelete

### DIFF
--- a/saleor/graphql/product/bulk_mutations/attributes.py
+++ b/saleor/graphql/product/bulk_mutations/attributes.py
@@ -3,7 +3,7 @@ import graphene
 from ....core.permissions import ProductPermissions
 from ....product import models
 from ...core.mutations import ModelBulkDeleteMutation
-from ...core.types.common import ProductError
+from ...core.types.common import AttributeError
 
 
 class AttributeBulkDelete(ModelBulkDeleteMutation):
@@ -16,8 +16,8 @@ class AttributeBulkDelete(ModelBulkDeleteMutation):
         description = "Deletes attributes."
         model = models.Attribute
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
-        error_type_class = ProductError
-        error_type_field = "product_errors"
+        error_type_class = AttributeError
+        error_type_field = "attribute_errors"
 
 
 class AttributeValueBulkDelete(ModelBulkDeleteMutation):
@@ -32,5 +32,5 @@ class AttributeValueBulkDelete(ModelBulkDeleteMutation):
         description = "Deletes values of attributes."
         model = models.AttributeValue
         permissions = (ProductPermissions.MANAGE_PRODUCTS,)
-        error_type_class = ProductError
-        error_type_field = "product_errors"
+        error_type_class = AttributeError
+        error_type_field = "attribute_errors"

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -413,7 +413,7 @@ type Attribute implements Node & ObjectWithMetadata {
 type AttributeBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 type AttributeClearMeta {
@@ -597,7 +597,7 @@ type AttributeValue implements Node {
 type AttributeValueBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
-  productErrors: [ProductError!]!
+  attributeErrors: [AttributeError!]!
 }
 
 type AttributeValueCreate {


### PR DESCRIPTION
`AttributeBulkDelete` and `AttributeValueBulkDelete` should return `AttributeErrorCode`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
