### PR TITLE
Update attribute queries with variant selection filter

### DIFF
--- a/saleor/attribute/__init__.py
+++ b/saleor/attribute/__init__.py
@@ -6,8 +6,8 @@ class AttributeInputType:
     FILE = "file"
 
     CHOICES = [(DROPDOWN, "Dropdown"), (MULTISELECT, "Multi Select"), (FILE, "File")]
-    # list the input types that cannot be assigned to a variant
-    NON_ASSIGNABLE_TO_VARIANTS = [MULTISELECT]
+    # list of the input types that can be used in variant selection
+    ALLOWED_IN_VARIANT_SELECTION = [DROPDOWN]
 
 
 class AttributeType:

--- a/saleor/graphql/attribute/tests/benchmark/test_attribute.py
+++ b/saleor/graphql/attribute/tests/benchmark/test_attribute.py
@@ -5,7 +5,7 @@ from ....tests.utils import get_graphql_content
 
 
 @pytest.mark.django_db
-@pytest.mark.count_queries(autouse=True)
+@pytest.mark.count_queries(autouse=False)
 def test_query_attribute(
     staff_api_client, color_attribute, permission_manage_products, count_queries,
 ):
@@ -40,7 +40,7 @@ def test_query_attribute(
 
 
 @pytest.mark.django_db
-@pytest.mark.count_queries(autouse=True)
+@pytest.mark.count_queries(autouse=False)
 def test_query_attributes(
     staff_api_client,
     size_attribute,

--- a/saleor/graphql/page/tests/benchmark/test_page_type.py
+++ b/saleor/graphql/page/tests/benchmark/test_page_type.py
@@ -5,7 +5,7 @@ from ....tests.utils import get_graphql_content
 
 
 @pytest.mark.django_db
-@pytest.mark.count_queries(autouse=True)
+@pytest.mark.count_queries(autouse=False)
 def test_query_page_type(
     page_type,
     staff_api_client,
@@ -68,7 +68,7 @@ def test_query_page_type(
 
 
 @pytest.mark.django_db
-@pytest.mark.count_queries(autouse=True)
+@pytest.mark.count_queries(autouse=False)
 def test_query_page_types(
     page_type_list,
     staff_api_client,

--- a/saleor/graphql/product/enums.py
+++ b/saleor/graphql/product/enums.py
@@ -24,3 +24,9 @@ class ProductTypeConfigurable(graphene.Enum):
 class ProductTypeEnum(graphene.Enum):
     DIGITAL = "digital"
     SHIPPABLE = "shippable"
+
+
+class VariantAttributeScope(graphene.Enum):
+    ALL = "all"
+    VARIANT_SELECTION = "variant_selection"
+    NOT_VARIANT_SELECTION = "not_variant_selection"

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -6,7 +6,7 @@ from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.db.models import Q
 
-from ....attribute import AttributeInputType, AttributeType, models as attribute_models
+from ....attribute import AttributeType, models as attribute_models
 from ....core.permissions import ProductTypePermissions
 from ....product import models
 from ....product.error_codes import ProductErrorCode
@@ -115,28 +115,6 @@ class ProductAttributeAssign(BaseMutation):
                 (f"{msg} have already been assigned to this product type."),
                 code=ProductErrorCode.ATTRIBUTE_ALREADY_ASSIGNED,
                 params={"attributes": invalid_attr_ids},
-            )
-            errors["operations"].append(error)
-
-        # check if attributes' input type is assignable to variants
-        not_assignable_to_variant = attribute_models.Attribute.objects.filter(
-            Q(pk__in=variant_attrs_pks)
-            & Q(input_type__in=AttributeInputType.NON_ASSIGNABLE_TO_VARIANTS)
-        )
-
-        if not_assignable_to_variant:
-            not_assignable_attr_ids = [
-                graphene.Node.to_global_id("Attribute", attr.pk)
-                for attr in not_assignable_to_variant
-            ]
-            error = ValidationError(
-                (
-                    f"Attributes having for input types "
-                    f"{AttributeInputType.NON_ASSIGNABLE_TO_VARIANTS} "
-                    f"cannot be assigned as variant attributes"
-                ),
-                code=ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED,
-                params={"attributes": not_assignable_attr_ids},
             )
             errors["operations"].append(error)
 

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -397,7 +397,7 @@ def test_assign_variant_attribute_to_product_type_with_disabled_variants(
     )
 
 
-def test_assign_variant_attribute_having_unsupported_input_type(
+def test_assign_variant_attribute_having_multiselect_input_type(
     staff_api_client,
     permission_manage_product_types_and_attributes,
     product_type,
@@ -417,26 +417,19 @@ def test_assign_variant_attribute_having_unsupported_input_type(
     )
 
     product_type_global_id = graphene.Node.to_global_id("ProductType", product_type.pk)
+    attr_id = graphene.Node.to_global_id("Attribute", attribute.pk)
 
     query = PRODUCT_ASSIGN_ATTR_QUERY
-    operations = [
-        {"type": "VARIANT", "id": graphene.Node.to_global_id("Attribute", attribute.pk)}
-    ]
+    operations = [{"type": "VARIANT", "id": attr_id}]
     variables = {"productTypeId": product_type_global_id, "operations": operations}
 
     content = get_graphql_content(staff_api_client.post_graphql(query, variables))[
         "data"
     ]["productAttributeAssign"]
-    assert content["productErrors"][0]["field"] == "operations"
-    assert (
-        content["productErrors"][0]["message"]
-        == "Attributes having for input types ['multiselect'] "
-        "cannot be assigned as variant attributes"
-    )
-    assert (
-        content["productErrors"][0]["code"]
-        == ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.name
-    )
+    assert not content["productErrors"]
+    assert content["productType"]["id"] == product_type_global_id
+    assert len(content["productType"]["variantAttributes"]) == 1
+    assert content["productType"]["variantAttributes"][0]["id"] == attr_id
 
 
 @pytest.mark.parametrize(
@@ -577,19 +570,13 @@ def test_assign_attribute_to_product_type_multiply_errors_returned(
     errors = data["productErrors"]
 
     assert not data["productType"]
-    assert len(errors) == 3
+    assert len(errors) == 2
     expected_errors = [
         {
             "code": ProductErrorCode.ATTRIBUTE_ALREADY_ASSIGNED.name,
             "field": "operations",
             "message": mock.ANY,
             "attributes": [color_attr_id],
-        },
-        {
-            "code": ProductErrorCode.ATTRIBUTE_CANNOT_BE_ASSIGNED.name,
-            "field": "operations",
-            "message": mock.ANY,
-            "attributes": [unsupported_type_attr_id],
         },
         {
             "code": ProductErrorCode.INVALID.name,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3869,7 +3869,7 @@ type ProductType implements Node & ObjectWithMetadata {
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   taxRate: TaxRateType
   taxType: TaxType
-  variantAttributes(variantSelection: Boolean): [Attribute]
+  variantAttributes(variantSelection: VariantAttributeScope): [Attribute]
   productAttributes: [Attribute]
   availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
 }
@@ -3976,7 +3976,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   price: Money
   pricing: VariantPricingInfo
   isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
-  attributes(variantSelection: Boolean): [SelectedAttribute!]!
+  attributes(variantSelection: VariantAttributeScope): [SelectedAttribute!]!
   costPrice: Money
   margin: Int
   quantityOrdered: Int
@@ -5019,6 +5019,12 @@ type VAT {
   countryCode: String!
   standardRate: Float
   reducedRates: [ReducedRate]!
+}
+
+enum VariantAttributeScope {
+  ALL
+  VARIANT_SELECTION
+  NOT_VARIANT_SELECTION
 }
 
 type VariantImageAssign {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3869,7 +3869,7 @@ type ProductType implements Node & ObjectWithMetadata {
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   taxRate: TaxRateType
   taxType: TaxType
-  variantAttributes: [Attribute]
+  variantAttributes(variantSelection: Boolean): [Attribute]
   productAttributes: [Attribute]
   availableAttributes(filter: AttributeFilterInput, before: String, after: String, first: Int, last: Int): AttributeCountableConnection
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3976,7 +3976,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   price: Money
   pricing: VariantPricingInfo
   isAvailable: Boolean @deprecated(reason: "Use the stock field instead. This field will be removed after 2020-07-31.")
-  attributes: [SelectedAttribute!]!
+  attributes(variantSelection: Boolean): [SelectedAttribute!]!
   costPrice: Money
   margin: Int
   quantityOrdered: Int

--- a/saleor/product/tests/test_get_variant_selection_attributes.py
+++ b/saleor/product/tests/test_get_variant_selection_attributes.py
@@ -1,0 +1,21 @@
+from ...attribute import AttributeInputType
+from ..utils.variants import get_variant_selection_attributes
+
+
+def test_get_variant_selection_attributes(
+    product_type_attribute_list, image_attribute_without_values_and_file_input_type
+):
+    # given
+    multiselect_attr = product_type_attribute_list[0]
+    multiselect_attr.input_type = AttributeInputType.MULTISELECT
+    multiselect_attr.save(update_fields=["input_type"])
+
+    attrs = product_type_attribute_list + [
+        image_attribute_without_values_and_file_input_type
+    ]
+
+    # when
+    result = get_variant_selection_attributes(attrs)
+
+    # then
+    assert result == product_type_attribute_list[1:]

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -20,9 +20,14 @@ def generate_name_for_variant(variant: "ProductVariant") -> str:
 
 
 def get_variant_selection_attributes(attributes):
+    """Return attributes that can be used in variant selection.
+
+    Attribute must be product attribute and attribute input type must be
+    in ALLOWED_IN_VARIANT_SELECTION list.
+    """
     return [
         attribute
         for attribute in attributes
-        if attribute.input_type == AttributeInputType.DROPDOWN
+        if attribute.input_type in AttributeInputType.ALLOWED_IN_VARIANT_SELECTION
         and attribute.type == AttributeType.PRODUCT_TYPE
     ]

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING
 
+from ...attribute import AttributeInputType, AttributeType
+
 if TYPE_CHECKING:
     from ...attribute.models import AssignedVariantAttribute
     from ..models import ProductVariant
@@ -15,3 +17,12 @@ def generate_name_for_variant(variant: "ProductVariant") -> str:
         attributes_display.append(", ".join(translated_values))
 
     return " / ".join(attributes_display)
+
+
+def get_variant_selection_attributes(attributes):
+    return [
+        attribute
+        for attribute in attributes
+        if attribute.input_type == AttributeInputType.DROPDOWN
+        and attribute.type == AttributeType.PRODUCT_TYPE
+    ]


### PR DESCRIPTION
* Update `productType.variantAttributes` query with `variantSelection` argument
* Update `variant.attributes` query with `variantSelection` argument

As default `variantSelection` is set to False and all attributes are returned, when `variantSelection` is set to True, only attributes that can be used in a variant selector are returned (attribute must be product attribute and `input_type` must be `DROPDOWN`). 


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
