### PR TITLE
Fix shop query postal codes filtering

### DIFF
--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -1,5 +1,6 @@
 from ...account.models import Address
 from ...shipping.models import ShippingMethod, ShippingMethodChannelListing
+from ...shipping.postal_codes import filter_shipping_methods_by_postal_code_rules
 from ..channel import ChannelContext
 
 
@@ -10,6 +11,9 @@ def resolve_available_shipping_methods(info, channel_slug: str, address):
     if address and address.country:
         available = available.filter(
             shipping_zone__countries__contains=address.country,
+        )
+        available = filter_shipping_methods_by_postal_code_rules(
+            available, Address(**address)
         )
         # Address instance needed for apply_taxes_to_shipping method
         address = Address(country=address.country)


### PR DESCRIPTION
I want to merge this change because there was one query we forgot about when implementing shipping method postal codes inclusion/exclusion.
Now the shop query takes postal code rules in account when it resolves available shipping methods.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
