### PR TITLE
Use CheckoutInfo in update_checkout_shipping_method_if_invalid method.

### DIFF
--- a/saleor/checkout/__init__.py
+++ b/saleor/checkout/__init__.py
@@ -1,15 +1,18 @@
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING, Iterable, List, Optional
 
 if TYPE_CHECKING:
+    from ..account.models import Address, User
+    from ..channel.models import Channel
     from ..product.models import (
         Collection,
         Product,
         ProductVariant,
         ProductVariantChannelListing,
     )
-    from .models import CheckoutLine
+    from ..shipping.models import ShippingMethod, ShippingMethodChannelListing
+    from .models import Checkout, CheckoutLine
 
 logger = logging.getLogger(__name__)
 
@@ -31,3 +34,21 @@ class CheckoutLineInfo:
     channel_listing: "ProductVariantChannelListing"
     product: "Product"
     collections: List["Collection"]
+
+
+@dataclass
+class CheckoutInfo:
+    checkout: "Checkout"
+    user: Optional["User"]
+    channel: "Channel"
+    billing_address: Optional["Address"]
+    shipping_address: Optional["Address"]
+    shipping_method: Optional["ShippingMethod"]
+    valid_shipping_methods: Iterable["ShippingMethod"]
+    shipping_method_channel_listings: Optional["ShippingMethodChannelListing"]
+
+    def get_country(self) -> str:
+        address = self.shipping_address or self.billing_address
+        if address is None or not address.country:
+            return self.checkout.country.code
+        return address.country.code

--- a/saleor/checkout/__init__.py
+++ b/saleor/checkout/__init__.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterable, List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     from ..account.models import Address, User
@@ -44,7 +44,7 @@ class CheckoutInfo:
     billing_address: Optional["Address"]
     shipping_address: Optional["Address"]
     shipping_method: Optional["ShippingMethod"]
-    valid_shipping_methods: Iterable["ShippingMethod"]
+    valid_shipping_methods: List["ShippingMethod"]
     shipping_method_channel_listings: Optional["ShippingMethodChannelListing"]
 
     def get_country(self) -> str:

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -89,7 +89,7 @@ def test_update_checkout_shipping_method_if_invalid(
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    update_checkout_shipping_method_if_invalid(checkout_info, lines, None)
+    update_checkout_shipping_method_if_invalid(checkout_info, lines)
 
     assert checkout.shipping_method == other_shipping_method
 
@@ -1340,9 +1340,7 @@ def test_checkout_lines_add(
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 def test_checkout_lines_add_with_unpublished_product(
@@ -1585,9 +1583,7 @@ def test_checkout_lines_update(
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 def test_create_checkout_with_unpublished_product(
@@ -1752,9 +1748,7 @@ def test_checkout_line_delete(
     assert checkout.lines.count() == 0
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 @mock.patch(
@@ -1786,9 +1780,7 @@ def test_checkout_line_delete_by_zero_quantity(
     assert checkout.lines.count() == 0
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 def test_checkout_customer_attach(
@@ -1950,9 +1942,7 @@ def test_checkout_shipping_address_update(
         ),
         channel=checkout.channel,
     )
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
 @mock.patch(
@@ -2014,9 +2004,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
         ),
         channel=checkout.channel,
     )
-    mocked_update_shipping_method.assert_called_once_with(
-        checkout_info, lines, mock.ANY
-    )
+    mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.country == shipping_address["country"]
 
 

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -5,7 +5,11 @@ import pytest
 from ....account.models import Address
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.models import Checkout
-from ....checkout.utils import add_variant_to_checkout, fetch_checkout_lines
+from ....checkout.utils import (
+    add_variant_to_checkout,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+)
 from ...checkout.mutations import update_checkout_shipping_method_if_invalid
 from ...tests.utils import get_graphql_content
 from .test_checkout import (
@@ -160,7 +164,8 @@ def test_remove_shipping_method_if_only_digital_in_checkout(
 
     assert checkout.shipping_method
     lines = fetch_checkout_lines(checkout)
-    update_checkout_shipping_method_if_invalid(checkout, lines, None)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
+    update_checkout_shipping_method_if_invalid(checkout_info, lines, None)
 
     checkout.refresh_from_db()
     assert not checkout.shipping_method

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -165,7 +165,7 @@ def test_remove_shipping_method_if_only_digital_in_checkout(
     assert checkout.shipping_method
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    update_checkout_shipping_method_if_invalid(checkout_info, lines, None)
+    update_checkout_shipping_method_if_invalid(checkout_info, lines)
 
     checkout.refresh_from_db()
     assert not checkout.shipping_method


### PR DESCRIPTION
- Introduce `CheckoutInfo` and `fetch_checkout_info` method.
- Refactor `update_checkout_shipping_method_if_invalid` method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
