### PR TITLE
Deallocate stocks for order lines in a bulk way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add SearchRank to search product by name and description. New enum added to `ProductOrderField` - `RANK` - which returns results sorted by search rank - #6872 by @d-wysocki
 - Allocate stocks for order lines in a bulk way - #6877 by @IKarbowiak
 - Add product description_plaintext to populatedb - #6894 by @d-wysocki
+- Deallocate stocks for order lines in a bulk way - #6896 by @IKarbowiak
 
 # 2.11.1
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -471,8 +471,9 @@ def _get_order_data(
             discounts=discounts,
         )
     except InsufficientStock as e:
+        variants = [str(item.variant) for item in e.items]
         raise ValidationError(
-            f"Insufficient product stock: {', '.join(e.items)}", code=e.code
+            f"Insufficient product stock: {', '.join(variants)}", code=e.code.value
         )
     except NotApplicable:
         raise ValidationError(
@@ -578,8 +579,9 @@ def complete_checkout(
         except InsufficientStock as e:
             release_voucher_usage(order_data)
             gateway.payment_refund_or_void(payment)
+            variants = [str(item.variant) for item in e.items]
             raise ValidationError(
-                f"Insufficient product stock: {', '.join(e.items)}", code=e.code
+                f"Insufficient product stock: {', '.join(variants)}", code=e.code.value
             )
 
     return order, action_required, action_data

--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -1,21 +1,33 @@
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, List, Optional, Union
+
 from ..checkout.error_codes import CheckoutErrorCode
+
+if TYPE_CHECKING:
+    from ..order.models import OrderLine
+    from ..product.models import ProductVariant
+
+
+@dataclass
+class InsufficientStockData:
+    variant: "ProductVariant"
+    order_line: Optional["OrderLine"] = None
+    warehouse_pk: Union[str, int, None] = None
+    available_quantity: Optional[int] = None
 
 
 class InsufficientStock(Exception):
-    def __init__(self, items, context=None):
-        items = [str(item) for item in items]
-        super().__init__(f"Insufficient stock for {', '.join(items)}")
+    def __init__(self, items: List[InsufficientStockData]):
+        variants = [str(item.variant) for item in items]
+        super().__init__(f"Insufficient stock for {', '.join(variants)}")
         self.items = items
-        self.context = context
         self.code = CheckoutErrorCode.INSUFFICIENT_STOCK
 
 
 class AllocationError(Exception):
     def __init__(self, order_lines):
-        order_lines = [str(line) for line in order_lines]
-        super().__init__(
-            f"Unable to deallocate stock for lines {', '.join(order_lines)}."
-        )
+        lines = [str(line) for line in order_lines]
+        super().__init__(f"Unable to deallocate stock for lines {', '.join(lines)}.")
         self.order_lines = order_lines
 
 

--- a/saleor/core/exceptions.py
+++ b/saleor/core/exceptions.py
@@ -11,13 +11,12 @@ class InsufficientStock(Exception):
 
 
 class AllocationError(Exception):
-    def __init__(self, order_line, quantity):
+    def __init__(self, order_lines):
+        order_lines = [str(line) for line in order_lines]
         super().__init__(
-            f"Can't deallocate {quantity} for variant: {order_line.variant}"
-            f" in order: {order_line.order}"
+            f"Unable to deallocate stock for lines {', '.join(order_lines)}."
         )
-        self.order_line = order_line
-        self.quantity = quantity
+        self.order_lines = order_lines
 
 
 class ReadOnlyException(Exception):

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -8,7 +8,7 @@ from ....checkout import calculations
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.models import Checkout
 from ....checkout.utils import fetch_checkout_lines
-from ....core.exceptions import InsufficientStock
+from ....core.exceptions import InsufficientStock, InsufficientStockData
 from ....core.taxes import zero_money
 from ....order import OrderStatus
 from ....order.models import Order
@@ -971,10 +971,12 @@ def test_order_already_exists(
 def test_create_order_raises_insufficient_stock(
     mocked_create_order, user_api_client, checkout_ready_to_complete, payment_dummy
 ):
-    mocked_create_order.side_effect = InsufficientStock("InsufficientStock")
     checkout = checkout_ready_to_complete
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    mocked_create_order.side_effect = InsufficientStock(
+        [InsufficientStockData(variant=lines[0].variant)]
+    )
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout, lines, checkout.shipping_address
     )

--- a/saleor/graphql/checkout/utils.py
+++ b/saleor/graphql/checkout/utils.py
@@ -1,0 +1,15 @@
+import graphene
+from django.core.exceptions import ValidationError
+
+
+def prepare_insufficient_stock_checkout_validation_error(exc):
+    variants = [str(item.variant) for item in exc.items]
+    variant_ids = [
+        graphene.Node.to_global_id("ProductVariant", item.variant.pk)
+        for item in exc.items
+    ]
+    return ValidationError(
+        f"Insufficient product stock: {', '.join(variants)}",
+        code=exc.code.value,
+        params={"variants": variant_ids},
+    )

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -369,10 +369,11 @@ class DraftOrderComplete(BaseMutation):
                 try:
                     allocate_stocks([line_data], country)
                 except InsufficientStock as exc:
+                    variants = [str(item.variant) for item in exc.items]
                     raise ValidationError(
                         {
                             "lines": ValidationError(
-                                f"Insufficient product stock: {', '.join(exc.items)}",
+                                f"Insufficient product stock: {', '.join(variants)}",
                                 code=OrderErrorCode.INSUFFICIENT_STOCK,
                             )
                         }

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -29,7 +29,7 @@ from ...core.types.common import OrderError
 from ...product.types import ProductVariant
 from ..types import Order, OrderLine
 from ..utils import (
-    prepare_insufficient_stock_validation_errors,
+    prepare_insufficient_stock_order_validation_errors,
     validate_draft_order,
     validate_product_is_published_in_channel,
     validate_variant_channel_listings,
@@ -370,7 +370,7 @@ class DraftOrderComplete(BaseMutation):
                 try:
                     allocate_stocks([line_data], country)
                 except InsufficientStock as exc:
-                    errors = prepare_insufficient_stock_validation_errors(exc)
+                    errors = prepare_insufficient_stock_order_validation_errors(exc)
                     raise ValidationError({"lines": errors})
         order_created(order, user=info.context.user, from_draft=True)
 

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -29,6 +29,7 @@ from ...core.types.common import OrderError
 from ...product.types import ProductVariant
 from ..types import Order, OrderLine
 from ..utils import (
+    prepare_insufficient_stock_validation_errors,
     validate_draft_order,
     validate_product_is_published_in_channel,
     validate_variant_channel_listings,
@@ -369,15 +370,8 @@ class DraftOrderComplete(BaseMutation):
                 try:
                     allocate_stocks([line_data], country)
                 except InsufficientStock as exc:
-                    variants = [str(item.variant) for item in exc.items]
-                    raise ValidationError(
-                        {
-                            "lines": ValidationError(
-                                f"Insufficient product stock: {', '.join(variants)}",
-                                code=OrderErrorCode.INSUFFICIENT_STOCK,
-                            )
-                        }
-                    )
+                    errors = prepare_insufficient_stock_validation_errors(exc)
+                    raise ValidationError({"lines": errors})
         order_created(order, user=info.context.user, from_draft=True)
 
         return DraftOrderComplete(order=order)

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -24,7 +24,7 @@ from ...core.utils import from_global_id_strict_type, get_duplicated_values
 from ...utils import get_user_or_app_from_context
 from ...warehouse.types import Warehouse
 from ..types import Fulfillment, FulfillmentLine, Order, OrderLine
-from ..utils import prepare_insufficient_stock_validation_errors
+from ..utils import prepare_insufficient_stock_order_validation_errors
 
 
 class OrderFulfillStockInput(graphene.InputObjectType):
@@ -218,7 +218,7 @@ class OrderFulfill(BaseMutation):
                 user, order, dict(lines_for_warehouses), notify_customer
             )
         except InsufficientStock as exc:
-            errors = prepare_insufficient_stock_validation_errors(exc)
+            errors = prepare_insufficient_stock_order_validation_errors(exc)
             raise ValidationError({"stocks": errors})
 
         return OrderFulfill(fulfillments=fulfillments, order=order)

--- a/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
+++ b/saleor/graphql/order/tests/benchmark/test_fulfillment_refund_and_return_products.py
@@ -1,0 +1,169 @@
+from unittest.mock import patch
+
+import graphene
+import pytest
+
+from .....payment import ChargeStatus
+from ....tests.utils import get_graphql_content
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.order.actions.gateway.refund")
+def test_fulfillment_refund_products_order_lines(
+    mocked_refund,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    payment_dummy,
+    count_queries,
+):
+    query = """
+        mutation OrderFulfillmentRefundProducts(
+            $order: ID!, $input: OrderRefundProductsInput!
+        ) {
+            orderFulfillmentRefundProducts(
+                order: $order,
+                input: $input
+            ) {
+                fulfillment{
+                    id
+                    status
+                    lines{
+                        id
+                        quantity
+                        orderLine{
+                            id
+                        }
+                    }
+                }
+                orderErrors {
+                    field
+                    code
+                    message
+                    warehouse
+                    orderLine
+                }
+            }
+        }
+    """
+    payment_dummy.total = order_with_lines.total_gross_amount
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    order_with_lines.payments.add(payment_dummy)
+    line_to_refund = order_with_lines.lines.first()
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.pk)
+    line_id = graphene.Node.to_global_id("OrderLine", line_to_refund.pk)
+    variables = {
+        "order": order_id,
+        "input": {"orderLines": [{"orderLineId": line_id, "quantity": 2}]},
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+
+    response = staff_api_client.post_graphql(query, variables)
+
+    content = get_graphql_content(response)
+    assert content["data"]["orderFulfillmentRefundProducts"]["fulfillment"]
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.order.actions.gateway.refund")
+def test_fulfillment_return_products_order_lines(
+    mocked_refund,
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines,
+    payment_dummy,
+    count_queries,
+):
+    query = """
+        mutation OrderFulfillmentReturnProducts(
+        $order: ID!, $input: OrderReturnProductsInput!
+    ) {
+        orderFulfillmentReturnProducts(
+            order: $order,
+            input: $input
+        ) {
+            returnFulfillment{
+                id
+                status
+                lines{
+                    id
+                    quantity
+                    orderLine{
+                        id
+                    }
+                }
+            }
+            replaceFulfillment{
+                id
+                status
+                lines{
+                    id
+                    quantity
+                    orderLine{
+                        id
+                    }
+                }
+            }
+            order{
+                id
+                status
+            }
+            replaceOrder{
+                id
+                status
+            }
+            orderErrors {
+                field
+                code
+                message
+                warehouse
+                orderLine
+            }
+        }
+    }
+    """
+    payment_dummy.total = order_with_lines.total_gross_amount
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    order_with_lines.payments.add(payment_dummy)
+    line_to_return = order_with_lines.lines.first()
+    line_quantity_to_return = 2
+
+    line_to_replace = order_with_lines.lines.last()
+    line_quantity_to_replace = 1
+
+    order_id = graphene.Node.to_global_id("Order", order_with_lines.pk)
+    line_id = graphene.Node.to_global_id("OrderLine", line_to_return.pk)
+    replace_line_id = graphene.Node.to_global_id("OrderLine", line_to_replace.pk)
+
+    variables = {
+        "order": order_id,
+        "input": {
+            "refund": True,
+            "includeShippingCosts": True,
+            "orderLines": [
+                {
+                    "orderLineId": line_id,
+                    "quantity": line_quantity_to_return,
+                    "replace": False,
+                },
+                {
+                    "orderLineId": replace_line_id,
+                    "quantity": line_quantity_to_replace,
+                    "replace": True,
+                },
+            ],
+        },
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(query, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentReturnProducts"]
+    assert data["returnFulfillment"]
+    assert data["replaceFulfillment"]

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import graphene
 from django.contrib.auth.models import AnonymousUser
 
-from ....core.exceptions import InsufficientStock
+from ....core.exceptions import InsufficientStock, InsufficientStockData
 from ....order import OrderStatus
 from ....order.error_codes import OrderErrorCode
 from ....order.events import OrderEvents
@@ -398,12 +398,14 @@ def test_order_fulfill_warehouse_with_insufficient_stock_exception(
         },
     }
 
-    error_context = {
-        "order_line": order_line,
-        "warehouse_pk": str(warehouse_no_shipping_zone.pk),
-    }
     mock_create_fulfillments.side_effect = InsufficientStock(
-        [order_line.variant], error_context
+        [
+            InsufficientStockData(
+                variant=order_line.variant,
+                order_line=order_line,
+                warehouse_pk=warehouse_no_shipping_zone.pk,
+            )
+        ]
     )
 
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -187,7 +187,11 @@ def test_orderline_query(staff_api_client, permission_manage_orders, fulfilled_o
         "Warehouse", allocation.stock.warehouse.pk
     )
     assert first_order_data_line["allocations"] == [
-        {"id": allocation_id, "quantity": 0, "warehouse": {"id": warehouse_id}}
+        {
+            "id": allocation_id,
+            "quantity": allocation.quantity_allocated,
+            "warehouse": {"id": warehouse_id},
+        }
     ]
 
 

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -82,10 +82,11 @@ def validate_order_lines(order, country):
             try:
                 check_stock_quantity(line.variant, country, line.quantity)
             except InsufficientStock as exc:
+                variants = [str(item.variant) for item in exc.items]
                 raise ValidationError(
                     {
                         "lines": ValidationError(
-                            f"Insufficient product stock: {', '.join(exc.items)}",
+                            f"Insufficient product stock: {', '.join(variants)}",
                             code=OrderErrorCode.INSUFFICIENT_STOCK,
                         )
                     }

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -82,15 +82,8 @@ def validate_order_lines(order, country):
             try:
                 check_stock_quantity(line.variant, country, line.quantity)
             except InsufficientStock as exc:
-                variants = [str(item.variant) for item in exc.items]
-                raise ValidationError(
-                    {
-                        "lines": ValidationError(
-                            f"Insufficient product stock: {', '.join(variants)}",
-                            code=OrderErrorCode.INSUFFICIENT_STOCK,
-                        )
-                    }
-                )
+                errors = prepare_insufficient_stock_validation_errors(exc)
+                raise ValidationError({"lines": errors})
 
 
 def validate_product_is_published(order):
@@ -218,3 +211,29 @@ def validate_draft_order(order, country):
     validate_product_is_published(order)
     validate_product_is_available_for_purchase(order)
     validate_channel_is_active(order.channel)
+
+
+def prepare_insufficient_stock_validation_errors(exc):
+    errors = []
+    for item in exc.items:
+        order_line_global_id = (
+            graphene.Node.to_global_id("OrderLine", item.order_line.pk)
+            if item.order_line
+            else None
+        )
+        warehouse_global_id = (
+            graphene.Node.to_global_id("Warehouse", item.warehouse_pk)
+            if item.warehouse_pk
+            else None
+        )
+        errors.append(
+            ValidationError(
+                f"Insufficient product stock: {item.variant}",
+                code=OrderErrorCode.INSUFFICIENT_STOCK,
+                params={
+                    "order_line": order_line_global_id,
+                    "warehouse": warehouse_global_id,
+                },
+            )
+        )
+    return errors

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -82,7 +82,7 @@ def validate_order_lines(order, country):
             try:
                 check_stock_quantity(line.variant, country, line.quantity)
             except InsufficientStock as exc:
-                errors = prepare_insufficient_stock_validation_errors(exc)
+                errors = prepare_insufficient_stock_order_validation_errors(exc)
                 raise ValidationError({"lines": errors})
 
 
@@ -213,7 +213,7 @@ def validate_draft_order(order, country):
     validate_channel_is_active(order.channel)
 
 
-def prepare_insufficient_stock_validation_errors(exc):
+def prepare_insufficient_stock_order_validation_errors(exc):
     errors = []
     for item in exc.items:
         order_line_global_id = (

--- a/saleor/order/__init__.py
+++ b/saleor/order/__init__.py
@@ -172,6 +172,7 @@ class OrderLineData:
     quantity: int
     variant: Optional["ProductVariant"] = None
     replace: bool = False
+    warehouse_pk: Optional[str] = None
 
 
 @dataclass

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -311,6 +311,7 @@ def clean_mark_order_as_paid(order: "Order"):
         )
 
 
+@transaction.atomic
 def fulfill_order_lines(order_lines_info: Iterable["OrderLineData"]):
     """Fulfill order line with given quantity."""
     lines_to_decrease_stock = get_order_lines_with_track_inventory(order_lines_info)
@@ -325,6 +326,7 @@ def fulfill_order_lines(order_lines_info: Iterable["OrderLineData"]):
     OrderLine.objects.bulk_update(order_lines, ["quantity_fulfilled"])
 
 
+@transaction.atomic
 def automatically_fulfill_digital_lines(order: "Order"):
     """Fulfill all digital lines which have enabled automatic fulfillment setting.
 
@@ -549,6 +551,7 @@ def _get_fulfillment_line(
     return moved_line, fulfillment_line_existed
 
 
+@transaction.atomic()
 def _move_order_lines_to_target_fulfillment(
     order_lines_to_move: List[OrderLineData],
     lines_in_target_fulfillment: List[FulfillmentLine],
@@ -608,6 +611,7 @@ def _move_order_lines_to_target_fulfillment(
     OrderLine.objects.bulk_update(order_lines_to_update, ["quantity_fulfilled"])
 
 
+@transaction.atomic()
 def _move_fulfillment_lines_to_target_fulfillment(
     fulfillment_lines_to_move: List[FulfillmentLineData],
     lines_in_target_fulfillment: List[FulfillmentLine],

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -407,6 +407,7 @@ def _create_fulfillment_lines(
     for stock in stocks:
         variant_to_stock[stock.product_variant_id].append(stock)
 
+    insufficient_stocks = []
     fulfillment_lines = []
     lines_info = []
     for line in lines_data:
@@ -420,7 +421,8 @@ def _create_fulfillment_lines(
                     order_line=order_line,
                     warehouse_pk=warehouse_pk,
                 )
-                raise InsufficientStock([error_data])
+                insufficient_stocks.append(error_data)
+                continue
             stock = line_stocks[0]
             lines_info.append(
                 OrderLineData(
@@ -440,6 +442,10 @@ def _create_fulfillment_lines(
                     stock=stock,
                 )
             )
+
+    if insufficient_stocks:
+        raise InsufficientStock(insufficient_stocks)
+
     if lines_info:
         fulfill_order_lines(lines_info)
 

--- a/saleor/order/tests/test_fulfullments_actions.py
+++ b/saleor/order/tests/test_fulfullments_actions.py
@@ -296,55 +296,6 @@ def test_create_fulfillments_without_allocations(
 
 
 @patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
-def test_create_fulfillments_warehouse_with_out_of_stock(
-    mock_email_fulfillment,
-    staff_user,
-    order_with_lines,
-    warehouse,
-):
-    order = order_with_lines
-    order_line1, order_line2 = order.lines.all()
-    order_line1.allocations.all().delete()
-    stock = order_line1.variant.stocks.get(warehouse=warehouse)
-    stock.quantity = 2
-    stock.save(update_fields=["quantity"])
-    fulfillment_lines_for_warehouses = {
-        str(warehouse.pk): [
-            {"order_line": order_line1, "quantity": 3},
-            {"order_line": order_line2, "quantity": 2},
-        ]
-    }
-
-    with pytest.raises(InsufficientStock) as exc:
-        create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
-
-    assert exc.value.items == [str(order_line1.variant)]
-    assert exc.value.context == {
-        "order_line": order_line1,
-        "warehouse_pk": str(warehouse.pk),
-    }
-
-    order.refresh_from_db()
-    assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0
-
-    assert order.status == OrderStatus.UNFULFILLED
-    assert order.fulfillments.all().count() == 0
-
-    order_line1, order_line2 = order.lines.all()
-    assert order_line1.quantity_fulfilled == 0
-    assert order_line2.quantity_fulfilled == 0
-
-    assert (
-        Allocation.objects.filter(
-            order_line__order=order, quantity_allocated__gt=0
-        ).count()
-        == 1
-    )
-
-    mock_email_fulfillment.assert_not_called()
-
-
-@patch("saleor.order.actions.send_fulfillment_confirmation_to_customer", autospec=True)
 def test_create_fulfillments_warehouse_without_stock(
     mock_email_fulfillment,
     staff_user,
@@ -363,11 +314,10 @@ def test_create_fulfillments_warehouse_without_stock(
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert exc.value.items == [str(order_line1.variant)]
-    assert exc.value.context == {
-        "order_line": order_line1,
-        "warehouse_pk": str(warehouse_no_shipping_zone.pk),
-    }
+    assert len(exc.value.items) == 1
+    assert exc.value.items[0].variant == order_line1.variant
+    assert exc.value.items[0].order_line == order_line1
+    assert exc.value.items[0].warehouse_pk == str(warehouse_no_shipping_zone.pk)
 
     order.refresh_from_db()
     assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0
@@ -405,11 +355,10 @@ def test_create_fulfillments_with_variant_without_inventory_tracking_and_without
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert exc.value.items == [str(order_line.variant)]
-    assert exc.value.context == {
-        "order_line": order_line,
-        "warehouse_pk": str(warehouse_no_shipping_zone.pk),
-    }
+    assert len(exc.value.items) == 1
+    assert exc.value.items[0].variant == order_line.variant
+    assert exc.value.items[0].order_line == order_line
+    assert exc.value.items[0].warehouse_pk == str(warehouse_no_shipping_zone.pk)
 
     order.refresh_from_db()
     assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0

--- a/saleor/order/tests/test_fulfullments_actions.py
+++ b/saleor/order/tests/test_fulfullments_actions.py
@@ -314,10 +314,15 @@ def test_create_fulfillments_warehouse_without_stock(
     with pytest.raises(InsufficientStock) as exc:
         create_fulfillments(staff_user, order, fulfillment_lines_for_warehouses, True)
 
-    assert len(exc.value.items) == 1
-    assert exc.value.items[0].variant == order_line1.variant
-    assert exc.value.items[0].order_line == order_line1
-    assert exc.value.items[0].warehouse_pk == str(warehouse_no_shipping_zone.pk)
+    assert len(exc.value.items) == 2
+    assert {item.variant for item in exc.value.items} == {
+        order_line1.variant,
+        order_line2.variant,
+    }
+    assert {item.order_line for item in exc.value.items} == {order_line1, order_line2}
+    assert {item.warehouse_pk for item in exc.value.items} == {
+        str(warehouse_no_shipping_zone.pk)
+    }
 
     order.refresh_from_db()
     assert FulfillmentLine.objects.filter(fulfillment__order=order).count() == 0

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -264,8 +264,14 @@ def test_fulfill_order_line(order_with_lines):
     stock_quantity_after = stock.quantity - line.quantity
 
     fulfill_order_line(
-        [OrderLineData(line=line, quantity=line.quantity, variant=variant)],
-        [stock.warehouse.pk],
+        [
+            OrderLineData(
+                line=line,
+                quantity=line.quantity,
+                variant=variant,
+                warehouse_pk=stock.warehouse.pk,
+            )
+        ],
     )
 
     stock.refresh_from_db()
@@ -279,9 +285,7 @@ def test_fulfill_order_line_with_variant_deleted(order_with_lines):
 
     line.refresh_from_db()
 
-    fulfill_order_line(
-        [OrderLineData(line=line, quantity=line.quantity)], ["warehouse_pk"]
-    )
+    fulfill_order_line([OrderLineData(line=line, quantity=line.quantity)])
 
 
 def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
@@ -297,8 +301,14 @@ def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
     stock_quantity_after = stock.quantity
 
     fulfill_order_line(
-        [OrderLineData(line=line, quantity=line.quantity, variant=variant)],
-        [stock.warehouse.pk],
+        [
+            OrderLineData(
+                line=line,
+                quantity=line.quantity,
+                variant=variant,
+                warehouse_pk=stock.warehouse.pk,
+            )
+        ]
     )
 
     stock.refresh_from_db()

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import pytest
 from prices import Money, TaxedMoney
 
+from ...order import OrderLineData
 from ...payment import ChargeStatus, PaymentError, TransactionKind
 from ...payment.models import Payment
 from ...plugins.manager import get_plugins_manager
@@ -262,7 +263,10 @@ def test_fulfill_order_line(order_with_lines):
     stock = Stock.objects.get(product_variant=variant)
     stock_quantity_after = stock.quantity - line.quantity
 
-    fulfill_order_line(line, line.quantity, stock.warehouse.pk)
+    fulfill_order_line(
+        [OrderLineData(line=line, quantity=line.quantity, variant=variant)],
+        [stock.warehouse.pk],
+    )
 
     stock.refresh_from_db()
     assert stock.quantity == stock_quantity_after
@@ -275,7 +279,9 @@ def test_fulfill_order_line_with_variant_deleted(order_with_lines):
 
     line.refresh_from_db()
 
-    fulfill_order_line(line, line.quantity, "warehouse_pk")
+    fulfill_order_line(
+        [OrderLineData(line=line, quantity=line.quantity)], ["warehouse_pk"]
+    )
 
 
 def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
@@ -290,7 +296,10 @@ def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
     # stock should not change
     stock_quantity_after = stock.quantity
 
-    fulfill_order_line(line, line.quantity, stock.warehouse.pk)
+    fulfill_order_line(
+        [OrderLineData(line=line, quantity=line.quantity, variant=variant)],
+        [stock.warehouse.pk],
+    )
 
     stock.refresh_from_db()
     assert stock.quantity == stock_quantity_after

--- a/saleor/order/tests/test_order_actions.py
+++ b/saleor/order/tests/test_order_actions.py
@@ -17,7 +17,7 @@ from ..actions import (
     cancel_fulfillment,
     cancel_order,
     clean_mark_order_as_paid,
-    fulfill_order_line,
+    fulfill_order_lines,
     handle_fully_paid_order,
     mark_order_as_paid,
     order_refunded,
@@ -255,7 +255,7 @@ def test_order_refunded(
     )
 
 
-def test_fulfill_order_line(order_with_lines):
+def test_fulfill_order_lines(order_with_lines):
     order = order_with_lines
     line = order.lines.first()
     quantity_fulfilled_before = line.quantity_fulfilled
@@ -263,7 +263,7 @@ def test_fulfill_order_line(order_with_lines):
     stock = Stock.objects.get(product_variant=variant)
     stock_quantity_after = stock.quantity - line.quantity
 
-    fulfill_order_line(
+    fulfill_order_lines(
         [
             OrderLineData(
                 line=line,
@@ -279,16 +279,16 @@ def test_fulfill_order_line(order_with_lines):
     assert line.quantity_fulfilled == quantity_fulfilled_before + line.quantity
 
 
-def test_fulfill_order_line_with_variant_deleted(order_with_lines):
+def test_fulfill_order_lines_with_variant_deleted(order_with_lines):
     line = order_with_lines.lines.first()
     line.variant.delete()
 
     line.refresh_from_db()
 
-    fulfill_order_line([OrderLineData(line=line, quantity=line.quantity)])
+    fulfill_order_lines([OrderLineData(line=line, quantity=line.quantity)])
 
 
-def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
+def test_fulfill_order_lines_without_inventory_tracking(order_with_lines):
     order = order_with_lines
     line = order.lines.first()
     quantity_fulfilled_before = line.quantity_fulfilled
@@ -300,7 +300,7 @@ def test_fulfill_order_line_without_inventory_tracking(order_with_lines):
     # stock should not change
     stock_quantity_after = stock.quantity
 
-    fulfill_order_line(
+    fulfill_order_lines(
         [
             OrderLineData(
                 line=line,

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -12,7 +12,7 @@ from ..core.taxes import zero_money
 from ..core.weight import zero_weight
 from ..discount.models import NotApplicable, Voucher, VoucherType
 from ..discount.utils import get_products_voucher_discount, validate_voucher_in_order
-from ..order import FulfillmentStatus, OrderStatus
+from ..order import FulfillmentStatus, OrderLineData, OrderStatus
 from ..order.models import Order, OrderLine
 from ..plugins.manager import get_plugins_manager
 from ..product.utils.digital_products import get_default_digital_content_settings
@@ -335,11 +335,13 @@ def restock_order_lines(order):
         shipping_zones__countries__contains=country
     ).first()
 
-    dellocating_stock_lines = []
+    dellocating_stock_lines: List[OrderLineData] = []
     for line in order:
         if line.variant and line.variant.track_inventory:
             if line.quantity_unfulfilled > 0:
-                dellocating_stock_lines.append((line, line.quantity_unfulfilled))
+                dellocating_stock_lines.append(
+                    OrderLineData(line=line, quantity=line.quantity_unfulfilled)
+                )
             if line.quantity_fulfilled > 0:
                 allocation = line.allocations.first()
                 warehouse = (

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -335,10 +335,11 @@ def restock_order_lines(order):
         shipping_zones__countries__contains=country
     ).first()
 
+    dellocating_stock_lines = []
     for line in order:
         if line.variant and line.variant.track_inventory:
             if line.quantity_unfulfilled > 0:
-                deallocate_stock(line, line.quantity_unfulfilled)
+                dellocating_stock_lines.append((line, line.quantity_unfulfilled))
             if line.quantity_fulfilled > 0:
                 allocation = line.allocations.first()
                 warehouse = (
@@ -349,6 +350,9 @@ def restock_order_lines(order):
         if line.quantity_fulfilled > 0:
             line.quantity_fulfilled = 0
             line.save(update_fields=["quantity_fulfilled"])
+
+    if dellocating_stock_lines:
+        deallocate_stock(dellocating_stock_lines)
 
 
 def restock_fulfillment_lines(fulfillment, warehouse):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -53,7 +53,7 @@ from ..discount.models import (
 )
 from ..giftcard.models import GiftCard
 from ..menu.models import Menu, MenuItem, MenuItemTranslation
-from ..order import OrderStatus
+from ..order import OrderLineData, OrderStatus
 from ..order.actions import cancel_fulfillment, fulfill_order_line
 from ..order.events import OrderEvents
 from ..order.models import FulfillmentStatus, Order, OrderEvent, OrderLine
@@ -2445,9 +2445,14 @@ def fulfilled_order(order_with_lines):
     stock_2 = line_2.allocations.get().stock
     warehouse_2_pk = stock_2.warehouse.pk
     fulfillment.lines.create(order_line=line_1, quantity=line_1.quantity, stock=stock_1)
-    fulfill_order_line(line_1, line_1.quantity, warehouse_1_pk)
     fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity, stock=stock_2)
-    fulfill_order_line(line_2, line_2.quantity, warehouse_2_pk)
+    fulfill_order_line(
+        [
+            OrderLineData(line=line_1, quantity=line_1.quantity),
+            OrderLineData(line=line_2, quantity=line_2.quantity),
+        ],
+        [warehouse_1_pk, warehouse_2_pk],
+    )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
     return order
@@ -2463,7 +2468,9 @@ def fulfilled_order_without_inventory_tracking(
     stock = line.variant.stocks.get()
     warehouse_pk = stock.warehouse.pk
     fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
-    fulfill_order_line(line, line.quantity, warehouse_pk)
+    fulfill_order_line(
+        [OrderLineData(line=line, quantity=line.quantity)], [warehouse_pk]
+    )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
     return order

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2448,10 +2448,13 @@ def fulfilled_order(order_with_lines):
     fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity, stock=stock_2)
     fulfill_order_line(
         [
-            OrderLineData(line=line_1, quantity=line_1.quantity),
-            OrderLineData(line=line_2, quantity=line_2.quantity),
+            OrderLineData(
+                line=line_1, quantity=line_1.quantity, warehouse_pk=warehouse_1_pk
+            ),
+            OrderLineData(
+                line=line_2, quantity=line_2.quantity, warehouse_pk=warehouse_2_pk
+            ),
         ],
-        [warehouse_1_pk, warehouse_2_pk],
     )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])
@@ -2469,7 +2472,7 @@ def fulfilled_order_without_inventory_tracking(
     warehouse_pk = stock.warehouse.pk
     fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
     fulfill_order_line(
-        [OrderLineData(line=line, quantity=line.quantity)], [warehouse_pk]
+        [OrderLineData(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk)]
     )
     order.status = OrderStatus.FULFILLED
     order.save(update_fields=["status"])

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -54,7 +54,7 @@ from ..discount.models import (
 from ..giftcard.models import GiftCard
 from ..menu.models import Menu, MenuItem, MenuItemTranslation
 from ..order import OrderLineData, OrderStatus
-from ..order.actions import cancel_fulfillment, fulfill_order_line
+from ..order.actions import cancel_fulfillment, fulfill_order_lines
 from ..order.events import OrderEvents
 from ..order.models import FulfillmentStatus, Order, OrderEvent, OrderLine
 from ..order.utils import recalculate_order
@@ -2446,7 +2446,7 @@ def fulfilled_order(order_with_lines):
     warehouse_2_pk = stock_2.warehouse.pk
     fulfillment.lines.create(order_line=line_1, quantity=line_1.quantity, stock=stock_1)
     fulfillment.lines.create(order_line=line_2, quantity=line_2.quantity, stock=stock_2)
-    fulfill_order_line(
+    fulfill_order_lines(
         [
             OrderLineData(
                 line=line_1, quantity=line_1.quantity, warehouse_pk=warehouse_1_pk
@@ -2471,7 +2471,7 @@ def fulfilled_order_without_inventory_tracking(
     stock = line.variant.stocks.get()
     warehouse_pk = stock.warehouse.pk
     fulfillment.lines.create(order_line=line, quantity=line.quantity, stock=stock)
-    fulfill_order_line(
+    fulfill_order_lines(
         [OrderLineData(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk)]
     )
     order.status = OrderStatus.FULFILLED

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from django.db.models import Sum
 from django.db.models.functions import Coalesce
@@ -52,28 +52,28 @@ def check_stock_quantity_bulk(variants, country_code, quantities):
     for stock in all_variants_stocks:
         variant_stocks[stock.product_variant_id].append(stock)
 
+    insufficient_stocks: List[InsufficientStockData] = []
     for variant, quantity in zip(variants, quantities):
         stocks = variant_stocks.get(variant.pk, [])
         available_quantity = sum([stock.available_quantity for stock in stocks])
 
         if not stocks:
-            raise InsufficientStock(
-                [
-                    InsufficientStockData(
-                        variant=variant, available_quantity=available_quantity
-                    )
-                ]
+            insufficient_stocks.append(
+                InsufficientStockData(
+                    variant=variant, available_quantity=available_quantity
+                )
             )
 
         if variant.track_inventory:
             if quantity > available_quantity:
-                raise InsufficientStock(
-                    [
-                        InsufficientStockData(
-                            variant=variant, available_quantity=available_quantity
-                        )
-                    ]
+                insufficient_stocks.append(
+                    InsufficientStockData(
+                        variant=variant, available_quantity=available_quantity
+                    )
                 )
+
+    if insufficient_stocks:
+        raise InsufficientStock(insufficient_stocks)
 
 
 def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -213,9 +213,7 @@ def increase_stock(
 
 
 @transaction.atomic
-def decrease_stock(
-    order_lines_info: Iterable["OrderLineData"], warehouse_pks: List[str]
-):
+def decrease_stock(order_lines_info: Iterable["OrderLineData"]):
     """Decrease stocks quantities for given `order_lines` in given warehouses.
 
     Function deallocate as many quantities as requested if order_line has less quantity
@@ -225,6 +223,7 @@ def decrease_stock(
     function decrease it by given value.
     """
     variants = [line_info.variant for line_info in order_lines_info]
+    warehouse_pks = [line_info.warehouse_pk for line_info in order_lines_info]
     try:
         deallocate_stock(order_lines_info)
     except AllocationError as exc:
@@ -263,8 +262,9 @@ def decrease_stock(
 
     insufficient_stocks: List[InsufficientStockData] = []
     stocks_to_update = []
-    for line_info, warehouse_pk in zip(order_lines_info, warehouse_pks):
+    for line_info in order_lines_info:
         variant = line_info.variant
+        warehouse_pk = line_info.warehouse_pk
         stock = variant_and_warehouse_to_stock.get(variant.pk, {}).get(  # type: ignore
             warehouse_pk
         )

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -28,11 +28,10 @@ def allocate_stocks(order_lines_info: Iterable["OrderLineData"], country_code: s
     """
     # allocation only applied to order lines with variants with track inventory
     # set to True
-    order_lines_info = [
-        line_info
-        for line_info in order_lines_info
-        if line_info.variant and line_info.variant.track_inventory
-    ]
+    order_lines_info = get_order_lines_with_track_inventory(order_lines_info)
+    if not order_lines_info:
+        return
+
     variants = [line_info.variant for line_info in order_lines_info]
 
     stocks = (
@@ -292,6 +291,17 @@ def decrease_stock(order_lines_info: Iterable["OrderLineData"]):
         stocks_to_update.append(stock)
 
     Stock.objects.bulk_update(stocks_to_update, ["quantity"])
+
+
+def get_order_lines_with_track_inventory(
+    order_lines_info: Iterable["OrderLineData"],
+) -> Iterable["OrderLineData"]:
+    """Return order lines with variants with track inventory set to True."""
+    return [
+        line_info
+        for line_info in order_lines_info
+        if line_info.variant and line_info.variant.track_inventory
+    ]
 
 
 @transaction.atomic

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -157,7 +157,7 @@ def deallocate_stock(order_lines_data: Iterable["OrderLineData"]):
             )
             if quantity_to_deallocate > 0:
                 allocation.quantity_allocated = (
-                    F("quantity_allocated") - quantity_to_deallocate
+                    allocation.quantity_allocated - quantity_to_deallocate
                 )
                 quantity_dealocated += quantity_to_deallocate
                 allocations_to_update.append(allocation)
@@ -287,7 +287,7 @@ def decrease_stock(order_lines_info: Iterable["OrderLineData"]):
             )
             continue
 
-        stock.quantity = F("quantity") - line_info.quantity
+        stock.quantity = stock.quantity - line_info.quantity
         stocks_to_update.append(stock)
 
     Stock.objects.bulk_update(stocks_to_update, ["quantity"])

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -168,7 +168,7 @@ def test_deallocate_stock(allocation):
     allocation.quantity_allocated = 80
     allocation.save(update_fields=["quantity_allocated"])
 
-    deallocate_stock(allocation.order_line, 80)
+    deallocate_stock([(allocation.order_line, 80)])
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -183,7 +183,7 @@ def test_deallocate_stock_partially(allocation):
     allocation.quantity_allocated = 80
     allocation.save(update_fields=["quantity_allocated"])
 
-    deallocate_stock(allocation.order_line, 50)
+    deallocate_stock([(allocation.order_line, 50)])
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -196,7 +196,7 @@ def test_deallocate_stock_many_allocations(
 ):
     order_line = order_line_with_allocation_in_many_stocks
 
-    deallocate_stock(order_line, 3)
+    deallocate_stock([(order_line, 3)])
 
     allocations = order_line.allocations.all()
     assert allocations[0].quantity_allocated == 0
@@ -208,7 +208,7 @@ def test_deallocate_stock_many_allocations_partially(
 ):
     order_line = order_line_with_allocation_in_many_stocks
 
-    deallocate_stock(order_line, 1)
+    deallocate_stock([(order_line, 1)])
 
     allocations = order_line.allocations.all()
     assert allocations[0].quantity_allocated == 1

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -269,10 +269,12 @@ def test_decrease_stock(allocation):
     decrease_stock(
         [
             OrderLineData(
-                line=allocation.order_line, quantity=50, variant=stock.product_variant
+                line=allocation.order_line,
+                quantity=50,
+                variant=stock.product_variant,
+                warehouse_pk=warehouse_pk,
             )
         ],
-        [warehouse_pk],
     )
 
     stock.refresh_from_db()
@@ -292,10 +294,12 @@ def test_decrease_stock_partially(allocation):
     decrease_stock(
         [
             OrderLineData(
-                line=allocation.order_line, quantity=80, variant=stock.product_variant
+                line=allocation.order_line,
+                quantity=80,
+                variant=stock.product_variant,
+                warehouse_pk=warehouse_pk,
             )
         ],
-        [warehouse_pk],
     )
 
     stock.refresh_from_db()
@@ -312,8 +316,14 @@ def test_decrease_stock_many_allocations(
     warehouse_pk = allocations[1].stock.warehouse.pk
 
     decrease_stock(
-        [OrderLineData(line=order_line, quantity=3, variant=order_line.variant)],
-        [warehouse_pk],
+        [
+            OrderLineData(
+                line=order_line,
+                quantity=3,
+                variant=order_line.variant,
+                warehouse_pk=warehouse_pk,
+            )
+        ],
     )
 
     assert allocations[0].quantity_allocated == 0
@@ -330,8 +340,14 @@ def test_decrease_stock_many_allocations_partially(
     warehouse_pk = allocations[0].stock.warehouse.pk
 
     decrease_stock(
-        [OrderLineData(line=order_line, quantity=2, variant=order_line.variant)],
-        [warehouse_pk],
+        [
+            OrderLineData(
+                line=order_line,
+                quantity=2,
+                variant=order_line.variant,
+                warehouse_pk=warehouse_pk,
+            )
+        ],
     )
 
     assert allocations[0].quantity_allocated == 0
@@ -352,8 +368,14 @@ def test_decrease_stock_more_then_allocated(
     assert quantity_allocated < 4
 
     decrease_stock(
-        [OrderLineData(line=order_line, quantity=4, variant=order_line.variant)],
-        [warehouse_pk],
+        [
+            OrderLineData(
+                line=order_line,
+                quantity=4,
+                variant=order_line.variant,
+                warehouse_pk=warehouse_pk,
+            )
+        ],
     )
 
     allocations = order_line.allocations.all()

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -168,7 +168,13 @@ def test_deallocate_stock(allocation):
     allocation.quantity_allocated = 80
     allocation.save(update_fields=["quantity_allocated"])
 
-    deallocate_stock([OrderLineData(line=allocation.order_line, quantity=80)])
+    deallocate_stock(
+        [
+            OrderLineData(
+                line=allocation.order_line, quantity=80, variant=stock.product_variant
+            )
+        ]
+    )
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -183,7 +189,13 @@ def test_deallocate_stock_partially(allocation):
     allocation.quantity_allocated = 80
     allocation.save(update_fields=["quantity_allocated"])
 
-    deallocate_stock([OrderLineData(line=allocation.order_line, quantity=50)])
+    deallocate_stock(
+        [
+            OrderLineData(
+                line=allocation.order_line, quantity=50, variant=stock.product_variant
+            )
+        ]
+    )
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -196,7 +208,9 @@ def test_deallocate_stock_many_allocations(
 ):
     order_line = order_line_with_allocation_in_many_stocks
 
-    deallocate_stock([OrderLineData(line=order_line, quantity=3)])
+    deallocate_stock(
+        [OrderLineData(line=order_line, quantity=3, variant=order_line.variant)]
+    )
 
     allocations = order_line.allocations.all()
     assert allocations[0].quantity_allocated == 0
@@ -208,7 +222,9 @@ def test_deallocate_stock_many_allocations_partially(
 ):
     order_line = order_line_with_allocation_in_many_stocks
 
-    deallocate_stock([OrderLineData(line=order_line, quantity=1)])
+    deallocate_stock(
+        [OrderLineData(line=order_line, quantity=1, variant=order_line.variant)]
+    )
 
     allocations = order_line.allocations.all()
     assert allocations[0].quantity_allocated == 1


### PR DESCRIPTION
- Refactor `deallocate_stock` to operate on multiply lines
- Refactor `decrease_stock` to operate on multiply lines

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
