### PR TITLE
Fix variant resolver on CheckoutLine and OrderLine 

### DIFF
--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -24,7 +24,6 @@ from ..product.dataloaders import (
     ProductVariantByIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
 )
-from ..product.resolvers import resolve_variant
 from ..shipping.dataloaders import (
     ShippingMethodByIdLoader,
     ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader,
@@ -85,8 +84,12 @@ class CheckoutLine(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_variant(root: models.CheckoutLine, info):
-        dataloader = ChannelByCheckoutLineIDLoader(info.context)
-        return resolve_variant(info, root, dataloader)
+        variant = ProductVariantByIdLoader(info.context).load(root.variant_id)
+        channel = ChannelByCheckoutLineIDLoader(info.context).load(root.id)
+
+        return Promise.all([variant, channel]).then(
+            lambda data: ChannelContext(node=data[0], channel_slug=data[1].slug)
+        )
 
     @staticmethod
     def resolve_total_price(root, info):

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4755,3 +4755,218 @@ def test_draft_orders_query_with_filter_search_by_id(
     response = staff_api_client.post_graphql(draft_orders_query_with_filter, variables)
     content = get_graphql_content(response)
     assert content["data"]["draftOrders"]["totalCount"] == 1
+
+
+QUERY_GET_VARIANTS_FROM_ORDER = """
+{
+  me{
+    orders(first:10){
+      edges{
+        node{
+          lines{
+            variant{
+              id
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_get_variant_from_order_line_variant_published_as_customer(
+    user_api_client, order_line
+):
+    # given
+
+    # when
+    response = user_api_client.post_graphql(QUERY_GET_VARIANTS_FROM_ORDER, {})
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_published_as_admin(
+    staff_api_client, order_line, permission_manage_products
+):
+    # given
+    order = order_line.order
+    order.user = staff_api_client.user
+    order.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GET_VARIANTS_FROM_ORDER,
+        {},
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_not_published_as_customer(
+    user_api_client, order_line
+):
+    # given
+    product = order_line.variant.product
+    product.channel_listings.update(is_published=False)
+
+    # when
+    response = user_api_client.post_graphql(QUERY_GET_VARIANTS_FROM_ORDER, {})
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"] is None
+
+
+def test_get_variant_from_order_line_variant_not_published_as_admin(
+    staff_api_client, order_line, permission_manage_products
+):
+    # given
+    order = order_line.order
+    order.user = staff_api_client.user
+    order.save()
+    product = order_line.variant.product
+    product.channel_listings.update(is_published=False)
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GET_VARIANTS_FROM_ORDER,
+        {},
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_not_assigned_to_channel_as_customer(
+    user_api_client, order_line
+):
+    # given
+    product = order_line.variant.product
+    product.channel_listings.all().delete()
+
+    # when
+    response = user_api_client.post_graphql(QUERY_GET_VARIANTS_FROM_ORDER, {})
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"] is None
+
+
+def test_get_variant_from_order_line_variant_not_assigned_to_channel_as_admin(
+    staff_api_client, order_line, permission_manage_products
+):
+    # given
+    order = order_line.order
+    order.user = staff_api_client.user
+    order.save()
+    product = order_line.variant.product
+    product.channel_listings.all().delete()
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GET_VARIANTS_FROM_ORDER,
+        {},
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_not_visible_in_listings_as_customer(
+    user_api_client, order_line
+):
+    # given
+    product = order_line.variant.product
+    product.channel_listings.update(visible_in_listings=False)
+
+    # when
+    response = user_api_client.post_graphql(QUERY_GET_VARIANTS_FROM_ORDER, {})
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_not_visible_in_listings_as_admin(
+    staff_api_client, order_line, permission_manage_products
+):
+    # given
+    order = order_line.order
+    order.user = staff_api_client.user
+    order.save()
+    product = order_line.variant.product
+    product.channel_listings.update(visible_in_listings=False)
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GET_VARIANTS_FROM_ORDER,
+        {},
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"]["id"]
+
+
+def test_get_variant_from_order_line_variant_not_exists_as_customer(
+    user_api_client, order_line
+):
+    # given
+    order_line.variant = None
+    order_line.save()
+
+    # when
+    response = user_api_client.post_graphql(QUERY_GET_VARIANTS_FROM_ORDER, {})
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"] is None
+
+
+def test_get_variant_from_order_line_variant_not_exists_as_staff(
+    staff_api_client, order_line, permission_manage_products
+):
+    # given
+    order = order_line.order
+    order.user = staff_api_client.user
+    order.save()
+    order_line.variant = None
+    order_line.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GET_VARIANTS_FROM_ORDER,
+        {},
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["me"]["orders"]["edges"]
+    assert orders[0]["node"]["lines"][0]["variant"] is None

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -1,22 +1,9 @@
-from typing import Union
-
 from django.db.models import Sum
-from promise import Promise
 
-from ...checkout.models import CheckoutLine
 from ...order import OrderStatus
-from ...order.models import OrderLine
 from ...product import models
-from ..channel import ChannelContext, ChannelQsContext
-from ..channel.dataloaders import (
-    ChannelByCheckoutLineIDLoader,
-    ChannelByOrderLineIdLoader,
-)
-from ..product.dataloaders import (
-    ProductChannelListingByProductIdAndChannelSlugLoader,
-    ProductVariantByIdLoader,
-)
-from ..utils import get_database_id, get_user_or_app_from_context
+from ..channel import ChannelQsContext
+from ..utils import get_database_id
 from ..utils.filters import filter_by_period
 from .filters import filter_products_by_stock_availability
 
@@ -148,41 +135,3 @@ def resolve_report_product_sales(period, channel_slug) -> ChannelQsContext:
     )
     qs = qs.order_by("-quantity_ordered")
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
-
-
-def resolve_variant(
-    info,
-    root: Union[CheckoutLine, OrderLine],
-    channel_dataloader: Union[
-        ChannelByCheckoutLineIDLoader, ChannelByOrderLineIdLoader
-    ],
-):
-    context = info.context
-    if not root.variant_id:
-        return None
-
-    def requestor_has_access_to_variant(data):
-        variant, channel = data
-
-        def product_is_available(product_channel_listing):
-            if not product_channel_listing:
-                return None
-            requester = get_user_or_app_from_context(context)
-            visible_in_listings = product_channel_listing.visible_in_listings
-            requestor_has_access_to_all = models.Product.objects.user_has_access_to_all(
-                requester
-            )
-            if visible_in_listings or requestor_has_access_to_all:
-                return ChannelContext(node=variant, channel_slug=channel.slug)
-            return None
-
-        return (
-            ProductChannelListingByProductIdAndChannelSlugLoader(context)
-            .load((variant.product_id, channel.slug))
-            .then(product_is_available)
-        )
-
-    variant = ProductVariantByIdLoader(context).load(root.variant_id)
-    channel = channel_dataloader.load(root.id)
-
-    return Promise.all([variant, channel]).then(requestor_has_access_to_variant)


### PR DESCRIPTION
Previously variant resolver on CheckoutLine without product channel listings or with `visible_on_listings=False` returned null on the required field. 

Assumptions:
* When the user adds a variant to checkout, this variant should be always visible in CheckoutLine.
* When the user wants to get a variant from OrderLine it should be returned in all case except:
** product is not published in this channel (only for ppl without manage_product permission)
** product is not assigned to this channel (only for ppl without manage_product permission)
** variant, not exits



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
