### PR TITLE
Fix failing test for generate_and_set_variant_name

### DIFF
--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -91,14 +91,22 @@ def test_generate_and_set_variant_name_only_variant_selection_attributes(
     # Create values
     colors = AttributeValue.objects.bulk_create(
         [
-            AttributeValue(attribute=color_attribute, name="Yellow", slug="yellow"),
-            AttributeValue(attribute=color_attribute, name="Blue", slug="blue"),
-            AttributeValue(attribute=color_attribute, name="Red", slug="red"),
+            AttributeValue(
+                attribute=color_attribute, name="Yellow", slug="yellow", sort_order=1
+            ),
+            AttributeValue(
+                attribute=color_attribute, name="Blue", slug="blue", sort_order=2
+            ),
+            AttributeValue(
+                attribute=color_attribute, name="Red", slug="red", sort_order=3
+            ),
         ]
     )
 
     # Retrieve the size attribute value "Big"
     size = size_attribute.values.get(slug="big")
+    size.sort_order = 4
+    size.save(update_fields=["sort_order"])
 
     # Associate the colors and size to variant attributes
     associate_attribute_values_to_instance(variant, color_attribute, *tuple(colors))


### PR DESCRIPTION
Add order for AttributeValues in `test_generate_and_set_variant_name_only_variant_selection_attributes` test.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
