### PR TITLE
Fix updating shipping method in the case of delivery days having no values

### DIFF
--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -370,7 +370,11 @@ class ShippingPriceMixin:
         if error_occurred:
             return
 
-        if min_delivery_days > max_delivery_days:
+        if (
+            min_delivery_days is not None
+            and max_delivery_days is not None
+            and min_delivery_days > max_delivery_days
+        ):
             if cleaned_input.get("minimum_delivery_days") is not None:
                 error_msg = (
                     "Minimum delivery days should be lower "


### PR DESCRIPTION
Fixed the minor bug occurring when either minimum_delivery_days or maximum_delivery_days was none during shipping method update.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
