### PR TITLE
Bump ubuntu on gh action with pytest

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: python:3.9
+    container: python:3.8
 
     services:
       postgres:
@@ -33,10 +33,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
 
       - name: Install system dependencies
         run: apt-get install -y libpq-dev

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,8 +15,8 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
-    container: python:3.8
+    runs-on: ubuntu-latest
+    container: python:3.9
 
     services:
       postgres:
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: "3.8"
+          python-version: "3.9"
 
       - name: Install system dependencies
         run: apt-get install -y libpq-dev


### PR DESCRIPTION
I want to merge this change because bumping ubuntu and python on gh action with pytest.

I Try to bump the python version from pytest action but we run pre-commit on the same env and mypy-0.740 doesn't work with python3.9. 

We have a separate task to bump mypy #5630 after this task we should bump the python version in this gh-action. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
