### PR TITLE
Remove default id resolver from open tracing

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -1,5 +1,6 @@
 from functools import partial
 
+from graphene.relay import GlobalID
 from graphene.types.resolver import default_resolver
 from graphql import ResolveInfo
 
@@ -25,8 +26,9 @@ def is_introspection_field(info: ResolveInfo):
 
 
 def is_default_resolver(resolver):
+    default_resolvers = [default_resolver, GlobalID.id_resolver]
     while isinstance(resolver, partial):
         resolver = resolver.func
-        if resolver is default_resolver:
+        if resolver in default_resolvers:
             return True
-    return resolver is default_resolver
+    return resolver in default_resolvers


### PR DESCRIPTION
I want to merge this change because of removing default id resolvers from open tracing.

We have the same PR to master 
#6716 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
