### PR TITLE
Fix logic to calculate prices with proper tax calculation

### DIFF
--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -243,10 +243,18 @@ class DraftOrderCreate(ModelMutation, I18nMixin):
             return
         shipping_address = cleaned_input.get("shipping_address")
         if shipping_address and instance.is_shipping_required():
-            update_order_prices(instance, info.context.plugins)
+            update_order_prices(
+                instance,
+                info.context.plugins,
+                info.context.site.settings.include_taxes_in_prices,
+            )
         billing_address = cleaned_input.get("billing_address")
         if billing_address and not instance.is_shipping_required():
-            update_order_prices(instance, info.context.plugins)
+            update_order_prices(
+                instance,
+                info.context.plugins,
+                info.context.site.settings.include_taxes_in_prices,
+            )
 
     @classmethod
     @transaction.atomic

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -280,7 +280,7 @@ class OrderUpdateShipping(BaseMutation):
                 "shipping_tax_rate",
             ]
         )
-        update_order_prices(order, info.context.plugins)
+        update_order_prices(order, info.context.plugins, info.context.site.settings)
         # Post-process the results
         order_shipping_updated(order)
         return OrderUpdateShipping(order=order)

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -456,7 +456,9 @@ def test_queryset_ready_to_capture(channel_USD):
 
 
 @patch("saleor.plugins.manager.PluginsManager.calculate_order_line_unit")
-def test_update_order_prices(mocked_calculate_order_line_unit, order_with_lines):
+def test_update_order_prices(
+    mocked_calculate_order_line_unit, order_with_lines, site_settings
+):
     manager = get_plugins_manager()
     channel = order_with_lines.channel
     address = order_with_lines.shipping_address
@@ -488,7 +490,7 @@ def test_update_order_prices(mocked_calculate_order_line_unit, order_with_lines)
     ).price
     shipping_price = TaxedMoney(net=shipping_price, gross=shipping_price)
 
-    update_order_prices(order_with_lines, manager)
+    update_order_prices(order_with_lines, manager, site_settings)
 
     line_1.refresh_from_db()
     line_2.refresh_from_db()
@@ -500,7 +502,7 @@ def test_update_order_prices(mocked_calculate_order_line_unit, order_with_lines)
     assert order_with_lines.total == total
 
 
-def test_update_order_prices_tax_included(order_with_lines, vatlayer):
+def test_update_order_prices_tax_included(order_with_lines, vatlayer, site_settings):
     manager = get_plugins_manager()
 
     channel = order_with_lines.channel
@@ -532,7 +534,7 @@ def test_update_order_prices_tax_included(order_with_lines, vatlayer):
         channel_id=order_with_lines.channel_id
     ).price
 
-    update_order_prices(order_with_lines, manager)
+    update_order_prices(order_with_lines, manager, site_settings)
 
     line_1.refresh_from_db()
     line_2.refresh_from_db()


### PR DESCRIPTION
I want to merge this change because it changes the way of applying the taxes to fit the case with discounted line/order.
Some fixmes section was just dropped as we had incorrect assumption.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
