### PR TITLE
Deprecate description field

### DIFF
--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -10,7 +10,7 @@ from ..translations.types import PageTranslation
 
 class Page(CountableDjangoObjectType):
     content = String(
-        description="Content for the page.",
+        description="Content of the page.",
         deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -11,9 +11,7 @@ from ..translations.types import PageTranslation
 class Page(CountableDjangoObjectType):
     content = String(
         description="Content for the page.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
-        ),
+        deprecation_reason="Use the `contentJson` instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -9,7 +9,7 @@ from ..translations.types import PageTranslation
 
 
 class Page(CountableDjangoObjectType):
-    description = String(
+    content = String(
         description="Content for the page.",
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `contentJson` instead."

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -1,4 +1,4 @@
-from graphene import Boolean, relay
+from graphene import Boolean, String, relay
 
 from ...page import models
 from ..core.connection import CountableDjangoObjectType
@@ -9,6 +9,13 @@ from ..translations.types import PageTranslation
 
 
 class Page(CountableDjangoObjectType):
+    description = String(
+        description="Content for the page.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
+        ),
+        required=True,
+    )
     translation = TranslationField(PageTranslation, type_name="page")
     is_published = Boolean(required=True, description="Whether the page is published.")
 
@@ -18,7 +25,6 @@ class Page(CountableDjangoObjectType):
             "dashboard."
         )
         only_fields = [
-            "content",
             "content_json",
             "created",
             "id",

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -11,7 +11,7 @@ from ..translations.types import PageTranslation
 class Page(CountableDjangoObjectType):
     content = String(
         description="Content for the page.",
-        deprecation_reason="Use the `contentJson` instead.",
+        deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -495,7 +495,7 @@ class Product(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the product.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
 
@@ -770,7 +770,7 @@ class Collection(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the collection.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
@@ -847,7 +847,7 @@ class Category(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the category.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
     children = PrefetchingConnectionField(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -493,6 +493,12 @@ class Product(CountableDjangoObjectType):
     is_published = graphene.Boolean(
         required=True, description="Whether the product is published."
     )
+    description = graphene.String(
+        description="Description for the product.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
 
     class Meta:
         description = "Represents an individual item for sale in the storefront."
@@ -502,7 +508,6 @@ class Product(CountableDjangoObjectType):
             "available_for_purchase",
             "category",
             "charge_taxes",
-            "description",
             "description_json",
             "id",
             "name",
@@ -764,6 +769,12 @@ class Collection(CountableDjangoObjectType):
     background_image = graphene.Field(
         Image, size=graphene.Int(description="Size of the image.")
     )
+    description = graphene.String(
+        description="Description for the collection.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     is_published = graphene.Boolean(
         required=True, description="Whether the collection is published."
@@ -772,7 +783,6 @@ class Collection(CountableDjangoObjectType):
     class Meta:
         description = "Represents a collection of products."
         only_fields = [
-            "description",
             "description_json",
             "id",
             "name",
@@ -837,6 +847,12 @@ class Category(CountableDjangoObjectType):
         description="The storefront's URL for the category.",
         deprecation_reason="This field will be removed after 2020-07-31.",
     )
+    description = graphene.String(
+        description="Description for the category.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
     children = PrefetchingConnectionField(
         lambda: Category, description="List of children of the category."
     )
@@ -852,7 +868,6 @@ class Category(CountableDjangoObjectType):
             "storefront."
         )
         only_fields = [
-            "description",
             "description_json",
             "id",
             "level",

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -494,7 +494,7 @@ class Product(CountableDjangoObjectType):
         required=True, description="Whether the product is published."
     )
     description = graphene.String(
-        description="Description for the product.",
+        description="Description of the product.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -769,7 +769,7 @@ class Collection(CountableDjangoObjectType):
         Image, size=graphene.Int(description="Size of the image.")
     )
     description = graphene.String(
-        description="Description for the collection.",
+        description="Description of the collection.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -846,7 +846,7 @@ class Category(CountableDjangoObjectType):
         deprecation_reason="This field will be removed after 2020-07-31.",
     )
     description = graphene.String(
-        description="Description for the category.",
+        description="Description of the category.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -498,6 +498,7 @@ class Product(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
 
     class Meta:
@@ -774,6 +775,7 @@ class Collection(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     is_published = graphene.Boolean(
@@ -852,6 +854,7 @@ class Category(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
     children = PrefetchingConnectionField(
         lambda: Category, description="List of children of the category."

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -495,9 +495,7 @@ class Product(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the product.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
 
@@ -772,9 +770,7 @@ class Collection(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the collection.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
@@ -851,9 +847,7 @@ class Category(CountableDjangoObjectType):
     )
     description = graphene.String(
         description="Description for the category.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
     children = PrefetchingConnectionField(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3257,7 +3257,7 @@ type Page implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   isPublished: Boolean!
 }
@@ -3369,7 +3369,7 @@ type PageTranslation implements Node {
   title: String!
   contentJson: JSONString!
   language: LanguageDisplay!
-  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
 }
 
 input PageTranslationInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -729,7 +729,7 @@ type Category implements Node & ObjectWithMetadata {
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
@@ -808,7 +808,7 @@ type CategoryTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
   category: Category
 }
@@ -826,7 +826,7 @@ type CategoryTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type CategoryUpdate {
@@ -1080,7 +1080,7 @@ type Collection implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   isPublished: Boolean!
 }
@@ -1204,7 +1204,7 @@ type CollectionTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   collection: Collection
 }
@@ -1222,7 +1222,7 @@ type CollectionTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type CollectionUpdate {
@@ -3249,7 +3249,6 @@ type Page implements Node & ObjectWithMetadata {
   seoDescription: String
   id: ID!
   title: String!
-  content: String!
   contentJson: JSONString!
   publicationDate: Date
   slug: String!
@@ -3258,6 +3257,7 @@ type Page implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   isPublished: Boolean!
 }
@@ -3350,8 +3350,8 @@ type PageTranslatableContent implements Node {
   seoDescription: String
   id: ID!
   title: String!
-  content: String!
   contentJson: JSONString!
+  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page
 }
@@ -3367,9 +3367,9 @@ type PageTranslation implements Node {
   seoDescription: String
   id: ID!
   title: String!
-  content: String!
   contentJson: JSONString!
   language: LanguageDisplay!
+  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 input PageTranslationInput {
@@ -3696,7 +3696,7 @@ type Product implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   isAvailableForPurchase: Boolean
   isPublished: Boolean!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type ProductBulkDelete {
@@ -3940,7 +3940,7 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   descriptionJson: JSONString!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product
 }
@@ -3958,7 +3958,7 @@ type ProductTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3369,7 +3369,7 @@ type PageTranslation implements Node {
   title: String!
   contentJson: JSONString!
   language: LanguageDisplay!
-  content: String! @deprecated(reason: "Use the `contentJson` field instead.")
+  content: String! @deprecated(reason: "Translated description of the page.")
 }
 
 input PageTranslationInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -729,7 +729,7 @@ type Category implements Node & ObjectWithMetadata {
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
@@ -808,7 +808,7 @@ type CategoryTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
   category: Category
 }
@@ -826,7 +826,7 @@ type CategoryTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
 }
 
 type CategoryUpdate {
@@ -1080,7 +1080,7 @@ type Collection implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   isPublished: Boolean!
 }
@@ -1204,7 +1204,7 @@ type CollectionTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   collection: Collection
 }
@@ -1222,7 +1222,7 @@ type CollectionTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
 }
 
 type CollectionUpdate {
@@ -3257,7 +3257,7 @@ type Page implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  content: String! @deprecated(reason: "Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   isPublished: Boolean!
 }
@@ -3351,7 +3351,7 @@ type PageTranslatableContent implements Node {
   id: ID!
   title: String!
   contentJson: JSONString!
-  content: String! @deprecated(reason: "Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page
 }
@@ -3369,7 +3369,7 @@ type PageTranslation implements Node {
   title: String!
   contentJson: JSONString!
   language: LanguageDisplay!
-  content: String! @deprecated(reason: "Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` field instead.")
 }
 
 input PageTranslationInput {
@@ -3696,7 +3696,7 @@ type Product implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   isAvailableForPurchase: Boolean
   isPublished: Boolean!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
 }
 
 type ProductBulkDelete {
@@ -3940,7 +3940,7 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product
 }
@@ -3958,7 +3958,7 @@ type ProductTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` field instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3369,7 +3369,7 @@ type PageTranslation implements Node {
   title: String!
   contentJson: JSONString!
   language: LanguageDisplay!
-  content: String! @deprecated(reason: "Translated description of the page.")
+  content: String! @deprecated(reason: "Use the `contentJson` field instead.")
 }
 
 input PageTranslationInput {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3351,7 +3351,7 @@ type PageTranslatableContent implements Node {
   id: ID!
   title: String!
   contentJson: JSONString!
-  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -718,7 +718,6 @@ type Category implements Node & ObjectWithMetadata {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
   slug: String!
   parent: Category
@@ -730,6 +729,7 @@ type Category implements Node & ObjectWithMetadata {
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
@@ -807,8 +807,8 @@ type CategoryTranslatableContent implements Node {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
   category: Category
 }
@@ -824,9 +824,9 @@ type CategoryTranslation implements Node {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type CategoryUpdate {
@@ -1071,7 +1071,6 @@ type Collection implements Node & ObjectWithMetadata {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
   publicationDate: Date
   slug: String!
@@ -1081,6 +1080,7 @@ type Collection implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   isPublished: Boolean!
 }
@@ -1203,8 +1203,8 @@ type CollectionTranslatableContent implements Node {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   collection: Collection
 }
@@ -1220,9 +1220,9 @@ type CollectionTranslation implements Node {
   seoDescription: String
   id: ID!
   name: String!
-  description: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type CollectionUpdate {
@@ -3665,7 +3665,6 @@ type Product implements Node & ObjectWithMetadata {
   seoTitle: String
   seoDescription: String
   name: String!
-  description: String!
   descriptionJson: JSONString!
   publicationDate: Date
   productType: ProductType!
@@ -3697,6 +3696,7 @@ type Product implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   isAvailableForPurchase: Boolean
   isPublished: Boolean!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type ProductBulkDelete {
@@ -3939,8 +3939,8 @@ type ProductTranslatableContent implements Node {
   seoTitle: String
   seoDescription: String
   name: String!
-  description: String!
   descriptionJson: JSONString!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product
 }
@@ -3956,9 +3956,9 @@ type ProductTranslation implements Node {
   seoTitle: String
   seoDescription: String
   name: String!
-  description: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
+  description: String @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -729,7 +729,7 @@ type Category implements Node & ObjectWithMetadata {
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
@@ -808,7 +808,7 @@ type CategoryTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
   category: Category
 }
@@ -826,7 +826,7 @@ type CategoryTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
 }
 
 type CategoryUpdate {
@@ -1080,7 +1080,7 @@ type Collection implements Node & ObjectWithMetadata {
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   isPublished: Boolean!
 }
@@ -1204,7 +1204,7 @@ type CollectionTranslatableContent implements Node {
   id: ID!
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
   collection: Collection
 }
@@ -1222,7 +1222,7 @@ type CollectionTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
 }
 
 type CollectionUpdate {
@@ -3257,7 +3257,7 @@ type Page implements Node & ObjectWithMetadata {
   metadata: [MetadataItem]!
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
-  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   isPublished: Boolean!
 }
@@ -3351,7 +3351,7 @@ type PageTranslatableContent implements Node {
   id: ID!
   title: String!
   contentJson: JSONString!
-  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page
 }
@@ -3369,7 +3369,7 @@ type PageTranslation implements Node {
   title: String!
   contentJson: JSONString!
   language: LanguageDisplay!
-  content: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `contentJson` instead.")
+  content: String! @deprecated(reason: "Use the `contentJson` instead.")
 }
 
 input PageTranslationInput {
@@ -3696,7 +3696,7 @@ type Product implements Node & ObjectWithMetadata {
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   isAvailableForPurchase: Boolean
   isPublished: Boolean!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
 }
 
 type ProductBulkDelete {
@@ -3940,7 +3940,7 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   descriptionJson: JSONString!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product
 }
@@ -3958,7 +3958,7 @@ type ProductTranslation implements Node {
   name: String!
   descriptionJson: JSONString!
   language: LanguageDisplay!
-  description: String! @deprecated(reason: "Will be removed in Saleor 3.0. Use the `descriptionJson` instead.")
+  description: String! @deprecated(reason: "Use the `descriptionJson` instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -134,9 +134,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 class ProductTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the product translation.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
 
@@ -149,9 +147,7 @@ class ProductTranslation(BaseTranslationType):
 class ProductTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the product.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
     translation = TranslationField(ProductTranslation, type_name="product")
@@ -177,9 +173,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 class CollectionTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the collection translation.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
 
@@ -192,9 +186,7 @@ class CollectionTranslation(BaseTranslationType):
 class CollectionTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the collection.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
@@ -220,9 +212,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 class CategoryTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the category translation.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
 
@@ -235,9 +225,7 @@ class CategoryTranslation(BaseTranslationType):
 class CategoryTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the category.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
-        ),
+        deprecation_reason="Use the `descriptionJson` instead.",
         required=True,
     )
     translation = TranslationField(CategoryTranslation, type_name="category")
@@ -259,9 +247,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 class PageTranslation(BaseTranslationType):
     content = graphene.String(
         description="Content for the page.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
-        ),
+        deprecation_reason="Use the `contentJson` instead.",
         required=True,
     )
 
@@ -280,9 +266,7 @@ class PageTranslation(BaseTranslationType):
 class PageTranslatableContent(CountableDjangoObjectType):
     content = graphene.String(
         description="Content for the page.",
-        deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
-        ),
+        deprecation_reason="Use the `contentJson` instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -133,7 +133,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 
 class ProductTranslation(BaseTranslationType):
     description = graphene.String(
-        description="Description for the product translation.",
+        description="Translated description of the product.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -146,7 +146,7 @@ class ProductTranslation(BaseTranslationType):
 
 class ProductTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
-        description="Description for the product.",
+        description="Description of the product.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -172,7 +172,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 
 class CollectionTranslation(BaseTranslationType):
     description = graphene.String(
-        description="Description for the collection translation.",
+        description="Translated description of the collection.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -185,7 +185,7 @@ class CollectionTranslation(BaseTranslationType):
 
 class CollectionTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
-        description="Description for the collection.",
+        description="Description of the collection.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -211,7 +211,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 
 class CategoryTranslation(BaseTranslationType):
     description = graphene.String(
-        description="Description for the category translation.",
+        description="Translated description of the category.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -224,7 +224,7 @@ class CategoryTranslation(BaseTranslationType):
 
 class CategoryTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
-        description="Description for the category.",
+        description="Description of the category.",
         deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
@@ -246,8 +246,8 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 
 class PageTranslation(BaseTranslationType):
     content = graphene.String(
-        description="Content for the page.",
-        deprecation_reason="Use the `contentJson` field instead.",
+        description="Content of the page.",
+        deprecation_reason="Translated description of the page.",
         required=True,
     )
 
@@ -265,7 +265,7 @@ class PageTranslation(BaseTranslationType):
 
 class PageTranslatableContent(CountableDjangoObjectType):
     content = graphene.String(
-        description="Content for the page.",
+        description="Content of the page.",
         deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -246,8 +246,8 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 
 class PageTranslation(BaseTranslationType):
     content = graphene.String(
-        description="Content of the page.",
-        deprecation_reason="Translated description of the page.",
+        description="Translated description of the page.",
+        deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -134,7 +134,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 class ProductTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the product translation.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
 
@@ -147,7 +147,7 @@ class ProductTranslation(BaseTranslationType):
 class ProductTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the product.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
     translation = TranslationField(ProductTranslation, type_name="product")
@@ -173,7 +173,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 class CollectionTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the collection translation.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
 
@@ -186,7 +186,7 @@ class CollectionTranslation(BaseTranslationType):
 class CollectionTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the collection.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
@@ -212,7 +212,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 class CategoryTranslation(BaseTranslationType):
     description = graphene.String(
         description="Description for the category translation.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
 
@@ -225,7 +225,7 @@ class CategoryTranslation(BaseTranslationType):
 class CategoryTranslatableContent(CountableDjangoObjectType):
     description = graphene.String(
         description="Description for the category.",
-        deprecation_reason="Use the `descriptionJson` instead.",
+        deprecation_reason="Use the `descriptionJson` field instead.",
         required=True,
     )
     translation = TranslationField(CategoryTranslation, type_name="category")
@@ -247,7 +247,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 class PageTranslation(BaseTranslationType):
     content = graphene.String(
         description="Content for the page.",
-        deprecation_reason="Use the `contentJson` instead.",
+        deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )
 
@@ -266,7 +266,7 @@ class PageTranslation(BaseTranslationType):
 class PageTranslatableContent(CountableDjangoObjectType):
     content = graphene.String(
         description="Content for the page.",
-        deprecation_reason="Use the `contentJson` instead.",
+        deprecation_reason="Use the `contentJson` field instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -137,6 +137,7 @@ class ProductTranslation(BaseTranslationType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
 
     class Meta:
@@ -151,6 +152,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
     translation = TranslationField(ProductTranslation, type_name="product")
     product = graphene.Field(
@@ -178,6 +180,7 @@ class CollectionTranslation(BaseTranslationType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
 
     class Meta:
@@ -192,6 +195,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     collection = graphene.Field(
@@ -219,6 +223,7 @@ class CategoryTranslation(BaseTranslationType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
 
     class Meta:
@@ -233,6 +238,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
         deprecation_reason=(
             "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
         ),
+        required=True,
     )
     translation = TranslationField(CategoryTranslation, type_name="category")
     category = graphene.Field(
@@ -251,11 +257,18 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 
 
 class PageTranslation(BaseTranslationType):
+    content = graphene.String(
+        description="Content for the page.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+        required=True,
+    )
+
     class Meta:
         model = page_models.PageTranslation
         interfaces = [graphene.relay.Node]
         only_fields = [
-            "content",
             "content_json",
             "id",
             "seo_description",
@@ -265,6 +278,13 @@ class PageTranslation(BaseTranslationType):
 
 
 class PageTranslatableContent(CountableDjangoObjectType):
+    content = graphene.String(
+        description="Content for the page.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+        required=True,
+    )
     translation = TranslationField(PageTranslation, type_name="page")
     page = graphene.Field(
         "saleor.graphql.page.types.Page",
@@ -278,7 +298,6 @@ class PageTranslatableContent(CountableDjangoObjectType):
         model = page_models.Page
         interfaces = [graphene.relay.Node]
         only_fields = [
-            "content",
             "content_json",
             "id",
             "seo_description",

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -260,7 +260,7 @@ class PageTranslation(BaseTranslationType):
     content = graphene.String(
         description="Content for the page.",
         deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
         ),
         required=True,
     )

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -281,7 +281,7 @@ class PageTranslatableContent(CountableDjangoObjectType):
     content = graphene.String(
         description="Content for the page.",
         deprecation_reason=(
-            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+            "Will be removed in Saleor 3.0. Use the `contentJson` instead."
         ),
         required=True,
     )

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -19,7 +19,6 @@ BASIC_TRANSLATABLE_FIELDS = ["id", "name"]
 EXTENDED_TRANSLATABLE_FIELDS = [
     "id",
     "name",
-    "description",
     "description_json",
     "seo_title",
     "seo_description",
@@ -133,6 +132,13 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 
 
 class ProductTranslation(BaseTranslationType):
+    description = graphene.String(
+        description="Description for the product translation.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
+
     class Meta:
         model = product_models.ProductTranslation
         interfaces = [graphene.relay.Node]
@@ -140,6 +146,12 @@ class ProductTranslation(BaseTranslationType):
 
 
 class ProductTranslatableContent(CountableDjangoObjectType):
+    description = graphene.String(
+        description="Description for the product.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
     translation = TranslationField(ProductTranslation, type_name="product")
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
@@ -161,6 +173,13 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 
 
 class CollectionTranslation(BaseTranslationType):
+    description = graphene.String(
+        description="Description for the collection translation.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
+
     class Meta:
         model = product_models.CollectionTranslation
         interfaces = [graphene.relay.Node]
@@ -168,6 +187,12 @@ class CollectionTranslation(BaseTranslationType):
 
 
 class CollectionTranslatableContent(CountableDjangoObjectType):
+    description = graphene.String(
+        description="Description for the collection.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     collection = graphene.Field(
         "saleor.graphql.product.types.products.Collection",
@@ -189,6 +214,13 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 
 
 class CategoryTranslation(BaseTranslationType):
+    description = graphene.String(
+        description="Description for the category translation.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
+
     class Meta:
         model = product_models.CategoryTranslation
         interfaces = [graphene.relay.Node]
@@ -196,6 +228,12 @@ class CategoryTranslation(BaseTranslationType):
 
 
 class CategoryTranslatableContent(CountableDjangoObjectType):
+    description = graphene.String(
+        description="Description for the category.",
+        deprecation_reason=(
+            "Will be removed in Saleor 3.0. Use the `descriptionJson` instead."
+        ),
+    )
     translation = TranslationField(CategoryTranslation, type_name="category")
     category = graphene.Field(
         "saleor.graphql.product.types.products.Category",


### PR DESCRIPTION
I want to merge this change because...I want to deprecate description fields of Product, Collectio, Category and Page content field

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [X] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
