### PR TITLE
Fix failing draftjs to editorjs format migrations

### DIFF
--- a/saleor/page/migrations/0015_migrate_from_draftjs_to_editorjs_format.py
+++ b/saleor/page/migrations/0015_migrate_from_draftjs_to_editorjs_format.py
@@ -24,7 +24,7 @@ def parse_to_editorjs(data):
     list_data = {}
     for block in blocks:
         # if block doesn't have key it means it isn't in draft.js format
-        if not block.get("key"):
+        if "key" not in block:
             return data
         key = block["type"]
         inline_style_ranges = block["inlineStyleRanges"]

--- a/saleor/product/migrations/0130_migrate_from_draftjs_to_editorjs_format.py
+++ b/saleor/product/migrations/0130_migrate_from_draftjs_to_editorjs_format.py
@@ -24,7 +24,7 @@ def parse_to_editorjs(data):
     list_data = {}
     for block in blocks:
         # if block doesn't have key it means it isn't in draft.js format
-        if not block.get("key"):
+        if "key" not in block:
             return data
         key = block["type"]
         inline_style_ranges = block["inlineStyleRanges"]


### PR DESCRIPTION
I want to merge this change because it fixes draftjs to editorjs format migrations

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
