### PR TITLE
Do not create new attribute values when instance is updated

### DIFF
--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -158,7 +158,11 @@ class AttributeAssignmentMixin:
         assignment = instance.attributes.filter(
             assignment__attribute=attribute, values__file_url=file_url
         ).first()
-        return None if assignment is None else assignment.values.get(file_url=file_url)
+        return (
+            None
+            if assignment is None
+            else assignment.values.filter(file_url=file_url).first()
+        )
 
     @classmethod
     def _validate_attributes_input(

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -123,7 +123,7 @@ class AttributeAssignmentMixin:
     @classmethod
     def _pre_save_file_value(
         cls,
-        instance,
+        instance: T_INSTANCE,
         attribute: attribute_models.Attribute,
         attr_value: AttrValuesInput,
     ):
@@ -153,7 +153,7 @@ class AttributeAssignmentMixin:
 
     @classmethod
     def _get_assigned_attribute_value_if_exists(
-        cls, instance, attribute: attribute_models.Attribute, file_url
+        cls, instance: T_INSTANCE, attribute: attribute_models.Attribute, file_url
     ):
         assignment = instance.attributes.filter(
             assignment__attribute=attribute, values__file_url=file_url

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -925,7 +925,7 @@ class ProductVariantUpdate(ProductVariantCreate):
             input_attribute_values = defaultdict(list)
             for attr, attr_data in attributes_data:
                 values = (
-                    slugify(attr_data.file_url)
+                    [slugify(attr_data.file_url.split("/")[-1])]
                     if attr.input_type == AttributeInputType.FILE
                     else attr_data.values
                 )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -878,14 +878,14 @@ def page_file_attribute(db):
         attribute=attribute,
         name="test_file.txt",
         slug="test_filetxt",
-        file_url="test_file.txt",
+        file_url="http://mirumee.com/test_media/test_file.txt",
         content_type="text/plain",
     )
     AttributeValue.objects.create(
         attribute=attribute,
         name="test_file.jpeg",
         slug="test_filejpeg",
-        file_url="test_file.jpeg",
+        file_url="http://mirumee.com/test_media/test_file.jpeg",
         content_type="image/jpeg",
     )
     return attribute


### PR DESCRIPTION
When the instance has assigned attribute value and in update value is not changed, don't create a new `AttributeValue` instance.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
