### PR TITLE
Add redirect_url param to send_fulfilment_email

### DIFF
--- a/saleor/order/emails.py
+++ b/saleor/order/emails.py
@@ -72,9 +72,11 @@ def prepare_order_details_url(order: Order, redirect_url: str) -> str:
     return prepare_url(params, redirect_url)
 
 
-def collect_data_for_fulfillment_email(order_pk, template, fulfillment_pk):
+def collect_data_for_fulfillment_email(
+    order_pk, template, fulfillment_pk, redirect_url=""
+):
     fulfillment = Fulfillment.objects.get(pk=fulfillment_pk)
-    email_data = collect_data_for_email(order_pk, template)
+    email_data = collect_data_for_email(order_pk, template, redirect_url)
     lines = fulfillment.lines.all()
     physical_lines = [line for line in lines if not line.order_line.is_digital]
     digital_lines = [line for line in lines if line.order_line.is_digital]
@@ -113,9 +115,9 @@ def send_staff_order_confirmation(order_pk, redirect_url):
 
 
 @app.task
-def send_fulfillment_confirmation(order_pk, fulfillment_pk):
+def send_fulfillment_confirmation(order_pk, fulfillment_pk, redirect_url):
     email_data = collect_data_for_fulfillment_email(
-        order_pk, CONFIRM_FULFILLMENT_TEMPLATE, fulfillment_pk
+        order_pk, CONFIRM_FULFILLMENT_TEMPLATE, fulfillment_pk, redirect_url
     )
     send_templated_mail(**email_data)
 

--- a/templates/templated_email/compiled/confirm_fulfillment.html
+++ b/templates/templated_email/compiled/confirm_fulfillment.html
@@ -3,7 +3,7 @@
     <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
       <head>
         <title>
-          
+
         </title>
         <!--[if !mso]><!-- -->
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -30,7 +30,7 @@
           .mj-outlook-group-fix { width:100% !important; }
         </style>
         <![endif]-->
-        
+
       <!--[if !mso]><!-->
         <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
         <style type="text/css">
@@ -38,31 +38,31 @@
         </style>
       <!--<![endif]-->
 
-    
-        
+
+
     <style type="text/css">
       @media only screen and (min-width:480px) {
         .mj-column-per-100 { width:100% !important; max-width: 100%; }
       }
     </style>
-    
-  
+
+
         <style type="text/css">
-        
-        
+
+
         </style>
         <style type="text/css">address {
     font-style: inherit;
     font-family: Ubuntu, Helvetica, Arial;
   }</style>
-        
+
       </head>
       <body>
-        
-        
+
+
       <div style>
         {% load i18n %}{% load static %}
-      
+
       <!--[if mso | IE]>
       <table
          align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
@@ -70,42 +70,45 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-    
-      
+
+
       <div style="margin:0px auto;max-width:600px;">
-        
+
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
                 <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                
+
         <tr>
-      
+
             <td
                class="" style="vertical-align:top;width:600px;"
             >
           <![endif]-->
-            
+
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
+
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        
+
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{% trans "Hi!" context "Standard e-mail greeting" %}</div>
-    
               </td>
             </tr>
-          
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Fulfillment confirmation email text" %}
-            Thank you for your order. Below is the list of fulfilled products.
-          {% endblocktrans %}
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">
+          {% if order_details_url %}
+            {% blocktrans trimmed context "Fulfillment confirmation email text with order details" %}
+              Thank you for your order. Below is the list of fulfilled products. To see your order details please visit: <a href="{{ order_details_url }}">{{ order_details_url }}</a>
+            {% endblocktrans %}
+          {% else %}
+            {% blocktrans trimmed context "Fulfillment confirmation email text" %}
+              Thank you for your order. Below is the list of fulfilled products.
+            {% endblocktrans %}
+          {% endif %}
           {% if fulfillment.tracking_number %}
             {% if fulfillment.is_tracking_number_url %}
               {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
@@ -117,49 +120,42 @@
               {% endblocktrans %}
             {% endif %}
           {% endif %}</div>
-    
               </td>
             </tr>
-          
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% if digital_lines %}
             {% blocktrans trimmed context "Fulfillment digital products email text" %}
               You can download your digital products by clicking in download link(s).
             {% endblocktrans %}
           {% endif %}</div>
-    
               </td>
             </tr>
-          
       </table>
-    
       </div>
-    
           <!--[if mso | IE]>
             </td>
-          
+
         </tr>
-      
+
                   </table>
                 <![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
-        
+
       </div>
-    
-      
+
+
       <!--[if mso | IE]>
           </td>
         </tr>
       </table>
       <![endif]-->
-    
+
     {% load display_translated_order_line_name from order_lines %}
-      
+
       <!--[if mso | IE]>
       <table
          align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
@@ -167,31 +163,31 @@
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-    
-      
+
+
       <div style="margin:0px auto;max-width:600px;">
-        
+
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
                 <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                
+
         <tr>
-      
+
             <td
                class="" style="vertical-align:top;width:600px;"
             >
           <![endif]-->
-            
+
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
+
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        
+
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
+
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% if physical_lines %}
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
@@ -230,224 +226,223 @@
           </tbody>
         </table>
       {% endif %}</div>
-    
+
               </td>
             </tr>
-          
+
       </table>
-    
+
       </div>
-    
+
           <!--[if mso | IE]>
             </td>
-          
+
         </tr>
-      
+
                   </table>
                 <![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
-        
+
       </div>
-    
-      
+
+
       <!--[if mso | IE]>
           </td>
         </tr>
       </table>
-      
+
       <table
          align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
       >
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-    
-      
+
+
       <div style="margin:0px auto;max-width:600px;">
-        
+
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
                 <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                
+
         <tr>
-      
+
             <td
                class="" style="vertical-align:top;width:600px;"
             >
           <![endif]-->
-            
+
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
+
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        
+
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
+
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% blocktrans trimmed context "Base email text" %}
         This is an automatically generated e-mail, please do not reply.
       {% endblocktrans %}</div>
-    
+
               </td>
             </tr>
-          
+
       </table>
-    
+
       </div>
-    
+
           <!--[if mso | IE]>
             </td>
-          
+
         </tr>
-      
+
                   </table>
                 <![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
-        
+
       </div>
-    
-      
+
+
       <!--[if mso | IE]>
           </td>
         </tr>
       </table>
-      
+
       <table
          align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
       >
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-    
-      
+
+
       <div style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:600px;">
-        
+
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;">
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
                 <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                
+
         <tr>
-      
+
             <td
                class="" style="vertical-align:top;width:600px;"
             >
           <![endif]-->
-            
+
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
+
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        
+
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
+
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{% blocktrans trimmed context "Base email footer" %}
         Sincerely, {{ site_name }}
       {% endblocktrans %}</div>
-    
+
               </td>
             </tr>
-          
+
       </table>
-    
+
       </div>
-    
+
           <!--[if mso | IE]>
             </td>
-          
+
         </tr>
-      
+
                   </table>
                 <![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
-        
+
       </div>
-    
-      
+
+
       <!--[if mso | IE]>
           </td>
         </tr>
       </table>
-      
+
       <table
          align="center" border="0" cellpadding="0" cellspacing="0" class="no-display-outlook" style="width:600px;" width="600"
       >
         <tr>
           <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
       <![endif]-->
-    
-      
+
+
       <div class="no-display" style="display: none; margin: 0px auto; max-width: 600px;">
-        
+
         <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
                 <!--[if mso | IE]>
                   <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-                
+
         <tr>
-      
+
             <td
                class="" style="vertical-align:top;width:600px;"
             >
           <![endif]-->
-            
+
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
-        
+
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
-        
+
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
-                
+
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{% if schema_markup %}
         <script type="application/ld+json">{{ schema_markup|safe }}</script>
       {% endif %}</div>
-    
+
               </td>
             </tr>
-          
+
       </table>
-    
+
       </div>
-    
+
           <!--[if mso | IE]>
             </td>
-          
+
         </tr>
-      
+
                   </table>
                 <![endif]-->
               </td>
             </tr>
           </tbody>
         </table>
-        
+
       </div>
-    
-      
+
+
       <!--[if mso | IE]>
           </td>
         </tr>
       </table>
       <![endif]-->
-    
-    
+
+
       </div>
-    
+
       </body>
     </html>
-  

--- a/templates/templated_email/order/confirm_fulfillment.email
+++ b/templates/templated_email/order/confirm_fulfillment.email
@@ -11,6 +11,12 @@
 {% blocktrans context "Fulfillment confirmation email text" %}
 Thank you for your order. Below is the list of fulfilled products.
 {% endblocktrans %}
+{% if order_details_url %}
+{% blocktrans context "Fulfillment confirmation email text with order details" %}
+To see your order details please visit:
+{{ order_details_url }}
+{% endblocktrans %}
+{% endif %}
 {% if fulfillment.tracking_number %}
 {% blocktrans trimmed with tracking_number=fulfillment.tracking_number context "Fulfillment confirmation email text" %}
 You can track your shipment with {{ tracking_number }} code.


### PR DESCRIPTION
I want to merge this change because...I want to add redirect_url param to send_fulfilment_email

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
