### PR TITLE
Fix for failing config when apple pay is missing

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -595,7 +595,7 @@ class AdyenGatewayPlugin(BasePlugin):
         """Validate if provided configuration is correct."""
         configuration = plugin_configuration.configuration
         configuration = {item["name"]: item["value"] for item in configuration}
-        apple_certificate = configuration["apple-pay-cert"]
+        apple_certificate = configuration.get("apple-pay-cert")
         if plugin_configuration.active and apple_certificate:
             global_apple_url = (
                 "https://apple-pay-gateway.apple.com/paymentservices/paymentSession"

--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -495,3 +495,13 @@ def test_validate_plugin_configuration_correct_cert(mocked_request, adyen_plugin
     mocked_request.side_effect = RequestException()
     configuration = PluginConfiguration.objects.get()
     plugin.validate_plugin_configuration(configuration)
+
+
+def test_validate_plugin_configuration_without_apple_cert(adyen_plugin):
+    plugin = adyen_plugin(apple_pay_cert="correct_cert")
+    configuration = [
+        {"name": "api-key", "value": "key"},
+    ]
+    plugin_configuration = PluginConfiguration.objects.get()
+    plugin_configuration.configuration = configuration
+    plugin.validate_plugin_configuration(plugin_configuration)


### PR DESCRIPTION
I assumed that the configuration comes from the default structure which already has a defined apple-pay field.
It fails the configuration of the payment gateway when apple-pay is not provided.