### PR TITLE
Use checkout info in complete checkout

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -41,7 +41,7 @@ from .utils import get_voucher_for_checkout
 
 if TYPE_CHECKING:
     from ..plugins.manager import PluginsManager
-    from .fetch import CheckoutLineInfo
+    from .fetch import CheckoutInfo, CheckoutLineInfo
     from .models import Channel
 
 
@@ -402,7 +402,7 @@ def _create_order(
 
 def _prepare_checkout(
     manager: "PluginsManager",
-    checkout: models.Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts,
     tracking_code,
@@ -410,8 +410,9 @@ def _prepare_checkout(
     payment,
 ):
     """Prepare checkout object to complete the checkout process."""
+    checkout = checkout_info.checkout
     subtotal = manager.calculate_checkout_subtotal(
-        checkout, lines, checkout.shipping_address, discounts
+        checkout, lines, checkout_info.shipping_address, discounts
     )
     clean_checkout_shipping(checkout, lines, discounts, CheckoutErrorCode, subtotal)
     clean_checkout_payment(
@@ -517,7 +518,7 @@ def _process_payment(
 
 def complete_checkout(
     manager: "PluginsManager",
-    checkout: models.Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     payment_data,
     store_source,
@@ -533,10 +534,11 @@ def complete_checkout(
     for thread race.
     :raises ValidationError
     """
+    checkout = checkout_info.checkout
     payment = checkout.get_last_active_payment()
     _prepare_checkout(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         discounts=discounts,
         tracking_code=tracking_code,

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -413,7 +413,12 @@ def _prepare_checkout(
     checkout = checkout_info.checkout
     clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
     clean_checkout_payment(
-        manager, checkout, lines, discounts, CheckoutErrorCode, last_payment=payment
+        manager,
+        checkout_info,
+        lines,
+        discounts,
+        CheckoutErrorCode,
+        last_payment=payment,
     )
     if not checkout.channel.is_active:
         raise ValidationError(

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -411,10 +411,7 @@ def _prepare_checkout(
 ):
     """Prepare checkout object to complete the checkout process."""
     checkout = checkout_info.checkout
-    subtotal = manager.calculate_checkout_subtotal(
-        checkout, lines, checkout_info.shipping_address, discounts
-    )
-    clean_checkout_shipping(checkout, lines, discounts, CheckoutErrorCode, subtotal)
+    clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
     clean_checkout_payment(
         manager, checkout, lines, discounts, CheckoutErrorCode, last_payment=payment
     )

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -52,7 +52,7 @@ def _get_voucher_data_for_order(checkout_info: "CheckoutInfo") -> dict:
     :raises NotApplicable: When the voucher is not applicable in the current checkout.
     """
     checkout = checkout_info.checkout
-    voucher = get_voucher_for_checkout(checkout, with_lock=True)
+    voucher = get_voucher_for_checkout(checkout_info, with_lock=True)
 
     if checkout.voucher_code and not voucher:
         msg = "Voucher expired in meantime. Order placement aborted."

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -34,7 +34,7 @@ from ..payment.utils import store_customer_id
 from ..product.models import ProductTranslation, ProductVariantTranslation
 from ..warehouse.availability import check_stock_quantity_bulk
 from ..warehouse.management import allocate_stocks
-from . import AddressType, models
+from . import AddressType
 from .checkout_cleaner import clean_checkout_payment, clean_checkout_shipping
 from .models import Checkout
 from .utils import get_voucher_for_checkout
@@ -42,16 +42,16 @@ from .utils import get_voucher_for_checkout
 if TYPE_CHECKING:
     from ..plugins.manager import PluginsManager
     from .fetch import CheckoutInfo, CheckoutLineInfo
-    from .models import Channel
 
 
-def _get_voucher_data_for_order(checkout: Checkout) -> dict:
+def _get_voucher_data_for_order(checkout_info: "CheckoutInfo") -> dict:
     """Fetch, process and return voucher/discount data from checkout.
 
     Careful! It should be called inside a transaction.
 
     :raises NotApplicable: When the voucher is not applicable in the current checkout.
     """
+    checkout = checkout_info.checkout
     voucher = get_voucher_for_checkout(checkout, with_lock=True)
 
     if checkout.voucher_code and not voucher:
@@ -63,7 +63,7 @@ def _get_voucher_data_for_order(checkout: Checkout) -> dict:
 
     increase_voucher_usage(voucher)
     if voucher.apply_once_per_customer:
-        add_voucher_usage_by_customer(voucher, checkout.get_customer_email())
+        add_voucher_usage_by_customer(voucher, checkout_info.get_customer_email())
     return {
         "voucher": voucher,
         "discount": checkout.discount,
@@ -73,49 +73,49 @@ def _get_voucher_data_for_order(checkout: Checkout) -> dict:
 
 
 def _process_shipping_data_for_order(
-    checkout: Checkout,
+    checkout_info: "CheckoutInfo",
     shipping_price: TaxedMoney,
     manager: "PluginsManager",
     lines: Iterable["CheckoutLineInfo"],
 ) -> dict:
     """Fetch, process and return shipping data from checkout."""
-    shipping_address = checkout.shipping_address
+    shipping_address = checkout_info.shipping_address
 
-    if checkout.user and shipping_address:
+    if checkout_info.user and shipping_address:
         store_user_address(
-            checkout.user, shipping_address, AddressType.SHIPPING, manager=manager
+            checkout_info.user, shipping_address, AddressType.SHIPPING, manager=manager
         )
-        if checkout.user.addresses.filter(pk=shipping_address.pk).exists():
+        if checkout_info.user.addresses.filter(pk=shipping_address.pk).exists():
             shipping_address = shipping_address.get_copy()
 
     return {
         "shipping_address": shipping_address,
-        "shipping_method": checkout.shipping_method,
-        "shipping_method_name": smart_text(checkout.shipping_method),
+        "shipping_method": checkout_info.shipping_method,
+        "shipping_method_name": smart_text(checkout_info.shipping_method),
         "shipping_price": shipping_price,
-        "weight": checkout.get_total_weight(lines),
+        "weight": checkout_info.checkout.get_total_weight(lines),
     }
 
 
-def _process_user_data_for_order(checkout: Checkout, manager):
+def _process_user_data_for_order(checkout_info: "CheckoutInfo", manager):
     """Fetch, process and return shipping data from checkout."""
-    billing_address = checkout.billing_address
+    billing_address = checkout_info.billing_address
 
-    if checkout.user:
+    if checkout_info.user:
         store_user_address(
-            checkout.user, billing_address, AddressType.BILLING, manager=manager
+            checkout_info.user, billing_address, AddressType.BILLING, manager=manager
         )
         if (
             billing_address
-            and checkout.user.addresses.filter(pk=billing_address.pk).exists()
+            and checkout_info.user.addresses.filter(pk=billing_address.pk).exists()
         ):
             billing_address = billing_address.get_copy()
 
     return {
-        "user": checkout.user,
-        "user_email": checkout.get_customer_email(),
+        "user": checkout_info.user,
+        "user_email": checkout_info.get_customer_email(),
         "billing_address": billing_address,
-        "customer_note": checkout.note,
+        "customer_note": checkout_info.checkout.note,
     }
 
 
@@ -131,10 +131,9 @@ def _validate_gift_cards(checkout: Checkout):
 
 def _create_line_for_order(
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     checkout_line_info: "CheckoutLineInfo",
     discounts: Iterable[DiscountInfo],
-    channel: "Channel",
     products_translation: Dict[int, Optional[str]],
     variants_translation: Dict[int, Optional[str]],
 ) -> OrderLineData:
@@ -142,12 +141,14 @@ def _create_line_for_order(
 
     :raises InsufficientStock: when there is not enough items in stock for this variant.
     """
+    checkout = checkout_info.checkout
+    channel = checkout_info.channel
     checkout_line = checkout_line_info.line
     quantity = checkout_line.quantity
     variant = checkout_line_info.variant
     product = checkout_line_info.product
     address = (
-        checkout.shipping_address or checkout.billing_address
+        checkout_info.shipping_address or checkout_info.billing_address
     )  # FIXME: check which address we need here
 
     product_name = str(product)
@@ -203,17 +204,16 @@ def _create_line_for_order(
 
 def _create_lines_for_order(
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts: Iterable[DiscountInfo],
-    channel: "Channel",
 ) -> Iterable[OrderLineData]:
     """Create a lines for the given order.
 
     :raises InsufficientStock: when there is not enough items in stock for this variant.
     """
     translation_language_code = get_language()
-    country_code = checkout.get_country()
+    country_code = checkout_info.get_country()
     variants = []
     quantities = []
     products = []
@@ -243,10 +243,9 @@ def _create_lines_for_order(
     return [
         _create_line_for_order(
             manager,
-            checkout,
+            checkout_info,
             checkout_line_info,
             discounts,
-            channel,
             product_translations,
             variants_translation,
         )
@@ -257,7 +256,7 @@ def _create_lines_for_order(
 def _prepare_order_data(
     *,
     manager: "PluginsManager",
-    checkout: Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts
 ) -> dict:
@@ -265,9 +264,10 @@ def _prepare_order_data(
 
     :raises NotApplicable InsufficientStock:
     """
+    checkout = checkout_info.checkout
     order_data = {}
     address = (
-        checkout.shipping_address or checkout.billing_address
+        checkout_info.shipping_address or checkout_info.billing_address
     )  # FIXME: check which address we need here
 
     taxed_total = calculations.checkout_total(
@@ -290,9 +290,9 @@ def _prepare_order_data(
         checkout, lines, address, discounts, shipping_total
     )
     order_data.update(
-        _process_shipping_data_for_order(checkout, shipping_total, manager, lines)
+        _process_shipping_data_for_order(checkout_info, shipping_total, manager, lines)
     )
-    order_data.update(_process_user_data_for_order(checkout, manager))
+    order_data.update(_process_user_data_for_order(checkout_info, manager))
     order_data.update(
         {
             "language_code": get_language(),
@@ -302,16 +302,15 @@ def _prepare_order_data(
         }
     )
 
-    channel = checkout.channel
     order_data["lines"] = _create_lines_for_order(
-        manager, checkout, lines, discounts, channel
+        manager, checkout_info, lines, discounts
     )
 
     # validate checkout gift cards
     _validate_gift_cards(checkout)
 
     # Get voucher data (last) as they require a transaction
-    order_data.update(_get_voucher_data_for_order(checkout))
+    order_data.update(_get_voucher_data_for_order(checkout_info))
 
     # assign gift cards to the order
 
@@ -420,7 +419,7 @@ def _prepare_checkout(
         CheckoutErrorCode,
         last_payment=payment,
     )
-    if not checkout.channel.is_active:
+    if not checkout_info.channel.is_active:
         raise ValidationError(
             {
                 "channel": ValidationError(
@@ -461,7 +460,7 @@ def release_voucher_usage(order_data: dict):
 
 def _get_order_data(
     manager: "PluginsManager",
-    checkout: models.Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts: List[DiscountInfo],
 ) -> dict:
@@ -469,7 +468,7 @@ def _get_order_data(
     try:
         order_data = _prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=discounts,
         )
@@ -549,7 +548,7 @@ def complete_checkout(
     )
 
     try:
-        order_data = _get_order_data(manager, checkout, lines, discounts)
+        order_data = _get_order_data(manager, checkout_info, lines, discounts)
     except ValidationError as error:
         gateway.payment_refund_or_void(payment)
         raise error

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -148,7 +148,11 @@ def update_checkout_info_shipping_method(
 ):
     checkout_info.shipping_method = shipping_method
     checkout_info.shipping_method_channel_listings = (
-        ShippingMethodChannelListing.objects.filter(
-            shipping_method=shipping_method, channel=checkout_info.channel
-        ).first()
+        (
+            ShippingMethodChannelListing.objects.filter(
+                shipping_method=shipping_method, channel=checkout_info.channel
+            ).first()
+        )
+        if shipping_method
+        else None
     )

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -39,26 +39,33 @@ def test_is_valid_shipping_method(checkout_with_item, address, shipping_zone):
     checkout.shipping_address = address
     checkout.save()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     # no shipping method assigned
-    assert not is_valid_shipping_method(checkout, lines, None)
+    assert not is_valid_shipping_method(checkout_info)
     shipping_method = shipping_zone.shipping_methods.first()
     checkout.shipping_method = shipping_method
     checkout.save()
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
-    assert is_valid_shipping_method(checkout, lines, None)
+    assert is_valid_shipping_method(checkout_info)
 
     zone = ShippingZone.objects.create(name="DE", countries=["DE"])
     shipping_method.shipping_zone = zone
     shipping_method.save()
-    assert not is_valid_shipping_method(checkout, lines, None)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
+
+    assert not is_valid_shipping_method(checkout_info)
 
 
 def test_clear_shipping_method(checkout, shipping_method):
     checkout.shipping_method = shipping_method
     checkout.save()
-    clear_shipping_method(checkout)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    clear_shipping_method(checkout_info)
     checkout.refresh_from_db()
     assert not checkout.shipping_method
+    assert not checkout_info.shipping_method
+    assert not checkout_info.shipping_method_channel_listings
 
 
 def test_last_change_update(checkout):

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -1036,6 +1036,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
         checkout=checkout,
@@ -1049,7 +1050,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
     payment.currency = total.gross.currency
     payment.checkout = checkout
     payment.save()
-    is_paid = is_fully_paid(manager, checkout, lines, None)
+    is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert is_paid
 
 
@@ -1057,6 +1058,7 @@ def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
         checkout=checkout,
@@ -1078,7 +1080,7 @@ def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
     payment2.currency = total.gross.currency
     payment2.checkout = checkout
     payment2.save()
-    is_paid = is_fully_paid(manager, checkout, lines, None)
+    is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert is_paid
 
 
@@ -1086,6 +1088,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
         checkout=checkout,
@@ -1099,7 +1102,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     payment.currency = total.gross.currency
     payment.checkout = checkout
     payment.save()
-    is_paid = is_fully_paid(manager, checkout, lines, None)
+    is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert not is_paid
 
 
@@ -1107,7 +1110,8 @@ def test_is_fully_paid_no_payment(checkout_with_item):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    is_paid = is_fully_paid(manager, checkout, lines, None)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
+    is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert not is_paid
 
 

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -660,7 +660,8 @@ def test_get_discount_for_checkout_shipping_voucher_not_applicable(
 
 
 def test_get_voucher_for_checkout(checkout_with_voucher, voucher):
-    checkout_voucher = get_voucher_for_checkout(checkout_with_voucher)
+    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [])
+    checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher == voucher
 
 
@@ -668,12 +669,14 @@ def test_get_voucher_for_checkout_expired_voucher(checkout_with_voucher, voucher
     date_yesterday = timezone.now() - datetime.timedelta(days=1)
     voucher.end_date = date_yesterday
     voucher.save()
-    checkout_voucher = get_voucher_for_checkout(checkout_with_voucher)
+    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [])
+    checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher is None
 
 
 def test_get_voucher_for_checkout_no_voucher_code(checkout):
-    checkout_voucher = get_voucher_for_checkout(checkout)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher is None
 
 

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -860,7 +860,7 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
 def test_change_address_in_checkout(checkout, address):
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout, checkout_info, address, lines, [])
+    change_shipping_address_in_checkout(checkout_info, address, lines, [])
     change_billing_address_in_checkout(checkout, address)
 
     checkout.refresh_from_db()
@@ -876,7 +876,7 @@ def test_change_address_in_checkout_to_none(checkout, address):
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout, checkout_info, None, lines, [])
+    change_shipping_address_in_checkout(checkout_info, None, lines, [])
     change_billing_address_in_checkout(checkout, None)
 
     checkout.refresh_from_db()
@@ -894,7 +894,7 @@ def test_change_address_in_checkout_to_same(checkout, address):
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout, checkout_info, address, lines, [])
+    change_shipping_address_in_checkout(checkout_info, address, lines, [])
     change_billing_address_in_checkout(checkout, address)
 
     checkout.refresh_from_db()
@@ -912,9 +912,7 @@ def test_change_address_in_checkout_to_other(checkout, address):
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(
-        checkout, checkout_info, other_address, lines, []
-    )
+    change_shipping_address_in_checkout(checkout_info, other_address, lines, [])
     change_billing_address_in_checkout(checkout, other_address)
 
     checkout.refresh_from_db()
@@ -936,9 +934,7 @@ def test_change_address_in_checkout_from_user_address_to_other(
 
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(
-        checkout, checkout_info, other_address, lines, []
-    )
+    change_shipping_address_in_checkout(checkout_info, other_address, lines, [])
     change_billing_address_in_checkout(checkout, other_address)
 
     checkout.refresh_from_db()

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -13,7 +13,7 @@ from ...product.models import ProductTranslation, ProductVariantTranslation
 from ...tests.utils import flush_post_commit_hooks
 from .. import calculations
 from ..complete_checkout import _create_order, _prepare_order_data
-from ..fetch import fetch_checkout_lines
+from ..fetch import fetch_checkout_info, fetch_checkout_lines
 from ..utils import add_variant_to_checkout
 
 
@@ -43,11 +43,12 @@ def test_create_order_captured_payment_creates_expected_events(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -182,11 +183,12 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -313,11 +315,12 @@ def test_create_order_preauth_payment_creates_expected_events(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -423,11 +426,12 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -512,10 +516,11 @@ def test_create_order_insufficient_stock(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     with pytest.raises(InsufficientStock):
         _prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         )
@@ -535,8 +540,9 @@ def test_create_order_doesnt_duplicate_order(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     order_data = _prepare_order_data(
-        manager=manager, checkout=checkout, lines=lines, discounts=None
+        manager=manager, checkout_info=checkout_info, lines=lines, discounts=None
     )
 
     order_1 = _create_order(
@@ -570,6 +576,7 @@ def test_create_order_with_gift_card(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -592,7 +599,7 @@ def test_create_order_with_gift_card(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -618,6 +625,7 @@ def test_create_order_with_gift_card_partial_use(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
@@ -634,7 +642,7 @@ def test_create_order_with_gift_card_partial_use(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -670,6 +678,7 @@ def test_create_order_with_many_gift_cards(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
@@ -690,7 +699,7 @@ def test_create_order_with_many_gift_cards(
         checkout=checkout,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -716,11 +725,12 @@ def test_note_in_created_order(checkout_with_item, address, customer_user):
     checkout_with_item.save()
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     order = _create_order(
         checkout=checkout_with_item,
         order_data=_prepare_order_data(
             manager=manager,
-            checkout=checkout_with_item,
+            checkout_info=checkout_info,
             lines=lines,
             discounts=None,
         ),
@@ -743,9 +753,10 @@ def test_create_order_with_variant_tracking_false(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     order_data = _prepare_order_data(
-        manager=manager, checkout=checkout, lines=lines, discounts=None
+        manager=manager, checkout_info=checkout_info, lines=lines, discounts=None
     )
 
     order_1 = _create_order(
@@ -774,6 +785,7 @@ def test_create_order_use_tanslations(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     variant = lines[0].variant
     product = lines[0].product
@@ -790,7 +802,7 @@ def test_create_order_use_tanslations(
     )
 
     order_data = _prepare_order_data(
-        manager=manager, checkout=checkout, lines=lines, discounts=None
+        manager=manager, checkout_info=checkout_info, lines=lines, discounts=None
     )
     order_line = order_data["lines"][0].line
 

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -45,7 +45,7 @@ def test_create_order_captured_payment_creates_expected_events(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -185,7 +185,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -317,7 +317,7 @@ def test_create_order_preauth_payment_creates_expected_events(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -428,7 +428,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -546,14 +546,14 @@ def test_create_order_doesnt_duplicate_order(
     )
 
     order_1 = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=order_data,
         user=customer_user,
     )
     assert order_1.checkout_token == checkout.token
 
     order_2 = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=order_data,
         user=customer_user,
     )
@@ -596,7 +596,7 @@ def test_create_order_with_gift_card(
     gift_cards_balance = checkout.get_total_gift_cards_balance()
 
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -639,7 +639,7 @@ def test_create_order_with_gift_card_partial_use(
     checkout.save()
 
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -696,7 +696,7 @@ def test_create_order_with_many_gift_cards(
     checkout.save()
 
     order = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -727,7 +727,7 @@ def test_note_in_created_order(checkout_with_item, address, customer_user):
     lines = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     order = _create_order(
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         order_data=_prepare_order_data(
             manager=manager,
             checkout_info=checkout_info,
@@ -760,7 +760,7 @@ def test_create_order_with_variant_tracking_false(
     )
 
     order_1 = _create_order(
-        checkout=checkout,
+        checkout_info=checkout_info,
         order_data=order_data,
         user=customer_user,
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -603,7 +603,7 @@ def clear_shipping_method(checkout_info: "CheckoutInfo"):
 
 def is_fully_paid(
     manager: PluginsManager,
-    checkout: Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts: Iterable[DiscountInfo],
 ):
@@ -611,9 +611,10 @@ def is_fully_paid(
 
     Note that these payments may not be captured or charged at all.
     """
+    checkout = checkout_info.checkout
     payments = [payment for payment in checkout.payments.all() if payment.is_active]
     total_paid = sum([p.total for p in payments])
-    address = checkout.shipping_address or checkout.billing_address
+    address = checkout_info.shipping_address or checkout_info.billing_address
     checkout_total = (
         calculations.checkout_total(
             manager=manager,
@@ -661,7 +662,7 @@ def clean_checkout(
             code=CheckoutErrorCode.BILLING_ADDRESS_NOT_SET.value,
         )
 
-    if not is_fully_paid(manager, checkout, lines, discounts):
+    if not is_fully_paid(manager, checkout_info, lines, discounts):
         raise ValidationError(
             "Provided payment methods can not cover the checkout's total amount",
             code=CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.value,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -193,13 +193,12 @@ def change_billing_address_in_checkout(checkout, address):
         checkout.save(update_fields=["billing_address", "last_change"])
 
 
-def change_shipping_address_in_checkout(
-    checkout, checkout_info, address, lines, discounts
-):
+def change_shipping_address_in_checkout(checkout_info, address, lines, discounts):
     """Save shipping address in checkout if changed.
 
     Remove previously saved address if not connected to any user.
     """
+    checkout = checkout_info.checkout
     changed, remove = _check_new_checkout_address(
         checkout, address, AddressType.SHIPPING
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -30,7 +30,10 @@ from ..shipping.models import ShippingMethod
 from ..warehouse.availability import check_stock_quantity, check_stock_quantity_bulk
 from . import AddressType, calculations
 from .error_codes import CheckoutErrorCode
-from .fetch import update_checkout_info_shipping_address, update_checkout_info_shipping_method
+from .fetch import (
+    update_checkout_info_shipping_address,
+    update_checkout_info_shipping_method,
+)
 from .models import Checkout, CheckoutLine
 
 if TYPE_CHECKING:

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -631,44 +631,6 @@ def is_fully_paid(
     return total_paid >= checkout_total.amount
 
 
-def clean_checkout(
-    manager: PluginsManager,
-    checkout_info: "CheckoutInfo",
-    lines: Iterable["CheckoutLineInfo"],
-    discounts: Iterable[DiscountInfo],
-):
-    """Check if checkout can be completed."""
-    checkout = checkout_info.checkout
-    if is_shipping_required(lines):
-        if not checkout.shipping_method:
-            raise ValidationError(
-                "Shipping method is not set",
-                code=CheckoutErrorCode.SHIPPING_METHOD_NOT_SET.value,
-            )
-        if not checkout.shipping_address:
-            raise ValidationError(
-                "Shipping address is not set",
-                code=CheckoutErrorCode.SHIPPING_ADDRESS_NOT_SET.value,
-            )
-        if not is_valid_shipping_method(checkout_info):
-            raise ValidationError(
-                "Shipping method is not valid for your shipping address",
-                code=CheckoutErrorCode.INVALID_SHIPPING_METHOD.value,
-            )
-
-    if not checkout.billing_address:
-        raise ValidationError(
-            "Billing address is not set",
-            code=CheckoutErrorCode.BILLING_ADDRESS_NOT_SET.value,
-        )
-
-    if not is_fully_paid(manager, checkout_info, lines, discounts):
-        raise ValidationError(
-            "Provided payment methods can not cover the checkout's total amount",
-            code=CheckoutErrorCode.CHECKOUT_NOT_FULLY_PAID.value,
-        )
-
-
 def cancel_active_payments(checkout: Checkout):
     checkout.payments.filter(is_active=True).update(is_active=False)
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -872,9 +872,10 @@ class CheckoutComplete(BaseMutation):
                 raise e
 
             lines = fetch_checkout_lines(checkout)
+            checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
             order, action_required, action_data = complete_checkout(
                 manager=info.context.plugins,
-                checkout=checkout,
+                checkout_info=checkout_info,
                 lines=lines,
                 payment_data=data.get("payment_data", {}),
                 store_source=store_source,

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -949,6 +949,7 @@ class CheckoutRemovePromoCode(BaseMutation):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
-        remove_promo_code_from_checkout(checkout, promo_code)
+        checkout_info = fetch_checkout_info(checkout, [], info.context.discounts)
+        remove_promo_code_from_checkout(checkout_info, promo_code)
         info.context.plugins.checkout_updated(checkout)
         return CheckoutRemovePromoCode(checkout=checkout)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -658,7 +658,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         with transaction.atomic():
             shipping_address.save()
             change_shipping_address_in_checkout(
-                checkout, checkout_info, shipping_address, lines, discounts
+                checkout_info, shipping_address, lines, discounts
             )
         recalculate_checkout_discount(
             info.context.plugins, checkout_info, lines, discounts

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2777,7 +2777,7 @@ def test_clean_checkout(checkout_with_item, payment_dummy, address, shipping_met
 
     clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
     clean_checkout_payment(
-        manager, checkout, lines, None, CheckoutErrorCode, last_payment=payment
+        manager, checkout_info, lines, None, CheckoutErrorCode, last_payment=payment
     )
 
 
@@ -2836,11 +2836,12 @@ def test_clean_checkout_no_billing_address(
     checkout.save()
     payment = checkout.get_last_active_payment()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
 
     with pytest.raises(ValidationError) as e:
         clean_checkout_payment(
-            manager, checkout, lines, None, CheckoutErrorCode, last_payment=payment
+            manager, checkout_info, lines, None, CheckoutErrorCode, last_payment=payment
         )
     msg = "Billing address is not set"
     assert e.value.error_dict["billing_address"][0].message == msg
@@ -2854,11 +2855,12 @@ def test_clean_checkout_no_payment(checkout_with_item, shipping_method, address)
     checkout.save()
     payment = checkout.get_last_active_payment()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
 
     with pytest.raises(ValidationError) as e:
         clean_checkout_payment(
-            manager, checkout, lines, None, CheckoutErrorCode, last_payment=payment
+            manager, checkout_info, lines, None, CheckoutErrorCode, last_payment=payment
         )
 
     msg = "Provided payment methods can not cover the checkout's total amount"

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2760,6 +2760,7 @@ def test_clean_checkout(checkout_with_item, payment_dummy, address, shipping_met
     checkout.save()
 
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
     total = calculations.checkout_total(
         manager=manager, checkout=checkout, lines=lines, address=address
@@ -2774,7 +2775,7 @@ def test_clean_checkout(checkout_with_item, payment_dummy, address, shipping_met
     payment.save()
     # Shouldn't raise any errors
 
-    clean_checkout_shipping(checkout, lines, None, CheckoutErrorCode)
+    clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
     clean_checkout_payment(
         manager, checkout, lines, None, CheckoutErrorCode, last_payment=payment
     )
@@ -2786,8 +2787,9 @@ def test_clean_checkout_no_shipping_method(checkout_with_item, address):
     checkout.save()
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     with pytest.raises(ValidationError) as e:
-        clean_checkout_shipping(checkout, lines, None, CheckoutErrorCode)
+        clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
 
     msg = "Shipping method is not set"
     assert e.value.error_dict["shipping_method"][0].message == msg
@@ -2799,8 +2801,9 @@ def test_clean_checkout_no_shipping_address(checkout_with_item, shipping_method)
     checkout.save()
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     with pytest.raises(ValidationError) as e:
-        clean_checkout_shipping(checkout, lines, None, CheckoutErrorCode)
+        clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
     msg = "Shipping address is not set"
     assert e.value.error_dict["shipping_address"][0].message == msg
 
@@ -2815,8 +2818,9 @@ def test_clean_checkout_invalid_shipping_method(
     checkout.save()
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     with pytest.raises(ValidationError) as e:
-        clean_checkout_shipping(checkout, lines, None, CheckoutErrorCode)
+        clean_checkout_shipping(checkout_info, lines, CheckoutErrorCode)
 
     msg = "Shipping method is not valid for your shipping address"
 

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -142,7 +142,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         )
         amount = data.get("amount", checkout_total.gross.amount)
         clean_checkout_shipping(checkout_info, lines, PaymentErrorCode)
-        clean_billing_address(checkout, PaymentErrorCode)
+        clean_billing_address(checkout_info, PaymentErrorCode)
         cls.clean_payment_amount(info, checkout_total, amount)
         extra_data = {
             "customer_user_agent": info.context.META.get("HTTP_USER_AGENT"),

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -3,7 +3,7 @@ from django.core.exceptions import ValidationError
 
 from ...checkout.calculations import calculate_checkout_total_with_gift_cards
 from ...checkout.checkout_cleaner import clean_billing_address, clean_checkout_shipping
-from ...checkout.fetch import fetch_checkout_lines
+from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...checkout.utils import cancel_active_payments
 from ...core.permissions import OrderPermissions
 from ...core.utils import get_client_ip
@@ -129,6 +129,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         cls.validate_return_url(data)
 
         lines = fetch_checkout_lines(checkout)
+        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
         address = (
             checkout.shipping_address or checkout.billing_address
         )  # FIXME: check which address we need here
@@ -140,9 +141,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
             discounts=info.context.discounts,
         )
         amount = data.get("amount", checkout_total.gross.amount)
-        clean_checkout_shipping(
-            checkout, lines, info.context.discounts, PaymentErrorCode
-        )
+        clean_checkout_shipping(checkout_info, lines, PaymentErrorCode)
         clean_billing_address(checkout, PaymentErrorCode)
         cls.clean_payment_amount(info, checkout_total, amount)
         extra_data = {

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -25,7 +25,7 @@ from django.http.response import HttpResponseRedirect
 from graphql_relay import from_global_id
 
 from ....checkout.complete_checkout import complete_checkout
-from ....checkout.fetch import fetch_checkout_lines
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
 from ....core.transactions import transaction_with_commit_on_errors
 from ....core.utils.url import prepare_url
@@ -156,9 +156,10 @@ def create_order(payment, checkout):
     try:
         discounts = fetch_active_discounts()
         lines = fetch_checkout_lines(checkout)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts)
         order, _, _ = complete_checkout(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             payment_data={},
             store_source=False,


### PR DESCRIPTION
- Drop `clean_checkout` method
- Use `CheckoutInfo` in `complete_checkout`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
