### PR TITLE
Channel inital migration add channel permission to all groups

### DIFF
--- a/saleor/channel/migrations/0001_initial.py
+++ b/saleor/channel/migrations/0001_initial.py
@@ -14,9 +14,8 @@ def assing_permissions(apps, schema_editor):
     manage_channels = Permission.objects.filter(
         codename="manage_channels", content_type__app_label="channel"
     ).first()
-    full_access = Group.objects.filter(name="Full Access").first()
-    if full_access:
-        full_access.permissions.add(manage_channels)
+    for group in Group.objects.iterator():
+        group.permissions.add(manage_channels)
 
 
 def get_default_currency(Checkout, Order, Product, ShippingMethod, Voucher):


### PR DESCRIPTION
I want to merge this change because...I want that channel inital migration should add channel permission to all existing groups

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
