### PR TITLE
Fix passing country to tax plugin

### DIFF
--- a/saleor/graphql/product/tests/test_variant_pricing.py
+++ b/saleor/graphql/product/tests/test_variant_pricing.py
@@ -1,5 +1,6 @@
 from unittest.mock import Mock
 
+from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
 from ....plugins.manager import PluginsManager
@@ -140,7 +141,7 @@ def test_variant_pricing(
         discounts=[],
         channel=channel_USD,
         local_currency="PLN",
-        country="US",
+        country=Country("US"),
     )
     assert pricing.price_local_currency.currency == "PLN"  # type: ignore
 

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -1,8 +1,7 @@
 from dataclasses import asdict
 
 import graphene
-
-from saleor.graphql.product.dataloaders.products import ProductByIdLoader
+from django_countries.fields import Country
 
 from ....core.permissions import ProductPermissions
 from ....core.utils import get_currency_for_country
@@ -21,6 +20,7 @@ from ...discount.dataloaders import DiscountsByDateTimeLoader
 from ...utils import get_user_country_context
 from ..dataloaders import (
     CollectionsByProductIdLoader,
+    ProductByIdLoader,
     ProductVariantsByProductIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
     VariantsChannelListingByProductIdAndChanneSlugLoader,
@@ -178,7 +178,7 @@ class ProductChannelListing(CountableDjangoObjectType):
                                     collections=collections,
                                     discounts=discounts,
                                     channel=channel,
-                                    country=country_code,
+                                    country=Country(country_code),
                                     local_currency=get_currency_for_country(
                                         country_code
                                     ),

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 import graphene
 from django.conf import settings
+from django_countries.fields import Country
 from graphene import relay
 from graphene_federation import key
 from graphql.error import GraphQLError
@@ -378,7 +379,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                                     collections=collections,
                                     discounts=discounts,
                                     channel=channel,
-                                    country=country_code,
+                                    country=Country(country_code),
                                     local_currency=get_currency_for_country(
                                         country_code
                                     ),
@@ -656,7 +657,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                                     collections=collections,
                                     discounts=discounts,
                                     channel=channel,
-                                    country=country_code,
+                                    country=Country(country_code),
                                     local_currency=get_currency_for_country(
                                         country_code
                                     ),

--- a/saleor/product/tests/test_product_availability.py
+++ b/saleor/product/tests/test_product_availability.py
@@ -2,6 +2,7 @@ import datetime
 from decimal import Decimal
 from unittest.mock import Mock
 
+from django_countries.fields import Country
 from freezegun import freeze_time
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
@@ -29,7 +30,7 @@ def test_availability(stock, monkeypatch, settings, channel_USD):
         channel=channel_USD,
         collections=[],
         discounts=[],
-        country="PL",
+        country=Country("PL"),
     )
     taxed_price_range = TaxedMoneyRange(start=taxed_price, stop=taxed_price)
     assert availability.price_range == taxed_price_range
@@ -50,7 +51,7 @@ def test_availability(stock, monkeypatch, settings, channel_USD):
         discounts=[],
         channel=channel_USD,
         local_currency="PLN",
-        country="PL",
+        country=Country("PL"),
     )
     assert availability.price_range_local_currency.start.currency == "PLN"
 
@@ -62,7 +63,7 @@ def test_availability(stock, monkeypatch, settings, channel_USD):
         collections=[],
         discounts=[],
         channel=channel_USD,
-        country="PL",
+        country=Country("PL"),
     )
     assert availability.price_range.start.tax.amount
     assert availability.price_range.stop.tax.amount
@@ -91,7 +92,7 @@ def test_availability_with_all_variant_channel_listings(stock, channel_USD):
         channel=channel_USD,
         collections=[],
         discounts=[],
-        country="PL",
+        country=Country("PL"),
     )
 
     # then
@@ -120,7 +121,7 @@ def test_availability_with_missing_variant_channel_listings(stock, channel_USD):
         channel=channel_USD,
         collections=[],
         discounts=[],
-        country="PL",
+        country=Country("PL"),
     )
 
     # then
@@ -147,7 +148,7 @@ def test_availability_without_variant_channel_listings(stock, channel_USD):
         channel=channel_USD,
         collections=[],
         discounts=[],
-        country="PL",
+        country=Country("PL"),
     )
 
     # then

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
 import opentracing
+from django_countries.fields import Country
 from prices import MoneyRange, TaxedMoney, TaxedMoneyRange
 
 from ...channel.models import Channel
@@ -145,7 +146,7 @@ def get_product_availability(
     collections: Iterable[Collection],
     discounts: Iterable[DiscountInfo],
     channel: Channel,
-    country: Optional[str] = None,
+    country: Optional[Country] = None,
     local_currency: Optional[str] = None,
     plugins: Optional["PluginsManager"] = None,
 ) -> ProductAvailability:
@@ -222,7 +223,7 @@ def get_variant_availability(
     collections: Iterable[Collection],
     discounts: Iterable[DiscountInfo],
     channel: Channel,
-    country: Optional[str] = None,
+    country: Optional[Country] = None,
     local_currency: Optional[str] = None,
     plugins: Optional["PluginsManager"] = None,
 ) -> VariantAvailability:


### PR DESCRIPTION
This PR fixes passing `Country` instead of country code as a string to tax plugins.  

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
