### PR TITLE
Skip processing shipping address if it is not passed in 

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -81,14 +81,11 @@ def _process_shipping_data_for_order(
     """Fetch, process and return shipping data from checkout."""
     shipping_address = checkout.shipping_address
 
-    if checkout.user:
+    if checkout.user and shipping_address:
         store_user_address(
             checkout.user, shipping_address, AddressType.SHIPPING, manager=manager
         )
-        if (
-            shipping_address
-            and checkout.user.addresses.filter(pk=shipping_address.pk).exists()
-        ):
+        if checkout.user.addresses.filter(pk=shipping_address.pk).exists():
             shipping_address = shipping_address.get_copy()
 
     return {


### PR DESCRIPTION
I want to merge this change because...

The cypress tests for `saleor-storefront` fail for virtual products because shipping address is `None` 
```
"message": "'NoneType' object has no attribute 'as_data'", 
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
