### PR TITLE
Drop set-env in favor of outputs

### DIFF
--- a/.github/workflows/test-env-cleanup.yml
+++ b/.github/workflows/test-env-cleanup.yml
@@ -12,7 +12,7 @@ jobs:
     if: ${{ ((github.event.action == 'unlabeled') && (github.event.label.name == 'test deployment')) || ((github.event.action == 'closed') && contains(github.event.pull_request.labels.*.name, 'test deployment')) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: rlespinasse/github-slug-action@2.0.0
+      - uses: rlespinasse/github-slug-action@3.1.0
 
       - name: Invoke deployment lambda
         uses: gagoar/invoke-aws-lambda@v3.3.0

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: rlespinasse/github-slug-action@2.0.0
+      - uses: rlespinasse/github-slug-action@3.1.0
 
       - name: Set domain
         id: set-domain

--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -16,9 +16,10 @@ jobs:
       - uses: rlespinasse/github-slug-action@2.0.0
 
       - name: Set domain
+        id: set-domain
         # Set test instance domain based on branch name slug
         run: |
-          echo "::set-env name=domain::${{ env.GITHUB_HEAD_REF_SLUG_URL }}.api.saleor.rocks"
+          echo "::set-output name=domain::${{ env.GITHUB_HEAD_REF_SLUG_URL }}.api.saleor.rocks"
 
       - name: Start deployment
         uses: bobheadxi/deployments@v0.4.2
@@ -61,5 +62,5 @@ jobs:
           step: finish
           token: ${{ secrets.GITHUB_TOKEN }}
           status: ${{ job.status }}
-          env_url: https://${{ env.domain }}/graphql/
+          env_url: https://${{ steps.set-domain.outputs.domain }}/graphql/
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
