### PR TITLE
Allow setting values of numeric attributes

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -174,3 +174,25 @@ class AttributeInput(graphene.InputObjectType):
     values = graphene.List(
         graphene.String, required=False, description=AttributeValueDescriptions.SLUG
     )
+
+
+class AttributeValueInput(graphene.InputObjectType):
+    id = graphene.ID(description="ID of the selected attribute.")
+    values = graphene.List(
+        graphene.String,
+        required=False,
+        description=(
+            "The value or slug of an attribute to resolve. "
+            "If the passed value is non-existent, it will be created."
+        ),
+    )
+    file = graphene.String(
+        required=False,
+        description="URL of the file attribute. Every time, a new value is created.",
+    )
+    content_type = graphene.String(required=False, description="File content type.")
+    references = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of entity IDs that will be used as references.",
+        required=False,
+    )

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -134,10 +134,16 @@ class AttributeAssignmentMixin:
     ):
         """Lazy-retrieve or create the database objects from the supplied raw values."""
         get_or_create = attribute.values.get_or_create
+        is_numeric_attr = attribute.input_type == AttributeInputType.NUMERIC
+
+        def get_slug_value(value):
+            slug_value = value if not is_numeric_attr else value.replace(".", "_")
+            return slugify(slug_value, allow_unicode=True)
+
         return tuple(
             get_or_create(
                 attribute=attribute,
-                slug=slugify(value, allow_unicode=True),
+                slug=get_slug_value(value),
                 defaults={"name": value},
             )[0]
             for value in attr_values.values
@@ -399,23 +405,26 @@ class AttributeInputErrors:
     All used error codes must be specified in PageErrorCode and ProductErrorCode.
     """
 
-    ERROR_NO_VALUE_GIVEN = ("Attribute expects a value but none were given", "REQUIRED")
-    ERROR_DROPDOWN_GET_MORE_THAN_ONE_VALUE = (
-        "Attribute must take only one value",
+    ERROR_NO_VALUE_GIVEN = (
+        "Attribute expects a value but none were given.",
+        "REQUIRED",
+    )
+    ERROR_MORE_THAN_ONE_VALUE_GIVEN = (
+        "Attribute must take only one value.",
         "INVALID",
     )
     ERROR_BLANK_VALUE = (
-        "Attribute values cannot be blank",
+        "Attribute values cannot be blank.",
         "REQUIRED",
     )
 
     # file errors
     ERROR_NO_FILE_GIVEN = (
-        "Attribute file url cannot be blank",
+        "Attribute file url cannot be blank.",
         "REQUIRED",
     )
     ERROR_BLANK_FILE_VALUE = (
-        "Attribute expects a file url but none were given",
+        "Attribute expects a file url but none were given.",
         "REQUIRED",
     )
 
@@ -423,6 +432,12 @@ class AttributeInputErrors:
     ERROR_NO_REFERENCE_GIVEN = (
         "Attribute expects an reference but none were given.",
         "REQUIRED",
+    )
+
+    # numeric errors
+    ERROR_NUMERIC_VALUE_REQUIRED = (
+        "Numeric value is required.",
+        "INVALID",
     )
 
 
@@ -521,14 +536,31 @@ def validate_standard_attributes_input(
         attribute.input_type != AttributeInputType.MULTISELECT
         and len(attr_values.values) != 1
     ):
-        attribute_errors[
-            AttributeInputErrors.ERROR_DROPDOWN_GET_MORE_THAN_ONE_VALUE
-        ].append(attribute_id)
-    for value in attr_values.values:
-        if value is None or not value.strip():
+        attribute_errors[AttributeInputErrors.ERROR_MORE_THAN_ONE_VALUE_GIVEN].append(
+            attribute_id
+        )
+
+    validate_values(
+        attribute_id, attribute.input_type, attr_values.values, attribute_errors
+    )
+
+
+def validate_values(
+    attribute_id: str, input_type: str, values: list, attribute_errors: T_ERROR_DICT
+):
+    is_numeric = input_type == AttributeInputType.NUMERIC
+    for value in values:
+        if value is None or (not is_numeric and not value.strip()):
             attribute_errors[AttributeInputErrors.ERROR_BLANK_VALUE].append(
                 attribute_id
             )
+        elif is_numeric:
+            try:
+                float(value)
+            except ValueError:
+                attribute_errors[
+                    AttributeInputErrors.ERROR_NUMERIC_VALUE_REQUIRED
+                ].append(attribute_id)
 
 
 def is_variant_selection_attribute(attribute: attribute_models.Attribute):

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -491,9 +491,7 @@ def validate_file_attributes_input(
     attribute_id = attr_values.global_id
     value = attr_values.file_url
     if not value:
-        if attribute.value_required or (
-            variant_validation and is_variant_selection_attribute(attribute)
-        ):
+        if is_value_required(attribute, variant_validation):
             attribute_errors[AttributeInputErrors.ERROR_NO_FILE_GIVEN].append(
                 attribute_id
             )
@@ -512,7 +510,7 @@ def validate_reference_attributes_input(
     attribute_id = attr_values.global_id
     references = attr_values.references
     if not references:
-        if attribute.value_required or variant_validation:
+        if is_value_required(attribute, variant_validation):
             attribute_errors[AttributeInputErrors.ERROR_NO_REFERENCE_GIVEN].append(
                 attribute_id
             )
@@ -526,9 +524,7 @@ def validate_standard_attributes_input(
 ):
     attribute_id = attr_values.global_id
     if not attr_values.values:
-        if attribute.value_required or (
-            variant_validation and is_variant_selection_attribute(attribute)
-        ):
+        if is_value_required(attribute, variant_validation):
             attribute_errors[AttributeInputErrors.ERROR_NO_VALUE_GIVEN].append(
                 attribute_id
             )
@@ -561,6 +557,12 @@ def validate_values(
                 attribute_errors[
                     AttributeInputErrors.ERROR_NUMERIC_VALUE_REQUIRED
                 ].append(attribute_id)
+
+
+def is_value_required(attribute: attribute_models.Attribute, variant_validation: bool):
+    return attribute.value_required or (
+        variant_validation and is_variant_selection_attribute(attribute)
+    )
 
 
 def is_variant_selection_attribute(attribute: attribute_models.Attribute):

--- a/saleor/graphql/page/mutations/pages.py
+++ b/saleor/graphql/page/mutations/pages.py
@@ -10,6 +10,7 @@ from ....attribute import AttributeType
 from ....core.permissions import PagePermissions, PageTypePermissions
 from ....page import models
 from ....page.error_codes import PageErrorCode
+from ...attribute.types import AttributeValueInput
 from ...attribute.utils import AttributeAssignmentMixin
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types.common import PageError, SeoInput
@@ -18,7 +19,6 @@ from ...core.utils import (
     get_duplicates_ids,
     validate_slug_and_generate_if_needed,
 )
-from ...product.mutations.products import AttributeValueInput
 
 if TYPE_CHECKING:
     from ....attribute.models import Attribute

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -6,7 +6,6 @@ import graphene
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import transaction
 from django.utils.text import slugify
-from graphene.types import InputObjectType
 
 from ....attribute import AttributeInputType, AttributeType
 from ....attribute import models as attribute_models
@@ -28,6 +27,7 @@ from ....product.thumbnails import (
 )
 from ....product.utils import delete_categories, get_products_ids_without_variants
 from ....product.utils.variants import generate_and_set_variant_name
+from ...attribute.types import AttributeValueInput
 from ...attribute.utils import AttributeAssignmentMixin, AttrValuesInput
 from ...channel import ChannelContext
 from ...core.inputs import ReorderInput
@@ -449,28 +449,6 @@ class CollectionRemoveProducts(BaseMutation):
         return CollectionRemoveProducts(
             collection=ChannelContext(node=collection, channel_slug=None)
         )
-
-
-class AttributeValueInput(InputObjectType):
-    id = graphene.ID(description="ID of the selected attribute.")
-    values = graphene.List(
-        graphene.String,
-        required=False,
-        description=(
-            "The value or slug of an attribute to resolve. "
-            "If the passed value is non-existent, it will be created."
-        ),
-    )
-    file = graphene.String(
-        required=False,
-        description="URL of the file attribute. Every time, a new value is created.",
-    )
-    content_type = graphene.String(required=False, description="File content type.")
-    references = graphene.List(
-        graphene.NonNull(graphene.ID),
-        description="List of entity IDs that will be used as references.",
-        required=False,
-    )
 
 
 class ProductInput(graphene.InputObjectType):

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -816,6 +816,102 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     updated_webhook_mock.assert_not_called()
 
 
+@patch("saleor.plugins.manager.PluginsManager.product_updated")
+def test_create_variant_with_numeric_attribute(
+    updated_webhook_mock,
+    staff_api_client,
+    product,
+    product_type,
+    permission_manage_products,
+    warehouse,
+    numeric_attribute,
+):
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    sku = "1"
+    weight = 10.22
+    product_type.variant_attributes.set([numeric_attribute])
+    variant_slug = numeric_attribute.slug
+    variant_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
+    variant_value = "22.31"
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
+            "quantity": 20,
+        }
+    ]
+
+    variables = {
+        "productId": product_id,
+        "sku": sku,
+        "stocks": stocks,
+        "weight": weight,
+        "attributes": [{"id": variant_id, "values": [variant_value]}],
+        "trackInventory": True,
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)["data"]["productVariantCreate"]
+    assert not content["productErrors"]
+    data = content["productVariant"]
+    assert data["name"] == variant_value
+    assert data["sku"] == sku
+    assert data["attributes"][0]["attribute"]["slug"] == variant_slug
+    assert data["attributes"][0]["values"][0]["slug"] == variant_value.replace(".", "_")
+    assert data["weight"]["unit"] == WeightUnitsEnum.KG.name
+    assert data["weight"]["value"] == weight
+    assert len(data["stocks"]) == 1
+    assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
+    assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+    updated_webhook_mock.assert_called_once_with(product)
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_updated")
+def test_create_variant_with_numeric_attribute_not_numeric_value_given(
+    updated_webhook_mock,
+    staff_api_client,
+    product,
+    product_type,
+    permission_manage_products,
+    warehouse,
+    numeric_attribute,
+):
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    sku = "1"
+    weight = 10.22
+    product_type.variant_attributes.set([numeric_attribute])
+    variant_id = graphene.Node.to_global_id("Attribute", numeric_attribute.pk)
+    variant_value = "abd"
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", warehouse.pk),
+            "quantity": 20,
+        }
+    ]
+
+    variables = {
+        "productId": product_id,
+        "sku": sku,
+        "stocks": stocks,
+        "weight": weight,
+        "attributes": [{"id": variant_id, "values": [variant_value]}],
+        "trackInventory": True,
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantCreate"]
+    error = data["productErrors"][0]
+    assert not data["productVariant"]
+    assert error["field"] == "attributes"
+    assert error["code"] == ProductErrorCode.INVALID.name
+
+    updated_webhook_mock.assert_not_called()
+
+
 def test_create_product_variant_with_negative_weight(
     staff_api_client, product, product_type, permission_manage_products
 ):
@@ -1743,10 +1839,10 @@ def test_update_product_variant_change_attribute_values_ordering(
 @pytest.mark.parametrize(
     "values, message",
     (
-        ([], "Attribute expects a value but none were given"),
-        (["one", "two"], "Attribute must take only one value"),
-        (["   "], "Attribute values cannot be blank"),
-        ([None], "Attribute values cannot be blank"),
+        ([], "Attribute expects a value but none were given."),
+        (["one", "two"], "Attribute must take only one value."),
+        (["   "], "Attribute values cannot be blank."),
+        ([None], "Attribute values cannot be blank."),
     ),
 )
 def test_update_product_variant_requires_values(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -641,6 +641,9 @@ def test_create_variant_with_page_reference_attribute_no_references_given(
     product_id = graphene.Node.to_global_id("Product", product.pk)
     sku = "1"
 
+    product_type_page_reference_attribute.value_required = True
+    product_type_page_reference_attribute.save(update_fields=["value_required"])
+
     product_type.variant_attributes.clear()
     product_type.variant_attributes.add(product_type_page_reference_attribute)
     ref_attr_id = graphene.Node.to_global_id(
@@ -695,6 +698,9 @@ def test_create_variant_with_product_reference_attribute(
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
     sku = "1"
+
+    product_type_product_reference_attribute.value_required = True
+    product_type_product_reference_attribute.save(update_fields=["value_required"])
 
     product_type.variant_attributes.clear()
     product_type.variant_attributes.add(product_type_product_reference_attribute)
@@ -775,6 +781,9 @@ def test_create_variant_with_product_reference_attribute_no_references_given(
     query = CREATE_VARIANT_MUTATION
     product_id = graphene.Node.to_global_id("Product", product.pk)
     sku = "1"
+
+    product_type_product_reference_attribute.value_required = True
+    product_type_product_reference_attribute.save(update_fields=["value_required"])
 
     product_type.variant_attributes.clear()
     product_type.variant_attributes.add(product_type_product_reference_attribute)


### PR DESCRIPTION
Allow setting values of numeric attributes in product mutations.

Linked task: [SALEOR-2077](https://app.clickup.com/t/2549495/SALEOR-2077)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
