### PR TITLE
Fix reordering products duplicates

### DIFF
--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -13,7 +13,7 @@ from django.db.models import (
     Subquery,
 )
 from django.db.models.expressions import Window
-from django.db.models.functions import Coalesce, RowNumber
+from django.db.models.functions import Coalesce, DenseRank
 
 from ...product.models import (
     Category,
@@ -131,7 +131,7 @@ class ProductOrderField(graphene.Enum):
     TYPE = ["product_type__name", "name", "slug"]
     PUBLISHED = ["is_published", "name", "slug"]
     PUBLICATION_DATE = ["publication_date", "name", "slug"]
-    COLLECTION = ["row_number"]
+    COLLECTION = ["sort_order"]
     RATING = ["rating", "name", "slug"]
 
     @property
@@ -204,8 +204,8 @@ class ProductOrderField(graphene.Enum):
     @staticmethod
     def qs_with_collection(queryset: QuerySet, **_kwargs) -> QuerySet:
         return queryset.annotate(
-            row_number=Window(
-                expression=RowNumber(),
+            sort_order=Window(
+                expression=DenseRank(),
                 order_by=(
                     F("collectionproduct__sort_order").asc(nulls_last=True),
                     F("collectionproduct__id"),

--- a/saleor/graphql/product/tests/test_product_sorting.py
+++ b/saleor/graphql/product/tests/test_product_sorting.py
@@ -115,7 +115,10 @@ def test_sort_products_within_collection(
 
     variables = {
         "collectionId": collection_id,
-        "moves": [{"productId": product, "sortOrder": 1}],
+        "moves": [
+            {"productId": product, "sortOrder": 1},
+            {"productId": second_product, "sortOrder": -1},
+        ],
     }
     content = get_graphql_content(
         staff_api_client.post_graphql(COLLECTION_RESORT_QUERY, variables)
@@ -123,8 +126,8 @@ def test_sort_products_within_collection(
 
     products = content["collection"]["products"]["edges"]
     assert products[0]["node"]["id"] == third_product
-    assert products[1]["node"]["id"] == product
-    assert products[2]["node"]["id"] == second_product
+    assert products[1]["node"]["id"] == second_product
+    assert products[2]["node"]["id"] == product
 
 
 GET_SORTED_PRODUCTS_QUERY = """


### PR DESCRIPTION
I want to merge this change because...I want to fix problem with duplicates on reordering products

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
