### PR TITLE
Assign permisson to external user

### DIFF
--- a/saleor/plugins/openid_connect/plugin.py
+++ b/saleor/plugins/openid_connect/plugin.py
@@ -175,6 +175,14 @@ class OpenIDConnectPlugin(BasePlugin):
             scope=scope,
         )
 
+    def _use_scope_permissions(self, user, scope):
+        user_permissions = None
+        if scope:
+            permissions = get_saleor_permissions_qs_from_scope(scope)
+            user_permissions = get_saleor_permission_names(permissions)
+            user.effective_permissions = permissions
+        return user_permissions
+
     def external_obtain_access_tokens(
         self, data: dict, request: WSGIRequest, previous_value
     ) -> ExternalAccessTokens:
@@ -214,11 +222,9 @@ class OpenIDConnectPlugin(BasePlugin):
 
         user_permissions = None
         if self.config.use_scope_permissions:
-            scope = token_data.get("scope")
-            if scope:
-                permissions = get_saleor_permissions_qs_from_scope(scope)
-                user_permissions = get_saleor_permission_names(permissions)
-                user.effective_permissions = permissions
+            user_permissions = self._use_scope_permissions(
+                user, token_data.get("scope")
+            )
 
         tokens = create_tokens_from_oauth_payload(
             token_data, user, parsed_id_token, user_permissions, owner=self.PLUGIN_ID
@@ -294,11 +300,9 @@ class OpenIDConnectPlugin(BasePlugin):
 
             user_permissions = None
             if self.config.use_scope_permissions:
-                scope = token_data.get("scope")
-                if scope:
-                    permissions = get_saleor_permissions_qs_from_scope(scope)
-                    user_permissions = get_saleor_permission_names(permissions)
-                    user.effective_permissions = permissions
+                user_permissions = self._use_scope_permissions(
+                    user, token_data.get("scope")
+                )
 
             tokens = create_tokens_from_oauth_payload(
                 token_data,

--- a/saleor/plugins/openid_connect/tests/test_utils.py
+++ b/saleor/plugins/openid_connect/tests/test_utils.py
@@ -22,7 +22,8 @@ from ..utils import (
     create_tokens_from_oauth_payload,
     fetch_jwks,
     get_or_create_user_from_token,
-    get_saleor_permissions_from_scope,
+    get_saleor_permission_names,
+    get_saleor_permissions_qs_from_scope,
     get_user_from_token,
     validate_refresh_token,
 )
@@ -108,7 +109,8 @@ def test_create_tokens_from_oauth_payload(
         "expires_at": 1600851112,
     }
     user = get_or_create_user_from_token(id_payload)
-    perms = get_saleor_permissions_from_scope(auth_payload.get("scope"))
+    permissions = get_saleor_permissions_qs_from_scope(auth_payload.get("scope"))
+    perms = get_saleor_permission_names(permissions)
     tokens = create_tokens_from_oauth_payload(
         auth_payload, user, id_payload, perms, "PluginID"
     )
@@ -170,5 +172,6 @@ def test_get_saleor_permissions_from_scope():
         ),
     }
     expected_permissions = {"MANAGE_USERS", "MANAGE_ORDERS"}
-    permissions = get_saleor_permissions_from_scope(auth_payload.get("scope"))
-    assert set(permissions) == expected_permissions
+    permissions = get_saleor_permissions_qs_from_scope(auth_payload.get("scope"))
+    permission_names = get_saleor_permission_names(permissions)
+    assert set(permission_names) == expected_permissions

--- a/saleor/plugins/openid_connect/utils.py
+++ b/saleor/plugins/openid_connect/utils.py
@@ -6,9 +6,11 @@ import requests
 from authlib.jose import jwt
 from authlib.jose.errors import DecodeError, JoseError
 from authlib.oidc.core import CodeIDToken
+from django.contrib.auth.models import Permission
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
 from django.core.validators import URLValidator
+from django.db.models import QuerySet
 from django.middleware.csrf import _compare_masked_tokens  # type: ignore
 from django.middleware.csrf import _get_new_csrf_token
 from jwt import PyJWTError
@@ -286,14 +288,16 @@ def get_incorrect_fields(plugin_configuration: "PluginConfiguration"):
         return incorrect_fields
 
 
-def get_saleor_permissions_from_scope(scope: str) -> List[str]:
-    if not scope:
-        return []
+def get_saleor_permissions_qs_from_scope(scope: str) -> QuerySet[Permission]:
     scope_list = scope.lower().strip().split()
     saleor_permissions_str = [s for s in scope_list if s.startswith("saleor:")]
     permission_codenames = list(
         map(lambda perm: perm.replace("saleor:", ""), saleor_permissions_str)
     )
     permissions = get_permissions_from_codenames(permission_codenames)
+    return permissions
+
+
+def get_saleor_permission_names(permissions: QuerySet) -> List[str]:
     permission_names = get_permission_names(permissions)
     return list(permission_names)


### PR DESCRIPTION
I want to merge this change because user returned from `external...` mutation doesn't have assigned permissions.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
