### PR TITLE
Deprecate geolocalization query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Deprecate `Shop.geolocalization` query - #6828 by @maarcingebala
+
 # 2.11.7
 
 - Deprecate `taxRate` field from `ProductType` - #6803 by @d-wysocki

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4779,7 +4779,7 @@ input ShippingZoneUpdateInput {
 
 type Shop {
   availablePaymentGateways(currency: String): [PaymentGateway!]!
-  geolocalization: Geolocalization
+  geolocalization: Geolocalization @deprecated(reason: "Server-side geolocalization will be dropped in Saleor 3.0.")
   authorizationKeys: [AuthorizationKey]!
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
   currencies: [String]! @deprecated(reason: "This field will be removed in Saleor 3.0")

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -77,7 +77,9 @@ class Shop(graphene.ObjectType):
         required=True,
     )
     geolocalization = graphene.Field(
-        Geolocalization, description="Customer's geolocalization data."
+        Geolocalization,
+        description="Customer's geolocalization data.",
+        deprecation_reason="Server-side geolocalization will be dropped in Saleor 3.0.",
     )
     authorization_keys = graphene.List(
         AuthorizationKey,


### PR DESCRIPTION
This PR deprecates `shop { geolocalization }` query since in Saleor 3.0 server-side geolocalization won't be supported.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
