### PR TITLE
Add query contains only schema validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable, unreleased changes to this project will be documented in this file. For the released changes, please visit the [Releases](https://github.com/mirumee/saleor/releases) page.
 
 ## [Unreleased]
+- Add query contains only schema validation - #6827 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -309,3 +309,24 @@ def test_example_query(api_client, product):
     response = api_client.post_graphql(EXAMPLE_QUERY)
     content = get_graphql_content(response)
     assert content["data"]["products"]["edges"][0]["node"]["name"] == product.name
+
+
+def test_query_contains_not_only_schema_raise_error(api_client, graphql_log_handler):
+    response = api_client.post_graphql(
+        """
+        query IntrospectionQuery {
+            me {
+                email
+            }
+            __schema {
+                queryType {
+                    name
+                }
+            }
+        }
+        """
+    )
+    assert response.status_code == 400
+    assert graphql_log_handler.messages == [
+        "saleor.graphql.errors.handled[INFO].GraphQLError"
+    ]

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -311,13 +311,16 @@ def test_example_query(api_client, product):
     assert content["data"]["products"]["edges"][0]["node"]["name"] == product.name
 
 
-def test_query_contains_not_only_schema_raise_error(api_client, graphql_log_handler):
-    response = api_client.post_graphql(
-        """
+@pytest.mark.parametrize(
+    "other_query",
+    ["me{email}", 'products(first:5,channel:"channel"){edges{node{name}}}'],
+)
+def test_query_contains_not_only_schema_raise_error(
+    other_query, api_client, graphql_log_handler
+):
+    query = """
         query IntrospectionQuery {
-            me {
-                email
-            }
+            %(other_query)s
             __schema {
                 queryType {
                     name
@@ -325,7 +328,7 @@ def test_query_contains_not_only_schema_raise_error(api_client, graphql_log_hand
             }
         }
         """
-    )
+    response = api_client.post_graphql(query % {"other_query": other_query})
     assert response.status_code == 400
     assert graphql_log_handler.messages == [
         "saleor.graphql.errors.handled[INFO].GraphQLError"


### PR DESCRIPTION
I want to merge this change because adding query contains only schema validation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
