### PR TITLE
Use separate services for external integrations

### DIFF
--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -3,6 +3,8 @@ from typing import List, Optional
 from urllib.parse import urlencode
 
 import Adyen
+import opentracing
+import opentracing.tags
 from django.contrib.auth.hashers import make_password
 from django.contrib.sites.models import Site
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -226,10 +228,16 @@ class AdyenGatewayPlugin(BasePlugin):
         if path.startswith(WEBHOOK_PATH):
             return handle_webhook(request, config)
         elif path.startswith(ADDITIONAL_ACTION_PATH):
-            return handle_additional_actions(
-                request,
-                self.adyen.checkout.payments_details,
-            )
+            with opentracing.global_tracer().start_active_span(
+                "adyen.checkout.payment_details"
+            ) as scope:
+                span = scope.span
+                span.set_tag(opentracing.tags.COMPONENT, "payment")
+                span.set_tag("service.name", "adyen")
+                return handle_additional_actions(
+                    request,
+                    self.adyen.checkout.payments_details,
+                )
         return HttpResponseNotFound()
 
     def _get_gateway_config(self) -> GatewayConfig:
@@ -265,7 +273,13 @@ class AdyenGatewayPlugin(BasePlugin):
         request = request_data_for_gateway_config(
             checkout, config.connection_params["merchant_account"]
         )
-        response = api_call(request, self.adyen.checkout.payment_methods)
+        with opentracing.global_tracer().start_active_span(
+            "adyen.checkout.payment_methods"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "adyen")
+            response = api_call(request, self.adyen.checkout.payment_methods)
         return PaymentGateway(
             id=self.PLUGIN_ID,
             name=self.PLUGIN_NAME,
@@ -314,7 +328,13 @@ class AdyenGatewayPlugin(BasePlugin):
             merchant_account=self.config.connection_params["merchant_account"],
             native_3d_secure=self.config.connection_params["enable_native_3d_secure"],
         )
-        result = api_call(request_data, self.adyen.checkout.payments)
+        with opentracing.global_tracer().start_active_span(
+            "adyen.checkout.payments"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "adyen")
+            result = api_call(request_data, self.adyen.checkout.payments)
         result_code = result.message["resultCode"].strip().lower()
         is_success = result_code not in FAILED_STATUSES
         adyen_auto_capture = self.config.connection_params["adyen_auto_capture"]
@@ -384,7 +404,13 @@ class AdyenGatewayPlugin(BasePlugin):
         if not additional_data:
             raise PaymentError("Unable to finish the payment.")
 
-        result = api_call(additional_data, self.adyen.checkout.payments_details)
+        with opentracing.global_tracer().start_active_span(
+            "adyen.checkout.payment_details"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "adyen")
+            result = api_call(additional_data, self.adyen.checkout.payments_details)
         result_code = result.message["resultCode"].strip().lower()
         is_success = result_code not in FAILED_STATUSES
         action_required = "action" in result.message
@@ -530,7 +556,13 @@ class AdyenGatewayPlugin(BasePlugin):
             merchant_account=self.config.connection_params["merchant_account"],
             token=transaction.token,
         )
-        result = api_call(request, self.adyen.payment.refund)
+        with opentracing.global_tracer().start_active_span(
+            "adyen.payment.refund"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "adyen")
+            result = api_call(request, self.adyen.payment.refund)
 
         amount = payment_information.amount
         currency = payment_information.currency
@@ -596,7 +628,13 @@ class AdyenGatewayPlugin(BasePlugin):
             merchant_account=self.config.connection_params["merchant_account"],
             token=payment_information.token,  # type: ignore
         )
-        result = api_call(request, self.adyen.payment.cancel)
+        with opentracing.global_tracer().start_active_span(
+            "adyen.payment.cancel"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "adyen")
+            result = api_call(request, self.adyen.payment.cancel)
 
         return GatewayResponse(
             is_success=True,

--- a/saleor/payment/gateways/stripe/__init__.py
+++ b/saleor/payment/gateways/stripe/__init__.py
@@ -1,5 +1,7 @@
 from typing import List
 
+import opentracing
+import opentracing.tags
 import stripe
 
 from ... import TransactionKind
@@ -44,19 +46,31 @@ def authorize(
     )
 
     try:
-        intent = client.PaymentIntent.create(
-            payment_method=payment_information.token,
-            amount=stripe_amount,
-            currency=currency,
-            confirmation_method="manual",
-            confirm=True,
-            capture_method=capture_method,
-            setup_future_usage=future_use,
-            customer=customer_id,
-            shipping=shipping,
-        )
+        with opentracing.global_tracer().start_active_span(
+            "stripe.PaymentIntent.create"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "stripe")
+            intent = client.PaymentIntent.create(
+                payment_method=payment_information.token,
+                amount=stripe_amount,
+                currency=currency,
+                confirmation_method="manual",
+                confirm=True,
+                capture_method=capture_method,
+                setup_future_usage=future_use,
+                customer=customer_id,
+                shipping=shipping,
+            )
         if config.store_customer and not customer_id:
-            customer = client.Customer.create(payment_method=intent.payment_method)
+            with opentracing.global_tracer().start_active_span(
+                "stripe.Customer.create"
+            ) as scope:
+                span = scope.span
+                span.set_tag(opentracing.tags.COMPONENT, "payment")
+                span.set_tag("service.name", "stripe")
+                customer = client.Customer.create(payment_method=intent.payment_method)
             customer_id = customer.id
 
     except stripe.error.StripeError as exc:
@@ -74,7 +88,13 @@ def capture(payment_information: PaymentData, config: GatewayConfig) -> GatewayR
     client = _get_client(**config.connection_params)
     intent = None
     try:
-        intent = client.PaymentIntent.retrieve(id=payment_information.token)
+        with opentracing.global_tracer().start_active_span(
+            "stripe.PaymentIntent.retrieve"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "stripe")
+            intent = client.PaymentIntent.retrieve(id=payment_information.token)
         capture = intent.capture()
     except stripe.error.StripeError as exc:
         action_required = intent.status == "requires_action" if intent else False
@@ -98,7 +118,13 @@ def confirm(payment_information: PaymentData, config: GatewayConfig) -> GatewayR
     client = _get_client(**config.connection_params)
     try:
         intent = client.PaymentIntent(id=payment_information.token)
-        intent.confirm()
+        with opentracing.global_tracer().start_active_span(
+            "stripe.PaymentIntent.confirm"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "stripe")
+            intent.confirm()
     except stripe.error.StripeError as exc:
         response = _error_response(
             kind=TransactionKind.CONFIRM, exc=exc, payment_info=payment_information
@@ -118,7 +144,13 @@ def refund(payment_information: PaymentData, config: GatewayConfig) -> GatewayRe
     currency = get_currency_for_stripe(payment_information.currency)
     stripe_amount = get_amount_for_stripe(payment_information.amount, currency)
     try:
-        intent = client.PaymentIntent.retrieve(id=payment_information.token)
+        with opentracing.global_tracer().start_active_span(
+            "stripe.PaymentIntent.retrieve"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "stripe")
+            intent = client.PaymentIntent.retrieve(id=payment_information.token)
         refund = intent["charges"]["data"][0].refund(amount=stripe_amount)
     except stripe.error.StripeError as exc:
         response = _error_response(
@@ -138,7 +170,13 @@ def refund(payment_information: PaymentData, config: GatewayConfig) -> GatewayRe
 def void(payment_information: PaymentData, config: GatewayConfig) -> GatewayResponse:
     client = _get_client(**config.connection_params)
     try:
-        intent = client.PaymentIntent.retrieve(id=payment_information.token)
+        with opentracing.global_tracer().start_active_span(
+            "stripe.PaymentIntent.retrieve"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "payment")
+            span.set_tag("service.name", "stripe")
+            intent = client.PaymentIntent.retrieve(id=payment_information.token)
         refund = intent["charges"]["data"][0].refund()
     except stripe.error.StripeError as exc:
         response = _error_response(
@@ -158,7 +196,13 @@ def list_client_sources(
     config: GatewayConfig, customer_id: str
 ) -> List[CustomerSource]:
     client = _get_client(**config.connection_params)
-    cards = client.PaymentMethod.list(customer=customer_id, type="card")["data"]
+    with opentracing.global_tracer().start_active_span(
+        "stripe.PaymentMethod.list"
+    ) as scope:
+        span = scope.span
+        span.set_tag(opentracing.tags.COMPONENT, "payment")
+        span.set_tag("service.name", "stripe")
+        cards = client.PaymentMethod.list(customer=customer_id, type="card")["data"]
     return [
         CustomerSource(
             id=c.id,

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -6,6 +6,8 @@ from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Union
 from urllib.parse import urljoin
 
+import opentracing
+import opentracing.tags
 import requests
 from django.conf import settings
 from django.contrib.sites.models import Site
@@ -394,7 +396,13 @@ def _fetch_new_taxes_data(
     transaction_url = urljoin(
         get_api_url(config.use_sandbox), "transactions/createoradjust"
     )
-    response = api_post_request(transaction_url, data, config)
+    with opentracing.global_tracer().start_active_span(
+        "avatax.transactions.crateoradjust"
+    ) as scope:
+        span = scope.span
+        span.set_tag(opentracing.tags.COMPONENT, "tax")
+        span.set_tag("service.name", "avatax")
+        response = api_post_request(transaction_url, data, config)
     if response and "error" not in response:
         cache.set(data_cache_key, (data, response), CACHE_TIME)
     else:
@@ -478,9 +486,15 @@ def get_cached_tax_codes_or_fetch(
     tax_codes = cache.get(TAX_CODES_CACHE_KEY, {})
     if not tax_codes:
         tax_codes_url = urljoin(get_api_url(config.use_sandbox), "definitions/taxcodes")
-        response = api_get_request(
-            tax_codes_url, config.username_or_account, config.password_or_license
-        )
+        with opentracing.global_tracer().start_active_span(
+            "avatax.definitions.taxcodes"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "tax")
+            span.set_tag("service.name", "avatax")
+            response = api_get_request(
+                tax_codes_url, config.username_or_account, config.password_or_license
+            )
         if response and "error" not in response:
             tax_codes = generate_tax_codes_dict(response)
             cache.set(TAX_CODES_CACHE_KEY, tax_codes, cache_time)

--- a/saleor/plugins/avatax/tasks.py
+++ b/saleor/plugins/avatax/tasks.py
@@ -1,5 +1,8 @@
 import logging
 
+import opentracing
+import opentracing.tags
+
 from ...celeryconf import app
 from ...core.taxes import TaxError
 from ...order.events import external_notification_event
@@ -29,7 +32,13 @@ def api_post_request_task(transaction_url, data, config, order_id):
         )
         return
 
-    response = api_post_request(transaction_url, data, config)
+    with opentracing.global_tracer().start_active_span(
+        "avatax.transactions.crateoradjust"
+    ) as scope:
+        span = scope.span
+        span.set_tag(opentracing.tags.COMPONENT, "tax")
+        span.set_tag("service.name", "avatax")
+        response = api_post_request(transaction_url, data, config)
     msg = f"Order sent to Avatax. Order ID: {order.token}"
     if not response or "error" in response:
         avatax_msg = response.get("error", {}).get("message", "")


### PR DESCRIPTION
This introduces separate services for tracing external integrations

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
