### PR TITLE
Add dataloader for fetching category settings

### DIFF
--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -1,4 +1,5 @@
 from .attributes import (
+    AttributeCategoriesBySiteSettingsIdLoader,
     ProductAttributesByProductTypeIdLoader,
     SelectedAttributesByCategoryIdLoader,
     SelectedAttributesByProductIdLoader,
@@ -33,6 +34,7 @@ from .products import (
 )
 
 __all__ = [
+    "AttributeCategoriesBySiteSettingsIdLoader",
     "CategoryByIdLoader",
     "CollectionByIdLoader",
     "CollectionChannelListingByCollectionIdAndChannelSlugLoader",

--- a/saleor/graphql/shop/dataloaders.py
+++ b/saleor/graphql/shop/dataloaders.py
@@ -1,0 +1,40 @@
+from ..attribute.dataloaders import AttributesByAttributeId
+from ..core.dataloaders import DataLoader
+from ..product.dataloaders import AttributeCategoriesBySiteSettingsIdLoader
+
+
+class CategoryAttributeBySiteSettingsIdLoader(DataLoader):
+    """Load category attributes settings by site settings ID."""
+
+    context_key = "category_attributes_by_sitesettings"
+
+    def batch_load(self, keys):
+        def with_attributes(attribute_categories):
+            site_settings_to_attributes_map = {}
+            attribute_ids = []
+            for site_settings, cat_attrs in zip(keys, attribute_categories):
+                site_attr_ids = [cat_attr.attribute_id for cat_attr in cat_attrs]
+                attribute_ids.extend(site_attr_ids)
+                site_settings_to_attributes_map[site_settings] = site_attr_ids
+
+            def map_attributes(attributes):
+                attributes_map = {attr.id: attr for attr in attributes}
+                return [
+                    [
+                        attributes_map[attr_id]
+                        for attr_id in site_settings_to_attributes_map[site_settings_id]
+                    ]
+                    for site_settings_id in keys
+                ]
+
+            return (
+                AttributesByAttributeId(self.context)
+                .load_many(attribute_ids)
+                .then(map_attributes)
+            )
+
+        return (
+            AttributeCategoriesBySiteSettingsIdLoader(self.context)
+            .load_many(keys)
+            .then(with_attributes)
+        )

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -13,7 +13,6 @@ from ...core.utils import get_client_ip, get_country_by_ip
 from ...plugins.manager import get_plugins_manager
 from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
-from ..attribute.dataloaders import AttributesByAttributeId
 from ..attribute.types import Attribute
 from ..channel import ChannelContext
 from ..checkout.types import PaymentGateway
@@ -30,6 +29,7 @@ from ..translations.fields import TranslationField
 from ..translations.resolvers import resolve_translation
 from ..translations.types import ShopTranslation
 from ..utils import format_permissions_for_display
+from .dataloaders import CategoryAttributeBySiteSettingsIdLoader
 from .resolvers import resolve_available_shipping_methods
 
 
@@ -74,10 +74,9 @@ class CategorySettings(graphene.ObjectType):
     @staticmethod
     def resolve_attributes(_, info):
         site_settings = info.context.site.settings
-        attribute_ids = site_settings.category_attributes.values_list(
-            "attribute_id", flat=True
+        return CategoryAttributeBySiteSettingsIdLoader(info.context).load(
+            site_settings.pk
         )
-        return AttributesByAttributeId(info.context).load_many(attribute_ids)
 
 
 class OrderSettings(CountableDjangoObjectType):
@@ -369,7 +368,6 @@ class Shop(graphene.ObjectType):
     @staticmethod
     def resolve_category_attributes(_, info):
         site_settings = info.context.site.settings
-        attribute_ids = site_settings.category_attributes.values_list(
-            "attribute_id", flat=True
+        return CategoryAttributeBySiteSettingsIdLoader(info.context).load(
+            site_settings.pk
         )
-        return AttributesByAttributeId(info.context).load_many(attribute_ids)


### PR DESCRIPTION
Add dataloader for fetching category settings.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
