### PR TITLE
Improve workflow of GraphQL Inspector

### DIFF
--- a/.github/graphql-inspector.yaml
+++ b/.github/graphql-inspector.yaml
@@ -2,7 +2,7 @@ branch: "master"
 schema: "saleor/graphql/schema.graphql"
 diff:
   # Pull Request annotations
-  annotations: false
+  annotations: true
   # Merge Pull Request's branch with the target branch to get the schema
   experimental_merge: true
   # Label to mark Pull Request introducing breaking changes as safe and expected

--- a/.github/graphql-inspector.yaml
+++ b/.github/graphql-inspector.yaml
@@ -1,2 +1,11 @@
 branch: "master"
 schema: "saleor/graphql/schema.graphql"
+diff:
+  # Pull Request annotations
+  annotations: false
+  # Merge Pull Request's branch with the target branch to get the schema
+  experimental_merge: true
+  # Label to mark Pull Request introducing breaking changes as safe and expected
+  approveLabel: 'approved-breaking-change'
+  # Limit a list of changes in summary
+  summaryLimit: 200


### PR DESCRIPTION
Hi :)

I noticed you're using GraphQL Inspector and wanted to improve the experience a bit. 

Few things:
 - `experimental_merge` - Instead of forcing users to do rebases to get the up to date schema Inspector can do it automatically. This way when PR is out of sync with master branch and some pieces of schema are missing, Inspector won't fail the check, it will use `refs/pull/1234/merge` branch.
- `annotations` - disabled them but feel free to change it back
- `approveLabel` - helpful when a PR introduces a breaking change. Instead of force-merging it, you can apply a label and to tell Inspector it's an expected breaking change. It will still list those changes as breaking but won't fail the check.
- `summaryLimit` - in case someone introduced a new feature and created 300 new types (very very very big feature), the summary report will be huge and GitHub will reject it. That's why Inspector limits a list of changes to 100, in this PR I bumped it to 200.

@patrys