### PR TITLE
Drop Django master from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ env:
     - QUERIES_RESULTS_PATH=/tmp/queries-results.json
   matrix:
     - DJANGO="3.1"
-    - DJANGO="master"
 
 matrix:
   fast_finish: true
@@ -56,9 +55,6 @@ matrix:
     - env: TOXENV=pydocstyle
       python: "3.8"
     - env: TOXENV=isort
-      python: "3.8"
-  allow_failures:
-    - env: DJANGO="master"
       python: "3.8"
 
 services:

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django{31,_master}
+envlist = py38-django31
 skipsdist = True
 
 [testenv]
@@ -10,7 +10,6 @@ deps =
     -rrequirements.txt
     -rrequirements_dev.txt
 commands =
-    django_master: pip install https://github.com/django/django/archive/master.tar.gz
     python manage.py collectstatic --noinput --verbosity=0
     pytest --cov --cov-report= --django-db-bench={env:QUERIES_RESULTS_PATH}
     codecov
@@ -68,4 +67,3 @@ unignore_outcomes = True
 [travis:env]
 DJANGO =
     3.1: django31
-    master: django_master


### PR DESCRIPTION
Drop testing Djagno's master branch as it consumes too much time and resources in Travis.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
