### PR TITLE
Fix removing page types in cleardb command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add CUSTOMER_UPDATED webhook, add addresses field to customer CUSTOMER_CREATED webhook - #6898 by @piotrgrundas
 - Add missing span in PluginManager - #6900 by @fowczarek
 - Fix Sentry reporting - #6902 by @fowczarek
+- Fix removing page types in cleardb command - #6918 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/core/management/commands/cleardb.py
+++ b/saleor/core/management/commands/cleardb.py
@@ -15,7 +15,7 @@ from ....checkout.models import Checkout
 from ....discount.models import Sale, Voucher
 from ....giftcard.models import GiftCard
 from ....order.models import Order
-from ....page.models import Page
+from ....page.models import Page, PageType
 from ....payment.models import Payment, Transaction
 from ....product.models import Category, Collection, Product, ProductType
 from ....shipping.models import ShippingMethod, ShippingZone
@@ -90,6 +90,9 @@ class Command(BaseCommand):
 
         Page.objects.all().delete()
         self.stdout.write("Removed pages")
+
+        PageType.objects.all().delete()
+        self.stdout.write("Removed page types")
 
         Webhook.objects.all().delete()
         self.stdout.write("Removed webhooks")


### PR DESCRIPTION
I want to merge this change because fixing remove page types in cleardb command. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
