### PR TITLE
Drop unused get_shipping_price_estimate function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Introduce page reference attributes - #6624 by @IKarbowiak
 - Introduce product reference attributes - #6711 by @IKarbowiak
 - Drop `type` field from `AttributeValue` type - #6710 by @IKarbowiak
+- Drop `apply_taxes_to_shipping_price_range` plugin hook - #6746 by @maarcingebala
 
 # 2.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,25 +4,31 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Breaking
+- Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki
+- Drop deprecated meta mutations - #6422 by @maarcingebala
+- Drop deprecated service accounts and webhooks API - #6431 by @maarcingebala
+- Drop deprecated fields from the `ProductVariant` type: `quantity`, `quantityAllocated`, `stockQuantity`, `isAvailable` - #6436 by @maarcingebala
+- Drop authorization keys API - #6631 by @maarcingebala
+- Drop `type` field from `AttributeValue` type - #6710 by @IKarbowiak
+- Drop `apply_taxes_to_shipping_price_range` plugin hook - #6746 by @maarcingebala
+
+### Other
+
 - Add possibility to provide external payment ID during the conversion draft order to order - #6320 by @korycins
 - Add basic rating for `Products` - #6284 by @korycins
 - Add metadata to shipping zones and shipping methods - #6340 by @maarcingebala
-- Drop deprecated meta mutations - #6422 by @maarcingebala
 - Add Page Types - #6261 by @IKarbowiak
 - Migrate draftjs content to editorjs format - #6430 by @IKarbowiak
-- Drop deprecated service accounts and webhooks API - #6431 by @maarcingebala
 - Add editorjs sanitizer - #6456 by @IKarbowiak
 - Add generic FileUpload mutation - #6470 by @IKarbowiak
 - Order confirmation backend - #6498 by @tomaszszymanski129
-- Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki
 - Fix password reset request - #6351 by @Manfred-Madelaine-pro, Ambroise and Pierre
 - Refund products support - #6530 by @korycins
 - Add possibility to exclude products from shipping method - #6506 by @korycins
 - Add availableShippingMethods to the Shop type - #6551 by @IKarbowiak
 - Add delivery time to shipping method - #6564 by @IKarbowiak
-- Drop deprecated fields from the `ProductVariant` type: `quantity`, `quantityAllocated`, `stockQuantity`, `isAvailable` - #6436 by @maarcingebala
 - Introduce file attributes - #6568 by @IKarbowiak
-- Drop authorization keys API - #6631 by @maarcingebala
 - Shipping zone description - #6653 by @tomaszszymanski129
 - Add metadata to menu and menu item - #6648 by @tomaszszymanski129
 - Get tax rate from plugins - #6649 by @IKarbowiak
@@ -31,8 +37,6 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix products visibility - #6704 by @IKarbowiak
 - Introduce page reference attributes - #6624 by @IKarbowiak
 - Introduce product reference attributes - #6711 by @IKarbowiak
-- Drop `type` field from `AttributeValue` type - #6710 by @IKarbowiak
-- Drop `apply_taxes_to_shipping_price_range` plugin hook - #6746 by @maarcingebala
 
 # 2.11.1
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -2,9 +2,9 @@
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple
 
 from django.core.exceptions import ValidationError
-from django.db.models import Max, Min, Sum
+from django.db.models import Sum
 from django.utils import timezone
-from prices import Money, MoneyRange, TaxedMoneyRange
+from prices import Money
 
 from ..account.models import User
 from ..channel.models import Channel
@@ -582,37 +582,6 @@ def is_valid_shipping_method(
         clear_shipping_method(checkout)
         return False
     return True
-
-
-def get_shipping_price_estimate(
-    checkout: Checkout,
-    lines: Iterable["CheckoutLineInfo"],
-    discounts: Iterable[DiscountInfo],
-    country_code: str,
-) -> Optional[TaxedMoneyRange]:
-    """Return the estimated price range for shipping for given order."""
-
-    shipping_methods = get_valid_shipping_methods_for_checkout(
-        checkout, lines, discounts, country_code=country_code
-    )
-
-    if shipping_methods is None:
-        return None
-
-    # TODO: extension manager should be able to have impact on shipping price estimates
-    min_price_amount, max_price_amount = shipping_methods.aggregate(
-        price_amount_min=Min("price_amount"), price_amount_max=Max("price_amount")
-    ).values()
-
-    if min_price_amount is None:
-        return None
-
-    manager = get_plugins_manager()
-    prices = MoneyRange(
-        start=Money(min_price_amount, checkout.currency),
-        stop=Money(max_price_amount, checkout.currency),
-    )
-    return manager.apply_taxes_to_shipping_price_range(prices, country_code)
 
 
 def clear_shipping_method(checkout: Checkout):

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse
 from django_countries.fields import Country
-from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
+from prices import Money, TaxedMoney
 
 from ..payment.interface import (
     CustomerSource,

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -237,15 +237,6 @@ class BasePlugin:
         """
         return NotImplemented
 
-    def apply_taxes_to_shipping_price_range(
-        self, prices: MoneyRange, country: Country, previous_value: TaxedMoneyRange
-    ) -> TaxedMoneyRange:
-        """Provide the estimation of shipping costs based on country.
-
-        It is used only by the old storefront in the cart view.
-        """
-        return NotImplemented
-
     def apply_taxes_to_shipping(
         self, price: Money, shipping_address: "Address", previous_value: TaxedMoney
     ) -> TaxedMoney:

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -7,7 +7,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse, HttpResponseNotFound
 from django.utils.module_loading import import_string
 from django_countries.fields import Country
-from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
+from prices import Money, TaxedMoney
 
 from ..checkout import base_calculations
 from ..core.payments import PaymentInterface
@@ -359,19 +359,6 @@ class PluginsManager(PaymentInterface):
                 "apply_taxes_to_shipping", default_value, price, shipping_address
             ),
             price.currency,
-        )
-
-    def apply_taxes_to_shipping_price_range(self, prices: MoneyRange, country: Country):
-        start = TaxedMoney(net=prices.start, gross=prices.start)
-        stop = TaxedMoney(net=prices.stop, gross=prices.stop)
-        default_value = quantize_price(
-            TaxedMoneyRange(start=start, stop=stop), start.currency
-        )
-        return quantize_price(
-            self.__run_method_on_plugins(
-                "apply_taxes_to_shipping_price_range", default_value, prices, country
-            ),
-            start.currency,
         )
 
     def preprocess_order_creation(

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -9,7 +9,7 @@ from django_prices_vatlayer.utils import (
     fetch_rates,
     get_tax_rate_types,
 )
-from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
+from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import calculations
 from ...core.taxes import TaxType
@@ -281,15 +281,6 @@ class VatlayerPlugin(BasePlugin):
         if not self.active:
             return previous_value
         return True
-
-    def apply_taxes_to_shipping_price_range(
-        self, prices: MoneyRange, country: Country, previous_value: TaxedMoneyRange
-    ) -> TaxedMoneyRange:
-        if self._skip_plugin(previous_value):
-            return previous_value
-
-        taxes = self._get_taxes_for_country(country)
-        return get_taxed_shipping_price(prices, taxes)
 
     def apply_taxes_to_shipping(
         self, price: Money, shipping_address: "Address", previous_value: TaxedMoney

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -416,21 +416,6 @@ def test_get_tax_rate_type_choices(vatlayer, settings, monkeypatch):
         assert choice.code in expected_choices
 
 
-def test_apply_taxes_to_shipping_price_range(vatlayer, settings):
-    settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
-    money_range = MoneyRange(Money(100, "USD"), Money(200, "USD"))
-    country = Country("PL")
-    manager = get_plugins_manager()
-
-    expected_start = TaxedMoney(net=Money("81.30", "USD"), gross=Money("100", "USD"))
-    expected_stop = TaxedMoney(net=Money("162.60", "USD"), gross=Money("200", "USD"))
-
-    price_range = manager.apply_taxes_to_shipping_price_range(money_range, country)
-
-    assert price_range.start == expected_start
-    assert price_range.stop == expected_stop
-
-
 def test_apply_taxes_to_product(
     vatlayer, settings, variant, discount_info, channel_USD
 ):


### PR DESCRIPTION
This PR drops unused function: `get_shipping_price_estimate`. As a result, the `apply_taxes_to_shipping_price_range` plugin hook gets removed as it is no longer used.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
