### PR TITLE
Postcodes delete return shipping_method

### DIFF
--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4696,6 +4696,7 @@ input ShippingZipCodeRulesCreateInputRange {
 
 type ShippingZipCodeRulesDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
+  shippingMethod: ShippingMethod
   shippingErrors: [ShippingError!]!
   shippingMethodZipCodeRule: ShippingMethodZipCodeRule
 }

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -213,6 +213,10 @@ class ShippingZipCodeRulesCreate(BaseMutation):
 
 
 class ShippingZipCodeRulesDelete(ModelDeleteMutation):
+    shipping_method = graphene.Field(
+        ShippingMethod, description="Related shipping method."
+    )
+
     class Arguments:
         id = graphene.ID(
             required=True, description="ID of a shipping method zip code to delete."
@@ -226,11 +230,13 @@ class ShippingZipCodeRulesDelete(ModelDeleteMutation):
         error_type_field = "shipping_errors"
 
     @classmethod
-    def success_response(cls, instance):
-        instance = ChannelContext(node=instance, channel_slug=None)
-        response = super().success_response(instance)
-
-        return response
+    def perform_mutation(cls, _root, info, **data):
+        instance = cls.get_instance(info, **data)
+        shipping_method = instance.shipping_method
+        super().perform_mutation(_root, info, **data)
+        return ShippingZipCodeRulesDelete(
+            shipping_method=ChannelContext(node=shipping_method, channel_slug=None)
+        )
 
 
 class ShippingZoneDelete(ModelDeleteMutation):

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -214,7 +214,7 @@ class ShippingZipCodeRulesCreate(BaseMutation):
 
 class ShippingZipCodeRulesDelete(ModelDeleteMutation):
     shipping_method = graphene.Field(
-        ShippingMethod, description="Related shipping method."
+        ShippingMethod, description="Shipping method of deleted zip code rule."
     )
 
     class Arguments:

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -451,6 +451,9 @@ DELETE_SHIPPING_METHOD_ZIP_CODE_MUTATION = """
         shippingMethodZipCodeRulesDelete(
             id: $id
         ){
+            shippingMethod {
+                name
+            }
             shippingErrors {
                 field
                 code
@@ -473,7 +476,9 @@ def test_delete_shipping_method_zip_code(
         permissions=[permission_manage_shipping],
     )
     content = get_graphql_content(response)
-    assert content["data"]["shippingMethodZipCodeRulesDelete"]["shippingErrors"] == []
+    data = content["data"]["shippingMethodZipCodeRulesDelete"]
+    assert data["shippingErrors"] == []
+    assert data["shippingMethod"]["name"] == shipping_method_excldued_by_zip_code.name
     assert not shipping_method_excldued_by_zip_code.zip_code_rules.exists()
 
 

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -452,6 +452,7 @@ DELETE_SHIPPING_METHOD_ZIP_CODE_MUTATION = """
             id: $id
         ){
             shippingMethod {
+                id
                 name
             }
             shippingErrors {
@@ -478,6 +479,9 @@ def test_delete_shipping_method_zip_code(
     content = get_graphql_content(response)
     data = content["data"]["shippingMethodZipCodeRulesDelete"]
     assert data["shippingErrors"] == []
+    assert data["shippingMethod"]["id"] == graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method_excldued_by_zip_code.id
+    )
     assert data["shippingMethod"]["name"] == shipping_method_excldued_by_zip_code.name
     assert not shipping_method_excldued_by_zip_code.zip_code_rules.exists()
 


### PR DESCRIPTION
I want to merge this change because it adds the field shippingMethod to ShippingZipCodeRulesDelete mutation response.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
