### PR TITLE
Update checkout_info when shipping method is updated

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -638,9 +638,10 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         shipping_address = cls.validate_address(
             shipping_address, instance=checkout.shipping_address, info=info
         )
+        discounts = info.context.discounts
 
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts)
 
         country = get_user_country_context(
             destination_address=shipping_address,
@@ -656,9 +657,11 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
 
         with transaction.atomic():
             shipping_address.save()
-            change_shipping_address_in_checkout(checkout, shipping_address)
+            change_shipping_address_in_checkout(
+                checkout, checkout_info, shipping_address, lines, discounts
+            )
         recalculate_checkout_discount(
-            info.context.plugins, checkout_info, lines, info.context.discounts
+            info.context.plugins, checkout_info, lines, discounts
         )
 
         info.context.plugins.checkout_updated(checkout)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -20,7 +20,7 @@ from ....checkout.checkout_cleaner import (
     clean_checkout_shipping,
 )
 from ....checkout.error_codes import CheckoutErrorCode
-from ....checkout.fetch import CheckoutInfo, fetch_checkout_info, fetch_checkout_lines
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
 from ....checkout.utils import add_variant_to_checkout
 from ....core.payments import PaymentInterface
@@ -1932,20 +1932,7 @@ def test_checkout_shipping_address_update(
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = CheckoutInfo(
-        checkout=checkout,
-        shipping_address=None,
-        billing_address=checkout.billing_address,
-        shipping_method=checkout.shipping_method,
-        user=checkout.user,
-        valid_shipping_methods=[],
-        shipping_method_channel_listings=(
-            shipping_models.ShippingMethodChannelListing.objects.filter(
-                shipping_method=checkout.shipping_method, channel=checkout.channel
-            ).first()
-        ),
-        channel=checkout.channel,
-    )
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
@@ -1962,7 +1949,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     graphql_address_data,
 ):
     variant = variant_with_many_stocks_different_shipping_zones
-    checkout = Checkout.objects.create(channel=channel_USD)
+    checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
     add_variant_to_checkout(checkout, variant, 1)
     assert checkout.shipping_address is None
@@ -1994,20 +1981,7 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     assert checkout.shipping_address.country == shipping_address["country"]
     assert checkout.shipping_address.city == shipping_address["city"].upper()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = CheckoutInfo(
-        checkout=checkout,
-        shipping_address=None,
-        billing_address=checkout.billing_address,
-        shipping_method=checkout.shipping_method,
-        user=checkout.user,
-        valid_shipping_methods=[],
-        shipping_method_channel_listings=(
-            shipping_models.ShippingMethodChannelListing.objects.filter(
-                shipping_method=checkout.shipping_method, channel=checkout.channel
-            ).first()
-        ),
-        channel=checkout.channel,
-    )
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
     assert checkout.country == shipping_address["country"]
 


### PR DESCRIPTION
Update `checkout_info` when the shipping method is updated in `change_shipping_address_in_checkout` method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
