### PR TITLE
Add missing translation resolvers

### DIFF
--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -2,19 +2,25 @@ import graphene
 import pytest
 from django.contrib.auth.models import Permission
 
+from ....tests.utils import dummy_editorjs
 from ...tests.utils import assert_no_permission, get_graphql_content
 from ..schema import TranslatableKinds
 from ..types import LanguageCodeEnum
 
 
 def test_product_translation(user_api_client, product, channel_USD):
-    product.translations.create(language_code="pl", name="Produkt")
+    description = dummy_editorjs("test desription")
+    product.translations.create(
+        language_code="pl", name="Produkt", description=description
+    )
 
     query = """
     query productById($productId: ID!, $channel: String) {
         product(id: $productId, channel: $channel) {
             translation(languageCode: PL) {
                 name
+                description
+                descriptionJson
                 language {
                     code
                 }
@@ -29,8 +35,14 @@ def test_product_translation(user_api_client, product, channel_USD):
     )
     data = get_graphql_content(response)["data"]
 
-    assert data["product"]["translation"]["name"] == "Produkt"
-    assert data["product"]["translation"]["language"]["code"] == "PL"
+    translation_data = data["product"]["translation"]
+    assert translation_data["name"] == "Produkt"
+    assert translation_data["language"]["code"] == "PL"
+    assert (
+        translation_data["description"]
+        == translation_data["descriptionJson"]
+        == dummy_editorjs("test desription", json_format=True)
+    )
 
 
 def test_product_translation_with_app(app_api_client, product, channel_USD):
@@ -86,13 +98,18 @@ def test_product_variant_translation(user_api_client, variant, channel_USD):
 
 
 def test_collection_translation(user_api_client, published_collection, channel_USD):
-    published_collection.translations.create(language_code="pl", name="Kolekcja")
+    description = dummy_editorjs("test desription")
+    published_collection.translations.create(
+        language_code="pl", name="Kolekcja", description=description
+    )
 
     query = """
     query collectionById($collectionId: ID!, $channel: String) {
         collection(id: $collectionId, channel: $channel) {
             translation(languageCode: PL) {
                 name
+                description
+                descriptionJson
                 language {
                     code
                 }
@@ -106,8 +123,14 @@ def test_collection_translation(user_api_client, published_collection, channel_U
     response = user_api_client.post_graphql(query, variables)
     data = get_graphql_content(response)["data"]
 
-    assert data["collection"]["translation"]["name"] == "Kolekcja"
-    assert data["collection"]["translation"]["language"]["code"] == "PL"
+    translation_data = data["collection"]["translation"]
+    assert translation_data["name"] == "Kolekcja"
+    assert translation_data["language"]["code"] == "PL"
+    assert (
+        translation_data["description"]
+        == translation_data["descriptionJson"]
+        == dummy_editorjs("test desription", json_format=True)
+    )
 
 
 def test_category_translation(user_api_client, category):
@@ -187,13 +210,16 @@ def test_sale_translation(staff_api_client, sale, permission_manage_discounts):
 
 
 def test_page_translation(user_api_client, page):
-    page.translations.create(language_code="pl", title="Strona")
+    content = dummy_editorjs("test content")
+    page.translations.create(language_code="pl", title="Strona", content=content)
 
     query = """
     query pageById($pageId: ID!) {
         page(id: $pageId) {
             translation(languageCode: PL) {
                 title
+                content
+                contentJson
                 language {
                     code
                 }
@@ -206,8 +232,14 @@ def test_page_translation(user_api_client, page):
     response = user_api_client.post_graphql(query, {"pageId": page_id})
     data = get_graphql_content(response)["data"]
 
-    assert data["page"]["translation"]["title"] == "Strona"
-    assert data["page"]["translation"]["language"]["code"] == "PL"
+    translation_data = data["page"]["translation"]
+    assert translation_data["title"] == "Strona"
+    assert translation_data["language"]["code"] == "PL"
+    assert (
+        translation_data["content"]
+        == translation_data["contentJson"]
+        == dummy_editorjs("test content", json_format=True)
+    )
 
 
 def test_attribute_translation(user_api_client, color_attribute):

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -141,6 +141,10 @@ class ProductTranslation(BaseTranslationType):
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
+    @staticmethod
+    def resolve_description_json(root: product_models.ProductTranslation, _info):
+        return root.description
+
 
 class ProductTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
@@ -164,6 +168,10 @@ class ProductTranslatableContent(CountableDjangoObjectType):
     def resolve_product(root: product_models.Product, info):
         return ChannelContext(node=root, channel_slug=None)
 
+    @staticmethod
+    def resolve_description_json(root: product_models.Product, _info):
+        return root.description
+
 
 class CollectionTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
@@ -177,6 +185,10 @@ class CollectionTranslation(BaseTranslationType):
         model = product_models.CollectionTranslation
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
+
+    @staticmethod
+    def resolve_description_json(root: product_models.CollectionTranslation, _info):
+        return root.description
 
 
 class CollectionTranslatableContent(CountableDjangoObjectType):
@@ -204,6 +216,10 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
             ChannelContext(node=collection, channel_slug=None) if collection else None
         )
 
+    @staticmethod
+    def resolve_description_json(root: product_models.Collection, _info):
+        return root.description
+
 
 class CategoryTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
@@ -217,6 +233,10 @@ class CategoryTranslation(BaseTranslationType):
         model = product_models.CategoryTranslation
         interfaces = [graphene.relay.Node]
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
+
+    @staticmethod
+    def resolve_description_json(root: product_models.CategoryTranslation, _info):
+        return root.description
 
 
 class CategoryTranslatableContent(CountableDjangoObjectType):
@@ -241,6 +261,10 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
     def resolve_category(root: product_models.Category, _info):
         return root
 
+    @staticmethod
+    def resolve_description_json(root: product_models.Category, _info):
+        return root.description
+
 
 class PageTranslation(BaseTranslationType):
     content_json = graphene.JSONString(
@@ -260,6 +284,10 @@ class PageTranslation(BaseTranslationType):
             "seo_title",
             "title",
         ]
+
+    @staticmethod
+    def resolve_content_json(root: page_models.PageTranslation, _info):
+        return root.content
 
 
 class PageTranslatableContent(CountableDjangoObjectType):
@@ -296,6 +324,10 @@ class PageTranslatableContent(CountableDjangoObjectType):
             .filter(pk=root.id)
             .first()
         )
+
+    @staticmethod
+    def resolve_description_json(root: page_models.Page, _info):
+        return root.content
 
 
 class VoucherTranslation(BaseTranslationType):


### PR DESCRIPTION
I want to merge this change because...I want to add missing content/description resolvers on translation type

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
