### PR TITLE
Export file attributes

### DIFF
--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -1,6 +1,7 @@
 from measurement.measures import Weight
 
 from .....attribute.models import Attribute
+from .....attribute.utils import associate_attribute_values_to_instance
 from .....channel.models import Channel
 from .....product.models import Product, ProductVariant, VariantImage
 from .....warehouse.models import Warehouse
@@ -225,9 +226,18 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     variant_with_many_stocks,
     product_with_image,
     product_with_variant_with_two_attributes,
+    file_attribute,
 ):
     # given
     product.variants.add(variant_with_many_stocks)
+    product.product_type.variant_attributes.add(file_attribute)
+    product.product_type.product_attributes.add(file_attribute)
+    associate_attribute_values_to_instance(
+        variant_with_many_stocks, file_attribute, file_attribute.values.first()
+    )
+    associate_attribute_values_to_instance(
+        product, file_attribute, file_attribute.values.first()
+    )
 
     products = Product.objects.all()
     export_fields = {"id", "variants__sku"}

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -1,12 +1,22 @@
+from .....attribute import AttributeInputType
+
+
 def add_product_attribute_data_to_expected_data(data, product, attribute_ids, pk=None):
     for assigned_attribute in product.attributes.all():
         if assigned_attribute:
             header = f"{assigned_attribute.attribute.slug} (product attribute)"
             if str(assigned_attribute.attribute.pk) in attribute_ids:
+                value = (
+                    assigned_attribute.values.first().slug
+                    if assigned_attribute.attribute.input_type
+                    != AttributeInputType.FILE
+                    else "http://mirumee.com/media/"
+                    + assigned_attribute.values.first().file_url
+                )
                 if pk:
-                    data[pk][header] = assigned_attribute.values.first().slug
+                    data[pk][header] = value
                 else:
-                    data[header] = assigned_attribute.values.first().slug
+                    data[header] = value
     return data
 
 
@@ -14,10 +24,16 @@ def add_variant_attribute_data_to_expected_data(data, variant, attribute_ids, pk
     for assigned_attribute in variant.attributes.all():
         header = f"{assigned_attribute.attribute.slug} (variant attribute)"
         if str(assigned_attribute.attribute.pk) in attribute_ids:
+            value = (
+                assigned_attribute.values.first().slug
+                if assigned_attribute.attribute.input_type != AttributeInputType.FILE
+                else "http://mirumee.com/media/"
+                + assigned_attribute.values.first().file_url
+            )
             if pk:
-                data[pk][header] = assigned_attribute.values.first().slug
+                data[pk][header] = value
             else:
-                data[header] = assigned_attribute.values.first().slug
+                data[header] = value
 
     return data
 

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -6,13 +6,13 @@ def add_product_attribute_data_to_expected_data(data, product, attribute_ids, pk
         if assigned_attribute:
             header = f"{assigned_attribute.attribute.slug} (product attribute)"
             if str(assigned_attribute.attribute.pk) in attribute_ids:
-                value = (
-                    assigned_attribute.values.first().slug
-                    if assigned_attribute.attribute.input_type
-                    != AttributeInputType.FILE
-                    else "http://mirumee.com/media/"
-                    + assigned_attribute.values.first().file_url
-                )
+                if assigned_attribute.attribute.input_type != AttributeInputType.FILE:
+                    value = assigned_attribute.values.first().slug
+                else:
+                    value = (
+                        "http://mirumee.com/media/"
+                        + assigned_attribute.values.first().file_url
+                    )
                 if pk:
                     data[pk][header] = value
                 else:

--- a/saleor/csv/utils/__init__.py
+++ b/saleor/csv/utils/__init__.py
@@ -22,7 +22,9 @@ class ProductExportFields:
 
     PRODUCT_ATTRIBUTE_FIELDS = {
         "value": "attributes__values__slug",
+        "file_url": "attributes__values__file_url",
         "slug": "attributes__assignment__attribute__slug",
+        "input_type": "attributes__assignment__attribute__input_type",
         "attribute_pk": "attributes__assignment__attribute__pk",
     }
 
@@ -44,7 +46,9 @@ class ProductExportFields:
 
     VARIANT_ATTRIBUTE_FIELDS = {
         "value": "variants__attributes__values__slug",
+        "file_url": "variants__attributes__values__file_url",
         "slug": "variants__attributes__assignment__attribute__slug",
+        "input_type": "variants__attributes__assignment__attribute__input_type",
         "attribute_pk": "variants__attributes__assignment__attribute__pk",
     }
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -1,11 +1,12 @@
 import os
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 
 from django.conf import settings
 from django.db.models import Case, CharField, Value as V, When
 from django.db.models.functions import Concat
 
+from ...attribute import AttributeInputType
 from ...attribute.models import Attribute
 from ...core.utils import build_absolute_uri
 from . import ProductExportFields
@@ -287,6 +288,9 @@ def add_image_uris_to_data(
     return result_data
 
 
+AttributeData = namedtuple("AttributeData", ["slug", "file_url", "value", "input_type"])
+
+
 def handle_attribute_data(
     pk: int,
     data: dict,
@@ -295,13 +299,13 @@ def handle_attribute_data(
     attribute_fields: dict,
     attribute_owner: str,
 ):
-    attribute_data: dict = {}
-
     attribute_pk = str(data.pop(attribute_fields["attribute_pk"], ""))
-    attribute_data = {
-        "slug": data.pop(attribute_fields["slug"], None),
-        "value": data.pop(attribute_fields["value"], None),
-    }
+    attribute_data = AttributeData(
+        slug=data.pop(attribute_fields["slug"], None),
+        input_type=data.pop(attribute_fields["input_type"], None),
+        file_url=data.pop(attribute_fields["file_url"], None),
+        value=data.pop(attribute_fields["value"], None),
+    )
 
     if attribute_ids and attribute_pk in attribute_ids:
         result_data = add_attribute_info_to_data(
@@ -360,7 +364,7 @@ def handle_warehouse_data(
 
 def add_attribute_info_to_data(
     pk: int,
-    attribute_data: Dict[str, Optional[Union[str]]],
+    attribute_data: AttributeData,
     attribute_owner: str,
     result_data: Dict[int, dict],
 ) -> Dict[int, dict]:
@@ -371,14 +375,21 @@ def add_attribute_info_to_data(
     to set with values.
     It returns updated data.
     """
-    slug = attribute_data["slug"]
+    slug = attribute_data.slug
     header = None
     if slug:
         header = f"{slug} ({attribute_owner})"
+        value = (
+            attribute_data.value
+            if attribute_data.input_type != AttributeInputType.FILE
+            else build_absolute_uri(
+                os.path.join(settings.MEDIA_URL, attribute_data.file_url)
+            )
+        )
         if header in result_data[pk]:
-            result_data[pk][header].add(attribute_data["value"])  # type: ignore
+            result_data[pk][header].add(value)  # type: ignore
         else:
-            result_data[pk][header] = {attribute_data["value"]}
+            result_data[pk][header] = {value}
     return result_data
 
 

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_update.py
@@ -200,12 +200,12 @@ def test_update_attribute_with_file_input_type_and_values(
 
 def test_update_attribute_with_file_input_type_invalid_settings(
     staff_api_client,
-    image_attribute_without_values_and_file_input_type,
+    file_attribute_with_file_input_type_without_values,
     permission_manage_product_types_and_attributes,
 ):
     # given
     query = UPDATE_ATTRIBUTE_MUTATION
-    attribute = image_attribute_without_values_and_file_input_type
+    attribute = file_attribute_with_file_input_type_without_values
     name = "Wings name"
     node_id = graphene.Node.to_global_id("Attribute", attribute.id)
 


### PR DESCRIPTION
Allow exporting `file_url` of file attributes.

Task linked [SALEOR-1356](https://app.clickup.com/t/2549495/SALEOR-1356)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
