### PR TITLE
Change graphql.errors.handled logger level to INFO

### DIFF
--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -217,7 +217,7 @@ def test_invalid_query_graphql_errors_are_logged_in_another_logger(
     response = api_client.post_graphql("{ shop }")
     assert response.status_code == 400
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
 
 
@@ -227,7 +227,7 @@ def test_invalid_syntax_graphql_errors_are_logged_in_another_logger(
     response = api_client.post_graphql("{ }")
     assert response.status_code == 400
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLSyntaxError"
+        "saleor.graphql.errors.handled[INFO].GraphQLSyntaxError"
     ]
 
 
@@ -247,7 +247,7 @@ def test_permission_denied_query_graphql_errors_are_logged_in_another_logger(
     )
     assert response.status_code == 200
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].PermissionDenied"
+        "saleor.graphql.errors.handled[INFO].PermissionDenied"
     ]
 
 

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -79,7 +79,7 @@ def test_menu_query_error_when_id_and_name_provided(
     }
     response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1
@@ -91,7 +91,7 @@ def test_menu_query_error_when_no_param(
     variables = {}
     response = user_api_client.post_graphql(QUERY_MENU, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -84,7 +84,7 @@ def test_category_query_error_when_id_and_slug_provided(
     }
     response = user_api_client.post_graphql(QUERY_CATEGORY, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1
@@ -96,7 +96,7 @@ def test_category_query_error_when_no_param(
     variables = {}
     response = user_api_client.post_graphql(QUERY_CATEGORY, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -116,7 +116,7 @@ def test_collection_query_error_when_id_and_slug_provided(
     }
     response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1
@@ -128,7 +128,7 @@ def test_collection_query_error_when_no_param(
     variables = {}
     response = user_api_client.post_graphql(QUERY_COLLECTION, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -838,7 +838,7 @@ def test_product_query_error_when_id_and_slug_provided(
     }
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1
@@ -850,7 +850,7 @@ def test_product_query_error_when_no_param(
     variables = {}
     response = user_api_client.post_graphql(QUERY_PRODUCT, variables=variables)
     assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[ERROR].GraphQLError"
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
     content = get_graphql_content(response, ignore_errors=True)
     assert len(content["errors"]) == 1

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -293,7 +293,7 @@ class GraphQLView(View):
             exc = exc.original_error
 
         if isinstance(exc, cls.HANDLED_EXCEPTIONS):
-            handled_errors_logger.error("A query had an error", exc_info=exc)
+            handled_errors_logger.info("A query had an error", exc_info=exc)
         else:
             unhandled_errors_logger.error("A query failed unexpectedly", exc_info=exc)
 

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -338,7 +338,7 @@ LOGGING = {
         "saleor": {"level": "DEBUG", "propagate": True},
         "saleor.graphql.errors.handled": {
             "handlers": ["default"],
-            "level": "ERROR",
+            "level": "INFO",
             "propagate": False,
         },
         "graphql.execution.utils": {"propagate": False},


### PR DESCRIPTION
Errors from `graphql.errors.handled` logger shouldn't be logged as errors. These include e.g. GraphQL syntax errors or permission denied errors.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
