### PR TITLE
Fix checkout_create to return checkout related with specific channel

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -287,11 +287,12 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         return channel
 
     @classmethod
-    def clean_input(cls, info, instance: models.Checkout, data, input_cls=None):
+    def clean_input(
+        cls, info, instance: models.Checkout, data, channel, input_cls=None
+    ):
         cleaned_input = super().clean_input(info, instance, data)
         user = info.context.user
         country = info.context.country.code
-        channel = cls.clean_channel(cleaned_input.get("channel"))
         cleaned_input["channel"] = channel
         cleaned_input["currency"] = channel.currency_code
 
@@ -308,7 +309,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             (
                 cleaned_input["variants"],
                 cleaned_input["quantities"],
-            ) = cls.process_checkout_lines(lines, country, cleaned_input["channel"].id)
+            ) = cls.process_checkout_lines(lines, country, channel.id)
 
         cleaned_input["shipping_address"] = cls.retrieve_shipping_address(user, data)
         cleaned_input["billing_address"] = cls.retrieve_billing_address(user, data)
@@ -372,11 +373,16 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         user = info.context.user
+        channel_input = data.get("input", {}).get("channel")
+        channel = cls.clean_channel(channel_input)
+        if channel_input:
+            del data["input"]["channel"]
 
         # `perform_mutation` is overridden to properly get or create a checkout
         # instance here and abort mutation if needed.
         if user.is_authenticated:
-            checkout = get_user_checkout(user)
+            checkout_queryset = models.Checkout.objects.filter(channel=channel)
+            checkout = get_user_checkout(user, checkout_queryset=checkout_queryset)
 
             if checkout is not None:
                 # If user has an active checkout, return it without any
@@ -386,7 +392,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             checkout = models.Checkout(user=user)
         else:
             checkout = models.Checkout()
-        cleaned_input = cls.clean_input(info, checkout, data.get("input"))
+        cleaned_input = cls.clean_input(info, checkout, data.get("input"), channel)
         checkout = cls.construct_instance(checkout, cleaned_input)
         cls.clean_instance(info, checkout)
         cls.save(info, checkout, cleaned_input)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -287,12 +287,12 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         return channel
 
     @classmethod
-    def clean_input(
-        cls, info, instance: models.Checkout, data, channel, input_cls=None
-    ):
-        cleaned_input = super().clean_input(info, instance, data)
+    def clean_input(cls, info, instance: models.Checkout, data, input_cls=None):
         user = info.context.user
         country = info.context.country.code
+        channel = data.pop("channel")
+        cleaned_input = super().clean_input(info, instance, data)
+
         cleaned_input["channel"] = channel
         cleaned_input["currency"] = channel.currency_code
 
@@ -375,8 +375,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         user = info.context.user
         channel_input = data.get("input", {}).get("channel")
         channel = cls.clean_channel(channel_input)
-        if channel_input:
-            del data["input"]["channel"]
+        if channel:
+            data["input"]["channel"] = channel
 
         # `perform_mutation` is overridden to properly get or create a checkout
         # instance here and abort mutation if needed.
@@ -392,7 +392,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             checkout = models.Checkout(user=user)
         else:
             checkout = models.Checkout()
-        cleaned_input = cls.clean_input(info, checkout, data.get("input"), channel)
+        cleaned_input = cls.clean_input(info, checkout, data.get("input"))
         checkout = cls.construct_instance(checkout, cleaned_input)
         cls.clean_instance(info, checkout)
         cls.save(info, checkout, cleaned_input)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -503,6 +503,19 @@ def user_checkout(customer_user, channel_USD):
 
 
 @pytest.fixture
+def user_checkout_PLN(customer_user, channel_PLN):
+    checkout = Checkout.objects.create(
+        user=customer_user,
+        channel=channel_PLN,
+        billing_address=customer_user.default_billing_address,
+        shipping_address=customer_user.default_shipping_address,
+        note="Test notes",
+        currency="PLN",
+    )
+    return checkout
+
+
+@pytest.fixture
 def user_checkout_with_items(user_checkout, product_list):
     for product in product_list:
         variant = product.variants.get()


### PR DESCRIPTION
I want to merge this change because...I want to fix `CheckoutCreate` mutation to return checkout related to specific channel.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
