### PR TITLE
Drop deprecated fields from Shop

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4734,8 +4734,6 @@ type Shop {
   geolocalization: Geolocalization
   authorizationKeys: [AuthorizationKey]!
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
-  currencies: [String]! @deprecated(reason: "This field will be removed in Saleor 3.0")
-  defaultCurrency: String! @deprecated(reason: "This field will be removed in Saleor 3.0")
   defaultCountry: CountryDisplay
   defaultMailSenderName: String
   defaultMailSenderAddress: String

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -95,17 +95,6 @@ class Shop(graphene.ObjectType):
         description="List of countries available in the shop.",
         required=True,
     )
-    currencies = graphene.List(
-        graphene.String,
-        description="List of available currencies.",
-        required=True,
-        deprecation_reason="This field will be removed in Saleor 3.0",
-    )
-    default_currency = graphene.String(
-        description="Shop's default currency.",
-        required=True,
-        deprecation_reason="This field will be removed in Saleor 3.0",
-    )
     default_country = graphene.Field(
         CountryDisplay, description="Shop's default country."
     )


### PR DESCRIPTION
I want to merge this change because...I want to drop deprecated fields from Shop type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [x] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
