### PR TITLE
Fix failing test for generating variant name

### DIFF
--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -115,7 +115,7 @@ def test_generate_and_set_variant_name_only_variant_selection_attributes(
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)
     variant.refresh_from_db()
-    assert variant.name == "Yellow, Blue, Red / Big"
+    assert variant.name == "Big / Yellow, Blue, Red"
 
 
 def test_generate_and_set_variant_name_only_not_variant_selection_attributes(

--- a/saleor/product/utils/variants.py
+++ b/saleor/product/utils/variants.py
@@ -19,11 +19,11 @@ def generate_and_set_variant_name(variant: "ProductVariant", sku: str):
     for (
         attribute_rel
     ) in variant_selection_attributes.iterator():  # type: AssignedVariantAttribute
-        values_qs = attribute_rel.values.order_by()
+        values_qs = attribute_rel.values.all()
         translated_values = [str(value.translated) for value in values_qs]
         attributes_display.append(", ".join(translated_values))
 
-    name = " / ".join(attributes_display)
+    name = " / ".join(sorted(attributes_display))
     if not name:
         name = sku
 


### PR DESCRIPTION
Fix failing test for generating variant name

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
