### PR TITLE
Allow assigning attribute values to category

### DIFF
--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -246,10 +246,10 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
 
     # add file attribute
     associate_attribute_values_to_instance(
-        variant_with_many_stocks, file_attribute, file_attribute.values.first()
+        variant_with_many_stocks, file_attribute, [file_attribute.values.first()]
     )
     associate_attribute_values_to_instance(
-        product, file_attribute, file_attribute.values.first()
+        product, file_attribute, [file_attribute.values.first()]
     )
 
     # add page reference attribute
@@ -266,10 +266,10 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
         product_type_page_reference_attribute,
-        variant_page_ref_value,
+        [variant_page_ref_value],
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, product_page_ref_value
+        product, product_type_page_reference_attribute, [product_page_ref_value]
     )
 
     # add product reference attribute
@@ -289,10 +289,10 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     associate_attribute_values_to_instance(
         variant_with_many_stocks,
         product_type_product_reference_attribute,
-        variant_product_ref_value,
+        [variant_product_ref_value],
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, product_product_ref_value
+        product, product_type_product_reference_attribute, [product_product_ref_value]
     )
 
     products = Product.objects.all()

--- a/saleor/csv/tests/export/products_data/test_handle_relations_data.py
+++ b/saleor/csv/tests/export/products_data/test_handle_relations_data.py
@@ -89,7 +89,7 @@ def test_get_products_relations_data_attribute_ids(
         product_type_product_reference_attribute,
     )
     associate_attribute_values_to_instance(
-        product, file_attribute, file_attribute.values.first()
+        product, file_attribute, [file_attribute.values.first()]
     )
     page_ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
@@ -97,7 +97,7 @@ def test_get_products_relations_data_attribute_ids(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, page_ref_value
+        product, product_type_page_reference_attribute, [page_ref_value]
     )
     product_ref_value = AttributeValue.objects.create(
         attribute=product_type_product_reference_attribute,
@@ -105,7 +105,7 @@ def test_get_products_relations_data_attribute_ids(
         name=product_list[1].name,
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, product_ref_value
+        product, product_type_product_reference_attribute, [product_ref_value]
     )
 
     qs = Product.objects.all()
@@ -163,7 +163,7 @@ def test_prepare_products_relations_data(
         file_attribute, product_type_page_reference_attribute
     )
     associate_attribute_values_to_instance(
-        product_with_image, file_attribute, file_attribute.values.first()
+        product_with_image, file_attribute, [file_attribute.values.first()]
     )
     ref_value = AttributeValue.objects.create(
         attribute=product_type_page_reference_attribute,
@@ -171,7 +171,7 @@ def test_prepare_products_relations_data(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        product_with_image, product_type_page_reference_attribute, ref_value
+        product_with_image, product_type_page_reference_attribute, [ref_value]
     )
 
     collection_list[0].products.add(product_with_image)
@@ -359,7 +359,7 @@ def test_get_variants_relations_data_attribute_ids(
     )
     variant = product.variants.first()
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant, file_attribute, [file_attribute.values.first()]
     )
     # add page reference attribute
     page_ref_value = AttributeValue.objects.create(
@@ -368,7 +368,7 @@ def test_get_variants_relations_data_attribute_ids(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, page_ref_value
+        variant, product_type_page_reference_attribute, [page_ref_value]
     )
     # add product reference attribute
     product_ref_value = AttributeValue.objects.create(
@@ -377,7 +377,7 @@ def test_get_variants_relations_data_attribute_ids(
         name=product_list[1].name,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, product_ref_value
+        variant, product_type_product_reference_attribute, [product_ref_value]
     )
 
     qs = Product.objects.all()
@@ -496,7 +496,7 @@ def test_prepare_variants_relations_data(
     )
     variant = product_1.variants.first()
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant, file_attribute, [file_attribute.values.first()]
     )
     # add page reference attribute
     page_ref_value = AttributeValue.objects.create(
@@ -505,7 +505,7 @@ def test_prepare_variants_relations_data(
         name=page.title,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, page_ref_value
+        variant, product_type_page_reference_attribute, [page_ref_value]
     )
     # add prodcut reference attribute
     product_ref_value = AttributeValue.objects.create(
@@ -514,7 +514,7 @@ def test_prepare_variants_relations_data(
         name=product.name,
     )
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, product_ref_value
+        variant, product_type_product_reference_attribute, [product_ref_value]
     )
 
     qs = Product.objects.all()

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
@@ -107,7 +107,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_customer(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -156,7 +156,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_staff_with_per
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -199,7 +199,7 @@ def test_filter_attributes_in_category_not_in_listings_by_staff_without_manage_p
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -245,7 +245,7 @@ def test_filter_attributes_in_category_not_visible_in_listings_by_app_with_perm(
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -288,7 +288,7 @@ def test_filter_attributes_in_category_not_in_listings_by_app_without_manage_pro
     last_product.channel_listings.all().update(visible_in_listings=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -328,7 +328,7 @@ def test_filter_attributes_in_category_not_published_by_customer(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -377,7 +377,7 @@ def test_filter_attributes_in_category_not_published_by_staff_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -420,7 +420,7 @@ def test_filter_attributes_in_category_not_published_by_staff_without_manage_pro
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -466,7 +466,7 @@ def test_filter_attributes_in_category_not_published_by_app_with_perm(
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -509,7 +509,7 @@ def test_filter_attributes_in_category_not_published_by_app_without_manage_produ
     last_product.channel_listings.all().update(is_published=False)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -552,7 +552,7 @@ def test_filter_attributes_in_collection_not_visible_in_listings_by_customer(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -594,7 +594,7 @@ def test_filter_in_collection_not_published_by_customer(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -646,7 +646,7 @@ def test_filter_in_collection_not_published_by_staff_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -692,7 +692,7 @@ def test_filter_in_collection_not_published_by_staff_without_manage_products(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -741,7 +741,7 @@ def test_filter_in_collection_not_published_by_app_with_perm(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()
@@ -787,7 +787,7 @@ def test_filter_in_collection_not_published_by_app_without_manage_products(
         collection.products.add(product)
 
     associate_attribute_values_to_instance(
-        product_list[-1], weight_attribute, weight_attribute.values.first()
+        product_list[-1], weight_attribute, [weight_attribute.values.first()]
     )
 
     attribute_count = Attribute.objects.count()

--- a/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
+++ b/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
@@ -120,7 +120,7 @@ def test_attributes_of_products_are_sorted(
     node = variant if is_variant else product  # type: Union[Product, ProductVariant]
     node.attributesrelated.clear()
     associate_attribute_values_to_instance(
-        node, color_attribute, color_attribute.values.first()
+        node, color_attribute, [color_attribute.values.first()]
     )
 
     # Sort the database attributes by their sort order and ID (when None)

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -382,7 +382,7 @@ class AttributeAssignmentMixin:
             else:
                 attribute_values = cls._pre_save_values(attribute, attr_values)
             associate_attribute_values_to_instance(
-                instance, attribute, *attribute_values
+                instance, attribute, attribute_values
             )
 
 

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from django.db.models import QuerySet
 
     from ...attribute.models import Attribute
+    from ...site.models import SiteSettings
 
 
 @dataclass
@@ -362,7 +363,12 @@ class AttributeAssignmentMixin:
         return values
 
     @classmethod
-    def save(cls, instance: T_INSTANCE, cleaned_input: T_INPUT_MAP):
+    def save(
+        cls,
+        instance: T_INSTANCE,
+        cleaned_input: T_INPUT_MAP,
+        site_settings: Optional["SiteSettings"] = None,
+    ):
         """Save the cleaned input into the database against the given instance.
 
         Note: this should always be ran inside a transaction.
@@ -382,7 +388,7 @@ class AttributeAssignmentMixin:
             else:
                 attribute_values = cls._pre_save_values(attribute, attr_values)
             associate_attribute_values_to_instance(
-                instance, attribute, attribute_values
+                instance, attribute, attribute_values, site_settings
             )
 
 

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -151,7 +151,7 @@ def test_get_page_with_sorted_attribute_values(
 
     attr_values = [attr_value_2, attr_value_1, attr_value_3]
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, *attr_values
+        page, page_type_product_reference_attribute, attr_values
     )
 
     page_id = graphene.Node.to_global_id("Page", page.id)
@@ -1264,7 +1264,7 @@ def test_update_page_with_file_attribute_new_value_is_not_created(
         "Attribute", page_file_attribute.pk
     )
     existing_value = page_file_attribute.values.first()
-    associate_attribute_values_to_instance(page, page_file_attribute, existing_value)
+    associate_attribute_values_to_instance(page, page_file_attribute, [existing_value])
 
     page_id = graphene.Node.to_global_id("Page", page.id)
 
@@ -1380,7 +1380,7 @@ def test_update_page_with_page_reference_attribute_existing_value(
         slug=f"{page.pk}_{ref_page.pk}",
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, attr_value
+        page, page_type_page_reference_attribute, [attr_value]
     )
 
     values_count = page_type_page_reference_attribute.values.count()
@@ -1497,7 +1497,7 @@ def test_update_page_with_product_reference_attribute_existing_value(
         slug=f"{page.pk}_{product.pk}",
     )
     associate_attribute_values_to_instance(
-        page, page_type_product_reference_attribute, attr_value
+        page, page_type_product_reference_attribute, [attr_value]
     )
 
     values_count = page_type_product_reference_attribute.values.count()
@@ -1687,9 +1687,7 @@ def test_update_page_change_attribute_values_ordering(
     associate_attribute_values_to_instance(
         page,
         page_type_product_reference_attribute,
-        attr_value_3,
-        attr_value_2,
-        attr_value_1,
+        [attr_value_3, attr_value_2, attr_value_1],
     )
 
     assert list(

--- a/saleor/graphql/page/tests/test_page_reorder_attribute_values.py
+++ b/saleor/graphql/page/tests/test_page_reorder_attribute_values.py
@@ -77,7 +77,7 @@ def test_sort_page_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, page_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -142,7 +142,7 @@ def test_sort_page_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, page_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -203,7 +203,7 @@ def test_sort_page_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        page, page_type_page_reference_attribute, *attr_values
+        page, page_type_page_reference_attribute, attr_values
     )
 
     invalid_value_id = graphene.Node.to_global_id(

--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -1,5 +1,6 @@
 from .attributes import (
     ProductAttributesByProductTypeIdLoader,
+    SelectedAttributesByCategoryIdLoader,
     SelectedAttributesByProductIdLoader,
     SelectedAttributesByProductVariantIdLoader,
     VariantAttributesByProductTypeIdLoader,
@@ -54,6 +55,7 @@ __all__ = [
     "ProductVariantsByProductIdLoader",
     "ProductImageByIdLoader",
     "ImagesByProductVariantIdLoader",
+    "SelectedAttributesByCategoryIdLoader",
     "SelectedAttributesByProductIdLoader",
     "SelectedAttributesByProductVariantIdLoader",
     "VariantAttributesByProductTypeIdLoader",

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -968,7 +968,7 @@ def test_sort_product_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, product_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -1035,7 +1035,7 @@ def test_sort_product_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, product_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -1098,7 +1098,7 @@ def test_sort_product_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, *attr_values
+        product, product_type_page_reference_attribute, attr_values
     )
 
     invalid_value_id = graphene.Node.to_global_id(
@@ -1203,7 +1203,7 @@ def test_sort_product_variant_attribute_values(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, product_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -1273,7 +1273,7 @@ def test_sort_product_variant_attribute_values_invalid_attribute_id(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, product_type_page_reference_attribute, attr_values
     )
 
     variables = {
@@ -1337,7 +1337,7 @@ def test_sort_product_variant_attribute_values_invalid_value_id(
         ]
     )
     associate_attribute_values_to_instance(
-        variant, product_type_page_reference_attribute, *attr_values
+        variant, product_type_page_reference_attribute, attr_values
     )
 
     invalid_value_id = graphene.Node.to_global_id(

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -1475,7 +1475,7 @@ def test_products_query_with_filter_attributes(
     second_product.product_type = product_type
     second_product.slug = "second-product"
     second_product.save()
-    associate_attribute_values_to_instance(second_product, attribute, attr_value)
+    associate_attribute_values_to_instance(second_product, attribute, [attr_value])
 
     variables = {
         "filter": {"attributes": [{"slug": attribute.slug, "value": attr_value.slug}]}
@@ -1974,7 +1974,7 @@ def test_get_product_with_sorted_attribute_values(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value_2, attr_value_1
+        product, product_type_page_reference_attribute, [attr_value_2, attr_value_1]
     )
 
     product_id = graphene.Node.to_global_id("Product", product.id)
@@ -3912,7 +3912,7 @@ def test_update_product_with_file_attribute_value_new_value_is_not_created(
     attribute_id = graphene.Node.to_global_id("Attribute", file_attribute.pk)
     product_type.product_attributes.add(file_attribute)
     existing_value = file_attribute.values.first()
-    associate_attribute_values_to_instance(product, file_attribute, existing_value)
+    associate_attribute_values_to_instance(product, file_attribute, [existing_value])
 
     values_count = file_attribute.values.count()
 
@@ -4074,7 +4074,7 @@ def test_update_product_with_page_reference_attribute_existing_value(
         slug=f"{product.pk}_{page.pk}",
     )
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value
+        product, product_type_page_reference_attribute, [attr_value]
     )
 
     values_count = product_type_page_reference_attribute.values.count()
@@ -4259,7 +4259,7 @@ def test_update_product_with_product_reference_attribute_existing_value(
         slug=f"{product.pk}_{product_ref.pk}",
     )
     associate_attribute_values_to_instance(
-        product, product_type_product_reference_attribute, attr_value
+        product, product_type_product_reference_attribute, [attr_value]
     )
 
     values_count = product_type_product_reference_attribute.values.count()
@@ -4384,7 +4384,7 @@ def test_update_product_change_values_ordering(
     )
 
     associate_attribute_values_to_instance(
-        product, product_type_page_reference_attribute, attr_value_2, attr_value_1
+        product, product_type_page_reference_attribute, [attr_value_2, attr_value_1]
     )
 
     assert list(

--- a/saleor/graphql/product/tests/test_product_pagination.py
+++ b/saleor/graphql/product/tests/test_product_pagination.py
@@ -366,10 +366,10 @@ def products_for_pagination(
 
     product_attrib_values = color_attribute.values.all()
     associate_attribute_values_to_instance(
-        products[1], color_attribute, product_attrib_values[0]
+        products[1], color_attribute, [product_attrib_values[0]]
     )
     associate_attribute_values_to_instance(
-        products[3], color_attribute, product_attrib_values[1]
+        products[3], color_attribute, [product_attrib_values[1]]
     )
 
     variants = ProductVariant.objects.bulk_create(

--- a/saleor/graphql/product/tests/test_product_sorting_attributes.py
+++ b/saleor/graphql/product/tests/test_product_sorting_attributes.py
@@ -207,18 +207,16 @@ def products_structures(category, channel_USD):
         currency=channel_USD.currency_code,
     )
     dummy_attr_value = attr_value(dummy_attr, DUMMIES[0])
-    associate_attribute_values_to_instance(dummy, dummy_attr, *dummy_attr_value)
+    associate_attribute_values_to_instance(dummy, dummy_attr, dummy_attr_value)
 
     for products in (apples, oranges):
         for product, attr_values in zip(products, COLORS):
             attr_values = attr_value(colors_attr, *attr_values)
-            associate_attribute_values_to_instance(product, colors_attr, *attr_values)
+            associate_attribute_values_to_instance(product, colors_attr, attr_values)
 
         for product, attr_values in zip(products, TRADEMARKS):
             attr_values = attr_value(trademark_attr, attr_values)
-            associate_attribute_values_to_instance(
-                product, trademark_attr, *attr_values
-            )
+            associate_attribute_values_to_instance(product, trademark_attr, attr_values)
 
     return colors_attr, trademark_attr, dummy_attr
 
@@ -576,7 +574,9 @@ def test_sort_product_not_having_attribute_data(api_client, category, count_quer
     product_having_attr_value = product_models.Product.objects.create(
         name="Z", slug="z", product_type=product_type, **product_create_kwargs
     )
-    associate_attribute_values_to_instance(product_having_attr_value, attribute, value)
+    associate_attribute_values_to_instance(
+        product_having_attr_value, attribute, [value]
+    )
 
     # Create a product having the same product type but no attribute data
     product_models.Product.objects.create(

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -1362,10 +1362,10 @@ def test_update_product_variant_with_duplicated_attribute(
     variant2.sku = str(uuid4())[:12]
     variant2.save()
     associate_attribute_values_to_instance(
-        variant2, color_attribute, color_attribute.values.last()
+        variant2, color_attribute, [color_attribute.values.last()]
     )
     associate_attribute_values_to_instance(
-        variant2, size_attribute, size_attribute.values.last()
+        variant2, size_attribute, [size_attribute.values.last()]
     )
 
     assert variant.attributes.first().values.first().slug == "red"
@@ -1459,7 +1459,7 @@ def test_update_product_variant_with_duplicated_file_attribute(
     variant2.sku = str(uuid4())[:12]
     variant2.save()
     file_attr_value = file_attribute.values.last()
-    associate_attribute_values_to_instance(variant2, file_attribute, file_attr_value)
+    associate_attribute_values_to_instance(variant2, file_attribute, [file_attr_value])
 
     sku = str(uuid4())[:12]
     assert not variant.sku == sku
@@ -1685,9 +1685,7 @@ def test_update_product_variant_change_attribute_values_ordering(
     associate_attribute_values_to_instance(
         variant,
         product_type_product_reference_attribute,
-        attr_value_3,
-        attr_value_2,
-        attr_value_1,
+        [attr_value_3, attr_value_2, attr_value_1],
     )
 
     assert list(

--- a/saleor/graphql/product/tests/test_variant_query.py
+++ b/saleor/graphql/product/tests/test_variant_query.py
@@ -459,7 +459,7 @@ def test_get_variant_with_sorted_attribute_values(
 
     attr_values = [attr_value_2, attr_value_1, attr_value_3]
     associate_attribute_values_to_instance(
-        variant, product_type_product_reference_attribute, *attr_values
+        variant, product_type_product_reference_attribute, attr_values
     )
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -77,6 +77,7 @@ from ..dataloaders import (
     ProductTypeByIdLoader,
     ProductVariantByIdLoader,
     ProductVariantsByProductIdLoader,
+    SelectedAttributesByCategoryIdLoader,
     SelectedAttributesByProductIdLoader,
     SelectedAttributesByProductVariantIdLoader,
     VariantAttributesByProductTypeIdLoader,
@@ -975,6 +976,10 @@ class Category(CountableDjangoObjectType):
         ),
         description="List of products in the category.",
     )
+    attributes = graphene.List(
+        graphene.NonNull(SelectedAttribute),
+        description="List of attributes assigned to this category.",
+    )
     url = graphene.String(
         description="The storefront's URL for the category.",
         deprecation_reason="This field will be removed after 2020-07-31.",
@@ -1053,6 +1058,10 @@ class Category(CountableDjangoObjectType):
             qs = qs.filter(channel_listings__channel__slug=channel)
         qs = qs.filter(category__in=tree)
         return ChannelQsContext(qs=qs, channel_slug=channel)
+
+    @staticmethod
+    def resolve_attributes(root: models.Category, info):
+        return SelectedAttributesByCategoryIdLoader(info.context).load(root.id)
 
     @staticmethod
     def __resolve_reference(root, _info, **_kwargs):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -680,6 +680,7 @@ type Category implements Node & ObjectWithMetadata {
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
+  attributes: [SelectedAttribute!]
   url: String @deprecated(reason: "This field will be removed after 2020-07-31.")
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   backgroundImage(size: Int): Image

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -728,6 +728,7 @@ input CategoryInput {
   seo: SeoInput
   backgroundImage: Upload
   backgroundImageAlt: String
+  attributes: [AttributeValueInput]
 }
 
 type CategorySettings {

--- a/saleor/graphql/shop/tests/benchmark/test_category_settings.py
+++ b/saleor/graphql/shop/tests/benchmark/test_category_settings.py
@@ -12,6 +12,7 @@ def test_category_settings_update_by_staff(
     page_type_page_reference_attribute,
     page_type_product_reference_attribute,
     size_page_attribute,
+    tag_page_attribute,
     permission_manage_settings,
     count_queries,
 ):
@@ -34,7 +35,7 @@ def test_category_settings_update_by_staff(
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_page_reference_attribute, size_page_attribute]
+        for attr in [page_type_page_reference_attribute, tag_page_attribute]
     ]
     variables = {
         "input": {

--- a/saleor/graphql/shop/tests/test_category_settings_update.py
+++ b/saleor/graphql/shop/tests/test_category_settings_update.py
@@ -25,7 +25,7 @@ def test_category_settings_update_by_staff(
     staff_api_client,
     site_settings_with_category_attributes,
     page_type_page_reference_attribute,
-    page_type_product_reference_attribute,
+    tag_page_attribute,
     size_page_attribute,
     permission_manage_settings,
 ):
@@ -33,21 +33,20 @@ def test_category_settings_update_by_staff(
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_page_reference_attribute, size_page_attribute]
+        for attr in [page_type_page_reference_attribute, tag_page_attribute]
     ]
     variables = {
         "input": {
             "addAttributes": add_attrs,
             "removeAttributes": [
                 graphene.Node.to_global_id("Attribute", attr.pk)
-                for attr in [page_type_product_reference_attribute]
+                for attr in [size_page_attribute]
             ],
         }
     }
@@ -68,32 +67,30 @@ def test_category_settings_update_by_staff(
     assert {attr["id"] for attr in attr_data} == set(add_attrs)
 
     site_settings.refresh_from_db()
-    assert (
-        page_type_product_reference_attribute.pk
-        not in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk not in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
 
 def test_category_settings_update_by_staff_only_remove_attrs(
     staff_api_client,
     site_settings_with_category_attributes,
-    page_type_product_reference_attribute,
+    size_page_attribute,
     permission_manage_settings,
 ):
     # given
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     variables = {
         "input": {
             "removeAttributes": [
                 graphene.Node.to_global_id("Attribute", attr.pk)
-                for attr in [page_type_product_reference_attribute]
+                for attr in [size_page_attribute]
             ],
         }
     }
@@ -113,9 +110,8 @@ def test_category_settings_update_by_staff_only_remove_attrs(
     assert len(attr_data) == 0
 
     site_settings.refresh_from_db()
-    assert (
-        page_type_product_reference_attribute.pk
-        not in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk not in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
 
@@ -123,7 +119,6 @@ def test_category_settings_update_add_existing_attr(
     staff_api_client,
     site_settings_with_category_attributes,
     page_type_page_reference_attribute,
-    page_type_product_reference_attribute,
     size_page_attribute,
     permission_manage_settings,
 ):
@@ -131,16 +126,15 @@ def test_category_settings_update_add_existing_attr(
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
         for attr in [
             page_type_page_reference_attribute,
-            page_type_product_reference_attribute,
+            size_page_attribute,
         ]
     ]
     variables = {
@@ -169,28 +163,27 @@ def test_category_settings_update_by_staff_no_perm(
     staff_api_client,
     site_settings_with_category_attributes,
     page_type_page_reference_attribute,
-    page_type_product_reference_attribute,
+    tag_page_attribute,
     size_page_attribute,
 ):
     # given
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_page_reference_attribute, size_page_attribute]
+        for attr in [page_type_page_reference_attribute, tag_page_attribute]
     ]
     variables = {
         "input": {
             "addAttributes": add_attrs,
             "removeAttributes": [
                 graphene.Node.to_global_id("Attribute", attr.pk)
-                for attr in [page_type_product_reference_attribute]
+                for attr in [size_page_attribute]
             ],
         }
     }
@@ -206,8 +199,8 @@ def test_category_settings_update_by_app(
     app_api_client,
     site_settings_with_category_attributes,
     page_type_page_reference_attribute,
-    page_type_product_reference_attribute,
     size_page_attribute,
+    tag_page_attribute,
     permission_manage_settings,
 ):
     # given
@@ -215,14 +208,13 @@ def test_category_settings_update_by_app(
     site_settings = site_settings_with_category_attributes
     app_api_client.app.permissions.add(permission_manage_settings)
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_page_reference_attribute, size_page_attribute]
+        for attr in [page_type_page_reference_attribute, tag_page_attribute]
     ]
     variables = {
         "input": {
@@ -242,11 +234,7 @@ def test_category_settings_update_by_app(
     assert not errors
     assert len(attr_data) == len(add_attrs) + 1
     add_attrs = set(add_attrs)
-    add_attrs.add(
-        graphene.Node.to_global_id(
-            "Attribute", page_type_product_reference_attribute.pk
-        )
-    )
+    add_attrs.add(graphene.Node.to_global_id("Attribute", size_page_attribute.pk))
     assert {attr["id"] for attr in attr_data} == add_attrs
 
 
@@ -256,19 +244,19 @@ def test_category_settings_update_by_customer(
     page_type_page_reference_attribute,
     page_type_product_reference_attribute,
     size_page_attribute,
+    tag_page_attribute,
 ):
     # given
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_page_reference_attribute, size_page_attribute]
+        for attr in [page_type_page_reference_attribute, tag_page_attribute]
     ]
     variables = {
         "input": {
@@ -298,9 +286,8 @@ def test_category_settings_update_duplicated_attrs(
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [
@@ -309,7 +296,7 @@ def test_category_settings_update_duplicated_attrs(
     ]
     remove_attributes = [
         graphene.Node.to_global_id("Attribute", attr.pk)
-        for attr in [page_type_product_reference_attribute]
+        for attr in [size_page_attribute]
     ]
     variables = {
         "input": {
@@ -340,6 +327,7 @@ def test_category_settings_update_assign_product_attribute(
     staff_api_client,
     site_settings_with_category_attributes,
     page_type_product_reference_attribute,
+    size_page_attribute,
     weight_attribute,
     permission_manage_settings,
 ):
@@ -347,9 +335,8 @@ def test_category_settings_update_assign_product_attribute(
     query = CATEGORY_SETTINGS_UPDATE_MUTATION
     site_settings = site_settings_with_category_attributes
 
-    assert (
-        page_type_product_reference_attribute.pk
-        in site_settings.category_attributes.values_list("attribute_id", flat=True)
+    assert size_page_attribute.pk in site_settings.category_attributes.values_list(
+        "attribute_id", flat=True
     )
 
     add_attrs = [

--- a/saleor/product/tests/test_generate_and_set_variant_name.py
+++ b/saleor/product/tests/test_generate_and_set_variant_name.py
@@ -66,8 +66,8 @@ def test_generate_and_set_variant_name_different_attributes(
     size = size_attribute.values.get(slug="big")
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *tuple(colors))
-    associate_attribute_values_to_instance(variant, size_attribute, size)
+    associate_attribute_values_to_instance(variant, color_attribute, tuple(colors))
+    associate_attribute_values_to_instance(variant, size_attribute, [size])
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)
@@ -111,8 +111,8 @@ def test_generate_and_set_variant_name_only_variant_selection_attributes(
     size.save(update_fields=["sort_order"])
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *tuple(colors))
-    associate_attribute_values_to_instance(variant, size_attribute, size)
+    associate_attribute_values_to_instance(variant, color_attribute, tuple(colors))
+    associate_attribute_values_to_instance(variant, size_attribute, [size])
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)
@@ -155,8 +155,8 @@ def test_generate_and_set_variant_name_only_not_variant_selection_attributes(
     )
 
     # Associate the colors and size to variant attributes
-    associate_attribute_values_to_instance(variant, color_attribute, *values[:2])
-    associate_attribute_values_to_instance(variant, file_attribute, values[-1])
+    associate_attribute_values_to_instance(variant, color_attribute, values[:2])
+    associate_attribute_values_to_instance(variant, file_attribute, [values[-1]])
 
     # Generate the variant name from the attributes
     generate_and_set_variant_name(variant, variant.sku)

--- a/saleor/product/tests/test_product.py
+++ b/saleor/product/tests/test_product.py
@@ -59,8 +59,8 @@ def test_filtering_by_attribute(
     color_2 = color_attribute.values.last()
 
     # Associate color to a product and a variant
-    associate_attribute_values_to_instance(product_a, color_attribute, color)
-    associate_attribute_values_to_instance(variant_b, color_attribute, color)
+    associate_attribute_values_to_instance(product_a, color_attribute, [color])
+    associate_attribute_values_to_instance(variant_b, color_attribute, [color])
 
     product_qs = models.Product.objects.all().values_list("pk", flat=True)
 
@@ -69,7 +69,7 @@ def test_filtering_by_attribute(
     assert product_a.pk in list(filtered)
     assert product_b.pk in list(filtered)
 
-    associate_attribute_values_to_instance(product_a, color_attribute, color_2)
+    associate_attribute_values_to_instance(product_a, color_attribute, [color_2])
 
     filters = {color_attribute.pk: [color.pk]}
     filtered = filter_products_by_attributes_values(product_qs, filters)
@@ -91,7 +91,7 @@ def test_filtering_by_attribute(
     # Associate additional attribute to a product
     size = size_attribute.values.first()
     product_type_a.product_attributes.add(size_attribute)
-    associate_attribute_values_to_instance(product_a, size_attribute, size)
+    associate_attribute_values_to_instance(product_a, size_attribute, [size])
 
     # Filter by multiple attributes
     filters = {color_attribute.pk: [color_2.pk], size_attribute.pk: [size.pk]}

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -244,11 +244,9 @@ def site_settings(db, settings) -> SiteSettings:
 
 
 @pytest.fixture
-def site_settings_with_category_attributes(
-    site_settings, page_type_product_reference_attribute
-):
+def site_settings_with_category_attributes(site_settings, size_page_attribute):
     AttributeCategory.objects.create(
-        attribute=page_type_product_reference_attribute,
+        attribute=size_page_attribute,
         site_settings=site_settings,
     )
     return site_settings
@@ -1007,6 +1005,16 @@ def category(db):  # pylint: disable=W0613
 
 
 @pytest.fixture
+def category_with_attribute(category, site_settings_with_category_attributes):
+    attr = site_settings_with_category_attributes.category_attributes.first().attribute
+    value = attr.values.first()
+    associate_attribute_values_to_instance(
+        category, attr, [value], site_settings_with_category_attributes
+    )
+    return category
+
+
+@pytest.fixture
 def category_with_image(db, image, media_root):  # pylint: disable=W0613
     return Category.objects.create(
         name="Default", slug="default", background_image=image
@@ -1035,7 +1043,7 @@ def categories_tree(db, product_type, channel_USD):  # pylint: disable=W0613
         visible_in_listings=True,
     )
 
-    associate_attribute_values_to_instance(product, product_attr, attr_value)
+    associate_attribute_values_to_instance(product, product_attr, [attr_value])
     return parent
 
 
@@ -1153,7 +1161,7 @@ def product(product_type, category, warehouse, channel_USD):
         available_for_purchase=datetime.date(1999, 1, 1),
     )
 
-    associate_attribute_values_to_instance(product, product_attr, product_attr_value)
+    associate_attribute_values_to_instance(product, product_attr, [product_attr_value])
 
     variant_attr = product_type.variant_attributes.first()
     variant_attr_value = variant_attr.values.first()
@@ -1168,7 +1176,7 @@ def product(product_type, category, warehouse, channel_USD):
     )
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
-    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    associate_attribute_values_to_instance(variant, variant_attr, [variant_attr_value])
     return product
 
 
@@ -1313,10 +1321,10 @@ def product_with_variant_with_two_attributes(
     )
 
     associate_attribute_values_to_instance(
-        variant, color_attribute, color_attribute.values.first()
+        variant, color_attribute, [color_attribute.values.first()]
     )
     associate_attribute_values_to_instance(
-        variant, size_attribute, size_attribute.values.first()
+        variant, size_attribute, [size_attribute.values.first()]
     )
 
     return product
@@ -1362,7 +1370,7 @@ def product_with_variant_with_file_attribute(
     )
 
     associate_attribute_values_to_instance(
-        variant, file_attribute, file_attribute.values.first()
+        variant, file_attribute, [file_attribute.values.first()]
     )
 
     return product
@@ -1388,7 +1396,7 @@ def product_with_multiple_values_attributes(product, product_type, category) -> 
     product_type.product_attributes.clear()
     product_type.product_attributes.add(attribute)
 
-    associate_attribute_values_to_instance(product, attribute, attr_val_1, attr_val_2)
+    associate_attribute_values_to_instance(product, attribute, [attr_val_1, attr_val_2])
     return product
 
 
@@ -1689,7 +1697,7 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
     Stock.objects.bulk_create(stocks)
 
     for product in products:
-        associate_attribute_values_to_instance(product, product_attr, attr_value)
+        associate_attribute_values_to_instance(product, product_attr, [attr_value])
 
     return products
 
@@ -1914,7 +1922,7 @@ def unavailable_product_with_variant(product_type, category, warehouse, channel_
     )
     Stock.objects.create(product_variant=variant, warehouse=warehouse, quantity=10)
 
-    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    associate_attribute_values_to_instance(variant, variant_attr, [variant_attr_value])
     return product
 
 
@@ -2881,7 +2889,7 @@ def page(db, page_type):
     page_attr = page_type.page_attributes.first()
     page_attr_value = page_attr.values.first()
 
-    associate_attribute_values_to_instance(page, page_attr, page_attr_value)
+    associate_attribute_values_to_instance(page, page_attr, [page_attr_value])
 
     return page
 


### PR DESCRIPTION
- Add `attributes` field on `Category` type
- Update `associate_attribute_values_to_instance` parameters to accept `site_settings`
- Add `attributes` field to `CategoryInput`

Linked task: [SALEOR-2151](https://app.clickup.com/t/2549495/SALEOR-2151)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
