### PR TITLE
docs: fix simple typo, serveral -> several

### DIFF
--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -37,7 +37,7 @@ def zero_weight():
 
 def convert_weight(weight: Weight, unit: str) -> Weight:
     """Covert weight to given unit and round it to 3 digits after decimal point."""
-    # Weight amount from the Weight instance can be retrived in serveral units
+    # Weight amount from the Weight instance can be retrived in several units
     # via its properties. eg. Weight(lb=10).kg
     converted_weight = getattr(weight, unit)
     weight = Weight(**{unit: converted_weight})


### PR DESCRIPTION
There is a small typo in saleor/core/weight.py.

Should read `several` rather than `serveral`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md