### PR TITLE
Fix get_ordering_qs on MenuItem model

### DIFF
--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -904,17 +904,17 @@ def test_menu_reorder(staff_api_client, permission_manage_menus, menu_item_list)
     ]
 
     moves_input = [
-        {"itemId": items_global_ids[0], "parentId": None, "sortOrder": 0},
-        {"itemId": items_global_ids[1], "parentId": None, "sortOrder": -1},
-        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": None},
+        {"itemId": items_global_ids[0], "parentId": None, "sortOrder": 2},
+        {"itemId": items_global_ids[1], "parentId": None, "sortOrder": None},
+        {"itemId": items_global_ids[2], "parentId": None, "sortOrder": -2},
     ]
 
     expected_data = {
         "id": menu_global_id,
         "items": [
+            {"id": items_global_ids[2], "parent": None, "children": []},
             {"id": items_global_ids[1], "parent": None, "children": []},
             {"id": items_global_ids[0], "parent": None, "children": []},
-            {"id": items_global_ids[2], "parent": None, "children": []},
         ],
     }
 
@@ -956,16 +956,13 @@ def test_menu_reorder_assign_parent(
     ]
 
     moves_input = [
+        {"itemId": items_global_ids[0], "parentId": parent_global_id, "sortOrder": 3},
         {
             "itemId": items_global_ids[2],
             "parentId": parent_global_id,
             "sortOrder": None,
         },
-        {
-            "itemId": items_global_ids[3],
-            "parentId": parent_global_id,
-            "sortOrder": None,
-        },
+        {"itemId": items_global_ids[3], "parentId": parent_global_id, "sortOrder": -3},
     ]
 
     expected_data = {
@@ -976,7 +973,7 @@ def test_menu_reorder_assign_parent(
                 "parent": None,
                 "children": [
                     {
-                        "id": items_global_ids[0],
+                        "id": items_global_ids[3],
                         "parent": {"id": parent_global_id},
                         "children": [],
                     },
@@ -986,7 +983,7 @@ def test_menu_reorder_assign_parent(
                         "children": [],
                     },
                     {
-                        "id": items_global_ids[3],
+                        "id": items_global_ids[0],
                         "parent": {"id": parent_global_id},
                         "children": [],
                     },

--- a/saleor/menu/models.py
+++ b/saleor/menu/models.py
@@ -50,7 +50,11 @@ class MenuItem(MPTTModel, SortableModel):
         return self.name
 
     def get_ordering_queryset(self):
-        return self.menu.items.all() if not self.parent else self.parent.children.all()
+        return (
+            self.menu.items.filter(level=0)
+            if not self.parent
+            else self.parent.children.all()
+        )
 
     @property
     def linked_object(self):


### PR DESCRIPTION
I want to merge this change because...I want to update `get_ordering_queryset` on MenuItem to resolve issue related with reordering MenuItems

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
