### PR TITLE
Do not expect that jwt payload will have exp field

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -68,6 +68,15 @@ def jwt_encode(payload: Dict[str, Any]) -> str:
     )
 
 
+def jwt_decode_with_exception_handler(
+    token: str, verify_expiration=settings.JWT_EXPIRE
+) -> Optional[Dict[str, Any]]:
+    try:
+        return jwt_decode(token, verify_expiration=verify_expiration)
+    except jwt.PyJWTError:
+        return None
+
+
 def jwt_decode(token: str, verify_expiration=settings.JWT_EXPIRE) -> Dict[str, Any]:
     return jwt.decode(
         token,

--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -12,7 +12,7 @@ from django_countries.fields import Country
 from ..discount.utils import fetch_discounts
 from ..plugins.manager import get_plugins_manager
 from . import analytics
-from .jwt import JWT_REFRESH_TOKEN_COOKIE_NAME, jwt_decode
+from .jwt import JWT_REFRESH_TOKEN_COOKIE_NAME, jwt_decode_with_exception_handler
 from .utils import get_client_ip, get_country_by_ip, get_currency_for_country
 
 logger = logging.getLogger(__name__)
@@ -126,8 +126,13 @@ def jwt_refresh_token_middleware(get_response):
         if jwt_refresh_token:
             expires = None
             if settings.JWT_EXPIRE:
-                refresh_token_payload = jwt_decode(jwt_refresh_token)
-                expires = datetime.utcfromtimestamp(refresh_token_payload["exp"])
+                refresh_token_payload = jwt_decode_with_exception_handler(
+                    jwt_refresh_token
+                )
+                if refresh_token_payload and refresh_token_payload.get("exp"):
+                    expires = datetime.utcfromtimestamp(
+                        refresh_token_payload.get("exp")
+                    )
             response.set_cookie(
                 JWT_REFRESH_TOKEN_COOKIE_NAME,
                 jwt_refresh_token,

--- a/saleor/core/tests/test_middleware.py
+++ b/saleor/core/tests/test_middleware.py
@@ -1,12 +1,41 @@
 from django.core.handlers.base import BaseHandler
 from freezegun import freeze_time
 
-from ..jwt import JWT_REFRESH_TOKEN_COOKIE_NAME, create_refresh_token
+from ..jwt import (
+    JWT_REFRESH_TOKEN_COOKIE_NAME,
+    JWT_REFRESH_TYPE,
+    create_refresh_token,
+    jwt_encode,
+    jwt_user_payload,
+)
 
 
 @freeze_time("2020-03-18 12:00:00")
 def test_jwt_refresh_token_middleware(rf, customer_user, settings):
     refresh_token = create_refresh_token(customer_user)
+    settings.MIDDLEWARE = [
+        "saleor.core.middleware.jwt_refresh_token_middleware",
+    ]
+    request = rf.request()
+    request.refresh_token = refresh_token
+    handler = BaseHandler()
+    handler.load_middleware()
+    response = handler.get_response(request)
+    cookie = response.cookies.get(JWT_REFRESH_TOKEN_COOKIE_NAME)
+    assert cookie.value == refresh_token
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_jwt_refresh_token_middleware_token_without_expire(rf, customer_user, settings):
+    settings.JWT_EXPIRE = True
+    payload = jwt_user_payload(
+        customer_user,
+        JWT_REFRESH_TYPE,
+        settings.JWT_TTL_REFRESH,
+    )
+    del payload["exp"]
+
+    refresh_token = jwt_encode(payload)
     settings.MIDDLEWARE = [
         "saleor.core.middleware.jwt_refresh_token_middleware",
     ]

--- a/saleor/graphql/account/tests/mutations/test_external_obtain_access_tokens.py
+++ b/saleor/graphql/account/tests/mutations/test_external_obtain_access_tokens.py
@@ -36,7 +36,7 @@ def test_external_obtain_access_tokens_plugin_not_active(api_client, customer_us
     assert data["user"] is None
 
 
-@patch("saleor.core.middleware.jwt_decode")
+@patch("saleor.core.middleware.jwt_decode_with_exception_handler")
 def test_external_obtain_access_tokens(
     mock_refresh_token_middleware, api_client, customer_user, monkeypatch, rf
 ):

--- a/saleor/graphql/account/tests/mutations/test_external_refresh.py
+++ b/saleor/graphql/account/tests/mutations/test_external_refresh.py
@@ -33,7 +33,7 @@ def test_external_refresh_plugin_not_active(api_client, customer_user):
     assert data["user"] is None
 
 
-@patch("saleor.core.middleware.jwt_decode")
+@patch("saleor.core.middleware.jwt_decode_with_exception_handler")
 def test_external_refresh(
     mock_refresh_token_middleware, api_client, customer_user, monkeypatch, rf
 ):


### PR DESCRIPTION
The external plugins can use the `request.refresh_token` to set their own token as a cookie. We can't assume that we will always get the `exp` from the payload.