### PR TITLE
Add logic for calling order_updated event for update order meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 - Deprecate `Shop.geolocalization` query - #6828 by @maarcingebala
 - Price precision validation fix - #6833 by @IKarbowiakg
+- Call webhook event - order_updated when the Order's meta has been changed - #6843 by @korycins
 
 # 2.11.7
 

--- a/saleor/graphql/meta/extra_methods.py
+++ b/saleor/graphql/meta/extra_methods.py
@@ -2,4 +2,8 @@ def extra_product_actions(instance, info, **data):
     info.context.plugins.product_updated(instance)
 
 
-MODEL_EXTRA_METHODS = {"Product": extra_product_actions}
+def extra_order_actions(instance, info, **data):
+    info.context.plugins.order_updated(instance)
+
+
+MODEL_EXTRA_METHODS = {"Product": extra_product_actions, "Order": extra_order_actions}

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -250,7 +250,10 @@ def test_add_public_metadata_for_myself_as_customer(user_api_client):
     )
 
 
-def test_add_private_metadata_for_invoice(staff_api_client, permission_manage_orders):
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_add_private_metadata_for_invoice(
+    mock_order_updated, staff_api_client, permission_manage_orders
+):
     # given
     invoice = Invoice.objects.create(number="1/7/2020")
     invoice_id = graphene.Node.to_global_id("Invoice", invoice.pk)
@@ -313,7 +316,8 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     )
 
 
-def test_add_public_metadata_for_order(api_client, order):
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_add_public_metadata_for_order(mocked_order_updated, api_client, order):
     # given
     order_id = graphene.Node.to_global_id("Order", order.pk)
 
@@ -326,9 +330,13 @@ def test_add_public_metadata_for_order(api_client, order):
     assert item_contains_proper_public_metadata(
         response["data"]["updateMetadata"]["item"], order, order_id
     )
+    assert mocked_order_updated.called
 
 
-def test_add_public_metadata_for_draft_order(api_client, draft_order):
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_add_public_metadata_for_draft_order(
+    mocked_order_updated, api_client, draft_order
+):
     # given
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
 
@@ -341,6 +349,7 @@ def test_add_public_metadata_for_draft_order(api_client, draft_order):
     assert item_contains_proper_public_metadata(
         response["data"]["updateMetadata"]["item"], draft_order, draft_order_id
     )
+    mocked_order_updated.called
 
 
 def test_add_public_metadata_for_attribute(
@@ -818,7 +827,8 @@ def test_delete_public_metadata_for_checkout(api_client, checkout):
     )
 
 
-def test_delete_public_metadata_for_order(api_client, order):
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_delete_public_metadata_for_order(mocked_order_updated, api_client, order):
     # given
     order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     order.save(update_fields=["metadata"])
@@ -833,9 +843,13 @@ def test_delete_public_metadata_for_order(api_client, order):
     assert item_without_public_metadata(
         response["data"]["deleteMetadata"]["item"], order, order_id
     )
+    assert mocked_order_updated.called
 
 
-def test_delete_public_metadata_for_draft_order(api_client, draft_order):
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
+def test_delete_public_metadata_for_draft_order(
+    mocked_order_updated, api_client, draft_order
+):
     # given
     draft_order.store_value_in_metadata({PUBLIC_KEY: PUBLIC_VALUE})
     draft_order.save(update_fields=["metadata"])
@@ -850,6 +864,7 @@ def test_delete_public_metadata_for_draft_order(api_client, draft_order):
     assert item_without_public_metadata(
         response["data"]["deleteMetadata"]["item"], draft_order, draft_order_id
     )
+    assert mocked_order_updated.called
 
 
 def test_delete_public_metadata_for_attribute(
@@ -1389,8 +1404,9 @@ def test_add_private_metadata_for_checkout(
     )
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 def test_add_private_metadata_for_order(
-    staff_api_client, order, permission_manage_orders
+    mocked_order_updated, staff_api_client, order, permission_manage_orders
 ):
     # given
     order_id = graphene.Node.to_global_id("Order", order.pk)
@@ -1404,10 +1420,12 @@ def test_add_private_metadata_for_order(
     assert item_contains_proper_private_metadata(
         response["data"]["updatePrivateMetadata"]["item"], order, order_id
     )
+    assert mocked_order_updated.called
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 def test_add_private_metadata_for_draft_order(
-    staff_api_client, draft_order, permission_manage_orders
+    mocked_order_updated, staff_api_client, draft_order, permission_manage_orders
 ):
     # given
     draft_order_id = graphene.Node.to_global_id("Order", draft_order.pk)
@@ -1421,6 +1439,7 @@ def test_add_private_metadata_for_draft_order(
     assert item_contains_proper_private_metadata(
         response["data"]["updatePrivateMetadata"]["item"], draft_order, draft_order_id
     )
+    assert mocked_order_updated.called
 
 
 def test_add_private_metadata_for_attribute(
@@ -1916,8 +1935,9 @@ def test_delete_private_metadata_for_checkout(
     )
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 def test_delete_private_metadata_for_order(
-    staff_api_client, order, permission_manage_orders
+    mocked_order_updated, staff_api_client, order, permission_manage_orders
 ):
     # given
     order.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
@@ -1933,10 +1953,12 @@ def test_delete_private_metadata_for_order(
     assert item_without_private_metadata(
         response["data"]["deletePrivateMetadata"]["item"], order, order_id
     )
+    assert mocked_order_updated.called
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 def test_delete_private_metadata_for_draft_order(
-    staff_api_client, draft_order, permission_manage_orders
+    mocked_order_updated, staff_api_client, draft_order, permission_manage_orders
 ):
     # given
     draft_order.store_value_in_private_metadata({PRIVATE_KEY: PRIVATE_VALUE})
@@ -1952,6 +1974,7 @@ def test_delete_private_metadata_for_draft_order(
     assert item_without_private_metadata(
         response["data"]["deletePrivateMetadata"]["item"], draft_order, draft_order_id
     )
+    assert mocked_order_updated.called
 
 
 def test_delete_private_metadata_for_attribute(


### PR DESCRIPTION
I want to merge this change because as we need to send webhook event order_updated when the order's meta has been changed

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
