### PR TITLE
Extend product webhook with attributes

### DIFF
--- a/saleor/webhook/serializers.py
+++ b/saleor/webhook/serializers.py
@@ -1,8 +1,9 @@
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, List, Union
 
 if TYPE_CHECKING:
     # pylint: disable=unused-import
     from ..checkout.models import Checkout
+    from ..product.models import Product, ProductVariant
 
 
 def serialize_checkout_lines(checkout: "Checkout") -> List[dict]:
@@ -22,4 +23,24 @@ def serialize_checkout_lines(checkout: "Checkout") -> List[dict]:
                 "variant_name": variant.name,
             }
         )
+    return data
+
+
+def serialize_attribute_assignments(
+    object_with_attributes: Union["Product", "ProductVariant"]
+):
+    data = []
+    for assignment in object_with_attributes.attributes.all():
+        values = []
+        for v in assignment.values.all():
+            values.append({"name": v.name, "slug": v.slug})
+        data.append(
+            {
+                "name": assignment.attribute.name,
+                "slug": assignment.attribute.slug,
+                "type": assignment.attribute.type,
+                "values": values,
+            }
+        )
+
     return data

--- a/templates/templated_email/source/shared/generic_information.mjml
+++ b/templates/templated_email/source/shared/generic_information.mjml
@@ -1,0 +1,27 @@
+<mj-section background-color="#ffffff" padding-left="10px" padding-right="10px" padding-top="0px">
+    <mj-column background-color="#f5f3f5">
+        <mj-image width="40px" src="https://res.cloudinary.com/lush/image/upload/v1596798696/emails/its-not-plastic.svg" />
+        <mj-text font-size="11px" color="#000000" font-family="Helvetica Neue" align="center" font-weight="bold">
+            It’s not plastic
+        </mj-text>
+        <mj-text font-size="11px" color="#000000" font-family="Helvetica Neue" align="center" padding-left="50px" padding-right="50px">
+            Your products will come packaged in biodegradeable Eco
+            Pops, made from expanded corn starch (not Polystyrene!).
+            Please dispose of in your home compost or food waste
+            bin. <a href="">Find out more</a>
+        </mj-text>
+    </mj-column>
+</mj-section>
+<mj-section background-color="#ffffff" padding-left="10px" padding-right="10px" padding-top="0px">
+    <mj-column background-color="#f5f3f5">
+        <mj-image width="40px" src="https://res.cloudinary.com/lush/image/upload/v1596798565/emails/close-the-loop.svg" />
+        <mj-text font-size="11px" color="#000000" font-family="Helvetica Neue" align="center" font-weight="bold">
+            Close the loop!
+        </mj-text>
+        <mj-text font-size="11px" color="#000000" font-family="Helvetica Neue" align="center" padding-left="50px" padding-right="50px">
+            Reuse or recycle your product packaging when you've
+            finished with it. Dont forget, black pots and bottle tops can
+            be recycled in store. <a href="">Find out more</a>
+        </mj-text>
+    </mj-column>
+</mj-section>


### PR DESCRIPTION
I want to merge this change because product and variant attributes were missing in webhook data.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
