### PR TITLE
Update verify_exp option in jwt decode

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -62,7 +62,7 @@ def jwt_decode(token: str) -> Dict[str, Any]:
         token,
         settings.SECRET_KEY,  # type: ignore
         algorithms=[JWT_ALGORITHM],
-        verify_expiration=settings.JWT_EXPIRE,
+        options={"verify_exp": settings.JWT_EXPIRE},
     )
 
 


### PR DESCRIPTION
I want to merge this change because...I want to update expiration verify in jwt.decode

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
