### PR TITLE
Fix CheckoutLinesInfoByCheckoutTokenLoader dataloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add product description_plaintext to populatedb - #6894 by @d-wysocki
 - Deallocate stocks for order lines in a bulk way - #6896 by @IKarbowiak
 - Prevent negative available quantity - #6897 by @d-wysocki
+- Fix CheckoutLinesInfoByCheckoutTokenLoader dataloader - #6929 by @IKarbowiak
 
 # 2.11.1
 

--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -26,6 +26,7 @@ from .products import (
     ProductVariantByIdLoader,
     ProductVariantChannelListingByIdLoader,
     ProductVariantsByProductIdLoader,
+    VariantChannelListingByVariantIdAndChannelIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
     VariantChannelListingByVariantIdLoader,
     VariantsChannelListingByProductIdAndChanneSlugLoader,
@@ -58,6 +59,7 @@ __all__ = [
     "SelectedAttributesByProductVariantIdLoader",
     "VariantAttributesByProductTypeIdLoader",
     "VariantChannelListingByVariantIdAndChannelSlugLoader",
+    "VariantChannelListingByVariantIdAndChannelIdLoader",
     "VariantChannelListingByVariantIdLoader",
     "VariantsChannelListingByProductIdAndChanneSlugLoader",
 ]


### PR DESCRIPTION
Fix `CheckoutLinesInfoByCheckoutTokenLoader` data loader. Previously, data was prepared only for the first key.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
