### PR TITLE
Remove default id resolver from opentracing

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -4,6 +4,8 @@ from graphene.relay import GlobalID
 from graphene.types.resolver import default_resolver
 from graphql import ResolveInfo
 
+DEFAULT_RESOLVERS = {default_resolver, GlobalID.id_resolver}
+
 
 def should_trace(info: ResolveInfo) -> bool:
     if info.field_name not in info.parent_type.fields:
@@ -26,9 +28,8 @@ def is_introspection_field(info: ResolveInfo):
 
 
 def is_default_resolver(resolver):
-    default_resolvers = [default_resolver, GlobalID.id_resolver]
     while isinstance(resolver, partial):
         resolver = resolver.func
-        if resolver in default_resolvers:
+        if resolver in DEFAULT_RESOLVERS:
             return True
-    return resolver in default_resolvers
+    return resolver in DEFAULT_RESOLVERS


### PR DESCRIPTION
I want to merge this change because refactoring `is_default_resolver` in open tracing

We have the same PR to master
#6739 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
