### PR TITLE
Deprecate tax type in ProductType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Deprecate `taxRate` field from `ProductType` - #6803 by @d-wysocki
+
 # 2.11.6
 
 - Add Authorize.Net integration - #6752 by @bufke

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -677,7 +677,12 @@ class ProductType(CountableDjangoObjectType):
     products = PrefetchingConnectionField(
         Product, description="List of products of this type."
     )
-    tax_rate = TaxRateType(description="A type of tax rate.")
+    tax_rate = TaxRateType(
+        description="A type of tax rate.",
+        deprecation_reason=(
+            "Use the TaxType instead. It will be removed in Saleor 3.0."
+        ),
+    )
     tax_type = graphene.Field(
         TaxType, description="A type of tax. Assigned by enabled tax gateway"
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3974,7 +3974,7 @@ type ProductType implements Node & ObjectWithMetadata {
   privateMeta: [MetaStore]! @deprecated(reason: "Use the `privetaMetadata` field. This field will be removed after 2020-07-31.")
   meta: [MetaStore]! @deprecated(reason: "Use the `metadata` field. This field will be removed after 2020-07-31.")
   products(before: String, after: String, first: Int, last: Int): ProductCountableConnection
-  taxRate: TaxRateType
+  taxRate: TaxRateType @deprecated(reason: "Use the TaxType instead. It will be removed in Saleor 3.0.")
   taxType: TaxType
   variantAttributes: [Attribute]
   productAttributes: [Attribute]


### PR DESCRIPTION
I want to merge this change because...I want to deprecate  `taxType` fiend in `ProductType`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
