### PR TITLE
Add separate event for admin reset emails

### DIFF
--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -22,8 +22,8 @@ def get_default_user_payload(user: User):
     }
 
 
-def send_user_password_reset_notification(redirect_url, user, manager):
-    """Trigger sending a password reset notification for the given user."""
+def send_password_reset_notification(redirect_url, user, manager, staff=False):
+    """Trigger sending a password reset notification for the given customer/staff."""
     token = default_token_generator.make_token(user)
     params = urlencode({"email": user.email, "token": token})
     reset_url = prepare_url(params, redirect_url)
@@ -35,7 +35,12 @@ def send_user_password_reset_notification(redirect_url, user, manager):
         "reset_url": reset_url,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=user_payload)
+    if staff:
+        manager.notify(
+            NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD, payload=user_payload
+        )
+    else:
+        manager.notify(NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=user_payload)
 
 
 def send_account_confirmation(user, redirect_url, manager):

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -35,12 +35,13 @@ def send_password_reset_notification(redirect_url, user, manager, staff=False):
         "reset_url": reset_url,
         **get_site_context(),
     }
-    if staff:
-        manager.notify(
-            NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD, payload=user_payload
-        )
-    else:
-        manager.notify(NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=user_payload)
+
+    event = (
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD
+        if staff
+        else NotifyEventType.ACCOUNT_PASSWORD_RESET
+    )
+    manager.notify(event, payload=user_payload)
 
 
 def send_account_confirmation(user, redirect_url, manager):

--- a/saleor/account/tests/test_notifications.py
+++ b/saleor/account/tests/test_notifications.py
@@ -1,8 +1,11 @@
 from unittest import mock
+from urllib.parse import urlencode
 
+import pytest
 from freezegun import freeze_time
 
-from ...core.notify_events import UserNotifyEvent
+from ...core.notify_events import NotifyEventType, UserNotifyEvent
+from ...core.utils.url import prepare_url
 from ...plugins.manager import get_plugins_manager
 from .. import notifications
 from ..notifications import get_default_user_payload
@@ -68,3 +71,35 @@ def test_send_email_changed_notification(mocked_notify, site_settings, customer_
     mocked_notify.assert_called_once_with(
         UserNotifyEvent.ACCOUNT_CHANGE_EMAIL_CONFIRM, payload=expected_payload
     )
+
+
+@pytest.mark.parametrize("is_staff", [True, False])
+@mock.patch("saleor.account.notifications.default_token_generator.make_token")
+@mock.patch("saleor.plugins.manager.PluginsManager.notify")
+def test_send_password_reset_notification(
+    mocked_notify, mocked_generator, is_staff, site_settings, customer_user
+):
+    token = "token_example"
+    mocked_generator.return_value = token
+    redirect_url = "http://localhost:8000/reset"
+    params = urlencode({"email": customer_user.email, "token": token})
+    reset_url = prepare_url(params, redirect_url)
+
+    notifications.send_password_reset_notification(
+        redirect_url, customer_user, get_plugins_manager(), staff=is_staff
+    )
+
+    expected_payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": customer_user.email,
+        "token": token,
+        "reset_url": reset_url,
+        "site_name": "mirumee.com",
+        "domain": "mirumee.com",
+    }
+    expected_event = (
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD
+        if is_staff
+        else NotifyEventType.ACCOUNT_PASSWORD_RESET
+    )
+    mocked_notify.assert_called_once_with(expected_event, payload=expected_payload)

--- a/saleor/core/notify_events.py
+++ b/saleor/core/notify_events.py
@@ -34,6 +34,7 @@ class UserNotifyEvent:
 
 class AdminNotifyEvent:
     ACCOUNT_SET_STAFF_PASSWORD = "account_set_staff_password"
+    ACCOUNT_STAFF_RESET_PASSWORD = "account_staff_reset_password"
     CSV_PRODUCT_EXPORT_SUCCESS = "csv_export_products_success"
     CSV_EXPORT_FAILED = "csv_export_failed"
     STAFF_ORDER_CONFIRMATION = "staff_order_confirmation"
@@ -43,6 +44,7 @@ class AdminNotifyEvent:
         CSV_PRODUCT_EXPORT_SUCCESS,
         CSV_EXPORT_FAILED,
         STAFF_ORDER_CONFIRMATION,
+        ACCOUNT_STAFF_RESET_PASSWORD,
     ]
 
 

--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -8,8 +8,8 @@ from ....account import events as account_events
 from ....account import models
 from ....account.error_codes import AccountErrorCode
 from ....account.notifications import (
+    send_password_reset_notification,
     send_set_password_notification,
-    send_user_password_reset_notification,
 )
 from ....core.exceptions import PermissionDenied
 from ....core.permissions import AccountPermissions
@@ -149,7 +149,9 @@ class RequestPasswordReset(BaseMutation):
                     )
                 }
             )
-        send_user_password_reset_notification(redirect_url, user, info.context.plugins)
+        send_password_reset_notification(
+            redirect_url, user, info.context.plugins, staff=user.is_staff
+        )
         return RequestPasswordReset()
 
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -3358,7 +3358,7 @@ def test_request_password_reset_email_for_staff(mocked_notify, staff_api_client)
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=expected_payload
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD, payload=expected_payload
     )
 
 

--- a/saleor/plugins/admin_email/constants.py
+++ b/saleor/plugins/admin_email/constants.py
@@ -10,29 +10,35 @@ STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD = "staff_order_confirmation_template"
 SET_STAFF_PASSWORD_TEMPLATE_FIELD = "set_staff_password_template"
 CSV_PRODUCT_EXPORT_SUCCESS_TEMPLATE_FIELD = "csv_product_export_success_template"
 CSV_EXPORT_FAILED_TEMPLATE_FIELD = "csv_export_failed_template"
+STAFF_PASSWORD_RESET_TEMPLATE_FIELD = "staff_password_reset_template"
+
 
 TEMPLATE_FIELDS = [
     STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
     SET_STAFF_PASSWORD_TEMPLATE_FIELD,
     CSV_PRODUCT_EXPORT_SUCCESS_TEMPLATE_FIELD,
     CSV_EXPORT_FAILED_TEMPLATE_FIELD,
+    STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
 ]
 
 SET_STAFF_PASSWORD_DEFAULT_TEMPLATE = "set_password.html"
 CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_TEMPLATE = "export_products_file.html"
 CSV_EXPORT_FAILED_TEMPLATE_DEFAULT_TEMPLATE = "export_failed.html"
 STAFF_ORDER_CONFIRMATION_DEFAULT_TEMPLATE = "staff_confirm_order.html"
+STAFF_PASSWORD_RESET_DEFAULT_TEMPLATE = "password_reset.html"
 
 STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD = "staff_order_confirmation_subject"
 SET_STAFF_PASSWORD_SUBJECT_FIELD = "set_staff_password_subject"
 CSV_PRODUCT_EXPORT_SUCCESS_SUBJECT_FIELD = "csv_product_export_success_subject"
 CSV_EXPORT_FAILED_SUBJECT_FIELD = "csv_export_failed_subject"
+STAFF_PASSWORD_RESET_SUBJECT_FIELD = "staff_password_reset_subject"
 
 
 STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.id }} details"
-SET_STAFF_PASSWORD_DEFAULT_SUBJECT = "Password reset e-mail"
+SET_STAFF_PASSWORD_DEFAULT_SUBJECT = "Set password e-mail"
 CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_SUBJECT = "Export products data"
 CSV_EXPORT_FAILED_DEFAULT_SUBJECT = "Export products data"
+STAFF_PASSWORD_RESET_DEFAULT_SUBJECT = "Staff password reset"
 
 
 PLUGIN_ID = "mirumee.notifications.admin_email"

--- a/saleor/plugins/admin_email/default_email_templates/password_reset.html
+++ b/saleor/plugins/admin_email/default_email_templates/password_reset.html
@@ -1,0 +1,335 @@
+
+    <!doctype html>
+    <html xmlns="http://www.w3.org/1999/xhtml" xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office">
+      <head>
+        <title>
+
+        </title>
+        <!--[if !mso]><!-- -->
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <!--<![endif]-->
+        <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+          #outlook a { padding:0; }
+          body { margin:0;padding:0;-webkit-text-size-adjust:100%;-ms-text-size-adjust:100%; }
+          table, td { border-collapse:collapse;mso-table-lspace:0pt;mso-table-rspace:0pt; }
+          img { border:0;height:auto;line-height:100%; outline:none;text-decoration:none;-ms-interpolation-mode:bicubic; }
+          p { display:block;margin:13px 0; }
+        </style>
+        <!--[if mso]>
+        <xml>
+        <o:OfficeDocumentSettings>
+          <o:AllowPNG/>
+          <o:PixelsPerInch>96</o:PixelsPerInch>
+        </o:OfficeDocumentSettings>
+        </xml>
+        <![endif]-->
+        <!--[if lte mso 11]>
+        <style type="text/css">
+          .mj-outlook-group-fix { width:100% !important; }
+        </style>
+        <![endif]-->
+
+      <!--[if !mso]><!-->
+        <link href="https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700" rel="stylesheet" type="text/css">
+        <style type="text/css">
+          @import url(https://fonts.googleapis.com/css?family=Ubuntu:300,400,500,700);
+        </style>
+      <!--<![endif]-->
+
+
+
+    <style type="text/css">
+      @media only screen and (min-width:480px) {
+        .mj-column-per-100 { width:100% !important; max-width: 100%; }
+      }
+    </style>
+
+
+        <style type="text/css">
+
+
+        </style>
+        <style type="text/css">address {
+    font-style: inherit;
+    font-family: Ubuntu, Helvetica, Arial;
+  }</style>
+
+      </head>
+      <body>
+
+
+      <div style>
+
+
+      <!--[if mso | IE]>
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+      >
+        <tr>
+          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+
+
+      <div style="margin:0px auto;max-width:600px;">
+
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+
+        <tr>
+
+            <td
+               class="" style="vertical-align:top;width:600px;"
+            >
+          <![endif]-->
+
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+
+            <tr>
+              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
+
+              </td>
+            </tr>
+
+            <tr>
+              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">You're receiving this e-mail because you or someone else has requested a password for your staff account at {{site_name}}.<br>
+            It can be safely ignored if you did not request a password reset. Click the link below to reset your password.</div>
+
+              </td>
+            </tr>
+
+            <tr>
+              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;"><a href="{{reset_url}}">
+            {{reset_url}}
+          </a></div>
+
+              </td>
+            </tr>
+
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]>
+            </td>
+
+        </tr>
+
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+      >
+        <tr>
+          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+
+
+      <div style="margin:0px auto;max-width:600px;">
+
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+
+        <tr>
+
+            <td
+               class="" style="vertical-align:top;width:600px;"
+            >
+          <![endif]-->
+
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+
+            <tr>
+              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
+
+              </td>
+            </tr>
+
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]>
+            </td>
+
+        </tr>
+
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
+      >
+        <tr>
+          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+
+
+      <div style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:600px;">
+
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="background:#F2F2F2;background-color:#F2F2F2;width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+
+        <tr>
+
+            <td
+               class="" style="vertical-align:top;width:600px;"
+            >
+          <![endif]-->
+
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+
+            <tr>
+              <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
+
+              </td>
+            </tr>
+
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]>
+            </td>
+
+        </tr>
+
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+
+      <table
+         align="center" border="0" cellpadding="0" cellspacing="0" class="no-display-outlook" style="width:600px;" width="600"
+      >
+        <tr>
+          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
+      <![endif]-->
+
+
+      <div class="no-display" style="display: none; margin: 0px auto; max-width: 600px;">
+
+        <table align="center" border="0" cellpadding="0" cellspacing="0" role="presentation" style="width:100%;">
+          <tbody>
+            <tr>
+              <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
+                <!--[if mso | IE]>
+                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
+
+        <tr>
+
+            <td
+               class="" style="vertical-align:top;width:600px;"
+            >
+          <![endif]-->
+
+      <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
+
+      <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+
+            <tr>
+              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if order}}
+        <script type="application/ld+json">
+        {{{{raw}}}}{{schema_markup}}{{{{/raw}}}}
+        </script>
+      {{/if}}</div>
+
+              </td>
+            </tr>
+
+      </table>
+
+      </div>
+
+          <!--[if mso | IE]>
+            </td>
+
+        </tr>
+
+                  </table>
+                <![endif]-->
+              </td>
+            </tr>
+          </tbody>
+        </table>
+
+      </div>
+
+
+      <!--[if mso | IE]>
+          </td>
+        </tr>
+      </table>
+      <![endif]-->
+
+
+      </div>
+
+      </body>
+    </html>

--- a/saleor/plugins/admin_email/notify_events.py
+++ b/saleor/plugins/admin_email/notify_events.py
@@ -3,6 +3,7 @@ from .tasks import (
     send_export_failed_email_task,
     send_set_staff_password_email_task,
     send_staff_order_confirmation_email_task,
+    send_staff_password_reset_email_task,
 )
 
 
@@ -32,3 +33,9 @@ def send_csv_export_failed(payload: dict, config: dict):
     recipient_email = payload.get("recipient_email")
     if recipient_email:
         send_export_failed_email_task.delay(recipient_email, payload, config)
+
+
+def send_staff_reset_password(payload: dict, config: dict):
+    recipient_email = payload.get("recipient_email")
+    if recipient_email:
+        send_staff_password_reset_email_task.delay(recipient_email, payload, config)

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -23,6 +23,7 @@ from .notify_events import (
     send_csv_product_export_success,
     send_set_staff_password_email,
     send_staff_order_confirmation,
+    send_staff_reset_password,
 )
 
 logger = logging.getLogger(__name__)
@@ -34,6 +35,7 @@ class AdminTemplate:
     set_staff_password_email: Optional[str]
     csv_product_export_success: Optional[str]
     csv_export_failed: Optional[str]
+    staff_reset_password: Optional[str]
 
 
 def get_admin_template_map(templates: AdminTemplate):
@@ -44,6 +46,9 @@ def get_admin_template_map(templates: AdminTemplate):
             templates.csv_product_export_success
         ),
         AdminNotifyEvent.CSV_EXPORT_FAILED: templates.csv_export_failed,
+        AdminNotifyEvent.ACCOUNT_STAFF_RESET_PASSWORD: (
+            templates.set_staff_password_email
+        ),
     }
 
 
@@ -51,6 +56,7 @@ def get_admin_event_map():
     return {
         AdminNotifyEvent.STAFF_ORDER_CONFIRMATION: send_staff_order_confirmation,
         AdminNotifyEvent.ACCOUNT_SET_STAFF_PASSWORD: send_set_staff_password_email,
+        AdminNotifyEvent.ACCOUNT_STAFF_RESET_PASSWORD: send_staff_reset_password,
         AdminNotifyEvent.CSV_PRODUCT_EXPORT_SUCCESS: send_csv_product_export_success,
         AdminNotifyEvent.CSV_EXPORT_FAILED: send_csv_export_failed,
     }
@@ -62,6 +68,14 @@ class AdminEmailPlugin(BasePlugin):
     DEFAULT_ACTIVE = True
 
     DEFAULT_CONFIGURATION = [
+        {
+            "name": constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD,
+            "value": constants.STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
+        },
+        {
+            "name": constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
+            "value": DEFAULT_EMAIL_VALUE,
+        },
         {
             "name": constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,
             "value": constants.STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT,
@@ -97,6 +111,16 @@ class AdminEmailPlugin(BasePlugin):
     ] + DEFAULT_EMAIL_CONFIGURATION  # type: ignore
 
     CONFIG_STRUCTURE = {
+        constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD: {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": DEFAULT_SUBJECT_HELP_TEXT,
+            "label": "Staff reset password subject",
+        },
+        constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD: {
+            "type": ConfigurationTypeField.MULTILINE,
+            "help_text": DEFAULT_TEMPLATE_HELP_TEXT,
+            "label": "Staff reset password template",
+        },
         constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD: {
             "type": ConfigurationTypeField.STRING,
             "help_text": DEFAULT_SUBJECT_HELP_TEXT,
@@ -164,6 +188,9 @@ class AdminEmailPlugin(BasePlugin):
             ],
             staff_order_confirmation=configuration[
                 constants.STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD
+            ],
+            staff_reset_password=configuration[
+                constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD
             ],
         )
 

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -65,6 +65,7 @@ def get_admin_event_map():
 class AdminEmailPlugin(BasePlugin):
     PLUGIN_ID = constants.PLUGIN_ID
     PLUGIN_NAME = "Admin emails"
+    PLUGIN_DESCRIPTION = "Plugin responsible for sending the staff emails."
     DEFAULT_ACTIVE = True
 
     DEFAULT_CONFIGURATION = [
@@ -114,32 +115,32 @@ class AdminEmailPlugin(BasePlugin):
         constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD: {
             "type": ConfigurationTypeField.STRING,
             "help_text": DEFAULT_SUBJECT_HELP_TEXT,
-            "label": "Staff reset password subject",
+            "label": "Reset password subject",
         },
         constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD: {
             "type": ConfigurationTypeField.MULTILINE,
             "help_text": DEFAULT_TEMPLATE_HELP_TEXT,
-            "label": "Staff reset password template",
+            "label": "Reset password template",
         },
         constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD: {
             "type": ConfigurationTypeField.STRING,
             "help_text": DEFAULT_SUBJECT_HELP_TEXT,
-            "label": "Staff order confirmation subject",
+            "label": "Order confirmation subject",
         },
         constants.STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD: {
             "type": ConfigurationTypeField.MULTILINE,
             "help_text": DEFAULT_TEMPLATE_HELP_TEXT,
-            "label": "Staff order confirmation template",
+            "label": "Order confirmation template",
         },
         constants.SET_STAFF_PASSWORD_SUBJECT_FIELD: {
             "type": ConfigurationTypeField.STRING,
             "help_text": DEFAULT_SUBJECT_HELP_TEXT,
-            "label": "Set staff password subject",
+            "label": "Set password subject",
         },
         constants.SET_STAFF_PASSWORD_TEMPLATE_FIELD: {
             "type": ConfigurationTypeField.MULTILINE,
             "help_text": DEFAULT_TEMPLATE_HELP_TEXT,
-            "label": "Set staff password email template",
+            "label": "Set password email template",
         },
         constants.CSV_PRODUCT_EXPORT_SUCCESS_SUBJECT_FIELD: {
             "type": ConfigurationTypeField.STRING,
@@ -163,6 +164,24 @@ class AdminEmailPlugin(BasePlugin):
         },
     }
     CONFIG_STRUCTURE.update(DEFAULT_EMAIL_CONFIG_STRUCTURE)
+    CONFIG_STRUCTURE["host"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_HOST."
+    CONFIG_STRUCTURE["port"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_PORT."
+    CONFIG_STRUCTURE["username"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_HOST_USER."
+    CONFIG_STRUCTURE["password"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_HOST_PASSWORD."
+    CONFIG_STRUCTURE["use_tls"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_USE_TLS."
+    CONFIG_STRUCTURE["use_ssl"][
+        "help_text"
+    ] += " Leave it blank if you want to use system environment - EMAIL_USE_SSL."
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/saleor/plugins/admin_email/tasks.py
+++ b/saleor/plugins/admin_email/tasks.py
@@ -109,3 +109,28 @@ def send_staff_order_confirmation_email_task(
         template_str=email_template_str,
         context=payload,
     )
+
+
+@app.task
+def send_staff_password_reset_email_task(recipient_email, payload, config):
+    email_config = EmailConfig(**config)
+
+    email_template_str = get_email_template_or_default(
+        constants.PLUGIN_ID,
+        constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
+        constants.STAFF_PASSWORD_RESET_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+
+    subject = get_email_subject(
+        constants.PLUGIN_ID,
+        constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD,
+        constants.STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
+    )
+    send_email(
+        config=email_config,
+        recipient_list=[recipient_email],
+        context=payload,
+        subject=subject,
+        template_str=email_template_str,
+    )

--- a/saleor/plugins/admin_email/tests/conftest.py
+++ b/saleor/plugins/admin_email/tests/conftest.py
@@ -17,6 +17,9 @@ from ..constants import (
     STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT,
     STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,
     STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
+    STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
+    STAFF_PASSWORD_RESET_SUBJECT_FIELD,
+    STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
 )
 from ..plugin import AdminEmailPlugin
 
@@ -53,6 +56,8 @@ def admin_email_plugin(settings):
         staff_order_confirmation_title=SET_STAFF_PASSWORD_DEFAULT_SUBJECT,
         csv_product_export_title=CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_SUBJECT,
         csv_product_export_failed_title=CSV_EXPORT_FAILED_DEFAULT_SUBJECT,
+        staff_password_reset_template=DEFAULT_EMAIL_VALUE,
+        staff_password_reset_subject=STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
     ):
         settings.PLUGINS = ["saleor.plugins.admin_email.plugin.AdminEmailPlugin"]
         manager = get_plugins_manager()
@@ -73,6 +78,10 @@ def admin_email_plugin(settings):
                         {"name": "use_tls", "value": use_tls},
                         {"name": "use_ssl", "value": use_ssl},
                         {
+                            "name": STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
+                            "value": staff_password_reset_template,
+                        },
+                        {
                             "name": SET_STAFF_PASSWORD_TEMPLATE_FIELD,
                             "value": set_staff_password_template,
                         },
@@ -87,6 +96,10 @@ def admin_email_plugin(settings):
                         {
                             "name": CSV_EXPORT_FAILED_TEMPLATE_FIELD,
                             "value": csv_product_export_failed,
+                        },
+                        {
+                            "name": STAFF_PASSWORD_RESET_SUBJECT_FIELD,
+                            "value": staff_password_reset_subject,
                         },
                         {
                             "name": STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,

--- a/saleor/plugins/admin_email/tests/test_notify_events.py
+++ b/saleor/plugins/admin_email/tests/test_notify_events.py
@@ -1,12 +1,36 @@
 from unittest import mock
 
+from ....account.notifications import get_default_user_payload
 from ....order.notifications import get_default_order_payload
 from ..notify_events import (
     send_csv_export_failed,
     send_csv_product_export_success,
     send_set_staff_password_email,
     send_staff_order_confirmation,
+    send_staff_reset_password,
 )
+
+
+@mock.patch(
+    "saleor.plugins.admin_email.notify_events.send_staff_password_reset_email_task."
+    "delay"
+)
+def test_send_account_password_reset_event(mocked_email_task, customer_user):
+    token = "token123"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": "user@example.com",
+        "token": token,
+        "reset_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+    config = {"host": "localhost", "port": "1025"}
+    send_staff_reset_password(
+        payload=payload,
+        config=config,
+    )
+    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(

--- a/saleor/plugins/admin_email/tests/test_plugin.py
+++ b/saleor/plugins/admin_email/tests/test_plugin.py
@@ -19,6 +19,7 @@ from ..notify_events import (
     send_csv_product_export_success,
     send_set_staff_password_email,
     send_staff_order_confirmation,
+    send_staff_reset_password,
 )
 from ..plugin import get_admin_event_map
 
@@ -29,6 +30,7 @@ def test_event_map():
         NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD: send_set_staff_password_email,
         NotifyEventType.CSV_PRODUCT_EXPORT_SUCCESS: send_csv_product_export_success,
         NotifyEventType.CSV_EXPORT_FAILED: send_csv_export_failed,
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD: send_staff_reset_password,
     }
 
 
@@ -39,6 +41,7 @@ def test_event_map():
         NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
         NotifyEventType.CSV_PRODUCT_EXPORT_SUCCESS,
         NotifyEventType.CSV_EXPORT_FAILED,
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD,
     ],
 )
 @patch("saleor.plugins.admin_email.plugin.get_admin_event_map")

--- a/saleor/plugins/admin_email/tests/test_tasks.py
+++ b/saleor/plugins/admin_email/tests/test_tasks.py
@@ -11,7 +11,62 @@ from ..tasks import (
     send_export_failed_email_task,
     send_set_staff_password_email_task,
     send_staff_order_confirmation_email_task,
+    send_staff_password_reset_email_task,
 )
+
+
+@mock.patch("saleor.plugins.email_common.send_mail")
+def test_send_staff_password_reset_email_task_default_template(
+    mocked_send_mail, email_dict_config, customer_user
+):
+    token = "token123"
+    recipient_email = "admin@example.com"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": recipient_email,
+        "token": token,
+        "reset_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+
+    send_staff_password_reset_email_task(recipient_email, payload, email_dict_config)
+
+    # confirm that mail has correct structure and email was sent
+    assert mocked_send_mail.called
+
+
+@mock.patch("saleor.plugins.admin_email.tasks.send_email")
+def test_send_staff_password_reset_email_task_custom_template(
+    mocked_send_email, email_dict_config, admin_email_plugin, customer_user
+):
+    expected_template_str = "<html><body>Template body</body></html>"
+    expected_subject = "Test Email Subject"
+    admin_email_plugin(
+        staff_password_reset_template=expected_template_str,
+        staff_password_reset_subject=expected_subject,
+    )
+    token = "token123"
+    recipient_email = "admin@example.com"
+    payload = {
+        "user": get_default_user_payload(customer_user),
+        "recipient_email": recipient_email,
+        "token": token,
+        "reset_url": f"http://localhost:8000/redirect{token}",
+        "domain": "localhost:8000",
+        "site_name": "Saleor",
+    }
+
+    send_staff_password_reset_email_task(recipient_email, payload, email_dict_config)
+
+    email_config = EmailConfig(**email_dict_config)
+    mocked_send_email.assert_called_with(
+        config=email_config,
+        recipient_list=[recipient_email],
+        context=payload,
+        subject=expected_subject,
+        template_str=expected_template_str,
+    )
 
 
 @mock.patch("saleor.plugins.email_common.send_mail")

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -55,37 +55,27 @@ DEFAULT_EMAIL_CONFIGURATION = [
     {"name": "use_tls", "value": False},
     {"name": "use_ssl", "value": False},
 ]
+
+
 DEFAULT_EMAIL_CONFIG_STRUCTURE = {
     "host": {
         "type": ConfigurationTypeField.STRING,
-        "help_text": (
-            "The host to use for sending email. Leave it blank if you want to use "
-            "system environment - EMAIL_HOST."
-        ),
+        "help_text": ("The host to use for sending email."),
         "label": "SMTP host",
     },
     "port": {
         "type": ConfigurationTypeField.STRING,
-        "help_text": (
-            "Port to use for the SMTP server. Leave it blank if you want to use "
-            "system environment - EMAIL_PORT."
-        ),
+        "help_text": ("Port to use for the SMTP server."),
         "label": "SMTP port",
     },
     "username": {
         "type": ConfigurationTypeField.STRING,
-        "help_text": (
-            "Username to use for the SMTP server. Leave it blank if you want to "
-            "use system environment - EMAIL_HOST_USER."
-        ),
+        "help_text": ("Username to use for the SMTP server."),
         "label": "SMTP user",
     },
     "password": {
         "type": ConfigurationTypeField.PASSWORD,
-        "help_text": (
-            "Password to use for the SMTP server. Leave it blank if you want to "
-            "use system environment - EMAIL_HOST_PASSWORD."
-        ),
+        "help_text": ("Password to use for the SMTP server."),
         "label": "Password",
     },
     "sender_name": {
@@ -104,8 +94,7 @@ DEFAULT_EMAIL_CONFIG_STRUCTURE = {
             "Whether to use a TLS (secure) connection when talking to the SMTP "
             "server. This is used for explicit TLS connections, generally on port "
             "587. Use TLS/Use SSL are mutually exclusive, so only set one of those"
-            " settings to True. Leave it blank if you want to use system environment"
-            " - EMAIL_USE_TLS"
+            " settings to True."
         ),
         "label": "Use TLS",
     },
@@ -116,8 +105,7 @@ DEFAULT_EMAIL_CONFIG_STRUCTURE = {
             "the SMTP server. In most email documentation this type of TLS "
             "connection is referred to as SSL. It is generally used on port 465. "
             "Use TLS/Use SSL are mutually exclusive, so only set one of those"
-            " settings to True. Leave it blank if you want to use system environment"
-            " - EMAIL_USE_SSL"
+            " settings to True."
         ),
         "label": "Use SSL",
     },


### PR DESCRIPTION
I want to merge this change because there is a missing event for AdminEmail plugin responsible for sending emails for staff reset password.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
