### PR TITLE
Add backward compatibility to ts_vector migrations

### DIFF
--- a/saleor/product/migrations/0139_description_vector_search.py
+++ b/saleor/product/migrations/0139_description_vector_search.py
@@ -39,7 +39,10 @@ class Migration(migrations.Migration):
     dependencies = [
         ("product", "0138_migrate_description_json_into_description"),
     ]
-
+    replaces = [
+        ("product", "0130_create_product_description_search_vector"),
+        ("product", "0131_update_ts_vector_existing_product_name"),
+    ]
     operations = [
         migrations.AddField(
             model_name="product",

--- a/saleor/product/migrations/0141_update_product_ts_vector.py
+++ b/saleor/product/migrations/0141_update_product_ts_vector.py
@@ -8,7 +8,10 @@ class Migration(migrations.Migration):
     dependencies = [
         ("product", "0140_auto_20210125_0905"),
     ]
-
+    replaces = [
+        ("product", "0130_create_product_description_search_vector"),
+        ("product", "0131_update_ts_vector_existing_product_name"),
+    ]
     operations = [
         migrations.RunSQL(
             """

--- a/saleor/product/migrations/0142_update_existing_product_name_ts_vector.py
+++ b/saleor/product/migrations/0142_update_existing_product_name_ts_vector.py
@@ -8,7 +8,9 @@ class Migration(migrations.Migration):
     dependencies = [
         ("product", "0141_update_product_ts_vector"),
     ]
-
+    replaces = [
+        ("product", "0131_update_ts_vector_existing_product_name"),
+    ]
     operations = [
         migrations.RunSQL(
             """


### PR DESCRIPTION
I want to merge this change because...I want to fix migrating saleor from 2.11 to 3.0 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
