### PR TITLE
Drop blocktrans function and tags from default email templates

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -125,11 +125,6 @@ DEFAULT_EMAIL_CONFIG_STRUCTURE = {
 }
 
 
-def block_trans(this, options, *args, **kwargs):
-    # TODO add translation here
-    return options["fn"](this)
-
-
 def format_address(this, address, include_phone=True, inline=False, latin=False):
     address["name"] = pgettext("Address data", "%(first_name)s %(last_name)s") % address
     address["country_code"] = address["country"]
@@ -191,7 +186,6 @@ def send_email(
     template = compiler.compile(template_str)
     subject_template = compiler.compile(subject)
     helpers = {
-        "blocktrans": block_trans,
         "format_address": format_address,
         "price": price,
     }

--- a/templates/templated_email/compiled/account_delete.html
+++ b/templates/templated_email/compiled/account_delete.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,12 +103,10 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Account delete e-mail text" }}
-            You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.<br>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.<br>
             Click the link below to delete your account.
 
-            Please note that this action is permanent and cannot be reversed.
-          {{/blocktrans}}</div>
+            Please note that this action is permanent and cannot be reversed.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/confirm.html
+++ b/templates/templated_email/compiled/confirm.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Account confirmation e-mail text" }}
-            In order to log into {{ site_name }}, you have to confirm your email address first.
-            Please click the link below to do so and log into your account.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">In order to log into {{ site_name }}, you have to confirm your email address first.
+            Please click the link below to do so and log into your account.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/confirm_fulfillment.html
+++ b/templates/templated_email/compiled/confirm_fulfillment.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -106,26 +104,18 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if order.order_details_url}}
-            {{#blocktrans "Fulfillment confirmation email text with order details"}}
-              Thank you for your order. Below is the list of fulfilled products. To see your order details please visit: <a href="{{ order.order_details_url }}">{{ order.order_details_url }}</a>
-            {{/blocktrans}}
+              Thank you for your order. Below is the list of fulfilled products. To see your order details please visit:
+               <a href="{{ order.order_details_url }}">{{ order.order_details_url }}</a>
           {{else}}
-            {{#blocktrans "Fulfillment confirmation email text"}}
               Thank you for your order. Below is the list of fulfilled products.
-            {{/blocktrans}}
           {{/if}}
-          {{#blocktrans "Fulfillment confirmation email text"}}
             Thank you for your order. Below is the list of fulfilled products.
-          {{/blocktrans}}
           {{#if fulfillment.tracking_number}}
             {{#if fulfillment.is_tracking_number_url}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
-                You can track your shipment with <a href="{{fulfillment.tracking_number}}">{{fulfillment.tracking_number}}</a> link.
-              {{/blocktrans}}
+                You can track your shipment with
+                <a href="{{fulfillment.tracking_number}}">{{fulfillment.tracking_number}}</a> link.
             {{else}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
                 You can track your shipment with {{fulfillment.tracking_number}} code.
-              {{/blocktrans}}
             {{/if}}
           {{/if}}</div>
     
@@ -136,9 +126,7 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if digital_lines}}
-            {{#blocktrans "Fulfillment digital products email text"}}
               You can download your digital products by clicking in download link(s).
-            {{/blocktrans}}
           {{/if}}</div>
     
               </td>
@@ -203,16 +191,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="padding: 5px; text-align: right;" align="right">
-                {{#blocktrans "Quantity ordered of a product"}}
-                  Quantity
-                {{/blocktrans}}
-              </th>
+              <th style="padding: 5px; text-align: left;" align="left">Item</th>
+              <th style="padding: 5px; text-align: right;" align="right">Quantity</th>
             </tr>
           </thead>
           <tbody>
@@ -233,16 +213,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="padding: 5px; text-align: right;" align="right">
-                {{#blocktrans "Ordered item download links"}}
-                  Download Link
-                {{/blocktrans}}
-              </th>
+              <th style="padding: 5px; text-align: left;" align="left">Item</th>
+              <th style="padding: 5px; text-align: right;" align="right">Download Link</th>
             </tr>
           </thead>
           <tbody>
@@ -320,9 +292,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -382,9 +352,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/confirm_order.html
+++ b/templates/templated_email/compiled/confirm_order.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -106,13 +104,10 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if order.order_details_url}}
-            {{#blocktrans "Order confirmation e-mail text with payment details"}}
-              Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-            {{/blocktrans}}
+              Thank you for your order. Below is the list of ordered products. To see your payment details please
+              visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
           {{else}}
-            {{#blocktrans "Order confirmation e-mail text"}}
               Thank you for your order. Below is the list of ordered products.
-            {{/blocktrans}}
           {{/if}}</div>
     
               </td>
@@ -176,20 +171,14 @@
       <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
         <tfoot>
         <tr>
-          <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
-              Subtotal
-            {{/blocktrans}}
-          </td>
+          <td colspan="3" style="padding: 5px; text-align: right;" align="right">Subtotal</td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.subtotal_net_amount order.subtotal_gross_amount order.currency display_gross=order.display_gross_prices}}
           </td>
         </tr>
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
               Shipping
-            {{/blocktrans}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.shipping_price_net_amount order.shipping_price_gross_amount order.currency display_gross=order.display_gross_prices}}
@@ -198,13 +187,9 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             {{#if order.display_gross_prices}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes (included)
-              {{/blocktrans}}
             {{else}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes
-              {{/blocktrans}}
             {{/if}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -215,9 +200,7 @@
           <tr>
             <td colspan="3" style="padding: 5px; text-align: right;" align="right">
               {{order.discount_amount}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Discount
-              {{/blocktrans}}
             </td>
             <td style="padding: 5px; text-align: right;" align="right">
               {{price order.discount_amount order.discount_amount order.currency display_gross=order.display_gross_prices}}
@@ -227,7 +210,7 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             <strong>
-              {{#blocktrans "E-mail order lines summary table"}}Total{{/blocktrans}}
+              Total
             </strong>
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -239,10 +222,10 @@
       </tfoot>
       <thead class="table-header-row" style="border-bottom: 2px solid #000;">
         <tr>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item name"}}Item{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Quantity ordered of a product"}}Quantity{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Unit price of a product"}}Per unit{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item subtotal (unit price * quantity)"}}Subtotal{{/blocktrans}}</th>
+          <th style="padding: 5px;">Item</th>
+          <th style="padding: 5px;">Quantity</th>
+          <th style="padding: 5px;">Per unit</th>
+          <th style="padding: 5px;">Subtotal</th>
         </tr>
       </thead>
       <tbody>
@@ -327,14 +310,10 @@
         <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
               <th style="padding: 5px;">
-                {{#blocktrans "Order confirmation e-mail billing address"}}
                   Billing address
-                {{/blocktrans}}
               </th>
               <th style="padding: 5px;">
-                {{#blocktrans "Order confirmation e-mail shipping address"}}
                   Shipping address
-                {{/blocktrans}}
               </th>
             </tr>
           </thead>
@@ -344,14 +323,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No billing address{{/blocktrans}}
+                 No billing address
                 {{/if}}
               </td>
               <td css-class="address" style="padding: 5px;">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>
@@ -416,9 +395,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -478,9 +455,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/confirm_payment.html
+++ b/templates/templated_email/compiled/confirm_payment.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Payment confirmation e-mail text"}}
-            Thank you for your payment.
-            Your payment was successfully processed.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Thank you for your payment.
+            Your payment was successfully processed.</div>
     
               </td>
             </tr>
@@ -168,9 +164,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -230,9 +224,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/confirmed_order.html
+++ b/templates/templated_email/compiled/confirmed_order.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -106,13 +104,10 @@
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if order.order_details_url}}
-            {{#blocktrans "Order confirmed e-mail text with order details"}}
-              Your order has been confirmed by staff. To see your order details please visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-            {{/blocktrans}}
+              Your order has been confirmed by staff. To see your order details please visit:
+               <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
           {{else}}
-            {{#blocktrans "Order confirmed e-mail text"}}
               Your order has been confirmed by staff. Below is the list of ordered products.
-            {{/blocktrans}}
           {{/if}}</div>
     
               </td>
@@ -176,20 +171,14 @@
       <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
         <tfoot>
         <tr>
-          <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
-              Subtotal
-            {{/blocktrans}}
-          </td>
+          <td colspan="3" style="padding: 5px; text-align: right;" align="right">Subtotal</td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.subtotal_net_amount order.subtotal_gross_amount order.currency display_gross=order.display_gross_prices}}
           </td>
         </tr>
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
               Shipping
-            {{/blocktrans}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.shipping_price_net_amount order.shipping_price_gross_amount order.currency display_gross=order.display_gross_prices}}
@@ -198,13 +187,9 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             {{#if order.display_gross_prices}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes (included)
-              {{/blocktrans}}
             {{else}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes
-              {{/blocktrans}}
             {{/if}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -215,9 +200,7 @@
           <tr>
             <td colspan="3" style="padding: 5px; text-align: right;" align="right">
               {{order.discount_amount}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Discount
-              {{/blocktrans}}
             </td>
             <td style="padding: 5px; text-align: right;" align="right">
               {{price order.discount_amount order.discount_amount order.currency display_gross=order.display_gross_prices}}
@@ -227,7 +210,7 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             <strong>
-              {{#blocktrans "E-mail order lines summary table"}}Total{{/blocktrans}}
+              Total
             </strong>
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -239,10 +222,10 @@
       </tfoot>
       <thead class="table-header-row" style="border-bottom: 2px solid #000;">
         <tr>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item name"}}Item{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Quantity ordered of a product"}}Quantity{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Unit price of a product"}}Per unit{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item subtotal (unit price * quantity)"}}Subtotal{{/blocktrans}}</th>
+          <th style="padding: 5px;">Item</th>
+          <th style="padding: 5px;">Quantity</th>
+          <th style="padding: 5px;">Per unit</th>
+          <th style="padding: 5px;">Subtotal</th>
         </tr>
       </thead>
       <tbody>
@@ -327,14 +310,10 @@
         <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
               <th style="padding: 5px;">
-                {{#blocktrans "Order confirmation e-mail billing address"}}
                   Billing address
-                {{/blocktrans}}
               </th>
               <th style="padding: 5px;">
-                {{#blocktrans "Order confirmation e-mail shipping address"}}
                   Shipping address
-                {{/blocktrans}}
               </th>
             </tr>
           </thead>
@@ -344,14 +323,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmed e-mail text"}}No billing address{{/blocktrans}}
+                  No billing address
                 {{/if}}
               </td>
               <td css-class="address" style="padding: 5px;">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmed e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>
@@ -416,9 +395,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -478,9 +455,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/email_changed_notification.html
+++ b/templates/templated_email/compiled/email_changed_notification.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Email change e-mail text"}}
-          You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.<br>
-          If you didn't request this change, please contact the administrator.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.<br>
+          If you didn't request this change, please contact the administrator.</div>
     
               </td>
             </tr>
@@ -168,9 +164,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -230,9 +224,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/export_failed.html
+++ b/templates/templated_email/compiled/export_failed.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Export products e-mail text"}}
-            Sorry, we couldn't finish exporting products, some unexpected errors occurred.
-            Please try again.
-        {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Sorry, we couldn't finish exporting products, some unexpected errors occurred.
+            Please try again.</div>
     
               </td>
             </tr>
@@ -168,9 +164,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -230,9 +224,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/export_products_file.html
+++ b/templates/templated_email/compiled/export_products_file.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,9 +103,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Export products e-mail text"}}
-            Your file with products data is ready to download: <a href="{{csv_link}}">{{csv_link}}</a>
-        {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Your file with products data is ready to download: <a href="{{csv_link}}">{{csv_link}}</a></div>
     
               </td>
             </tr>
@@ -167,9 +163,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -229,9 +223,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/order_cancel.html
+++ b/templates/templated_email/compiled/order_cancel.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,9 +103,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Order cancel e-mail text"}}
-            Your order #{{order.id}} has been canceled.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Your order #{{order.id}} has been canceled.</div>
     
               </td>
             </tr>
@@ -167,9 +163,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -229,9 +223,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/order_refund.html
+++ b/templates/templated_email/compiled/order_refund.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,9 +103,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Order refund e-mail text"}}
-            A payment of {{amount}} {{currency}} has been refunded for your order.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">A payment of {{amount}} {{currency}} has been refunded for your order.</div>
     
               </td>
             </tr>
@@ -167,9 +163,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -229,9 +223,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/password_reset.html
+++ b/templates/templated_email/compiled/password_reset.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Password reset e-mail text"}}
-            You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_name}}.<br>
-            It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_name}}.<br>
+            It can be safely ignored if you did not request a password reset. Click the link below to reset your password.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/request_email_change.html
+++ b/templates/templated_email/compiled/request_email_change.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Email change e-mail text"}}
-          You're receiving this e-mail because you or someone else has requested an email change for your user account at {{site_name}}.<br>
-          It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you or someone else has requested an email change for your user account at {{site_name}}.<br>
+          It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/send_invoice.html
+++ b/templates/templated_email/compiled/send_invoice.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,9 +103,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Send invoice e-mail text"}}
-            In order to download invoice {{number}}, click the link below.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">In order to download invoice {{number}}, click the link below.</div>
     
               </td>
             </tr>
@@ -177,9 +173,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -239,9 +233,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/set_customer_password.html
+++ b/templates/templated_email/compiled/set_customer_password.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Set password for customer e-mail text"}}
-            You're receiving this e-mail because you have to set password for your customer account at {{site_name}}.<br>
-            Click the link below to set up your password.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you have to set password for your customer account at {{site_name}}.<br>
+            Click the link below to set up your password.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/set_password.html
+++ b/templates/templated_email/compiled/set_password.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Set password for staff member e-mail text"}}
-            You're receiving this e-mail because you have to set password for your staff member account at {{site_name}}.<br>
-            Click the link below to set up your password.
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you have to set password for your staff member account at {{site_name}}.<br>
+            Click the link below to set up your password.</div>
     
               </td>
             </tr>
@@ -178,9 +174,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -240,9 +234,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/staff_confirm_order.html
+++ b/templates/templated_email/compiled/staff_confirm_order.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,10 +103,8 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Order confirmation staff e-mail text"}}
-            Someone placed a new order in your store. To see order details please visit:
-            <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Someone placed a new order in your store. To see order details please visit:
+            <a href="{{order.order_details_url}}">{{order.order_details_url}}</a></div>
     
               </td>
             </tr>
@@ -171,20 +167,14 @@
       <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
         <tfoot>
         <tr>
-          <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
-              Subtotal
-            {{/blocktrans}}
-          </td>
+          <td colspan="3" style="padding: 5px; text-align: right;" align="right">Subtotal</td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.subtotal_net_amount order.subtotal_gross_amount order.currency display_gross=order.display_gross_prices}}
           </td>
         </tr>
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
-            {{#blocktrans "E-mail order lines summary table"}}
               Shipping
-            {{/blocktrans}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
             {{price order.shipping_price_net_amount order.shipping_price_gross_amount order.currency display_gross=order.display_gross_prices}}
@@ -193,13 +183,9 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             {{#if order.display_gross_prices}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes (included)
-              {{/blocktrans}}
             {{else}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes
-              {{/blocktrans}}
             {{/if}}
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -210,9 +196,7 @@
           <tr>
             <td colspan="3" style="padding: 5px; text-align: right;" align="right">
               {{order.discount_amount}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Discount
-              {{/blocktrans}}
             </td>
             <td style="padding: 5px; text-align: right;" align="right">
               {{price order.discount_amount order.discount_amount order.currency display_gross=order.display_gross_prices}}
@@ -222,7 +206,7 @@
         <tr>
           <td colspan="3" style="padding: 5px; text-align: right;" align="right">
             <strong>
-              {{#blocktrans "E-mail order lines summary table"}}Total{{/blocktrans}}
+              Total
             </strong>
           </td>
           <td style="padding: 5px; text-align: right;" align="right">
@@ -234,10 +218,10 @@
       </tfoot>
       <thead class="table-header-row" style="border-bottom: 2px solid #000;">
         <tr>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item name"}}Item{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Quantity ordered of a product"}}Quantity{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Unit price of a product"}}Per unit{{/blocktrans}}</th>
-          <th style="padding: 5px;">{{#blocktrans "Ordered item subtotal (unit price * quantity)"}}Subtotal{{/blocktrans}}</th>
+          <th style="padding: 5px;">Item</th>
+          <th style="padding: 5px;">Quantity</th>
+          <th style="padding: 5px;">Per unit</th>
+          <th style="padding: 5px;">Subtotal</th>
         </tr>
       </thead>
       <tbody>
@@ -321,8 +305,8 @@
       <table cellpadding="0" cellspacing="0" width="100%" border="0" style="color:#000000;font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:22px;table-layout:auto;width:100%;border:none;">
         <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px;">{{#blocktrans "Order confirmation e-mail billing address"}}Billing address{{/blocktrans}}</th>
-              <th style="padding: 5px;">{{#blocktrans "Order confirmation e-mail shipping address"}}Shipping address{{/blocktrans}}</th>
+              <th style="padding: 5px;">Billing address</th>
+              <th style="padding: 5px;">Shipping address</th>
             </tr>
           </thead>
           <tbody>
@@ -331,14 +315,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No billing address{{/blocktrans}}
+                  No billing address
                 {{/if}}
               </td>
               <td css-class="address" style="padding: 5px;">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>
@@ -403,9 +387,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -465,9 +447,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/compiled/update_fulfillment.html
+++ b/templates/templated_email/compiled/update_fulfillment.html
@@ -95,9 +95,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Standard e-mail greeting"}}
-            Hi!
-          {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
     
               </td>
             </tr>
@@ -105,18 +103,14 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Fulfillment update email text"}}
-            Your shipping status has been updated. Below is the list of ordered products that have been updated with new tracking number.
-          {{/blocktrans}}
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Your shipping status has been updated. Below is the list of ordered products that have been updated with
+            new tracking number.
           {{#if fulfillment.tracking_number}}
             {{#if fulfillment.is_tracking_number_url}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
-                You can track your shipment with <a href="{{ fulfillment.tracking_number }}">{{ fulfillment.tracking_number }}</a> link.
-              {{/blocktrans}}
+                You can track your shipment with
+                <a href="{{ fulfillment.tracking_number }}">{{ fulfillment.tracking_number }}</a> link.
             {{else}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
                 You can track your shipment with {{ fulfillment.tracking_number }} code.
-              {{/blocktrans}}
             {{/if}}
           {{/if}}</div>
     
@@ -182,16 +176,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="padding: 5px; text-align: right;" align="right">
-                {{#blocktrans "Quantity ordered of a product"}}
-                  Quantity
-                {{/blocktrans}}
-              </th>
+              <th style="padding: 5px; text-align: left;" align="left">Item</th>
+              <th style="padding: 5px; text-align: right;" align="right">Quantity</th>
             </tr>
           </thead>
           <tbody>
@@ -212,16 +198,8 @@
         <table style="width:100%">
           <thead class="table-header-row" style="border-bottom: 2px solid #000;">
             <tr>
-              <th style="padding: 5px; text-align: left;" align="left">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="padding: 5px; text-align: right;" align="right">
-                {{#blocktrans "Ordered item download links"}}
-                  Download Link
-                {{/blocktrans}}
-              </th>
+              <th style="padding: 5px; text-align: left;" align="left">Item</th>
+              <th style="padding: 5px; text-align: right;" align="right">Download Link</th>
             </tr>
           </thead>
           <tbody>
@@ -299,9 +277,7 @@
             <tr>
               <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#blocktrans "Base email text" }}
-        This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
     
               </td>
             </tr>
@@ -361,9 +337,7 @@
             <tr>
               <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
                 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">{{#blocktrans "Base email footer" }}
-        Sincerely, {{ site_name }}
-      {{/blocktrans}}</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
     
               </td>
             </tr>

--- a/templates/templated_email/source/account_delete.mjml
+++ b/templates/templated_email/source/account_delete.mjml
@@ -7,17 +7,13 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Account delete e-mail text" }}
             You're receiving this e-mail because you or someone else has requested a deletion of your user account at {{ site_name }}.<br/>
             Click the link below to delete your account.
 
             Please note that this action is permanent and cannot be reversed.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{ delete_url }}">{{ delete_url }}</a>

--- a/templates/templated_email/source/confirm.mjml
+++ b/templates/templated_email/source/confirm.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Account confirmation e-mail text" }}
             In order to log into {{ site_name }}, you have to confirm your email address first.
             Please click the link below to do so and log into your account.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{ confirm_url }}">

--- a/templates/templated_email/source/confirm_fulfillment.mjml
+++ b/templates/templated_email/source/confirm_fulfillment.mjml
@@ -7,40 +7,28 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           {{#if order.order_details_url}}
-            {{#blocktrans "Fulfillment confirmation email text with order details"}}
-              Thank you for your order. Below is the list of fulfilled products. To see your order details please visit: <a href="{{ order.order_details_url }}">{{ order.order_details_url }}</a>
-            {{/blocktrans}}
+              Thank you for your order. Below is the list of fulfilled products. To see your order details please visit:
+               <a href="{{ order.order_details_url }}">{{ order.order_details_url }}</a>
           {{else}}
-            {{#blocktrans "Fulfillment confirmation email text"}}
               Thank you for your order. Below is the list of fulfilled products.
-            {{/blocktrans}}
           {{/if}}
-          {{#blocktrans "Fulfillment confirmation email text"}}
             Thank you for your order. Below is the list of fulfilled products.
-          {{/blocktrans}}
           {{#if fulfillment.tracking_number}}
             {{#if fulfillment.is_tracking_number_url}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
-                You can track your shipment with <a href="{{fulfillment.tracking_number}}">{{fulfillment.tracking_number}}</a> link.
-              {{/blocktrans}}
+                You can track your shipment with
+                <a href="{{fulfillment.tracking_number}}">{{fulfillment.tracking_number}}</a> link.
             {{else}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
                 You can track your shipment with {{fulfillment.tracking_number}} code.
-              {{/blocktrans}}
             {{/if}}
           {{/if}}
         </mj-text>
         <mj-text>
           {{#if digital_lines}}
-            {{#blocktrans "Fulfillment digital products email text"}}
               You can download your digital products by clicking in download link(s).
-            {{/blocktrans}}
           {{/if}}
         </mj-text>
       </mj-column>

--- a/templates/templated_email/source/confirm_order.mjml
+++ b/templates/templated_email/source/confirm_order.mjml
@@ -7,19 +7,14 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           {{#if order.order_details_url}}
-            {{#blocktrans "Order confirmation e-mail text with payment details"}}
-              Thank you for your order. Below is the list of ordered products. To see your payment details please visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-            {{/blocktrans}}
+              Thank you for your order. Below is the list of ordered products. To see your payment details please
+              visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
           {{else}}
-            {{#blocktrans "Order confirmation e-mail text"}}
               Thank you for your order. Below is the list of ordered products.
-            {{/blocktrans}}
           {{/if}}
         </mj-text>
       </mj-column>
@@ -31,14 +26,10 @@
           <thead class="table-header-row">
             <tr>
               <th>
-                {{#blocktrans "Order confirmation e-mail billing address"}}
                   Billing address
-                {{/blocktrans}}
               </th>
               <th>
-                {{#blocktrans "Order confirmation e-mail shipping address"}}
                   Shipping address
-                {{/blocktrans}}
               </th>
             </tr>
           </thead>
@@ -48,14 +39,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No billing address{{/blocktrans}}
+                 No billing address
                 {{/if}}
               </td>
               <td css-class="address">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>

--- a/templates/templated_email/source/confirm_payment.mjml
+++ b/templates/templated_email/source/confirm_payment.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Payment confirmation e-mail text"}}
             Thank you for your payment.
             Your payment was successfully processed.
-          {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/confirmed_order.mjml
+++ b/templates/templated_email/source/confirmed_order.mjml
@@ -7,19 +7,14 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           {{#if order.order_details_url}}
-            {{#blocktrans "Order confirmed e-mail text with order details"}}
-              Your order has been confirmed by staff. To see your order details please visit: <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-            {{/blocktrans}}
+              Your order has been confirmed by staff. To see your order details please visit:
+               <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
           {{else}}
-            {{#blocktrans "Order confirmed e-mail text"}}
               Your order has been confirmed by staff. Below is the list of ordered products.
-            {{/blocktrans}}
           {{/if}}
         </mj-text>
       </mj-column>
@@ -31,14 +26,10 @@
           <thead class="table-header-row">
             <tr>
               <th>
-                {{#blocktrans "Order confirmation e-mail billing address"}}
                   Billing address
-                {{/blocktrans}}
               </th>
               <th>
-                {{#blocktrans "Order confirmation e-mail shipping address"}}
                   Shipping address
-                {{/blocktrans}}
               </th>
             </tr>
           </thead>
@@ -48,14 +39,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmed e-mail text"}}No billing address{{/blocktrans}}
+                  No billing address
                 {{/if}}
               </td>
               <td css-class="address">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmed e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>

--- a/templates/templated_email/source/email_changed_notification.mjml
+++ b/templates/templated_email/source/email_changed_notification.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Email change e-mail text"}}
           You're receiving this e-mail because you or someone else has changed email for your user account at {{ site_name }}.<br />
           If you didn't request this change, please contact the administrator.
-          {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/export_failed.mjml
+++ b/templates/templated_email/source/export_failed.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-        {{#blocktrans "Export products e-mail text"}}
             Sorry, we couldn't finish exporting products, some unexpected errors occurred.
             Please try again.
-        {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/export_products_file.mjml
+++ b/templates/templated_email/source/export_products_file.mjml
@@ -7,14 +7,10 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-        {{#blocktrans "Export products e-mail text"}}
             Your file with products data is ready to download: <a href="{{csv_link}}">{{csv_link}}</a>
-        {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/order_cancel.mjml
+++ b/templates/templated_email/source/order_cancel.mjml
@@ -7,14 +7,10 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Order cancel e-mail text"}}
             Your order #{{order.id}} has been canceled.
-          {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/order_refund.mjml
+++ b/templates/templated_email/source/order_refund.mjml
@@ -7,14 +7,10 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Order refund e-mail text"}}
             A payment of {{amount}} {{currency}} has been refunded for your order.
-          {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>

--- a/templates/templated_email/source/partials/_fulfillment_lines.mjml
+++ b/templates/templated_email/source/partials/_fulfillment_lines.mjml
@@ -5,16 +5,8 @@
         <table style="width:100%">
           <thead class="table-header-row">
             <tr>
-              <th style="text-align: left;">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="text-align: right;">
-                {{#blocktrans "Quantity ordered of a product"}}
-                  Quantity
-                {{/blocktrans}}
-              </th>
+              <th style="text-align: left;">Item</th>
+              <th style="text-align: right;">Quantity</th>
             </tr>
           </thead>
           <tbody>
@@ -35,16 +27,8 @@
         <table style="width:100%">
           <thead class="table-header-row">
             <tr>
-              <th style="text-align: left;">
-                {{#blocktrans "Ordered item name"}}
-                  Item
-                {{/blocktrans}}
-              </th>
-              <th style="text-align: right;">
-                {{#blocktrans "Ordered item download links"}}
-                  Download Link
-                {{/blocktrans}}
-              </th>
+              <th style="text-align: left;">Item</th>
+              <th style="text-align: right;">Download Link</th>
             </tr>
           </thead>
           <tbody>

--- a/templates/templated_email/source/partials/_order_lines.mjml
+++ b/templates/templated_email/source/partials/_order_lines.mjml
@@ -3,20 +3,14 @@
     <mj-table>
       <tfoot>
         <tr>
-          <td colspan="3" style="text-align: right;">
-            {{#blocktrans "E-mail order lines summary table"}}
-              Subtotal
-            {{/blocktrans}}
-          </td>
+          <td colspan="3" style="text-align: right;">Subtotal</td>
           <td style="text-align: right;">
             {{price order.subtotal_net_amount order.subtotal_gross_amount order.currency display_gross=order.display_gross_prices}}
           </td>
         </tr>
         <tr>
           <td colspan="3" style="text-align: right;">
-            {{#blocktrans "E-mail order lines summary table"}}
               Shipping
-            {{/blocktrans}}
           </td>
           <td style="text-align: right;">
             {{price order.shipping_price_net_amount order.shipping_price_gross_amount order.currency display_gross=order.display_gross_prices}}
@@ -25,13 +19,9 @@
         <tr>
           <td colspan="3" style="text-align: right;">
             {{#if order.display_gross_prices}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes (included)
-              {{/blocktrans}}
             {{else}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Taxes
-              {{/blocktrans}}
             {{/if}}
           </td>
           <td style="text-align: right;">
@@ -42,9 +32,7 @@
           <tr>
             <td colspan="3" style="text-align: right;">
               {{order.discount_amount}}
-              {{#blocktrans "E-mail order lines summary table"}}
                 Discount
-              {{/blocktrans}}
             </td>
             <td style="text-align: right;">
               {{price order.discount_amount order.discount_amount order.currency display_gross=order.display_gross_prices}}
@@ -54,7 +42,7 @@
         <tr>
           <td colspan="3" style="text-align: right;">
             <strong>
-              {{#blocktrans "E-mail order lines summary table"}}Total{{/blocktrans}}
+              Total
             </strong>
           </td>
           <td style="text-align: right;">
@@ -66,10 +54,10 @@
       </tfoot>
       <thead class="table-header-row">
         <tr>
-          <th>{{#blocktrans "Ordered item name"}}Item{{/blocktrans}}</th>
-          <th>{{#blocktrans "Quantity ordered of a product"}}Quantity{{/blocktrans}}</th>
-          <th>{{#blocktrans "Unit price of a product"}}Per unit{{/blocktrans}}</th>
-          <th>{{#blocktrans "Ordered item subtotal (unit price * quantity)"}}Subtotal{{/blocktrans}}</th>
+          <th>Item</th>
+          <th>Quantity</th>
+          <th>Per unit</th>
+          <th>Subtotal</th>
         </tr>
       </thead>
       <tbody>

--- a/templates/templated_email/source/password_reset.mjml
+++ b/templates/templated_email/source/password_reset.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Password reset e-mail text"}}
             You're receiving this e-mail because you or someone else has requested a password for your user account at {{site_name}}.<br/>
             It can be safely ignored if you did not request a password reset. Click the link below to reset your password.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{reset_url}}">

--- a/templates/templated_email/source/request_email_change.mjml
+++ b/templates/templated_email/source/request_email_change.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Email change e-mail text"}}
           You're receiving this e-mail because you or someone else has requested an email change for your user account at {{site_name}}.<br />
           It can be safely ignored if you did not request an email change. Click the link below to confirm new email address.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{redirect_url}}">

--- a/templates/templated_email/source/send_invoice.mjml
+++ b/templates/templated_email/source/send_invoice.mjml
@@ -7,14 +7,10 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Send invoice e-mail text"}}
             In order to download invoice {{number}}, click the link below.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{download_url}}">

--- a/templates/templated_email/source/set_customer_password.mjml
+++ b/templates/templated_email/source/set_customer_password.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Set password for customer e-mail text"}}
             You're receiving this e-mail because you have to set password for your customer account at {{site_name}}.<br/>
             Click the link below to set up your password.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{password_set_url}}">

--- a/templates/templated_email/source/set_password.mjml
+++ b/templates/templated_email/source/set_password.mjml
@@ -6,15 +6,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Set password for staff member e-mail text"}}
             You're receiving this e-mail because you have to set password for your staff member account at {{site_name}}.<br/>
             Click the link below to set up your password.
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
           <a href="{{ password_set_url}}">

--- a/templates/templated_email/source/shared/footer.mjml
+++ b/templates/templated_email/source/shared/footer.mjml
@@ -1,18 +1,14 @@
 <mj-section>
   <mj-column>
     <mj-text>
-      {{#blocktrans "Base email text" }}
         This is an automatically generated e-mail, please do not reply.
-      {{/blocktrans}}
     </mj-text>
   </mj-column>
 </mj-section>
 <mj-section background-color="#F2F2F2">
   <mj-column>
     <mj-text align="center">
-      {{#blocktrans "Base email footer" }}
         Sincerely, {{ site_name }}
-      {{/blocktrans}}
     </mj-text>
   </mj-column>
 </mj-section>

--- a/templates/templated_email/source/staff_confirm_order.mjml
+++ b/templates/templated_email/source/staff_confirm_order.mjml
@@ -7,15 +7,11 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Order confirmation staff e-mail text"}}
             Someone placed a new order in your store. To see order details please visit:
             <a href="{{order.order_details_url}}">{{order.order_details_url}}</a>
-          {{/blocktrans}}
         </mj-text>
       </mj-column>
     </mj-section>
@@ -25,8 +21,8 @@
         <mj-table>
           <thead class="table-header-row">
             <tr>
-              <th>{{#blocktrans "Order confirmation e-mail billing address"}}Billing address{{/blocktrans}}</th>
-              <th>{{#blocktrans "Order confirmation e-mail shipping address"}}Shipping address{{/blocktrans}}</th>
+              <th>Billing address</th>
+              <th>Shipping address</th>
             </tr>
           </thead>
           <tbody>
@@ -35,14 +31,14 @@
                 {{#if order.billing_address}}
                   {{format_address order.billing_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No billing address{{/blocktrans}}
+                  No billing address
                 {{/if}}
               </td>
               <td css-class="address">
                 {{#if order.shipping_address}}
                   {{format_address order.shipping_address}}
                 {{else}}
-                  {{#blocktrans "Order confirmation e-mail text"}}No shipping required{{/blocktrans}}
+                  No shipping required
                 {{/if}}
               </td>
             </tr>

--- a/templates/templated_email/source/update_fulfillment.mjml
+++ b/templates/templated_email/source/update_fulfillment.mjml
@@ -7,23 +7,17 @@
     <mj-section>
       <mj-column>
         <mj-text font-size="16px">
-          {{#blocktrans "Standard e-mail greeting"}}
             Hi!
-          {{/blocktrans}}
         </mj-text>
         <mj-text>
-          {{#blocktrans "Fulfillment update email text"}}
-            Your shipping status has been updated. Below is the list of ordered products that have been updated with new tracking number.
-          {{/blocktrans}}
+            Your shipping status has been updated. Below is the list of ordered products that have been updated with
+            new tracking number.
           {{#if fulfillment.tracking_number}}
             {{#if fulfillment.is_tracking_number_url}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
-                You can track your shipment with <a href="{{ fulfillment.tracking_number }}">{{ fulfillment.tracking_number }}</a> link.
-              {{/blocktrans}}
+                You can track your shipment with
+                <a href="{{ fulfillment.tracking_number }}">{{ fulfillment.tracking_number }}</a> link.
             {{else}}
-              {{#blocktrans "Fulfillment confirmation email text"}}
                 You can track your shipment with {{ fulfillment.tracking_number }} code.
-              {{/blocktrans}}
             {{/if}}
           {{/if}}
         </mj-text>


### PR DESCRIPTION
Drop dummy `blocktrans` translation method, as we plan to add language_code to the email payloads.