### PR TITLE
Use checkout info in calculate checkout total

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from ..account.models import Address
     from ..channel.models import Channel
     from ..plugins.manager import PluginsManager
-    from .fetch import CheckoutLineInfo
+    from .fetch import CheckoutInfo, CheckoutLineInfo
     from .models import Checkout
 
 
@@ -52,7 +52,7 @@ def checkout_subtotal(
 
 def calculate_checkout_total_with_gift_cards(
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -60,12 +60,12 @@ def calculate_checkout_total_with_gift_cards(
     total = (
         checkout_total(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=address,
             discounts=discounts,
         )
-        - checkout.get_total_gift_cards_balance()
+        - checkout_info.checkout.get_total_gift_cards_balance()
     )
 
     return max(total, zero_taxed_money(total.currency))
@@ -74,7 +74,7 @@ def calculate_checkout_total_with_gift_cards(
 def checkout_total(
     *,
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -87,9 +87,9 @@ def checkout_total(
     It takes in account all plugins.
     """
     calculated_checkout_total = manager.calculate_checkout_total(
-        checkout, lines, address, discounts or []
+        checkout_info.checkout, lines, address, discounts or []
     )
-    return quantize_price(calculated_checkout_total, checkout.currency)
+    return quantize_price(calculated_checkout_total, checkout_info.checkout.currency)
 
 
 def checkout_line_total(

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -87,7 +87,7 @@ def checkout_total(
     It takes in account all plugins.
     """
     calculated_checkout_total = manager.calculate_checkout_total(
-        checkout_info.checkout, lines, address, discounts or []
+        checkout_info, lines, address, discounts or []
     )
     return quantize_price(calculated_checkout_total, checkout_info.checkout.currency)
 

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -272,7 +272,7 @@ def _prepare_order_data(
 
     taxed_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=discounts,

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -720,7 +720,7 @@ def test_recalculate_checkout_discount_with_sale(
     assert (
         calculations.checkout_total(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=checkout.shipping_address,
             discounts=[discount_info],
@@ -789,7 +789,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     assert checkout.discount_name == "Free shipping"
     checkout_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -830,7 +830,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     assert checkout.discount_name == "Free shipping"
     checkout_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -1038,7 +1038,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
     checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -1060,7 +1060,7 @@ def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
     checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -1090,7 +1090,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -629,7 +629,7 @@ def test_create_order_with_gift_card_partial_use(
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -682,7 +682,7 @@ def test_create_order_with_many_gift_cards(
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -618,7 +618,7 @@ def is_fully_paid(
     checkout_total = (
         calculations.checkout_total(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=address,
             discounts=discounts,

--- a/saleor/graphql/account/dataloaders.py
+++ b/saleor/graphql/account/dataloaders.py
@@ -1,4 +1,4 @@
-from ...account.models import Address
+from ...account.models import Address, User
 from ..core.dataloaders import DataLoader
 
 
@@ -8,3 +8,11 @@ class AddressByIdLoader(DataLoader):
     def batch_load(self, keys):
         address_map = Address.objects.in_bulk(keys)
         return [address_map.get(address_id) for address_id in keys]
+
+
+class UserByUserIdLoader(DataLoader):
+    context_key = "user_by_id"
+
+    def batch_load(self, keys):
+        user_map = User.objects.in_bulk(keys)
+        return [user_map.get(user_id) for user_id in keys]

--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -3,14 +3,19 @@ from collections import defaultdict
 from django.db.models import F
 from promise import Promise
 
-from ...checkout.fetch import CheckoutLineInfo
+from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
 from ...checkout.models import Checkout, CheckoutLine
+from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..core.dataloaders import DataLoader
 from ..product.dataloaders import (
     CollectionsByVariantIdLoader,
     ProductByVariantIdLoader,
     ProductVariantByIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
+)
+from ..shipping.dataloaders import (
+    ShippingMethodByIdLoader,
+    ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader,
 )
 
 
@@ -128,6 +133,111 @@ class CheckoutByUserAndChannelLoader(DataLoader):
             key = (checkout.user_id, checkout.channel_slug)
             checkout_by_user_and_channel_map[key].append(checkout)
         return [checkout_by_user_and_channel_map.get(key) for key in keys]
+
+
+class CheckoutInfoByCheckoutTokenLoader(DataLoader):
+    context_key = "checkoutinfo_by_checkout"
+
+    def batch_load(self, keys):
+        def with_checkout(checkouts):
+            from ..channel.dataloaders import ChannelByIdLoader
+
+            channel_pks = [checkout.channel_id for checkout in checkouts]
+
+            def with_channel(channels):
+                billing_address_ids = {
+                    checkout.billing_address_id
+                    for checkout in checkouts
+                    if checkout.billing_address_id
+                }
+                shipping_address_ids = {
+                    checkout.shipping_address_id
+                    for checkout in checkouts
+                    if checkout.shipping_address_id
+                }
+                addresses = AddressByIdLoader(self.context).load_many(
+                    billing_address_ids | shipping_address_ids
+                )
+                users = UserByUserIdLoader(self.context).load_many(
+                    [checkout.user_id for checkout in checkouts if checkout.user_id]
+                )
+                shipping_method_ids = [
+                    checkout.shipping_method_id
+                    for checkout in checkouts
+                    if checkout.shipping_method_id
+                ]
+                shipping_methods = ShippingMethodByIdLoader(self.context).load_many(
+                    shipping_method_ids
+                )
+                shipping_method_ids_channel_slugs = [
+                    (checkout.shipping_method_id, channel.slug)
+                    for checkout, channel in zip(checkouts, channels)
+                    if checkout.shipping_method_id
+                ]
+                shipping_method_channel_listings = (
+                    ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader(
+                        self.context
+                    ).load_many(shipping_method_ids_channel_slugs)
+                )
+
+                def with_checkout_info(results):
+                    (
+                        addresses,
+                        users,
+                        shipping_methods,
+                        channel_listings,
+                    ) = results
+                    address_map = {address.id: address for address in addresses}
+                    user_map = {user.id: user for user in users}
+                    shipping_method_map = {
+                        shipping_method.id: shipping_method
+                        for shipping_method in shipping_methods
+                    }
+                    shipping_method_channel_listing_map = {
+                        (listing.shipping_method_id, listing.channel_id): listing
+                        for listing in channel_listings
+                    }
+
+                    checkout_info_map = {}
+                    for key, checkout, channel in zip(keys, checkouts, channels):
+                        checkout_info_map[key] = CheckoutInfo(
+                            checkout=checkout,
+                            user=user_map.get(checkout.user_id),
+                            channel=channel,
+                            billing_address=address_map.get(
+                                checkout.billing_address_id
+                            ),
+                            shipping_address=address_map.get(
+                                checkout.shipping_address_id
+                            ),
+                            shipping_method=shipping_method_map.get(
+                                checkout.shipping_method_id
+                            ),
+                            valid_shipping_methods=[],
+                            shipping_method_channel_listings=(
+                                shipping_method_channel_listing_map.get(
+                                    (checkout.shipping_method_id, channel.id)
+                                ),
+                            ),
+                        )
+                    return [checkout_info_map[key] for key in keys]
+
+                return Promise.all(
+                    [
+                        addresses,
+                        users,
+                        shipping_methods,
+                        shipping_method_channel_listings,
+                    ]
+                ).then(with_checkout_info)
+
+            return (
+                ChannelByIdLoader(self.context)
+                .load_many(channel_pks)
+                .then(with_channel)
+            )
+
+        return CheckoutByTokenLoader(self.context).load_many(keys).then(with_checkout)
 
 
 class CheckoutLineByIdLoader(DataLoader):

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -77,10 +77,11 @@ def checkout_with_voucher(checkout_with_billing_address, voucher):
 def checkout_with_charged_payment(checkout_with_voucher):
     checkout = checkout_with_voucher
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [])
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -2,7 +2,7 @@ import pytest
 from graphene import Node
 
 from .....checkout import calculations
-from .....checkout.fetch import fetch_checkout_lines
+from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....plugins.manager import get_plugins_manager
 from ....tests.utils import get_graphql_content
@@ -492,10 +492,11 @@ def test_checkout_payment_charge(
     """
 
     lines = fetch_checkout_lines(checkout_with_billing_address)
+    checkout_info = fetch_checkout_info(checkout_with_billing_address, lines, [])
     manager = get_plugins_manager()
     total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout_with_billing_address,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_billing_address.shipping_address,
     )

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2529,10 +2529,11 @@ def test_checkout_prices(user_api_client, checkout_with_item):
     assert data["token"] == str(checkout_with_item.token)
     assert len(data["lines"]) == checkout_with_item.lines.count()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     manager = get_plugins_manager()
     total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )
@@ -2763,7 +2764,7 @@ def test_clean_checkout(checkout_with_item, payment_dummy, address, shipping_met
     checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     payment = payment_dummy

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -6,7 +6,7 @@ import pytest
 
 from ....checkout import calculations
 from ....checkout.error_codes import CheckoutErrorCode
-from ....checkout.fetch import fetch_checkout_lines
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
 from ....core.exceptions import InsufficientStock
 from ....core.taxes import zero_money
@@ -131,9 +131,14 @@ def test_checkout_complete_with_inactive_channel(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager=manager, checkout=checkout, lines=lines, address=address, discounts=[]
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=address,
+        discounts=[],
     )
     payment = payment_dummy
     payment.is_active = True
@@ -183,8 +188,9 @@ def test_checkout_complete(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     site_settings.automatically_confirm_all_new_orders = True
     site_settings.save()
@@ -291,9 +297,10 @@ def test_checkout_with_voucher_complete(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -360,8 +367,9 @@ def test_checkout_complete_without_inventory_tracking(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -434,8 +442,9 @@ def test_checkout_complete_error_in_gateway_response_for_dummy_credit_card(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     payment = payment_dummy_credit_card
     payment.is_active = True
@@ -507,8 +516,9 @@ def test_checkout_complete_does_not_delete_checkout_after_unsuccessful_payment(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     taxed_total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -596,8 +606,9 @@ def test_checkout_complete_confirmation_needed(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -649,8 +660,9 @@ def test_checkout_confirm(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_txn_to_confirm
     payment.is_active = True
@@ -693,8 +705,9 @@ def test_checkout_complete_insufficient_stock(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     payment = payment_dummy
@@ -738,8 +751,9 @@ def test_checkout_complete_insufficient_stock_payment_refunded(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     payment = payment_dummy
@@ -792,8 +806,9 @@ def test_checkout_complete_insufficient_stock_payment_voided(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     payment = payment_txn_preauth
@@ -845,8 +860,9 @@ def test_checkout_complete_without_redirect_url(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -909,8 +925,9 @@ def test_checkout_complete_payment_payment_total_different_than_checkout(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     payment = payment_dummy
@@ -975,8 +992,9 @@ def test_create_order_raises_insufficient_stock(
     checkout = checkout_ready_to_complete
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, checkout.shipping_address
+        manager, checkout_info, lines, checkout.shipping_address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -1018,8 +1036,9 @@ def test_checkout_complete_with_digital(
     # Create a dummy payment to charge
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True
@@ -1075,8 +1094,9 @@ def test_checkout_complete_0_total_value(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     payment = payment_dummy
     payment.is_active = True

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -145,9 +145,10 @@ def test_checkout_totals_use_discounts(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts)
     taxed_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
         discounts=discounts,
@@ -506,10 +507,11 @@ def test_checkout_add_many_gift_card_code(
 
 def test_checkout_get_total_with_gift_card(api_client, checkout_with_item, gift_card):
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )
@@ -529,10 +531,11 @@ def test_checkout_get_total_with_many_gift_card(
     api_client, checkout_with_gift_card, gift_card_created_by_staff
 ):
     lines = fetch_checkout_lines(checkout_with_gift_card)
+    checkout_info = fetch_checkout_info(checkout_with_gift_card, lines, [])
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
         manager=manager,
-        checkout=checkout_with_gift_card,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_gift_card.shipping_address,
     )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -135,7 +135,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         )  # FIXME: check which address we need here
         checkout_total = calculate_checkout_total_with_gift_cards(
             manager=info.context.plugins,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=address,
             discounts=info.context.discounts,

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -6,7 +6,7 @@ import graphene
 import pytest
 
 from ....checkout import calculations
-from ....checkout.fetch import fetch_checkout_lines
+from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....payment import PaymentError
 from ....payment.error_codes import PaymentErrorCode
 from ....payment.gateways.dummy_credit_card import (
@@ -115,8 +115,9 @@ def test_checkout_add_payment_without_shipping_method_and_not_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     variables = {
         "checkoutId": checkout_id,
@@ -155,8 +156,9 @@ def test_checkout_add_payment_without_shipping_method_with_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     variables = {
         "checkoutId": checkout_id,
@@ -186,8 +188,9 @@ def test_checkout_add_payment_with_shipping_method_and_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     variables = {
         "checkoutId": checkout_id,
@@ -226,8 +229,9 @@ def test_checkout_add_payment(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     return_url = "https://www.example.com"
     variables = {
@@ -269,8 +273,9 @@ def test_checkout_add_payment_default_amount(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     variables = {
@@ -302,8 +307,9 @@ def test_checkout_add_payment_bad_amount(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     variables = {
@@ -352,8 +358,9 @@ def test_use_checkout_billing_address_as_payment_billing(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     variables = {
         "checkoutId": checkout_id,
@@ -400,8 +407,9 @@ def test_create_payment_for_checkout_with_active_payments(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.checkout_total(
-        manager=manager, checkout=checkout, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     variables = {

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -3,7 +3,7 @@ from unittest import mock
 import pytest
 
 from .....checkout import calculations
-from .....checkout.fetch import fetch_checkout_lines
+from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....plugins.manager import get_plugins_manager
 from .... import TransactionKind
 from ....models import Transaction
@@ -73,8 +73,9 @@ def payment_adyen_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.save()
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_items)
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout_with_items, lines, address
+        manager, checkout_info, lines, address
     )
     payment = create_payment(
         gateway=AdyenGatewayPlugin.PLUGIN_ID,

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -6,7 +6,7 @@ import graphene
 import pytest
 
 from ......checkout import calculations
-from ......checkout.fetch import fetch_checkout_lines
+from ......checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ......order import OrderEvents, OrderStatus
 from ......plugins.manager import get_plugins_manager
 from ..... import ChargeStatus, TransactionKind
@@ -157,8 +157,9 @@ def test_handle_authorization_for_checkout(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     payment.is_active = True
     payment.order = None
@@ -203,8 +204,9 @@ def test_handle_authorization_with_adyen_auto_capture(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     payment.is_active = True
     payment.order = None
@@ -396,8 +398,9 @@ def test_handle_capture_for_checkout(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     total = calculations.calculate_checkout_total_with_gift_cards(
-        manager, checkout, lines, address
+        manager, checkout_info, lines, address
     )
     payment.is_active = True
     payment.order = None

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -15,7 +15,7 @@ from .....checkout.calculations import (
     checkout_shipping_price,
     checkout_total,
 )
-from .....checkout.fetch import fetch_checkout_lines
+from .....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from .....checkout.models import Checkout
 from .....core.prices import quantize_price
 from .....discount.utils import fetch_active_discounts
@@ -267,9 +267,10 @@ def request_data_for_gateway_config(
     address = checkout.billing_address or checkout.shipping_address
     discounts = fetch_active_discounts()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts)
     total = checkout_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=discounts,

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -4,7 +4,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from ...checkout.calculations import checkout_total
-from ...checkout.fetch import fetch_checkout_lines
+from ...checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ...plugins.manager import PluginsManager, get_plugins_manager
 from .. import ChargeStatus, GatewayError, PaymentError, TransactionKind, gateway
 from ..error_codes import PaymentErrorCode
@@ -88,8 +88,9 @@ def test_create_payment(checkout_with_item, address):
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     total = checkout_total(
-        manager=manager, checkout=checkout_with_item, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     data = {
@@ -127,8 +128,9 @@ def test_create_payment_from_checkout_requires_billing_address(checkout_with_ite
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     total = checkout_total(
-        manager=manager, checkout=checkout_with_item, lines=lines, address=None
+        manager=manager, checkout_info=checkout_info, lines=lines, address=None
     )
 
     data = {
@@ -168,8 +170,9 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     total = checkout_total(
-        manager=manager, checkout=checkout_with_item, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
 
     data = {

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -10,7 +10,11 @@ from prices import Money, TaxedMoney
 from requests import RequestException
 
 from ....account.models import Address
-from ....checkout.fetch import CheckoutLineInfo, fetch_checkout_lines
+from ....checkout.fetch import (
+    CheckoutLineInfo,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+)
 from ....checkout.utils import add_variant_to_checkout
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, TaxType
@@ -193,9 +197,8 @@ def test_calculate_checkout_total_uses_default_calculation(
 
     discounts = [discount_info] if with_discount else None
     lines = fetch_checkout_lines(checkout_with_item)
-    total = manager.calculate_checkout_total(
-        checkout_with_item, lines, address, discounts
-    )
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+    total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(
         net=Money(expected_net, "USD"), gross=Money(expected_gross, "USD")
@@ -265,8 +268,9 @@ def test_calculate_checkout_total(
 
     discounts = [discount_info] if with_discount else None
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
     total = manager.calculate_checkout_total(
-        checkout_with_item, lines, ship_to_pl_address, discounts
+        checkout_info, lines, ship_to_pl_address, discounts
     )
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -21,20 +21,14 @@ if TYPE_CHECKING:
     # flake8: noqa
     from ..account.models import Address, User
     from ..channel.models import Channel
-    from ..checkout.fetch import CheckoutLineInfo
-    from ..checkout.models import Checkout, CheckoutLine
+    from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
+    from ..checkout.models import Checkout
     from ..core.taxes import TaxType
     from ..discount import DiscountInfo
     from ..invoice.models import Invoice
     from ..order.models import Fulfillment, Order, OrderLine
     from ..page.models import Page
-    from ..product.models import (
-        Collection,
-        Product,
-        ProductType,
-        ProductVariant,
-        ProductVariantChannelListing,
-    )
+    from ..product.models import Product, ProductType, ProductVariant
 
 
 PluginConfigurationType = List[dict]
@@ -156,7 +150,7 @@ class BasePlugin:
 
     def calculate_checkout_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: List["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: List["DiscountInfo"],

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -21,8 +21,8 @@ if TYPE_CHECKING:
     # flake8: noqa
     from ..account.models import Address, User
     from ..channel.models import Channel
-    from ..checkout.fetch import CheckoutLineInfo
-    from ..checkout.models import Checkout, CheckoutLine
+    from ..checkout.fetch import CheckoutInfo, CheckoutLineInfo
+    from ..checkout.models import Checkout
     from ..invoice.models import Invoice
     from ..order.models import Fulfillment, Order, OrderLine
     from ..page.models import Page
@@ -119,7 +119,7 @@ class PluginsManager(PaymentInterface):
 
     def calculate_checkout_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
@@ -127,24 +127,24 @@ class PluginsManager(PaymentInterface):
 
         default_value = base_calculations.base_checkout_total(
             subtotal=self.calculate_checkout_subtotal(
-                checkout, lines, address, discounts
+                checkout_info.checkout, lines, address, discounts
             ),
             shipping_price=self.calculate_checkout_shipping(
-                checkout, lines, address, discounts
+                checkout_info.checkout, lines, address, discounts
             ),
-            discount=checkout.discount,
-            currency=checkout.currency,
+            discount=checkout_info.checkout.discount,
+            currency=checkout_info.checkout.currency,
         )
         return quantize_price(
             self.__run_method_on_plugins(
                 "calculate_checkout_total",
                 default_value,
-                checkout,
+                checkout_info,
                 lines,
                 address,
                 discounts,
             ),
-            checkout.currency,
+            checkout_info.checkout.currency,
         )
 
     def calculate_checkout_subtotal(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -69,9 +69,9 @@ class PluginSample(BasePlugin):
         return HttpResponseNotFound()
 
     def calculate_checkout_total(
-        self, checkout, lines, address, discounts, previous_value
+        self, checkout_info, lines, address, discounts, previous_value
     ):
-        total = Money("1.0", currency=checkout.currency)
+        total = Money("1.0", currency=checkout_info.checkout.currency)
         return TaxedMoney(total, total)
 
     def calculate_checkout_subtotal(

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -6,7 +6,11 @@ from django.http import HttpResponseNotFound, JsonResponse
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
-from ...checkout.fetch import CheckoutLineInfo, fetch_checkout_lines
+from ...checkout.fetch import (
+    CheckoutLineInfo,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+)
 from ...core.taxes import TaxType
 from ...payment.interface import PaymentGateway
 from ...product.models import Product
@@ -41,8 +45,9 @@ def test_manager_calculates_checkout_total(
     expected_total = Money(total_amount, currency)
     manager = PluginsManager(plugins=plugins)
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     taxed_total = manager.calculate_checkout_total(
-        checkout_with_item, lines, None, [discount_info]
+        checkout_info, lines, None, [discount_info]
     )
     assert TaxedMoney(expected_total, expected_total) == taxed_total
 

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -30,8 +30,8 @@ if TYPE_CHECKING:
     # flake8: noqa
     from ...account.models import Address
     from ...channel.models import Channel
-    from ...checkout.fetch import CheckoutLineInfo
-    from ...checkout.models import Checkout, CheckoutLine
+    from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
+    from ...checkout.models import Checkout
     from ...discount import DiscountInfo
     from ...order.models import Order, OrderLine
     from ...product.models import (
@@ -83,7 +83,7 @@ class VatlayerPlugin(BasePlugin):
 
     def calculate_checkout_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: List["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: List["DiscountInfo"],
@@ -96,19 +96,19 @@ class VatlayerPlugin(BasePlugin):
         return (
             calculations.checkout_subtotal(
                 manager=manager,
-                checkout=checkout,
+                checkout=checkout_info.checkout,
                 lines=lines,
                 address=address,
                 discounts=discounts,
             )
             + calculations.checkout_shipping_price(
                 manager=manager,
-                checkout=checkout,
+                checkout=checkout_info.checkout,
                 lines=lines,
                 address=address,
                 discounts=discounts,
             )
-            - checkout.discount
+            - checkout_info.checkout.discount
         )
 
     def _get_taxes_for_country(self, country: Country):

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -9,7 +9,11 @@ from django_countries.fields import Country
 from prices import Money, MoneyRange, TaxedMoney, TaxedMoneyRange
 
 from ....checkout import calculations
-from ....checkout.fetch import CheckoutLineInfo, fetch_checkout_lines
+from ....checkout.fetch import (
+    CheckoutLineInfo,
+    fetch_checkout_info,
+    fetch_checkout_lines,
+)
 from ....checkout.utils import add_variant_to_checkout
 from ....core.prices import quantize_price
 from ....core.taxes import zero_taxed_money
@@ -554,9 +558,10 @@ def test_calculations_checkout_total_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     checkout_subtotal = calculations.checkout_total(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -249,9 +249,8 @@ def test_calculate_checkout_total(
 
     discounts = [discount_info] if with_discount else None
     lines = fetch_checkout_lines(checkout_with_item)
-    total = manager.calculate_checkout_total(
-        checkout_with_item, lines, address, discounts
-    )
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+    total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(
         net=Money(expected_net, "USD"), gross=Money(expected_gross, "USD")


### PR DESCRIPTION
Use `CheckoutInfo` in plugins methods for calculating checkout total.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
