### PR TITLE
Use checkout info in calculate checkout subtotal

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -45,7 +45,7 @@ def checkout_subtotal(
     It takes in account all plugins.
     """
     calculated_checkout_subtotal = manager.calculate_checkout_subtotal(
-        checkout_info.checkout, lines, address, discounts or []
+        checkout_info, lines, address, discounts or []
     )
     return quantize_price(calculated_checkout_subtotal, checkout_info.checkout.currency)
 

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -35,7 +35,7 @@ def checkout_shipping_price(
 def checkout_subtotal(
     *,
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -45,9 +45,9 @@ def checkout_subtotal(
     It takes in account all plugins.
     """
     calculated_checkout_subtotal = manager.calculate_checkout_subtotal(
-        checkout, lines, address, discounts or []
+        checkout_info.checkout, lines, address, discounts or []
     )
-    return quantize_price(calculated_checkout_subtotal, checkout.currency)
+    return quantize_price(calculated_checkout_subtotal, checkout_info.checkout.currency)
 
 
 def calculate_checkout_total_with_gift_cards(

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -315,7 +315,7 @@ def _prepare_order_data(
     # assign gift cards to the order
 
     order_data["total_price_left"] = (
-        manager.calculate_checkout_subtotal(checkout, lines, address, discounts)
+        manager.calculate_checkout_subtotal(checkout_info, lines, address, discounts)
         + shipping_total
         - checkout.discount
     ).gross

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -37,11 +37,12 @@ def test_adding_same_variant(checkout, product):
     assert checkout.quantity == 3
     subtotal = TaxedMoney(Money("30.00", "USD"), Money("30.00", "USD"))
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
     assert (
         calculations.checkout_subtotal(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=checkout.shipping_address,
         )

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -157,9 +157,7 @@ def test_get_voucher_discount_for_checkout_voucher_validation(
     manager = get_plugins_manager()
     address = checkout_with_voucher.shipping_address
     get_voucher_discount_for_checkout(manager, voucher, checkout_info, lines, address)
-    subtotal = manager.calculate_checkout_subtotal(
-        checkout_with_voucher, lines, address, []
-    )
+    subtotal = manager.calculate_checkout_subtotal(checkout_info, lines, address, [])
     quantity = checkout_with_voucher.quantity
     customer_email = checkout_with_voucher.get_customer_email()
     mock_validate_voucher.assert_called_once_with(

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -125,11 +125,11 @@ def test_get_discount_for_checkout_value_voucher(
     subtotal = TaxedMoney(Money(total, "USD"), Money(total, "USD"))
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     checkout_info = CheckoutInfo(
         checkout=checkout,
@@ -204,11 +204,11 @@ def test_get_discount_for_checkout_entire_order_voucher_not_applicable(
     subtotal = TaxedMoney(Money(total, "USD"), Money(total, "USD"))
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     checkout_info = CheckoutInfo(
         checkout=checkout,
@@ -298,13 +298,13 @@ def test_get_discount_for_checkout_specific_products_voucher_not_applicable(
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: TaxedMoney(
+        lambda manager, checkout_info, lines, address, discounts: TaxedMoney(
             Money(total, "USD"), Money(total, "USD")
         ),
     )
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: TaxedMoney(
+        lambda manager, checkout_info, lines, address, discounts: TaxedMoney(
             Money(total, "USD"), Money(total, "USD")
         ),
     )
@@ -364,11 +364,11 @@ def test_get_discount_for_checkout_shipping_voucher(
     subtotal = TaxedMoney(Money(100, "USD"), Money(100, "USD"))
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.checkout.utils.is_shipping_required", lambda lines: True
@@ -416,11 +416,11 @@ def test_get_discount_for_checkout_shipping_voucher_all_countries(
     subtotal = TaxedMoney(Money(100, "USD"), Money(100, "USD"))
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.checkout.utils.is_shipping_required", lambda lines: True
@@ -476,7 +476,7 @@ def test_get_discount_for_checkout_shipping_voucher_limited_countries(
     shipping_total = TaxedMoney(net=Money(10, "USD"), gross=Money(10, "USD"))
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     checkout = Mock(
         get_subtotal=Mock(return_value=subtotal),
@@ -610,11 +610,11 @@ def test_get_discount_for_checkout_shipping_voucher_not_applicable(
 ):
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.discount.utils.calculations.checkout_subtotal",
-        lambda manager, checkout, lines, address, discounts: subtotal,
+        lambda manager, checkout_info, lines, address, discounts: subtotal,
     )
     monkeypatch.setattr(
         "saleor.checkout.utils.is_shipping_required", lambda lines: is_shipping_required
@@ -770,11 +770,12 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     channel_listing = shipping_method.channel_listings.get(channel_id=channel_USD.id)
     channel_listing.price = (
         calculations.checkout_subtotal(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=checkout.shipping_address,
         ).gross
@@ -795,7 +796,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     )
     checkout_subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
@@ -811,11 +812,12 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     channel_listing = shipping_method.channel_listings.get(channel=channel_USD)
     channel_listing.price = (
         calculations.checkout_subtotal(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=checkout.shipping_address,
         ).gross
@@ -836,7 +838,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     )
     checkout_subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -580,7 +580,7 @@ def test_create_order_with_gift_card(
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -349,7 +349,7 @@ def get_voucher_discount_for_checkout(
     if voucher.type == VoucherType.ENTIRE_ORDER:
         subtotal = calculations.checkout_subtotal(
             manager=manager,
-            checkout=checkout,
+            checkout_info=checkout_info,
             lines=lines,
             address=address,
             discounts=discounts,
@@ -410,7 +410,7 @@ def recalculate_checkout_discount(
         else:
             subtotal = calculations.checkout_subtotal(
                 manager=manager,
-                checkout=checkout,
+                checkout_info=checkout_info,
                 lines=lines,
                 address=address,
                 discounts=discounts,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -554,7 +554,7 @@ def remove_voucher_from_checkout(checkout: Checkout):
 
 
 def get_valid_shipping_methods_for_checkout(
-    checkout: Checkout,
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     discounts: Iterable[DiscountInfo],
     country_code: Optional[str] = None,
@@ -562,18 +562,18 @@ def get_valid_shipping_methods_for_checkout(
 ):
     if not is_shipping_required(lines):
         return None
-    if not checkout.shipping_address:
+    if not checkout_info.shipping_address:
         return None
     # TODO: subtotal should comes from arg instead of calculate it in this function
     # use info.context.plugins from resolver
     if subtotal is None:
         manager = get_plugins_manager()
         subtotal = manager.calculate_checkout_subtotal(
-            checkout, lines, checkout.shipping_address, discounts
+            checkout_info, lines, checkout_info.shipping_address, discounts
         )
     return ShippingMethod.objects.applicable_shipping_methods_for_instance(
-        checkout,
-        channel_id=checkout.channel_id,
+        checkout_info.checkout,
+        channel_id=checkout_info.checkout.channel_id,
         price=subtotal.gross,
         country_code=country_code,
         lines=lines,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -344,7 +344,6 @@ def get_voucher_discount_for_checkout(
 
     Raise NotApplicable if voucher of given type cannot be applied.
     """
-    checkout = checkout_info.checkout
     validate_voucher_for_checkout(manager, voucher, checkout_info, lines, discounts)
     if voucher.type == VoucherType.ENTIRE_ORDER:
         subtotal = calculations.checkout_subtotal(

--- a/saleor/discount/utils.py
+++ b/saleor/discount/utils.py
@@ -120,7 +120,7 @@ def validate_voucher_for_checkout(
     address = checkout_info.shipping_address or checkout_info.billing_address
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout_info.checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=discounts,

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2540,7 +2540,7 @@ def test_checkout_prices(user_api_client, checkout_with_item):
     assert data["totalPrice"]["gross"]["amount"] == (total.gross.amount)
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -25,9 +25,10 @@ def test_checkout_lines_delete_with_not_applicable_voucher(
 ):
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )
@@ -277,14 +278,15 @@ def test_checkout_add_voucher_code_checkout_with_sale(
     api_client, checkout_with_item, voucher_percentage, discount_info
 ):
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     manager = get_plugins_manager()
     address = checkout_with_item.shipping_address
     subtotal = calculations.checkout_subtotal(
-        manager=manager, checkout=checkout_with_item, lines=lines, address=address
+        manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=[discount_info],
@@ -308,16 +310,18 @@ def test_checkout_add_specific_product_voucher_code_checkout_with_sale(
     expected_discount = Decimal(1.5)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
         discounts=[discount_info],
@@ -346,17 +350,20 @@ def test_checkout_add_products_voucher_code_checkout_with_sale(
     voucher.products.add(product)
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
+
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
         discounts=[discount_info],
@@ -384,16 +391,18 @@ def test_checkout_add_collection_voucher_code_checkout_with_sale(
     voucher.collections.add(collection)
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
         discounts=[discount_info],
@@ -420,17 +429,19 @@ def test_checkout_add_category_code_checkout_with_sale(
     voucher.categories.add(category)
 
     lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
         discounts=[discount_info],

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -374,17 +374,17 @@ class Checkout(CountableDjangoObjectType):
     # TODO: We should optimize it in/after PR#5819
     def resolve_available_shipping_methods(root: models.Checkout, info):
         def calculate_available_shipping_methods(data):
-            address, lines, discounts, channel = data
+            address, lines, checkout_info, discounts, channel = data
             channel_slug = channel.slug
             display_gross = info.context.site.settings.display_gross_prices
             manager = info.context.plugins
             subtotal = manager.calculate_checkout_subtotal(
-                root, lines, address, discounts
+                checkout_info, lines, address, discounts
             )
             if not address:
                 return []
             available = get_valid_shipping_methods_for_checkout(
-                root,
+                checkout_info,
                 lines,
                 discounts,
                 subtotal=subtotal,
@@ -440,10 +440,11 @@ class Checkout(CountableDjangoObjectType):
             else None
         )
         lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(root.token)
+        checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(root.token)
         discounts = DiscountsByDateTimeLoader(info.context).load(
             info.context.request_time
         )
-        return Promise.all([address, lines, discounts, channel]).then(
+        return Promise.all([address, lines, checkout_info, discounts, channel]).then(
             calculate_available_shipping_methods
         )
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -320,10 +320,10 @@ class Checkout(CountableDjangoObjectType):
     # TODO: We should optimize it in/after PR#5819
     def resolve_subtotal_price(root: models.Checkout, info):
         def calculate_subtotal_price(data):
-            address, lines, discounts = data
+            address, lines, checkout_info, discounts = data
             return calculations.checkout_subtotal(
                 manager=info.context.plugins,
-                checkout=root,
+                checkout_info=checkout_info,
                 lines=lines,
                 address=address,
                 discounts=discounts,
@@ -334,10 +334,13 @@ class Checkout(CountableDjangoObjectType):
             AddressByIdLoader(info.context).load(address_id) if address_id else None
         )
         lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(root.token)
+        checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(root.token)
         discounts = DiscountsByDateTimeLoader(info.context).load(
             info.context.request_time
         )
-        return Promise.all([address, lines, discounts]).then(calculate_subtotal_price)
+        return Promise.all([address, lines, checkout_info, discounts]).then(
+            calculate_subtotal_price
+        )
 
     @staticmethod
     # TODO: We should optimize it in/after PR#5819

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -356,8 +356,9 @@ def test_calculate_checkout_subtotal(
     discounts = [discount_info] if with_discount else None
     add_variant_to_checkout(checkout_with_item, variant, 2)
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
     total = manager.calculate_checkout_subtotal(
-        checkout_with_item, lines, address, discounts
+        checkout_info, lines, address, discounts
     )
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -165,7 +165,7 @@ class BasePlugin:
 
     def calculate_checkout_subtotal(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: List["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: List["DiscountInfo"],

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -127,7 +127,7 @@ class PluginsManager(PaymentInterface):
 
         default_value = base_calculations.base_checkout_total(
             subtotal=self.calculate_checkout_subtotal(
-                checkout_info.checkout, lines, address, discounts
+                checkout_info, lines, address, discounts
             ),
             shipping_price=self.calculate_checkout_shipping(
                 checkout_info.checkout, lines, address, discounts
@@ -149,14 +149,14 @@ class PluginsManager(PaymentInterface):
 
     def calculate_checkout_subtotal(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
     ) -> TaxedMoney:
         line_totals = [
             self.calculate_checkout_line_total(
-                checkout,
+                checkout_info.checkout,
                 line_info,
                 address,
                 line_info.channel_listing.channel,
@@ -165,18 +165,18 @@ class PluginsManager(PaymentInterface):
             for line_info in lines
         ]
         default_value = base_calculations.base_checkout_subtotal(
-            line_totals, checkout.currency
+            line_totals, checkout_info.checkout.currency
         )
         return quantize_price(
             self.__run_method_on_plugins(
                 "calculate_checkout_subtotal",
                 default_value,
-                checkout,
+                checkout_info,
                 lines,
                 address,
                 discounts,
             ),
-            checkout.currency,
+            checkout_info.checkout.currency,
         )
 
     def calculate_checkout_shipping(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -75,9 +75,9 @@ class PluginSample(BasePlugin):
         return TaxedMoney(total, total)
 
     def calculate_checkout_subtotal(
-        self, checkout, lines, address, discounts, previous_value
+        self, checkout_info, lines, address, discounts, previous_value
     ):
-        subtotal = Money("1.0", currency=checkout.currency)
+        subtotal = Money("1.0", currency=checkout_info.checkout.currency)
         return TaxedMoney(subtotal, subtotal)
 
     def calculate_checkout_shipping(

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -62,8 +62,9 @@ def test_manager_calculates_checkout_subtotal(
     currency = checkout_with_item.currency
     expected_subtotal = Money(subtotal_amount, currency)
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     taxed_subtotal = PluginsManager(plugins=plugins).calculate_checkout_subtotal(
-        checkout_with_item, lines, None, [discount_info]
+        checkout_info, lines, None, [discount_info]
     )
     assert TaxedMoney(expected_subtotal, expected_subtotal) == taxed_subtotal
 

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -96,7 +96,7 @@ class VatlayerPlugin(BasePlugin):
         return (
             calculations.checkout_subtotal(
                 manager=manager,
-                checkout=checkout_info.checkout,
+                checkout_info=checkout_info,
                 lines=lines,
                 address=address,
                 discounts=discounts,

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -297,8 +297,9 @@ def test_calculate_checkout_subtotal(
     discounts = [discount_info] if with_discount else None
     add_variant_to_checkout(checkout_with_item, variant, 2)
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
     total = manager.calculate_checkout_subtotal(
-        checkout_with_item, lines, address, discounts
+        checkout_info, lines, address, discounts
     )
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -575,9 +575,10 @@ def test_calculations_checkout_subtotal_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     checkout_subtotal = calculations.checkout_subtotal(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )


### PR DESCRIPTION
Use `CheckoutInfo` in plugins methods for calculating checkout subtotal.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
