### PR TITLE
Allocate stocks for order lines in a bulk way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix `product_updated` and `product_created` webhooks - #6798 by @d-wysocki
 - Add interface for integrating the auth plugins - #6799 by @korycins
 - Fix page `contentJson` field to return JSON - #6832 by @d-wysocki
+- Allocate stocks for order lines in a bulk way - #6877 by @IKarbowiak
 
 # 2.11.1
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -24,7 +24,7 @@ from ..discount.utils import (
     increase_voucher_usage,
     remove_voucher_usage_by_customer,
 )
-from ..order import OrderLineInfo, OrderStatus
+from ..order import OrderLineData, OrderStatus
 from ..order.actions import order_created
 from ..order.emails import send_order_confirmation, send_staff_order_confirmation
 from ..order.models import Order, OrderLine
@@ -33,7 +33,7 @@ from ..payment.models import Payment, Transaction
 from ..payment.utils import store_customer_id
 from ..product.models import ProductTranslation, ProductVariantTranslation
 from ..warehouse.availability import check_stock_quantity_bulk
-from ..warehouse.management import allocate_stock
+from ..warehouse.management import allocate_stocks
 from . import AddressType, models
 from .checkout_cleaner import clean_checkout_payment, clean_checkout_shipping
 from .models import Checkout
@@ -135,10 +135,9 @@ def _create_line_for_order(
     checkout_line_info: "CheckoutLineInfo",
     discounts: Iterable[DiscountInfo],
     channel: "Channel",
-    country_code: str,
     products_translation: Dict[int, Optional[str]],
     variants_translation: Dict[int, Optional[str]],
-) -> OrderLineInfo:
+) -> OrderLineData:
     """Create a line for the given order.
 
     :raises InsufficientStock: when there is not enough items in stock for this variant.
@@ -197,9 +196,7 @@ def _create_line_for_order(
         tax_rate=tax_rate,
     )
 
-    line_info = OrderLineInfo(
-        line=line, quantity=quantity, variant=variant, country_code=country_code
-    )
+    line_info = OrderLineData(line=line, quantity=quantity, variant=variant)
 
     return line_info
 
@@ -210,7 +207,7 @@ def _create_lines_for_order(
     lines: Iterable["CheckoutLineInfo"],
     discounts: Iterable[DiscountInfo],
     channel: "Channel",
-) -> Iterable[OrderLineInfo]:
+) -> Iterable[OrderLineData]:
     """Create a lines for the given order.
 
     :raises InsufficientStock: when there is not enough items in stock for this variant.
@@ -250,7 +247,6 @@ def _create_lines_for_order(
             checkout_line_info,
             discounts,
             channel,
-            country_code,
             product_translations,
             variants_translation,
         )
@@ -375,11 +371,8 @@ def _create_order(
 
     OrderLine.objects.bulk_create(order_lines)
 
-    # allocate stocks from the lines
-    for line_info in order_lines_info:  # type: OrderLineInfo
-        variant = line_info.variant
-        if variant and variant.track_inventory:
-            allocate_stock(line_info.line, line_info.country_code, line_info.quantity)
+    country_code = checkout.get_country()
+    allocate_stocks(order_lines_info, country_code)
 
     # Add gift cards to the order
     for gift_card in checkout.gift_cards.select_for_update():

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -471,7 +471,9 @@ def _get_order_data(
             discounts=discounts,
         )
     except InsufficientStock as e:
-        raise ValidationError(f"Insufficient product stock: {e.item}", code=e.code)
+        raise ValidationError(
+            f"Insufficient product stock: {', '.join(e.items)}", code=e.code
+        )
     except NotApplicable:
         raise ValidationError(
             "Voucher not applicable",
@@ -576,6 +578,8 @@ def complete_checkout(
         except InsufficientStock as e:
             release_voucher_usage(order_data)
             gateway.payment_refund_or_void(payment)
-            raise ValidationError(f"Insufficient product stock: {e.item}", code=e.code)
+            raise ValidationError(
+                f"Insufficient product stock: {', '.join(e.items)}", code=e.code
+            )
 
     return order, action_required, action_data

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -791,7 +791,7 @@ def test_create_order_use_tanslations(
     order_data = _prepare_order_data(
         manager=manager, checkout=checkout, lines=lines, discounts=None
     )
-    order_line = order_data["lines"][0]
+    order_line = order_data["lines"][0].line
 
     assert order_line.translated_product_name == translated_product_name
     assert order_line.translated_variant_name == translated_variant_name

--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -2,9 +2,10 @@ from ..checkout.error_codes import CheckoutErrorCode
 
 
 class InsufficientStock(Exception):
-    def __init__(self, item, context=None):
-        super().__init__("Insufficient stock for %r" % (item,))
-        self.item = item
+    def __init__(self, items, context=None):
+        items = [str(item) for item in items]
+        super().__init__(f"Insufficient stock for {', '.join(items)}")
+        self.items = items
         self.context = context
         self.code = CheckoutErrorCode.INSUFFICIENT_STOCK
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -869,6 +869,7 @@ class CheckoutComplete(BaseMutation):
                 store_source=store_source,
                 discounts=info.context.discounts,
                 user=info.context.user,
+                site_settings=info.context.site.settings,
                 tracking_code=tracking_code,
                 redirect_url=data.get("redirect_url"),
             )

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -122,9 +122,9 @@ def check_lines_quantity(variants, quantities, country):
         check_stock_quantity_bulk(variants, country, quantities)
     except InsufficientStock as e:
         remaining = e.context["available_quantity"]
-        item_name = e.item.display_product()
         message = (
-            f"Could not add item {item_name}. Only {remaining} remaining in stock."
+            f"Could not add items {', '.join(e.items)}. "
+            f"Only {remaining} remaining in stock."
         )
         raise ValidationError({"quantity": ValidationError(message, code=e.code)})
 
@@ -336,7 +336,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
                 add_variants_to_checkout(instance, variants, quantities)
             except InsufficientStock as exc:
                 raise ValidationError(
-                    f"Insufficient product stock: {exc.item}", code=exc.code
+                    f"Insufficient product stock: {', '.join(exc.items)}", code=exc.code
                 )
             except ProductNotPublished as exc:
                 raise ValidationError(
@@ -427,7 +427,8 @@ class CheckoutLinesAdd(BaseMutation):
                     )
                 except InsufficientStock as exc:
                     raise ValidationError(
-                        f"Insufficient product stock: {exc.item}", code=exc.code
+                        f"Insufficient product stock: {', '.join(exc.items)}",
+                        code=exc.code,
                     )
                 except ProductNotPublished as exc:
                     raise ValidationError(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -910,7 +910,7 @@ def test_checkout_create_check_lines_quantity_multiple_warehouse(
     content = get_graphql_content(response)
     data = content["data"]["checkoutCreate"]
     assert data["checkoutErrors"][0]["message"] == (
-        "Could not add item Test product (SKU_A). Only 7 remaining in stock."
+        "Could not add items SKU_A. Only 7 remaining in stock."
     )
     assert data["checkoutErrors"][0]["field"] == "quantity"
 
@@ -1004,7 +1004,7 @@ def test_checkout_create_check_lines_quantity(
     content = get_graphql_content(response)
     data = content["data"]["checkoutCreate"]
     assert data["checkoutErrors"][0]["message"] == (
-        "Could not add item Test product (SKU_A). Only 15 remaining in stock."
+        "Could not add items SKU_A. Only 15 remaining in stock."
     )
     assert data["checkoutErrors"][0]["field"] == "quantity"
 
@@ -1493,7 +1493,7 @@ def test_checkout_lines_add_check_lines_quantity(user_api_client, checkout, stoc
     content = get_graphql_content(response)
     data = content["data"]["checkoutLinesAdd"]
     assert data["checkoutErrors"][0]["message"] == (
-        "Could not add item Test product (SKU_A). Only 15 remaining in stock."
+        "Could not add items SKU_A. Only 15 remaining in stock."
     )
     assert data["checkoutErrors"][0]["field"] == "quantity"
 
@@ -1664,7 +1664,7 @@ def test_checkout_lines_update_check_lines_quantity(
 
     data = content["data"]["checkoutLinesUpdate"]
     assert data["checkoutErrors"][0]["message"] == (
-        "Could not add item Test product (123). Only 10 remaining in stock."
+        "Could not add items 123. Only 10 remaining in stock."
     )
     assert data["checkoutErrors"][0]["field"] == "quantity"
 

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -372,7 +372,7 @@ class DraftOrderComplete(BaseMutation):
                     raise ValidationError(
                         {
                             "lines": ValidationError(
-                                f"Insufficient product stock: {exc.item}",
+                                f"Insufficient product stock: {', '.join(exc.items)}",
                                 code=OrderErrorCode.INSUFFICIENT_STOCK,
                             )
                         }

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -8,7 +8,7 @@ from ....core.exceptions import InsufficientStock
 from ....core.permissions import OrderPermissions
 from ....core.taxes import TaxError, zero_taxed_money
 from ....core.utils.url import validate_storefront_url
-from ....order import OrderStatus, events, models
+from ....order import OrderLineData, OrderStatus, events, models
 from ....order.actions import order_created
 from ....order.error_codes import OrderErrorCode
 from ....order.utils import (
@@ -19,7 +19,7 @@ from ....order.utils import (
     recalculate_order,
     update_order_prices,
 )
-from ....warehouse.management import allocate_stock
+from ....warehouse.management import allocate_stocks
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...channel.types import Channel
@@ -363,8 +363,11 @@ class DraftOrderComplete(BaseMutation):
 
         for line in order:
             if line.variant.track_inventory:
+                line_data = OrderLineData(
+                    line=line, quantity=line.quantity, variant=line.variant
+                )
                 try:
-                    allocate_stock(line, country, line.quantity)
+                    allocate_stocks([line_data], country)
                 except InsufficientStock as exc:
                     raise ValidationError(
                         {

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -227,7 +227,7 @@ class OrderFulfill(BaseMutation):
             raise ValidationError(
                 {
                     "stocks": ValidationError(
-                        f"Insufficient product stock: {exc.item}",
+                        f"Insufficient product stock: {', '.join(exc.items)}",
                         code=OrderErrorCode.INSUFFICIENT_STOCK,
                         params={
                             "order_line": order_line_global_id,

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -403,7 +403,7 @@ def test_order_fulfill_warehouse_with_insufficient_stock_exception(
         "warehouse_pk": str(warehouse_no_shipping_zone.pk),
     }
     mock_create_fulfillments.side_effect = InsufficientStock(
-        order_line.variant, error_context
+        [order_line.variant], error_context
     )
 
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -85,7 +85,7 @@ def validate_order_lines(order, country):
                 raise ValidationError(
                     {
                         "lines": ValidationError(
-                            f"Insufficient product stock: {exc.item}",
+                            f"Insufficient product stock: {', '.join(exc.items)}",
                             code=OrderErrorCode.INSUFFICIENT_STOCK,
                         )
                     }

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from ..product.models import ProductVariant
@@ -170,15 +170,8 @@ class OrderEventsEmails:
 class OrderLineData:
     line: "OrderLine"
     quantity: int
+    variant: Optional["ProductVariant"] = None
     replace: bool = False
-
-
-@dataclass
-class OrderLineInfo:
-    line: "OrderLine"
-    quantity: int
-    variant: "ProductVariant"
-    country_code: str
 
 
 @dataclass

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ..product.models import ProductVariant
     from .models import FulfillmentLine, OrderLine
 
 
@@ -170,6 +171,14 @@ class OrderLineData:
     line: "OrderLine"
     quantity: int
     replace: bool = False
+
+
+@dataclass
+class OrderLineInfo:
+    line: "OrderLine"
+    quantity: int
+    variant: "ProductVariant"
+    country_code: str
 
 
 @dataclass

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -383,7 +383,7 @@ def _create_fulfillment_lines(
             stock = order_line.variant.stocks.filter(warehouse=warehouse_pk).first()
             if stock is None:
                 error_context = {"order_line": order_line, "warehouse_pk": warehouse_pk}
-                raise InsufficientStock(order_line.variant, error_context)
+                raise InsufficientStock([order_line.variant], error_context)
             fulfill_order_line(order_line, quantity, warehouse_pk)
             if order_line.is_digital:
                 order_line.variant.digital_content.urls.create(line=order_line)

--- a/saleor/order/tests/test_fulfullments_actions.py
+++ b/saleor/order/tests/test_fulfullments_actions.py
@@ -318,7 +318,7 @@ def test_create_fulfillments_warehouse_with_out_of_stock(
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert exc.value.item == order_line1.variant
+    assert exc.value.items == [str(order_line1.variant)]
     assert exc.value.context == {
         "order_line": order_line1,
         "warehouse_pk": str(warehouse.pk),
@@ -363,7 +363,7 @@ def test_create_fulfillments_warehouse_without_stock(
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert exc.value.item == order_line1.variant
+    assert exc.value.items == [str(order_line1.variant)]
     assert exc.value.context == {
         "order_line": order_line1,
         "warehouse_pk": str(warehouse_no_shipping_zone.pk),
@@ -405,7 +405,7 @@ def test_create_fulfillments_with_variant_without_inventory_tracking_and_without
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert exc.value.item == order_line.variant
+    assert exc.value.items == [str(order_line.variant)]
     assert exc.value.context == {
         "order_line": order_line,
         "warehouse_pk": str(warehouse_no_shipping_zone.pk),

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -31,10 +31,10 @@ def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity:
     if variant.track_inventory:
         stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
         if not stocks:
-            raise InsufficientStock(variant)
+            raise InsufficientStock([variant])
 
         if quantity > _get_available_quantity(stocks):
-            raise InsufficientStock(variant)
+            raise InsufficientStock([variant])
 
 
 def check_stock_quantity_bulk(variants, country_code, quantities):
@@ -58,13 +58,13 @@ def check_stock_quantity_bulk(variants, country_code, quantities):
 
         if not stocks:
             raise InsufficientStock(
-                variant, context={"available_quantity": available_quantity}
+                [variant], context={"available_quantity": available_quantity}
             )
 
         if variant.track_inventory:
             if quantity > available_quantity:
                 raise InsufficientStock(
-                    variant, context={"available_quantity": available_quantity}
+                    [variant], context={"available_quantity": available_quantity}
                 )
 
 


### PR DESCRIPTION
Allocate stocks for all order lines in a bulk way.

Linked task: [SALEOR-1935](https://app.clickup.com/t/2549495/SALEOR-1935)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
