### PR TITLE
Fix creating translations with app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ### Other
 
+- Fix creating translations with app - #6804 by @krzysztofwolski
 - Add possibility to provide external payment ID during the conversion draft order to order - #6320 by @korycins
 - Add basic rating for `Products` - #6284 by @korycins
 - Add metadata to shipping zones and shipping methods - #6340 by @maarcingebala

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -25,10 +25,6 @@ class BaseTranslateMutation(ModelMutation):
         abstract = True
 
     @classmethod
-    def check_permissions(cls, context):
-        return context.user.has_perm(SitePermissions.MANAGE_TRANSLATIONS)
-
-    @classmethod
     def perform_mutation(cls, _root, info, **data):
         if "id" in data and not data["id"]:
             raise ValidationError(
@@ -69,6 +65,7 @@ class CategoryTranslate(BaseTranslateMutation):
         model = product_models.Category
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
 
 class ProductTranslate(BaseTranslateMutation):
@@ -84,6 +81,7 @@ class ProductTranslate(BaseTranslateMutation):
         model = product_models.Product
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -114,6 +112,7 @@ class CollectionTranslate(BaseTranslateMutation):
         model = product_models.Collection
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -135,6 +134,7 @@ class ProductVariantTranslate(BaseTranslateMutation):
         model = product_models.ProductVariant
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -165,6 +165,7 @@ class AttributeTranslate(BaseTranslateMutation):
         model = attribute_models.Attribute
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
 
 class AttributeValueTranslate(BaseTranslateMutation):
@@ -180,6 +181,7 @@ class AttributeValueTranslate(BaseTranslateMutation):
         model = attribute_models.AttributeValue
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
 
 class SaleTranslate(BaseTranslateMutation):
@@ -195,6 +197,7 @@ class SaleTranslate(BaseTranslateMutation):
         model = discount_models.Sale
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -216,6 +219,7 @@ class VoucherTranslate(BaseTranslateMutation):
         model = discount_models.Voucher
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -237,6 +241,7 @@ class ShippingPriceTranslate(BaseTranslateMutation):
         model = shipping_models.ShippingMethod
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -258,6 +263,7 @@ class MenuItemTranslate(BaseTranslateMutation):
         model = menu_models.MenuItem
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
@@ -284,6 +290,7 @@ class PageTranslate(BaseTranslateMutation):
         model = page_models.Page
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
 
 class ShopSettingsTranslationInput(graphene.InputObjectType):
@@ -308,6 +315,7 @@ class ShopSettingsTranslate(BaseMutation):
         permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
         error_type_class = TranslationError
         error_type_field = "translation_errors"
+        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
 
     @classmethod
     def perform_mutation(cls, _root, info, language_code, **data):

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -312,7 +312,6 @@ class ShopSettingsTranslate(BaseMutation):
 
     class Meta:
         description = "Creates/Updates translations for Shop Settings."
-        permissions = (SitePermissions.MANAGE_TRANSLATIONS,)
         error_type_class = TranslationError
         error_type_field = "translation_errors"
         permissions = (SitePermissions.MANAGE_TRANSLATIONS,)


### PR DESCRIPTION
I want to merge this change because apps were not able to create translations.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
