### PR TITLE
Fix incorrect callculation of lines for draft order

### DIFF
--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -793,6 +793,17 @@ def test_ordered_item_change_quantity(transactional_db, order_with_lines):
     assert order_with_lines.get_total_quantity() == 0
 
 
+def test_change_order_line_quantity_changes_total_prices(
+    transactional_db, order_with_lines
+):
+    assert not order_with_lines.events.count()
+    line = order_with_lines.lines.all()[0]
+    new_quantity = line.quantity + 1
+    change_order_line_quantity(None, line, line.quantity, new_quantity)
+    line.refresh_from_db()
+    assert line.total_price == line.unit_price * new_quantity
+
+
 @patch("saleor.order.actions.emails.send_fulfillment_confirmation")
 @pytest.mark.parametrize(
     "has_standard,has_digital", ((True, True), (True, False), (False, True))

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from functools import wraps
 from typing import Iterable, List
 
@@ -256,7 +257,19 @@ def change_order_line_quantity(user, line, old_quantity, new_quantity):
     """Change the quantity of ordered items in a order line."""
     if new_quantity:
         line.quantity = new_quantity
-        line.save(update_fields=["quantity"])
+        total_price_net_amount = line.quantity * line.unit_price_net_amount
+        total_price_gross_amount = line.quantity * line.unit_price_gross_amount
+        line.total_price_net_amount = total_price_net_amount.quantize(Decimal("0.001"))
+        line.total_price_gross_amount = total_price_gross_amount.quantize(
+            Decimal("0.001")
+        )
+        line.save(
+            update_fields=[
+                "quantity",
+                "total_price_net_amount",
+                "total_price_gross_amount",
+            ]
+        )
     else:
         delete_order_line(line)
 


### PR DESCRIPTION
After we introduced the fields for the line.total_price we forgot about updating the price when quantity is changed. 
The fix updates the total amount of values for updated lines.