### PR TITLE
Fix product related dataloaders to be accessible by app

### DIFF
--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -12,6 +12,7 @@ from ....product.models import (
     AttributeVariant,
 )
 from ...core.dataloaders import DataLoader
+from ...utils import get_user_or_app_from_context
 from .products import ProductByIdLoader, ProductVariantByIdLoader
 
 
@@ -46,8 +47,10 @@ class BaseProductAttributesByProductTypeIdLoader(DataLoader):
         if not self.model_name:
             raise ValueError("Provide a model_name for this dataloader.")
 
-        user = self.user
-        if user.is_active and user.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+        requestor = get_user_or_app_from_context(self.context)
+        if requestor.is_active and requestor.has_perm(
+            ProductPermissions.MANAGE_PRODUCTS
+        ):
             qs = self.model_name.objects.all()
         else:
             qs = self.model_name.objects.filter(attribute__visible_in_storefront=True)
@@ -100,8 +103,10 @@ class AttributeProductsByProductTypeIdLoader(DataLoader):
     context_key = "attributeproducts_by_producttype"
 
     def batch_load(self, keys):
-        user = self.user
-        if user.is_active and user.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+        requestor = get_user_or_app_from_context(self.context)
+        if requestor.is_active and requestor.has_perm(
+            ProductPermissions.MANAGE_PRODUCTS
+        ):
             qs = AttributeProduct.objects.all()
         else:
             qs = AttributeProduct.objects.filter(attribute__visible_in_storefront=True)
@@ -118,8 +123,10 @@ class AttributeVariantsByProductTypeIdLoader(DataLoader):
     context_key = "attributevariants_by_producttype"
 
     def batch_load(self, keys):
-        user = self.user
-        if user.is_active and user.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+        requestor = get_user_or_app_from_context(self.context)
+        if requestor.is_active and requestor.has_perm(
+            ProductPermissions.MANAGE_PRODUCTS
+        ):
             qs = AttributeVariant.objects.all()
         else:
             qs = AttributeVariant.objects.filter(attribute__visible_in_storefront=True)
@@ -136,8 +143,10 @@ class AssignedProductAttributesByProductIdLoader(DataLoader):
     context_key = "assignedproductattributes_by_product"
 
     def batch_load(self, keys):
-        user = self.user
-        if user.is_active and user.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+        requestor = get_user_or_app_from_context(self.context)
+        if requestor.is_active and requestor.has_perm(
+            ProductPermissions.MANAGE_PRODUCTS
+        ):
             qs = AssignedProductAttribute.objects.all()
         else:
             qs = AssignedProductAttribute.objects.filter(
@@ -156,8 +165,10 @@ class AssignedVariantAttributesByProductVariantId(DataLoader):
     context_key = "assignedvariantattributes_by_productvariant"
 
     def batch_load(self, keys):
-        user = self.user
-        if user.is_active and user.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+        requestor = get_user_or_app_from_context(self.context)
+        if requestor.is_active and requestor.has_perm(
+            ProductPermissions.MANAGE_PRODUCTS
+        ):
             qs = AssignedVariantAttribute.objects.all()
         else:
             qs = AssignedVariantAttribute.objects.filter(
@@ -244,7 +255,7 @@ class SelectedAttributesByProductIdLoader(DataLoader):
     context_key = "selectedattributes_by_product"
 
     def batch_load(self, keys):
-        def with_products_and_assigned_attributed(result):
+        def with_products_and_assigned_attributes(result):
             products, product_attributes = result
             assigned_product_attribute_ids = [
                 a.id for attrs in product_attributes for a in attrs
@@ -316,7 +327,7 @@ class SelectedAttributesByProductIdLoader(DataLoader):
         ).load_many(keys)
 
         return Promise.all([products, assigned_attributes]).then(
-            with_products_and_assigned_attributed
+            with_products_and_assigned_attributes
         )
 
 

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -11,6 +11,7 @@ from ....product.models import (
     VariantImage,
 )
 from ...core.dataloaders import DataLoader
+from ...utils import get_user_or_app_from_context
 
 
 class CategoryByIdLoader(DataLoader):
@@ -25,7 +26,8 @@ class ProductByIdLoader(DataLoader):
     context_key = "product_by_id"
 
     def batch_load(self, keys):
-        products = Product.objects.visible_to_user(self.user).in_bulk(keys)
+        requestor = get_user_or_app_from_context(self.context)
+        products = Product.objects.visible_to_user(requestor).in_bulk(keys)
         return [products.get(product_id) for product_id in keys]
 
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -64,6 +64,28 @@ def query_products_with_filter():
 
 
 @pytest.fixture
+def query_products_with_attributes():
+    query = """
+        query {
+          products(first:5) {
+            edges{
+              node{
+                id
+                name
+                attributes {
+                    attribute {
+                        id
+                    }
+                }
+              }
+            }
+          }
+        }
+        """
+    return query
+
+
+@pytest.fixture
 def query_collections_with_filter():
     query = """
     query ($filter: CollectionFilterInput!, ) {
@@ -770,6 +792,34 @@ def test_products_query_with_filter_category_and_search(
     assert len(products) == 1
     assert products[0]["node"]["id"] == product_id
     assert products[0]["node"]["name"] == product.name
+
+
+def test_products_with_variants_query_as_app(
+    query_products_with_attributes,
+    app_api_client,
+    product_with_multiple_values_attributes,
+    permission_manage_products,
+):
+    product = product_with_multiple_values_attributes
+    attribute = product.attributes.first().attribute
+    attribute.visible_in_storefront = False
+    attribute.save()
+    second_product = product
+    second_product.id = None
+    second_product.slug = "second-product"
+    second_product.save()
+    product.save()
+
+    app_api_client.app.permissions.add(permission_manage_products)
+    response = app_api_client.post_graphql(query_products_with_attributes)
+    content = get_graphql_content(response)
+    products = content["data"]["products"]["edges"]
+    assert len(products) == 2
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    for response_product in products:
+        attrs = response_product["node"]["attributes"]
+        assert len(attrs) == 1
+        assert attrs[0]["attribute"]["id"] == attribute_id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it fixes product related dataloaders to they can be used by an app.

Related ticket: [SALEOR-1464](https://app.clickup.com/t/2549495/SALEOR-1464)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
