### PR TITLE
Zip codes exclusion UK islands fallbacks

### DIFF
--- a/saleor/shipping/tests/test_zip_codes.py
+++ b/saleor/shipping/tests/test_zip_codes.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 
 from ..zip_codes import check_zip_code_in_excluded_range
@@ -60,3 +62,18 @@ def test_check_zip_code_for_ireland(code, start, end, in_range):
 )
 def test_check_zip_code_for_other_countries(code, start, end, in_range):
     assert check_zip_code_in_excluded_range("PL", code, start, end) is in_range
+
+
+@pytest.mark.parametrize(
+    "country, code, start, end",
+    [
+        ["IM", "IM16 7HF", "IM16 7HA", "IM16 7HG"],
+        ["GG", "GG16 7HF", "GG16 7HA", "GG16 7HG"],
+        ["JE", "GY16 7HZ", "GY16 7HA", "GY16 7HG"],
+    ],
+)
+@patch("saleor.shipping.zip_codes.check_uk_zip_code")
+def test_check_uk_islands_follow_uk_check(check_uk_mock, country, code, start, end):
+    """Check if Isle of Man, Guernsey and Jersey triggers check_uk_zip_code method."""
+    assert check_zip_code_in_excluded_range(country, code, start, end)
+    check_uk_mock.assert_called_once_with(code, start, end)

--- a/saleor/shipping/zip_codes.py
+++ b/saleor/shipping/zip_codes.py
@@ -72,6 +72,9 @@ def check_any_zip_code(code, start, end):
 def check_zip_code_in_excluded_range(country, code, start, end):
     country_func_map = {
         "GB": check_uk_zip_code,  # United Kingdom
+        "IM": check_uk_zip_code,  # Isle of Man
+        "GG": check_uk_zip_code,  # Guernsey
+        "JE": check_uk_zip_code,  # Jersey
         "IR": check_irish_zip_code,  # Ireland
     }
     return country_func_map.get(country, check_any_zip_code)(code, start, end)


### PR DESCRIPTION
I want to merge this change because it adds some handy fallbacks so the UK islands zip codes will be checked in more detail

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
