### PR TITLE
Fix bad parameters passing which breaks populatedb

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -798,7 +798,7 @@ def _create_staff_user(email=None, superuser=False):
 def create_staff_users(how_many=2, superuser=False):
     users = []
     for _ in range(how_many):
-        staff_user = _create_staff_user(superuser)
+        staff_user = _create_staff_user(superuser=superuser)
         users.append(staff_user)
     return users
 


### PR DESCRIPTION
I want to merge this change because...

It fixes `populatedb` command

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
