### PR TITLE
Fix for failing refunds for products  without tracking inventory

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -487,7 +487,7 @@ class FulfillmentRefundProducts(BaseMutation):
             field="order_lines",
             only_type=OrderLine,
             qs=order_models.OrderLine.objects.prefetch_related(
-                "fulfillment_lines__fulfillment"
+                "fulfillment_lines__fulfillment", "variant", "allocations"
             ),
         )
         lines_to_refund = list(lines_to_refund)

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -1308,6 +1308,8 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
     )
     net = variant.get_price(channel_USD.slug)
     gross = Money(amount=net.amount * Decimal(1.23), currency=net.currency)
+    variant.track_inventory = False
+    variant.save()
     order_line = fulfilled_order.lines.create(
         product_name=str(variant.product),
         variant_name=str(variant),
@@ -1318,9 +1320,6 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
         variant=variant,
         unit_price=TaxedMoney(net=net, gross=gross),
         tax_rate=23,
-    )
-    Allocation.objects.create(
-        order_line=order_line, stock=stock, quantity_allocated=order_line.quantity
     )
     fulfillment = fulfilled_order.fulfillments.get()
     fulfillment.lines.create(order_line=order_line, quantity=2, stock=stock)

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -483,7 +483,9 @@ def _refund_fulfillment_for_order_lines(
             try:
                 deallocate_stock(line_to_refund, unfulfilled_to_refund)
             except AllocationError:
-                logger.warning(f"Unable to deallocate stock for line {line_to_refund}")
+                logger.warning(
+                    f"Unable to deallocate stock for line {line_to_refund.id}"
+                )
 
         # prepare structure which will be used to create new order event.
         all_refunded_lines[line_to_refund.id] = (

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -6,7 +6,7 @@ from django.contrib.sites.models import Site
 from django.db import transaction
 
 from ..core import analytics
-from ..core.exceptions import InsufficientStock
+from ..core.exceptions import AllocationError, InsufficientStock
 from ..order.emails import send_order_confirmed
 from ..payment import (
     ChargeStatus,
@@ -478,7 +478,12 @@ def _refund_fulfillment_for_order_lines(
             # quantity
             fulfillment_lines_to_update.append(refunded_line)
 
-        deallocate_stock(line_to_refund, unfulfilled_to_refund)
+        line_allocations_exists = line_to_refund.allocations.exists()
+        if line_allocations_exists:
+            try:
+                deallocate_stock(line_to_refund, unfulfilled_to_refund)
+            except AllocationError:
+                logger.warning(f"Unable to deallocate stock for line {line_to_refund}")
 
         # prepare structure which will be used to create new order event.
         all_refunded_lines[line_to_refund.id] = (


### PR DESCRIPTION
The refund flow for a product without tracking_inventory was failing as the logic wanted to deallocate stock. 