### PR TITLE
Allow exporting swatch attributes

### DIFF
--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -226,6 +226,7 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     product_type_page_reference_attribute,
     product_type_product_reference_attribute,
     numeric_attribute,
+    swatch_attribute,
     page_list,
 ):
     # given
@@ -235,12 +236,14 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
         product_type_page_reference_attribute,
         product_type_product_reference_attribute,
         numeric_attribute,
+        swatch_attribute,
     )
     product.product_type.product_attributes.add(
         file_attribute,
         product_type_page_reference_attribute,
         product_type_product_reference_attribute,
         numeric_attribute,
+        swatch_attribute,
     )
 
     # add file attribute
@@ -302,6 +305,15 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
         variant_with_many_stocks, numeric_attribute, numeric_value_1
     )
     associate_attribute_values_to_instance(product, numeric_attribute, numeric_value_2)
+
+    # add swatch attribute
+    swatch_value_1 = swatch_attribute.values.first()
+    swatch_value_2 = swatch_attribute.values.last()
+
+    associate_attribute_values_to_instance(
+        variant_with_many_stocks, swatch_attribute, swatch_value_1
+    )
+    associate_attribute_values_to_instance(product, swatch_attribute, swatch_value_2)
 
     products = Product.objects.all()
     export_fields = {"id", "variants__sku"}

--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -768,10 +768,11 @@ def test_add_attribute_info_to_data(product):
     # given
     pk = product.pk
     slug = "test_attribute_slug"
-    value = "test value"
+    value_slug = "test value"
     attribute_data = AttributeData(
         slug=slug,
-        value=value,
+        value_slug=value_slug,
+        value=None,
         file_url=None,
         input_type="dropdown",
         entity_type=None,
@@ -786,19 +787,20 @@ def test_add_attribute_info_to_data(product):
 
     # then
     expected_header = f"{slug} (product attribute)"
-    assert result[pk][expected_header] == {value}
+    assert result[pk][expected_header] == {value_slug}
 
 
 def test_add_attribute_info_to_data_update_attribute_data(product):
     # given
     pk = product.pk
     slug = "test_attribute_slug"
-    value = "test value"
+    value_slug = "test-value"
     expected_header = f"{slug} (variant attribute)"
 
     attribute_data = AttributeData(
         slug=slug,
-        value=value,
+        value_slug=value_slug,
+        value=None,
         file_url=None,
         input_type="dropdown",
         entity_type=None,
@@ -812,7 +814,7 @@ def test_add_attribute_info_to_data_update_attribute_data(product):
     )
 
     # then
-    assert result[pk][expected_header] == {value, "value1"}
+    assert result[pk][expected_header] == {value_slug, "value1"}
 
 
 def test_add_attribute_info_to_data_no_slug(product):
@@ -820,6 +822,7 @@ def test_add_attribute_info_to_data_no_slug(product):
     pk = product.pk
     attribute_data = AttributeData(
         slug=None,
+        value_slug=None,
         value=None,
         file_url=None,
         input_type="dropdown",
@@ -844,6 +847,7 @@ def test_add_file_attribute_info_to_data(product):
     test_url = "test.txt"
     attribute_data = AttributeData(
         slug=slug,
+        value_slug=None,
         value=None,
         file_url=test_url,
         input_type="file",
@@ -866,10 +870,11 @@ def test_add_reference_attribute_info_to_data(product, page):
     # given
     pk = product.pk
     slug = "test_attribute_slug"
-    value = f"{product.id}_{page.id}"
+    value_slug = f"{product.id}_{page.id}"
     attribute_data = AttributeData(
         slug=slug,
-        value=value,
+        value_slug=value_slug,
+        value=None,
         file_url=None,
         input_type="reference",
         entity_type="Page",
@@ -891,13 +896,14 @@ def test_add_reference_info_to_data_update_attribute_data(product, page):
     # given
     pk = product.pk
     slug = "test_attribute_slug"
-    value = f"{product.id}_{page.id}"
+    value_slug = f"{product.id}_{page.id}"
     expected_header = f"{slug} (variant attribute)"
     values = {"Page_989"}
 
     attribute_data = AttributeData(
         slug=slug,
-        value=value,
+        value_slug=value_slug,
+        value=None,
         file_url=None,
         input_type="reference",
         entity_type="Page",
@@ -918,10 +924,11 @@ def test_add_reference_info_to_data_update_attribute_data(product, page):
 def test_add_numeric_attribute_info_to_data(product, numeric_attribute):
     # given
     pk = product.pk
-    value = "12.3"
+    slug = "12.3"
     attribute_data = AttributeData(
         slug=numeric_attribute.slug,
-        value=value,
+        value_slug=slug,
+        value=None,
         file_url=None,
         input_type="numeric",
         entity_type=None,
@@ -936,16 +943,17 @@ def test_add_numeric_attribute_info_to_data(product, numeric_attribute):
 
     # then
     expected_header = f"{numeric_attribute.slug} (product attribute)"
-    assert result[pk][expected_header] == {f"{value} {numeric_attribute.unit}"}
+    assert result[pk][expected_header] == {f"{slug} {numeric_attribute.unit}"}
 
 
 def test_add_numeric_attribute_info_to_data_no_unit(product, numeric_attribute):
     # given
     pk = product.pk
-    value = "12.3"
+    slug = "12.3"
     attribute_data = AttributeData(
         slug=numeric_attribute.slug,
-        value=value,
+        value_slug=slug,
+        value=None,
         file_url=None,
         input_type="numeric",
         entity_type=None,
@@ -960,7 +968,59 @@ def test_add_numeric_attribute_info_to_data_no_unit(product, numeric_attribute):
 
     # then
     expected_header = f"{numeric_attribute.slug} (product attribute)"
+    assert result[pk][expected_header] == {slug}
+
+
+def test_add_swatch_attribute_file_info_to_data(product, swatch_attribute):
+    # given
+    pk = product.pk
+    slug = "white"
+    value = "#ffffff"
+    attribute_data = AttributeData(
+        slug=swatch_attribute.slug,
+        value_slug=slug,
+        value=value,
+        file_url=None,
+        input_type="swatch",
+        entity_type=None,
+        unit=None,
+    )
+    input_data = {pk: {}}
+
+    # when
+    result = add_attribute_info_to_data(
+        product.pk, attribute_data, "product attribute", input_data
+    )
+
+    # then
+    expected_header = f"{swatch_attribute.slug} (product attribute)"
     assert result[pk][expected_header] == {value}
+
+
+def test_add_swatch_attribute_value_info_to_data(product, numeric_attribute):
+    # given
+    pk = product.pk
+    slug = "Logo"
+    test_url = "test.txt"
+    attribute_data = AttributeData(
+        slug=numeric_attribute.slug,
+        value_slug=slug,
+        value=None,
+        file_url=test_url,
+        input_type="swatch",
+        entity_type=None,
+        unit=None,
+    )
+    input_data = {pk: {}}
+
+    # when
+    result = add_attribute_info_to_data(
+        product.pk, attribute_data, "product attribute", input_data
+    )
+
+    # then
+    expected_header = f"{numeric_attribute.slug} (product attribute)"
+    assert result[pk][expected_header] == {"http://mirumee.com/media/" + test_url}
 
 
 def test_add_warehouse_info_to_data(product):

--- a/saleor/csv/tests/export/products_data/utils.py
+++ b/saleor/csv/tests/export/products_data/utils.py
@@ -39,6 +39,10 @@ def get_attribute_value(assigned_attribute):
         value = f"{value_instance.name}"
         if attribute.unit:
             value += f" {attribute.unit}"
+    elif attribute.input_type == AttributeInputType.SWATCH:
+        value = (
+            value_instance.file_url if value_instance.file_url else value_instance.value
+        )
     else:
         value = value_instance.slug
     return value

--- a/saleor/csv/utils/__init__.py
+++ b/saleor/csv/utils/__init__.py
@@ -21,8 +21,9 @@ class ProductExportFields:
     }
 
     PRODUCT_ATTRIBUTE_FIELDS = {
-        "value": "attributes__values__slug",
+        "value_slug": "attributes__values__slug",
         "file_url": "attributes__values__file_url",
+        "value": "attributes__values__value",
         "slug": "attributes__assignment__attribute__slug",
         "input_type": "attributes__assignment__attribute__input_type",
         "entity_type": "attributes__assignment__attribute__entity_type",
@@ -47,8 +48,9 @@ class ProductExportFields:
     }
 
     VARIANT_ATTRIBUTE_FIELDS = {
-        "value": "variants__attributes__values__slug",
+        "value_slug": "variants__attributes__values__slug",
         "file_url": "variants__attributes__values__file_url",
+        "value": "variants__attributes__values__value",
         "slug": "variants__attributes__assignment__attribute__slug",
         "input_type": "variants__attributes__assignment__attribute__input_type",
         "entity_type": "variants__attributes__assignment__attribute__entity_type",


### PR DESCRIPTION
Add ability to export swatch attributes. Export swatch file or swatch color value.

Linked task: [SALEOR-2045](https://app.clickup.com/t/2549495/SALEOR-2045)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
