### PR TITLE
Fix product updated and created webhooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Introduce product reference attributes - #6711 by @IKarbowiak
 - Add metadata to warehouse - #6727 by @d-wysocki
 - Add page webhooks: `PAGE_CREATED`, `PAGE_UPDATED` and `PAGE_DELETED` - #6787 by @d-wysocki
+- Fix `product_updated` and `product_created` webhooks - #6798 by @d-wysocki
 
 # 2.11.1
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -623,10 +623,13 @@ class ProductCreate(ModelMutation):
             instance.collections.set(collections)
 
     @classmethod
+    def post_save_action(cls, info, instance, cleaned_input):
+        info.context.plugins.product_created(instance)
+
+    @classmethod
     def perform_mutation(cls, _root, info, **data):
         response = super().perform_mutation(_root, info, **data)
         product = getattr(response, cls._meta.return_field_name)
-        info.context.plugins.product_created(product)
 
         # Wrap product instance with ChannelContext in response
         setattr(
@@ -658,6 +661,9 @@ class ProductUpdate(ProductCreate):
         attributes = cleaned_input.get("attributes")
         if attributes:
             AttributeAssignmentMixin.save(instance, attributes)
+
+    @classmethod
+    def post_save_action(cls, info, instance, cleaned_input):
         info.context.plugins.product_updated(instance)
 
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -2268,7 +2268,11 @@ CREATE_PRODUCT_MUTATION = """
 """
 
 
+@patch("saleor.plugins.manager.PluginsManager.product_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_created")
 def test_create_product(
+    created_webhook_mock,
+    updated_webhook_mock,
     staff_api_client,
     product_type,
     category,
@@ -2341,6 +2345,11 @@ def test_create_product(
     )
     assert slugify(non_existent_attr_value) in values
     assert color_value_slug in values
+
+    product = Product.objects.first()
+    created_webhook_mock.assert_called_once_with(product)
+
+    updated_webhook_mock.assert_not_called()
 
 
 def test_create_product_description_plaintext(
@@ -3677,7 +3686,9 @@ MUTATION_UPDATE_PRODUCT = """
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_updated")
+@patch("saleor.plugins.manager.PluginsManager.product_created")
 def test_update_product(
+    created_webhook_mock,
     updated_webhook_mock,
     staff_api_client,
     category,
@@ -3743,6 +3754,7 @@ def test_update_product(
     assert attributes[0]["values"][0]["slug"] == "rainbow"
 
     updated_webhook_mock.assert_called_once_with(product)
+    created_webhook_mock.assert_not_called()
 
 
 def test_update_and_search_product_by_description(


### PR DESCRIPTION
I want to merge this change because...I want to fix product_updated and product_created webhooks

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
