### PR TITLE
Fix page content_json field to return JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `PRODUCT_DELETED` webhook - #6794 by @d-wysocki
 - Fix `product_updated` and `product_created` webhooks - #6798 by @d-wysocki
 - Add interface for integrating the auth plugins - #6799 by @korycins
+- Fix page `contentJson` field to return JSON - #6832 by @d-wysocki
 
 # 2.11.1
 

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -24,6 +24,8 @@ PAGE_QUERY = """
             pageType {
                 id
             }
+            content
+            contentJson
             attributes {
                 attribute {
                     slug
@@ -56,6 +58,11 @@ def test_query_published_page(user_api_client, page):
     response = user_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)
     page_data = content["data"]["page"]
+    assert (
+        page_data["content"]
+        == page_data["contentJson"]
+        == dummy_editorjs("Test content.", True)
+    )
     assert page_data["title"] == page.title
     assert page_data["slug"] == page.slug
     assert page_data["pageType"]["id"] == graphene.Node.to_global_id(

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -21,7 +21,7 @@ from .dataloaders import (
 
 
 class Page(CountableDjangoObjectType):
-    content_json = graphene.String(
+    content_json = graphene.JSONString(
         description="Content of the page (JSON).",
         deprecation_reason=(
             "Will be removed in Saleor 4.0. Use the `content` field instead."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3319,7 +3319,7 @@ type Page implements Node & ObjectWithMetadata {
   created: DateTime!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  contentJson: String! @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString! @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   attributes: [SelectedAttribute!]!
 }
@@ -3446,7 +3446,7 @@ type PageTranslatableContent implements Node {
   id: ID!
   title: String!
   content: JSONString!
-  contentJson: String @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page
 }
@@ -3464,7 +3464,7 @@ type PageTranslation implements Node {
   title: String!
   content: JSONString!
   language: LanguageDisplay!
-  contentJson: String @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
 }
 
 input PageTranslationInput {

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -243,7 +243,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 
 
 class PageTranslation(BaseTranslationType):
-    content_json = graphene.String(
+    content_json = graphene.JSONString(
         description="Translated description of the page (JSON).",
         deprecation_reason=(
             "Will be removed in Saleor 4.0. Use the `content` field instead."
@@ -263,7 +263,7 @@ class PageTranslation(BaseTranslationType):
 
 
 class PageTranslatableContent(CountableDjangoObjectType):
-    content_json = graphene.String(
+    content_json = graphene.JSONString(
         description="Content of the page (JSON).",
         deprecation_reason=(
             "Will be removed in Saleor 4.0. Use the `content` field instead."


### PR DESCRIPTION
I want to merge this change because...I want to change `contentJson` field on Page to return JSON instead of String.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
