### PR TITLE
Bump Pillow to 8.1.0 #6679

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -86,7 +86,7 @@ openpyxl==3.0.5; python_version >= "3.6"
 opentracing==2.3.0
 petl==1.6.8; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 phonenumberslite==8.12.12
-pillow==7.2.0; python_version >= "3.6"
+pillow==8.1.0; python_version >= "3.6"
 prices==1.1.0
 promise==2.3
 prompt-toolkit==3.0.7; python_full_version >= "3.6.1" and python_version >= "3.6"


### PR DESCRIPTION
Currently Pillow is incompatible with Python 3.9

I want to merge this change because...

#6679

# Impact
* [X]Updated dependencies
* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
