### PR TITLE
Update vatlayer shipping tax rate calculation

### DIFF
--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -262,7 +262,7 @@ class VatlayerPlugin(BasePlugin):
             return previous_value
         tax = taxes.get(DEFAULT_TAX_RATE_NAME)
         # tax value is given in precentage so it need be be converted into decimal value
-        return Decimal(tax["value"] / 100)
+        return Decimal(tax["value"]) / 100
 
     def get_tax_rate_type_choices(
         self, previous_value: List["TaxType"]


### PR DESCRIPTION
Update order of operations. Previously firstly float was created and then converted to the `Decimal` type. Right now division is made on `Decimal`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
