### PR TITLE
Secure invoice request and create mutations to deny unconfirmed order

### DIFF
--- a/saleor/graphql/invoice/mutations.py
+++ b/saleor/graphql/invoice/mutations.py
@@ -35,11 +35,11 @@ class InvoiceRequest(ModelMutation):
 
     @staticmethod
     def clean_order(order):
-        if order.status == OrderStatus.DRAFT:
+        if order.status in (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED):
             raise ValidationError(
                 {
                     "orderId": ValidationError(
-                        "Cannot request an invoice for draft order.",
+                        "Cannot request an invoice for draft or unconfirmed order.",
                         code=InvoiceErrorCode.INVALID_STATUS,
                     )
                 }
@@ -121,11 +121,11 @@ class InvoiceCreate(ModelMutation):
 
     @classmethod
     def clean_order(cls, info, order):
-        if order.status == OrderStatus.DRAFT:
+        if order.status in (OrderStatus.DRAFT, OrderStatus.UNCONFIRMED):
             raise ValidationError(
                 {
                     "orderId": ValidationError(
-                        "Cannot request an invoice for draft order.",
+                        "Cannot create an invoice for draft or unconfirmed order.",
                         code=InvoiceErrorCode.INVALID_STATUS,
                     )
                 }
@@ -135,7 +135,7 @@ class InvoiceCreate(ModelMutation):
             raise ValidationError(
                 {
                     "orderId": ValidationError(
-                        "Cannot request an invoice for order without billing address.",
+                        "Cannot create an invoice for order without billing address.",
                         code=InvoiceErrorCode.NOT_READY,
                     )
                 }

--- a/saleor/graphql/invoice/tests/test_invoice_create.py
+++ b/saleor/graphql/invoice/tests/test_invoice_create.py
@@ -1,4 +1,5 @@
 import graphene
+import pytest
 
 from ....core import JobStatus
 from ....graphql.tests.utils import get_graphql_content
@@ -86,10 +87,11 @@ def test_create_invoice_no_billing_address(
     assert not order.events.filter(type=OrderEvents.INVOICE_GENERATED).exists()
 
 
-def test_create_invoice_for_draft_order(
-    staff_api_client, permission_manage_orders, order
+@pytest.mark.parametrize("status", [OrderStatus.DRAFT, OrderStatus.UNCONFIRMED])
+def test_create_invoice_invalid_order_status(
+    status, staff_api_client, permission_manage_orders, order
 ):
-    order.status = OrderStatus.DRAFT
+    order.status = status
     order.save()
     number = "01/12/2020/TEST"
     url = "http://www.example.com"

--- a/saleor/graphql/invoice/tests/test_invoice_request.py
+++ b/saleor/graphql/invoice/tests/test_invoice_request.py
@@ -78,8 +78,11 @@ def test_invoice_request(
     ).exists()
 
 
-def test_invoice_request_draft_order(staff_api_client, permission_manage_orders, order):
-    order.status = OrderStatus.DRAFT
+@pytest.mark.parametrize("status", [OrderStatus.DRAFT, OrderStatus.UNCONFIRMED])
+def test_invoice_request_invalid_order_status(
+    status, staff_api_client, permission_manage_orders, order
+):
+    order.status = status
     order.save()
     number = "01/12/2020/TEST"
     variables = {
@@ -128,7 +131,7 @@ def test_invoice_request_no_number(staff_api_client, permission_manage_orders, o
     assert not OrderEvent.objects.filter(type=OrderEvents.INVOICE_REQUESTED).exists()
 
 
-def test_invoice_request_invalid_order(staff_api_client, permission_manage_orders):
+def test_invoice_request_invalid_id(staff_api_client, permission_manage_orders):
     variables = {"orderId": "T3JkZXI6MTMzNzEzMzc=", "number": "01/12/2020/TEST"}
     response = staff_api_client.post_graphql(
         INVOICE_REQUEST_MUTATION, variables, permissions=[permission_manage_orders]


### PR DESCRIPTION
I want to merge this change because it secures `InvoiceRequest` and `InvoiceCreate` mutations so they won't allow unconfirmed orders when provided.

Related ticket: [SALEOR-2040](https://app.clickup.com/t/2549495/SALEOR-2040)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
