### PR TITLE
Use total_price instead of get_total (removed)

### DIFF
--- a/templates/invoices/invoice_products_table.html
+++ b/templates/invoices/invoice_products_table.html
@@ -32,7 +32,7 @@
                 <span class="normal-text-table cell-quantity-content">{{ product.quantity }}</span>
             </td>
             <td class="cell-total-price">
-                <span class="normal-text-table">{% price product.get_total.gross %}</span>
+                <span class="normal-text-table">{% price product.total_price.gross %}</span>
             </td>
         </tr>
         {% endfor %}


### PR DESCRIPTION
@IKarbowiak @fowczarek @patrys  With the PR [6640](https://github.com/mirumee/saleor/pull/6640), the generation of invoices stopped working. This is related to the removed `get_total` method, which is used in the template: `templates/invoices/invoice_products_table.html`. Works fine after changing to `total_price`. Details below:

The code:
`            <td class="cell-total-price">
                <span class="normal-text-table">{% price product.get_total.gross %}</span>
            </td>`

The error message: 
`AttributeError: 'str' object has no attribute 'amount'`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
