### PR TITLE
Update variant name generator

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -11,7 +11,7 @@ from ....product import models
 from ....product.error_codes import ProductErrorCode
 from ....product.tasks import update_product_discounted_price_task
 from ....product.utils import delete_categories
-from ....product.utils.variants import generate_name_for_variant
+from ....product.utils.variants import generate_and_set_variant_name
 from ....warehouse import models as warehouse_models
 from ....warehouse.error_codes import StockErrorCode
 from ...channel import ChannelContext
@@ -302,11 +302,7 @@ class ProductVariantBulkCreate(BaseMutation):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
-            name = generate_name_for_variant(instance)
-            if not name:
-                name = cleaned_input.get("sku")
-            instance.name = name
-            instance.save(update_fields=["name"])
+            generate_and_set_variant_name(instance, cleaned_input.get("sku"))
 
     @classmethod
     def create_variants(cls, info, cleaned_inputs, product, errors):

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -302,7 +302,10 @@ class ProductVariantBulkCreate(BaseMutation):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
-            instance.name = generate_name_for_variant(instance)
+            name = generate_name_for_variant(instance)
+            if not name:
+                name = cleaned_input.get("sku")
+            instance.name = name
             instance.save(update_fields=["name"])
 
     @classmethod

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -25,7 +25,7 @@ from ....product.thumbnails import (
     create_product_thumbnails,
 )
 from ....product.utils import delete_categories, get_products_ids_without_variants
-from ....product.utils.variants import generate_name_for_variant
+from ....product.utils.variants import generate_and_set_variant_name
 from ...attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ...channel import ChannelContext
 from ...core.inputs import ReorderInput
@@ -879,11 +879,7 @@ class ProductVariantCreate(ModelMutation):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
-            name = generate_name_for_variant(instance)
-            if not name:
-                name = cleaned_input.get("sku")
-            instance.name = name
-            instance.save(update_fields=["name"])
+            generate_and_set_variant_name(instance, cleaned_input.get("sku"))
         info.context.plugins.product_updated(instance.product)
 
     @classmethod

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -879,7 +879,10 @@ class ProductVariantCreate(ModelMutation):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
-            instance.name = generate_name_for_variant(instance)
+            name = generate_name_for_variant(instance)
+            if not name:
+                name = cleaned_input.get("sku")
+            instance.name = name
             instance.save(update_fields=["name"])
         info.context.plugins.product_updated(instance.product)
 

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -395,7 +395,7 @@ def test_create_variant_with_file_attribute(
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     assert not content["productErrors"]
     data = content["productVariant"]
-    assert data["name"] == existing_value.name
+    assert data["name"] == sku
     assert data["sku"] == sku
     assert data["attributes"][0]["attribute"]["slug"] == file_attribute.slug
     assert data["attributes"][0]["values"][0]["slug"] == f"{existing_value.slug}-2"
@@ -459,7 +459,7 @@ def test_create_variant_with_file_attribute_new_value(
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     assert not content["productErrors"]
     data = content["productVariant"]
-    assert data["name"] == new_value
+    assert data["name"] == sku
     assert data["sku"] == sku
     assert data["attributes"][0]["attribute"]["slug"] == file_attribute.slug
     assert data["attributes"][0]["values"][0]["slug"] == slugify(new_value)

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -7,6 +7,7 @@ from django.utils.text import slugify
 from measurement.measures import Weight
 from prices import Money, TaxedMoney
 
+from ....attribute import AttributeInputType
 from ....attribute.utils import associate_attribute_values_to_instance
 from ....core.weight import WeightUnits
 from ....order import OrderStatus
@@ -1702,6 +1703,7 @@ PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
             }
             productVariants{
                 id
+                name
                 sku
                 stocks {
                     warehouse {
@@ -1756,6 +1758,50 @@ def test_product_variant_bulk_create_by_attribute_id(
     data = content["data"]["productVariantBulkCreate"]
     assert not data["bulkProductErrors"]
     assert data["count"] == 1
+    assert data["productVariants"][0]["name"] == attribute_value.name
+    assert product_variant_count + 1 == ProductVariant.objects.count()
+    assert attribute_value_count == size_attribute.values.count()
+    product_variant = ProductVariant.objects.get(sku=sku)
+    product.refresh_from_db()
+    assert product.default_variant == product_variant
+
+
+def test_product_variant_bulk_create_only_not_variant_selection_attributes(
+    staff_api_client, product, size_attribute, permission_manage_products
+):
+    """Ensure that sku is set as variant name when only variant selection attributes
+    are assigned.
+    """
+    product_variant_count = ProductVariant.objects.count()
+    attribute_value_count = size_attribute.values.count()
+
+    size_attribute.input_type = AttributeInputType.MULTISELECT
+    size_attribute.save(update_fields=["input_type"])
+
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribut_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
+
+    attribute_value = size_attribute.values.last()
+    sku = str(uuid4())[:12]
+    variants = [
+        {
+            "sku": sku,
+            "weight": 2.5,
+            "trackInventory": True,
+            "attributes": [{"id": attribut_id, "values": [attribute_value.name]}],
+        }
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+    assert not data["bulkProductErrors"]
+    assert data["count"] == 1
+    assert data["productVariants"][0]["name"] == sku
     assert product_variant_count + 1 == ProductVariant.objects.count()
     assert attribute_value_count == size_attribute.values.count()
     product_variant = ProductVariant.objects.get(sku=sku)

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -31,7 +31,10 @@ def _update_variants_names(instance: ProductType, saved_attributes: Iterable):
         "attributes__values__translations"
     ).all()
     for variant in variants_to_be_updated:
-        variant.name = generate_name_for_variant(variant)
+        name = generate_name_for_variant(variant)
+        if not name:
+            name = variant.sku
+        variant.name = name
         variant.save(update_fields=["name"])
 
 

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -10,7 +10,7 @@ from .utils.variant_prices import (
     update_products_discounted_prices_of_catalogues,
     update_products_discounted_prices_of_discount,
 )
-from .utils.variants import generate_name_for_variant
+from .utils.variants import generate_and_set_variant_name
 
 
 def _update_variants_names(instance: ProductType, saved_attributes: Iterable):
@@ -31,11 +31,7 @@ def _update_variants_names(instance: ProductType, saved_attributes: Iterable):
         "attributes__values__translations"
     ).all()
     for variant in variants_to_be_updated:
-        name = generate_name_for_variant(variant)
-        if not name:
-            name = variant.sku
-        variant.name = name
-        variant.save(update_fields=["name"])
+        generate_and_set_variant_name(variant, variant.sku)
 
 
 @app.task

--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -9,7 +9,7 @@ from ...attribute.utils import associate_attribute_values_to_instance
 from ...product.models import ProductVariantChannelListing
 from ..models import Product, ProductType, ProductVariant
 from ..tasks import _update_variants_names
-from ..utils.variants import generate_name_for_variant
+from ..utils.variants import generate_and_set_variant_name
 
 
 @pytest.fixture()
@@ -32,7 +32,7 @@ def variant_with_no_attributes(category, channel_USD):
     return variant
 
 
-def test_generate_name_for_variant_different_attributes(
+def test_generate_and_set_variant_name_different_attributes(
     variant_with_no_attributes, color_attribute_without_values, size_attribute
 ):
     """Test the name generation from a given variant containing multiple attributes and
@@ -68,11 +68,12 @@ def test_generate_name_for_variant_different_attributes(
     associate_attribute_values_to_instance(variant, size_attribute, size)
 
     # Generate the variant name from the attributes
-    name = generate_name_for_variant(variant)
-    assert name == "Big"
+    generate_and_set_variant_name(variant, variant.sku)
+    variant.refresh_from_db()
+    assert variant.name == "Big"
 
 
-def test_generate_name_for_variant_only_variant_selection_attributes(
+def test_generate_and_set_variant_name_only_variant_selection_attributes(
     variant_with_no_attributes, color_attribute_without_values, size_attribute
 ):
     """Test the name generation for a given variant containing multiple attributes
@@ -104,11 +105,12 @@ def test_generate_name_for_variant_only_variant_selection_attributes(
     associate_attribute_values_to_instance(variant, size_attribute, size)
 
     # Generate the variant name from the attributes
-    name = generate_name_for_variant(variant)
-    assert name == "Yellow, Blue, Red / Big"
+    generate_and_set_variant_name(variant, variant.sku)
+    variant.refresh_from_db()
+    assert variant.name == "Yellow, Blue, Red / Big"
 
 
-def test_generate_name_for_variant_only_not_variant_selection_attributes(
+def test_generate_and_set_variant_name_only_not_variant_selection_attributes(
     variant_with_no_attributes, color_attribute_without_values, file_attribute
 ):
     """Test the name generation for a given variant containing multiple attributes
@@ -147,15 +149,18 @@ def test_generate_name_for_variant_only_not_variant_selection_attributes(
     associate_attribute_values_to_instance(variant, file_attribute, values[-1])
 
     # Generate the variant name from the attributes
-    name = generate_name_for_variant(variant)
-    assert name == ""
+    generate_and_set_variant_name(variant, variant.sku)
+    variant.refresh_from_db()
+    assert variant.name == variant.sku
 
 
 def test_generate_name_from_values_empty(variant_with_no_attributes):
     """Ensure generate a variant name from a variant without any attributes assigned
     returns an empty string."""
-    name = generate_name_for_variant(variant_with_no_attributes)
-    assert name == ""
+    variant = variant_with_no_attributes
+    generate_and_set_variant_name(variant, variant.sku)
+    variant.refresh_from_db()
+    assert variant.name == variant.sku
 
 
 def test_product_type_update_changes_variant_name(product):

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -7,7 +7,7 @@ if TYPE_CHECKING:
     from ..models import ProductVariant
 
 
-def generate_name_for_variant(variant: "ProductVariant") -> str:
+def generate_and_set_variant_name(variant: "ProductVariant", sku: str):
     """Generate ProductVariant's name based on its attributes."""
     attributes_display = []
 
@@ -23,7 +23,12 @@ def generate_name_for_variant(variant: "ProductVariant") -> str:
         translated_values = [str(value.translated) for value in values_qs]
         attributes_display.append(", ".join(translated_values))
 
-    return " / ".join(attributes_display)
+    name = " / ".join(attributes_display)
+    if not name:
+        name = sku
+
+    variant.name = name
+    variant.save(update_fields=["name"])
 
 
 def get_variant_selection_attributes(attributes):

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -19,7 +19,7 @@ def generate_and_set_variant_name(variant: "ProductVariant", sku: str):
     for (
         attribute_rel
     ) in variant_selection_attributes.iterator():  # type: AssignedVariantAttribute
-        values_qs = attribute_rel.values.all()  # FIXME: this should be sorted
+        values_qs = attribute_rel.values.order_by()
         translated_values = [str(value.translated) for value in values_qs]
         attributes_display.append(", ".join(translated_values))
 

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -11,7 +11,14 @@ def generate_name_for_variant(variant: "ProductVariant") -> str:
     """Generate ProductVariant's name based on its attributes."""
     attributes_display = []
 
-    for attribute_rel in variant.attributes.all():  # type: AssignedVariantAttribute
+    variant_selection_input_types = AttributeInputType.ALLOWED_IN_VARIANT_SELECTION
+    variant_selection_attributes = variant.attributes.filter(
+        assignment__attribute__input_type__in=variant_selection_input_types,
+        assignment__attribute__type=AttributeType.PRODUCT_TYPE,
+    )
+    for (
+        attribute_rel
+    ) in variant_selection_attributes.iterator():  # type: AssignedVariantAttribute
         values_qs = attribute_rel.values.all()  # FIXME: this should be sorted
         translated_values = [str(value.translated) for value in values_qs]
         attributes_display.append(", ".join(translated_values))


### PR DESCRIPTION
Create a variant name based only on variant selection attribute values. When there are no variant selection attributes, set variant SKU as a variant name.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
