### PR TITLE
Add more tracing information

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -42,6 +42,10 @@ def tracing_wrapper(execute, sql, params, many, context):
         span.set_tag(opentracing.tags.COMPONENT, "db")
         span.set_tag(opentracing.tags.DATABASE_STATEMENT, sql)
         span.set_tag(opentracing.tags.DATABASE_TYPE, conn.display_name)
+        span.set_tag(opentracing.tags.PEER_HOSTNAME, conn.settings_dict.get("HOST"))
+        span.set_tag(opentracing.tags.PEER_PORT, conn.settings_dict.get("PORT"))
+        span.set_tag("service.name", "postgres")
+        span.set_tag("span.type", "sql")
         return execute(sql, params, many, context)
 
 
@@ -137,6 +141,7 @@ class GraphQLView(View):
                 opentracing.tags.HTTP_URL,
                 request.build_absolute_uri(request.get_full_path()),
             )
+            span.set_tag("span.type", "web")
 
             request_ips = request.META.get(settings.REAL_IP_ENVIRON, "")
             for ip in request_ips.split(","):
@@ -224,9 +229,7 @@ class GraphQLView(View):
                 return error
 
             if document is not None:
-                raw_query_string = document.document_string[
-                    : settings.OPENTRACING_MAX_QUERY_LENGTH_LOG
-                ]
+                raw_query_string = document.document_string
                 span.set_tag("graphql.query", raw_query_string)
 
             extra_options: Dict[str, Optional[Any]] = {}

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -481,9 +481,6 @@ CELERY_RESULT_BACKEND = os.environ.get("CELERY_RESULT_BACKEND", None)
 # e.g. HTTP_CF_Connecting_IP for Cloudflare or X_FORWARDED_FOR
 REAL_IP_ENVIRON = os.environ.get("REAL_IP_ENVIRON", "REMOTE_ADDR")
 
-# The maximum length of a graphql query to log in tracings
-OPENTRACING_MAX_QUERY_LENGTH_LOG = 2000
-
 # Slugs for menus precreated in Django migrations
 DEFAULT_MENUS = {"top_menu_name": "navbar", "bottom_menu_name": "footer"}
 


### PR DESCRIPTION
This adds more information and removes the length limit from the GraphQL query string.

We should test it on the master branch (with Datadog) and then I can backport this to the 2.11 branch.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
