### PR TITLE
Require value only from required and variant selection attributes

### DIFF
--- a/saleor/graphql/attribute/tests/test_utils.py
+++ b/saleor/graphql/attribute/tests/test_utils.py
@@ -666,6 +666,50 @@ def test_validate_attributes_input_no_values_given(
     }
 
 
+def test_validate_not_required_variant_selection_attributes_input_no_values_given(
+    weight_attribute, color_attribute, product_type
+):
+    # given
+    color_attribute.value_required = False
+    color_attribute.input_type = AttributeInputType.MULTISELECT
+    color_attribute.save(update_fields=["value_required", "input_type"])
+
+    weight_attribute.value_required = False
+    weight_attribute.input_type = AttributeInputType.MULTISELECT
+    weight_attribute.save(update_fields=["value_required", "input_type"])
+
+    input_data = [
+        (
+            weight_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", weight_attribute.pk),
+                values=[],
+                file_url=None,
+                content_type=None,
+            ),
+        ),
+        (
+            color_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", color_attribute.pk),
+                values=[],
+                file_url=None,
+                content_type=None,
+            ),
+        ),
+    ]
+
+    attributes = product_type.variant_attributes.all()
+
+    # when
+    errors = validate_attributes_input(
+        input_data, attributes, is_page_attributes=False, variant_validation=True
+    )
+
+    # then
+    assert not errors
+
+
 def test_validate_attributes_input_too_many_values_given(
     weight_attribute, color_attribute, product_type
 ):
@@ -901,6 +945,49 @@ def test_validate_attributes_with_file_input_type_for_product_no_file_given(
     assert set(error.params["attributes"]) == {
         graphene.Node.to_global_id("Attribute", file_attribute.pk)
     }
+
+
+def test_validate_not_required_attrs_with_file_input_type_for_product_no_file_given(
+    weight_attribute, file_attribute, product_type
+):
+    # given
+    file_attribute.value_required = False
+    file_attribute.save(update_fields=["value_required"])
+
+    weight_attribute.value_required = False
+    weight_attribute.save(update_fields=["value_required"])
+
+    input_data = [
+        (
+            weight_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", weight_attribute.pk),
+                values=["a"],
+                file_url=None,
+                content_type=None,
+            ),
+        ),
+        (
+            file_attribute,
+            AttrValuesInput(
+                global_id=graphene.Node.to_global_id("Attribute", file_attribute.pk),
+                values=[],
+                file_url="",
+                content_type="image/jpeg",
+            ),
+        ),
+    ]
+
+    # when
+    errors = validate_attributes_input(
+        input_data,
+        product_type.product_attributes.all(),
+        is_page_attributes=False,
+        variant_validation=False,
+    )
+
+    # then
+    assert not errors
 
 
 def test_validate_attributes_with_file_input_type_for_product_empty_file_value(

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -402,7 +402,9 @@ def validate_file_attributes_input(
     attribute_id = attr_values.global_id
     value = attr_values.file_url
     if not value:
-        if attribute.value_required or variant_validation:
+        if attribute.value_required or (
+            variant_validation and is_variant_selection_attribute(attribute)
+        ):
             attribute_errors[errors_data_structure.ERROR_NO_FILE_GIVEN].append(
                 attribute_id
             )
@@ -421,7 +423,9 @@ def validate_not_file_attributes_input(
 ):
     attribute_id = attr_values.global_id
     if not attr_values.values:
-        if attribute.value_required or variant_validation:
+        if attribute.value_required or (
+            variant_validation and is_variant_selection_attribute(attribute)
+        ):
             attribute_errors[errors_data_structure.ERROR_NO_VALUE_GIVEN].append(
                 attribute_id
             )
@@ -437,6 +441,10 @@ def validate_not_file_attributes_input(
             attribute_errors[errors_data_structure.ERROR_BLANK_VALUE].append(
                 attribute_id
             )
+
+
+def is_variant_selection_attribute(attribute: attribute_models.Attribute):
+    return attribute.input_type in AttributeInputType.ALLOWED_IN_VARIANT_SELECTION
 
 
 def validate_required_attributes(

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -754,11 +754,14 @@ class ProductVariantCreate(ModelMutation):
     ):
         attribute_values = defaultdict(list)
         for attr, attr_data in attributes_data:
-            values = (
-                [slugify(attr_data.file_url.split("/")[-1])]
-                if attr.input_type == AttributeInputType.FILE
-                else attr_data.values
-            )
+            if attr.input_type == AttributeInputType.FILE:
+                values = (
+                    [slugify(attr_data.file_url.split("/")[-1])]
+                    if attr_data.file_url
+                    else []
+                )
+            else:
+                values = attr_data.values
             attribute_values[attr_data.global_id].extend(values)
         if attribute_values in used_attribute_values:
             raise ValidationError(
@@ -923,11 +926,14 @@ class ProductVariantUpdate(ProductVariantCreate):
             assigned_attributes = get_used_attribute_values_for_variant(instance)
             input_attribute_values = defaultdict(list)
             for attr, attr_data in attributes_data:
-                values = (
-                    [slugify(attr_data.file_url.split("/")[-1])]
-                    if attr.input_type == AttributeInputType.FILE
-                    else attr_data.values
-                )
+                if attr.input_type == AttributeInputType.FILE:
+                    values = (
+                        [slugify(attr_data.file_url.split("/")[-1])]
+                        if attr_data.file_url
+                        else []
+                    )
+                else:
+                    values = attr_data.values
                 input_attribute_values[attr_data.global_id].extend(values)
             if input_attribute_values == assigned_attributes:
                 return

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -522,16 +522,21 @@ def test_create_variant_with_file_attribute_no_file_url_given(
     content = get_graphql_content(response)["data"]["productVariantCreate"]
     errors = content["productErrors"]
     data = content["productVariant"]
-    assert not data
-    assert len(errors) == 1
-    assert errors[0]["code"] == ProductErrorCode.REQUIRED.name
-    assert errors[0]["field"] == "attributes"
-    assert errors[0]["attributes"] == [file_attr_id]
+    assert not errors
+    assert data["name"] == sku
+    assert data["sku"] == sku
+    assert data["attributes"][0]["attribute"]["slug"] == file_attribute.slug
+    assert len(data["attributes"][0]["values"]) == 0
+    assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
+    assert data["weight"]["value"] == weight
+    assert len(data["stocks"]) == 1
+    assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
+    assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
 
     file_attribute.refresh_from_db()
     assert file_attribute.values.count() == values_count
 
-    updated_webhook_mock.assert_not_called()
+    updated_webhook_mock.assert_called_once_with(product)
 
 
 def test_create_product_variant_with_negative_weight(


### PR DESCRIPTION
Do not require value when an attribute is not required and is a variant selection attribute.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
