### PR TITLE
Add introspection caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 - Add query contains only schema validation - #6827 by @fowczarek
+- Add introspection caching - #6871 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -5,6 +5,7 @@ import pytest
 from django.test import override_settings
 from graphql.execution.base import ExecutionResult
 
+from .... import __version__ as saleor_version
 from ....demo.views import EXAMPLE_QUERY
 from ...tests.fixtures import (
     ACCESS_CONTROL_ALLOW_CREDENTIALS,
@@ -360,7 +361,9 @@ def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_clien
     content = get_graphql_content(response)
     assert content["data"] == INTROSPECTION_RESULT
     cache_get_mock.assert_called_once_with(cache_key)
-    cache_set_mock.assert_called_once_with(cache_key, mock.ANY)
+    cache_set_mock.assert_called_once_with(
+        cache_key, ExecutionResult(data=INTROSPECTION_RESULT)
+    )
 
 
 @mock.patch("saleor.graphql.views.cache.set")
@@ -389,3 +392,8 @@ def test_introspection_query_is_not_cached_in_debug_mode(
     assert content["data"] == INTROSPECTION_RESULT
     cache_get_mock.assert_not_called()
     cache_set_mock.assert_not_called()
+
+
+def test_generate_cache_key_use_saleor_version():
+    cache_key = generate_cache_key(INTROSPECTION_QUERY)
+    assert saleor_version in cache_key

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -3,6 +3,7 @@ from unittest import mock
 import graphene
 import pytest
 from django.test import override_settings
+from graphql.execution.base import ExecutionResult
 
 from ....demo.views import EXAMPLE_QUERY
 from ...tests.fixtures import (
@@ -13,6 +14,7 @@ from ...tests.fixtures import (
     API_PATH,
 )
 from ...tests.utils import get_graphql_content, get_graphql_content_from_response
+from ...views import generate_cache_key
 
 
 def test_batch_queries(category, product, api_client, channel_USD):
@@ -333,3 +335,57 @@ def test_query_contains_not_only_schema_raise_error(
     assert graphql_log_handler.messages == [
         "saleor.graphql.errors.handled[INFO].GraphQLError"
     ]
+
+
+INTROSPECTION_QUERY = """
+query IntrospectionQuery {
+    __schema {
+        queryType {
+            name
+        }
+    }
+}
+"""
+
+INTROSPECTION_RESULT = {"__schema": {"queryType": {"name": "Query"}}}
+
+
+@mock.patch("saleor.graphql.views.cache.set")
+@mock.patch("saleor.graphql.views.cache.get")
+@override_settings(DEBUG=False)
+def test_introspection_query_is_cached(cache_get_mock, cache_set_mock, api_client):
+    cache_get_mock.return_value = None
+    cache_key = generate_cache_key(INTROSPECTION_QUERY)
+    response = api_client.post_graphql(INTROSPECTION_QUERY)
+    content = get_graphql_content(response)
+    assert content["data"] == INTROSPECTION_RESULT
+    cache_get_mock.assert_called_once_with(cache_key)
+    cache_set_mock.assert_called_once_with(cache_key, mock.ANY)
+
+
+@mock.patch("saleor.graphql.views.cache.set")
+@mock.patch("saleor.graphql.views.cache.get")
+@override_settings(DEBUG=False)
+def test_introspection_query_is_cached_only_once(
+    cache_get_mock, cache_set_mock, api_client
+):
+    cache_get_mock.return_value = ExecutionResult(data=INTROSPECTION_RESULT)
+    cache_key = generate_cache_key(INTROSPECTION_QUERY)
+    response = api_client.post_graphql(INTROSPECTION_QUERY)
+    content = get_graphql_content(response)
+    assert content["data"] == INTROSPECTION_RESULT
+    cache_get_mock.assert_called_once_with(cache_key)
+    cache_set_mock.assert_not_called()
+
+
+@mock.patch("saleor.graphql.views.cache.set")
+@mock.patch("saleor.graphql.views.cache.get")
+@override_settings(DEBUG=True)
+def test_introspection_query_is_not_cached_in_debug_mode(
+    cache_get_mock, cache_set_mock, api_client
+):
+    response = api_client.post_graphql(INTROSPECTION_QUERY)
+    content = get_graphql_content(response)
+    assert content["data"] == INTROSPECTION_RESULT
+    cache_get_mock.assert_not_called()
+    cache_set_mock.assert_not_called()

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -1,4 +1,5 @@
 import fnmatch
+import hashlib
 import json
 import logging
 import traceback
@@ -7,6 +8,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 import opentracing
 import opentracing.tags
 from django.conf import settings
+from django.core.cache import cache
 from django.db import connection
 from django.db.backends.postgresql.base import DatabaseWrapper
 from django.http import HttpRequest, HttpResponseNotAllowed, JsonResponse
@@ -213,14 +215,18 @@ class GraphQLView(View):
             return None, ExecutionResult(errors=[e], invalid=True)
 
     def check_if_query_contains_only_schema(self, document: GraphQLDocument):
+        query_with_schema = False
         for definition in document.document_ast.definitions:
             selections = definition.selection_set.selections
-            if len(selections) > 1:
-                for selection in selections:
-                    selection_name = str(selection.name.value)
-                    if selection_name == "__schema":
+            selection_count = len(selections)
+            for selection in selections:
+                selection_name = str(selection.name.value)
+                if selection_name == "__schema":
+                    query_with_schema = True
+                    if selection_count > 1:
                         msg = "`__schema` must be fetched in separete query"
                         raise GraphQLError(msg)
+        return query_with_schema
 
     def execute_graphql_request(self, request: HttpRequest, data: dict):
         with opentracing.global_tracer().start_active_span("graphql_query") as scope:
@@ -237,7 +243,9 @@ class GraphQLView(View):
                 raw_query_string = document.document_string
                 span.set_tag("graphql.query", raw_query_string)
                 try:
-                    self.check_if_query_contains_only_schema(document)
+                    query_contains_schema = self.check_if_query_contains_only_schema(
+                        document
+                    )
                 except GraphQLError as e:
                     return ExecutionResult(errors=[e], invalid=True)
 
@@ -249,14 +257,24 @@ class GraphQLView(View):
                 extra_options["executor"] = self.executor
             try:
                 with connection.execute_wrapper(tracing_wrapper):
-                    return document.execute(  # type: ignore
-                        root=self.get_root_value(),
-                        variables=variables,
-                        operation_name=operation_name,
-                        context=request,
-                        middleware=self.middleware,
-                        **extra_options,
-                    )
+                    response = None
+                    should_use_cache = query_contains_schema & (not settings.DEBUG)
+                    if should_use_cache:
+                        key = generate_cache_key(raw_query_string)
+                        response = cache.get(key)
+
+                    if not response:
+                        response = document.execute(  # type: ignore
+                            root=self.get_root_value(),
+                            variables=variables,
+                            operation_name=operation_name,
+                            context=request,
+                            middleware=self.middleware,
+                            **extra_options,
+                        )
+                        if should_use_cache:
+                            cache.set(key, response)
+                    return response
             except Exception as e:
                 span.set_tag(opentracing.tags.ERROR, True)
                 return ExecutionResult(errors=[e], invalid=True)
@@ -365,3 +383,7 @@ def obj_set(obj, path, value, do_not_replace):
         except IndexError:
             pass
     return obj_set(obj[current_path], path[1:], value, do_not_replace)
+
+
+def generate_cache_key(raw_query: str) -> str:
+    return hashlib.sha256(str(raw_query).encode("utf-8")).hexdigest()

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -571,6 +571,7 @@ REDIS_URL = os.environ.get("REDIS_URL")
 if REDIS_URL:
     CACHE_URL = os.environ.setdefault("CACHE_URL", REDIS_URL)
 CACHES = {"default": django_cache_url.config()}
+CACHES["default"]["TIMEOUT"] = parse(os.environ.get("CACHE_TIMEOUT", "7 days"))
 
 # Default False because storefront and dashboard don't support expiration of token
 JWT_EXPIRE = get_bool_from_env("JWT_EXPIRE", False)


### PR DESCRIPTION
I want to merge this change because adding caching to introspection queries

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
