### PR TITLE
Remove lazy string from warm-up WSGI request and add missing value

### DIFF
--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -14,15 +14,8 @@ framework.
 import os
 
 from django.core.wsgi import get_wsgi_application
-from django.utils.functional import SimpleLazyObject
 
 from saleor.wsgi.health_check import health_check
-
-
-def get_allowed_host_lazy():
-    from django.conf import settings
-
-    return settings.ALLOWED_HOSTS[0]
 
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "saleor.settings")
@@ -34,8 +27,9 @@ application = health_check(application, "/health/")
 application(
     {
         "REQUEST_METHOD": "GET",
-        "SERVER_NAME": SimpleLazyObject(get_allowed_host_lazy),
+        "SERVER_NAME": "127.0.0.1",
         "REMOTE_ADDR": "127.0.0.1",
+        "HTTP_X_FORWARDED_PROTO": "http",
         "SERVER_PORT": 80,
         "PATH_INFO": "/graphql/",
         "wsgi.input": b"",

--- a/saleor/wsgi/__init__.py
+++ b/saleor/wsgi/__init__.py
@@ -24,6 +24,8 @@ application = get_wsgi_application()
 application = health_check(application, "/health/")
 
 # Warm-up the django application instead of letting it lazy-load
+# It might hit a not host allowed error but will still 
+# cause the Django application to warm-up
 application(
     {
         "REQUEST_METHOD": "GET",


### PR DESCRIPTION
This fixes errors when a third-party application such as DataDog tries to parse the URL which contains a type checking that will never try to resolve the lazy object.

Also adds the protocol in the warm-up request as `None` would be returned by django which is invalid.

```
Exception in thread django-main-thread:
Traceback (most recent call last):
  File "/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/lib/python3.8/threading.py", line 870, in run
    self._target(*self._args, **self._kwargs)
  File "/lib/python3.8/site-packages/django/utils/autoreload.py", line 53, in wrapper
    fn(*args, **kwargs)
  File "/lib/python3.8/site-packages/django/core/management/commands/runserver.py", line 138, in inner_run
    handler = self.get_handler(*args, **options)
  File "/lib/python3.8/site-packages/django/contrib/staticfiles/management/commands/runserver.py", line 27, in get_handler
    handler = super().get_handler(*args, **options)
  File "/lib/python3.8/site-packages/django/core/management/commands/runserver.py", line 65, in get_handler
    return get_internal_wsgi_application()
  File "/lib/python3.8/site-packages/django/core/servers/basehttp.py", line 45, in get_internal_wsgi_application
    return import_string(app_path)
  File "/lib/python3.8/site-packages/django/utils/module_loading.py", line 17, in import_string
    module = import_module(module_path)
  File "/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 783, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/app/saleor/wsgi/__init__.py", line 34, in <module>
    application(
  File "/app/saleor/wsgi/health_check.py", line 6, in health_check_wrapper
    return application(environ, start_response)
  File "/lib/python3.8/site-packages/django/core/handlers/wsgi.py", line 133, in __call__
    response = self.get_response(request)
  File "/lib/python3.8/site-packages/ddtrace/contrib/trace_utils.py", line 47, in wrapper
    return func(mod, pin, wrapped, instance, args, kwargs)
  File "/lib/python3.8/site-packages/ddtrace/contrib/django/patch.py", line 396, in traced_get_response
    span.set_tag(http.URL, utils.get_request_uri(request))
  File "/lib/python3.8/site-packages/ddtrace/contrib/django/utils.py", line 104, in get_request_uri
    return parse.urlunparse(parse.ParseResult(**urlparts))
  File "/lib/python3.8/urllib/parse.py", line 480, in urlunparse
    _coerce_args(*components))
  File "/lib/python3.8/urllib/parse.py", line 121, in _coerce_args
    raise TypeError("Cannot mix str and non-str arguments")
TypeError: Cannot mix str and non-str arguments
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
