### PR TITLE
Export attribute references

### DIFF
--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -1,6 +1,6 @@
 from measurement.measures import Weight
 
-from .....attribute.models import Attribute
+from .....attribute.models import Attribute, AttributeValue
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....channel.models import Channel
 from .....product.models import Product, ProductVariant, VariantImage
@@ -227,16 +227,38 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     product_with_image,
     product_with_variant_with_two_attributes,
     file_attribute,
+    page_reference_attribute,
+    page_list,
 ):
     # given
     product.variants.add(variant_with_many_stocks)
-    product.product_type.variant_attributes.add(file_attribute)
-    product.product_type.product_attributes.add(file_attribute)
+    product.product_type.variant_attributes.add(
+        file_attribute, page_reference_attribute
+    )
+    product.product_type.product_attributes.add(
+        file_attribute, page_reference_attribute
+    )
     associate_attribute_values_to_instance(
         variant_with_many_stocks, file_attribute, file_attribute.values.first()
     )
     associate_attribute_values_to_instance(
         product, file_attribute, file_attribute.values.first()
+    )
+    product_ref_value = AttributeValue.objects.create(
+        attribute=page_reference_attribute,
+        slug=f"{product.pk}_{page_list[0].pk}",
+        name=page_list[0].title,
+    )
+    variant_ref_value = AttributeValue.objects.create(
+        attribute=page_reference_attribute,
+        slug=f"{variant_with_many_stocks.pk}_{page_list[1].pk}",
+        name=page_list[1].title,
+    )
+    associate_attribute_values_to_instance(
+        variant_with_many_stocks, page_reference_attribute, variant_ref_value
+    )
+    associate_attribute_values_to_instance(
+        product, page_reference_attribute, product_ref_value
     )
 
     products = Product.objects.all()

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -6,13 +6,7 @@ def add_product_attribute_data_to_expected_data(data, product, attribute_ids, pk
         if assigned_attribute:
             header = f"{assigned_attribute.attribute.slug} (product attribute)"
             if str(assigned_attribute.attribute.pk) in attribute_ids:
-                if assigned_attribute.attribute.input_type != AttributeInputType.FILE:
-                    value = assigned_attribute.values.first().slug
-                else:
-                    value = (
-                        "http://mirumee.com/media/"
-                        + assigned_attribute.values.first().file_url
-                    )
+                value = get_attribute_value(assigned_attribute)
                 if pk:
                     data[pk][header] = value
                 else:
@@ -24,19 +18,26 @@ def add_variant_attribute_data_to_expected_data(data, variant, attribute_ids, pk
     for assigned_attribute in variant.attributes.all():
         header = f"{assigned_attribute.attribute.slug} (variant attribute)"
         if str(assigned_attribute.attribute.pk) in attribute_ids:
-            if assigned_attribute.attribute.input_type != AttributeInputType.FILE:
-                value = assigned_attribute.values.first().slug
-            else:
-                value = (
-                    "http://mirumee.com/media/"
-                    + assigned_attribute.values.first().file_url
-                )
+            value = get_attribute_value(assigned_attribute)
             if pk:
                 data[pk][header] = value
             else:
                 data[header] = value
 
     return data
+
+
+def get_attribute_value(assigned_attribute):
+    value_instance = assigned_attribute.values.first()
+    attribute = assigned_attribute.attribute
+    if attribute.input_type == AttributeInputType.FILE:
+        value = "http://mirumee.com/media/" + value_instance.file_url
+    elif attribute.input_type == AttributeInputType.REFERENCE:
+        ref_id = value_instance.slug.split("_")[1]
+        value = f"{attribute.entity_type}_{ref_id}"
+    else:
+        value = value_instance.slug
+    return value
 
 
 def add_stocks_to_expected_data(data, variant, warehouse_ids, pk=None):

--- a/saleor/csv/utils/__init__.py
+++ b/saleor/csv/utils/__init__.py
@@ -25,6 +25,7 @@ class ProductExportFields:
         "file_url": "attributes__values__file_url",
         "slug": "attributes__assignment__attribute__slug",
         "input_type": "attributes__assignment__attribute__input_type",
+        "entity_type": "attributes__assignment__attribute__entity_type",
         "attribute_pk": "attributes__assignment__attribute__pk",
     }
 
@@ -49,6 +50,7 @@ class ProductExportFields:
         "file_url": "variants__attributes__values__file_url",
         "slug": "variants__attributes__assignment__attribute__slug",
         "input_type": "variants__attributes__assignment__attribute__input_type",
+        "entity_type": "variants__attributes__assignment__attribute__entity_type",
         "attribute_pk": "variants__attributes__assignment__attribute__pk",
     }
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -11,7 +11,6 @@ from ...core.utils import build_absolute_uri
 from . import ProductExportFields
 
 if TYPE_CHECKING:
-    # flake8: noqa
     from django.db.models import QuerySet
 
 
@@ -287,7 +286,9 @@ def add_image_uris_to_data(
     return result_data
 
 
-AttributeData = namedtuple("AttributeData", ["slug", "file_url", "value", "input_type"])
+AttributeData = namedtuple(
+    "AttributeData", ["slug", "file_url", "value", "input_type", "entity_type"]
+)
 
 
 def handle_attribute_data(
@@ -304,6 +305,7 @@ def handle_attribute_data(
         input_type=data.pop(attribute_fields["input_type"], None),
         file_url=data.pop(attribute_fields["file_url"], None),
         value=data.pop(attribute_fields["value"], None),
+        entity_type=data.pop(attribute_fields["entity_type"], None),
     )
 
     if attribute_ids and attribute_pk in attribute_ids:
@@ -378,13 +380,16 @@ def add_attribute_info_to_data(
     header = None
     if slug:
         header = f"{slug} ({attribute_owner})"
-        value = (
-            attribute_data.value
-            if attribute_data.input_type != AttributeInputType.FILE
-            else build_absolute_uri(
+        input_type = attribute_data.input_type
+        if input_type == AttributeInputType.FILE:
+            value = build_absolute_uri(
                 os.path.join(settings.MEDIA_URL, attribute_data.file_url)
             )
-        )
+        elif input_type == AttributeInputType.REFERENCE:
+            reference_id = attribute_data.value.split("_")[1]
+            value = f"{attribute_data.entity_type}_{reference_id}"
+        else:
+            value = attribute_data.value
         if header in result_data[pk]:
             result_data[pk][header].add(value)  # type: ignore
         else:


### PR DESCRIPTION
Allow exporting attribute references.
Attribute reference value will be exported as follows: `entityType_referenceId`.

Task linked: [SALEOR-1420](https://app.clickup.com/t/2549495/SALEOR-1420)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
