### PR TITLE
Fix collection resolver on menu with invalid channel

### DIFF
--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -122,6 +122,8 @@ class MenuItem(ChannelContextType, CountableDjangoObjectType):
 
         def calculate_collection_availability(collection_channel_listing):
             def calculate_collection_availability_with_channel(channel):
+                if not channel:
+                    return None
                 collection_is_visible = (
                     collection_channel_listing.is_visible
                     if collection_channel_listing


### PR DESCRIPTION
I want to merge this change because...I want to fix resolver collection on menu item if given channel is invalid

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
