### PR TITLE
Remove deprecated webhook header

### DIFF
--- a/saleor/plugins/webhook/tasks.py
+++ b/saleor/plugins/webhook/tasks.py
@@ -58,10 +58,6 @@ def send_webhook_using_http(target_url, message, domain, signature, event_type):
         "X-Saleor-Signature": signature,
     }
 
-    if signature:
-        # This header is depreceated and will be removed in Saleor3.0
-        headers["X-Saleor-HMAC-SHA256"] = f"sha1={signature}"
-
     response = requests.post(
         target_url, data=message, headers=headers, timeout=WEBHOOK_TIMEOUT
     )

--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -226,7 +226,6 @@ def test_trigger_webhooks_with_http_and_secret_key(
         "X-Saleor-Event": "order_created",
         "X-Saleor-Domain": "mirumee.com",
         "X-Saleor-Signature": expected_signature,
-        "X-Saleor-HMAC-SHA256": f"sha1={expected_signature}",
     }
 
     mock_request.assert_called_once_with(


### PR DESCRIPTION
I want to merge this change because...I want to drop deprecated webhook header - `X-Saleor-HMAC-SHA256`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
