### PR TITLE
Add filter through channels in orders query

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4133,7 +4133,7 @@ def test_order_query_with_filter_channels_without_channel(
     assert len(orders) == 5
 
 
-def test_order_query_with_filter_channels_without_many_channel(
+def test_order_query_with_filter_channels_with_many_channel(
     orders_query_with_filter,
     staff_api_client,
     permission_manage_orders,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2940,6 +2940,7 @@ input OrderDraftFilterInput {
   customer: String
   created: DateRangeInput
   search: String
+  channels: [ID]
 }
 
 type OrderError {
@@ -3073,6 +3074,7 @@ input OrderFilterInput {
   customer: String
   created: DateRangeInput
   search: String
+  channels: [ID]
 }
 
 type OrderFulfill {


### PR DESCRIPTION
I want to merge this change because of adding filtering through channels in orders query.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
