### PR TITLE
Use checkout info in calculate checkout line total

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -8,7 +8,6 @@ if TYPE_CHECKING:
     from prices import TaxedMoney
 
     from ..account.models import Address
-    from ..channel.models import Channel
     from ..plugins.manager import PluginsManager
     from .fetch import CheckoutInfo, CheckoutLineInfo
     from .models import Checkout
@@ -95,21 +94,20 @@ def checkout_total(
 def checkout_line_total(
     *,
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     checkout_line_info: "CheckoutLineInfo",
-    address: Optional["Address"],
-    channel: "Channel",
     discounts: Iterable[DiscountInfo] = [],
 ) -> "TaxedMoney":
     """Return the total price of provided line, taxes included.
 
     It takes in account all plugins.
     """
+    address = checkout_info.shipping_address or checkout_info.billing_address
     calculated_line_total = manager.calculate_checkout_line_total(
-        checkout,
+        checkout_info.checkout,
         checkout_line_info,
         address,
-        channel,
+        checkout_info.channel,
         discounts or [],
     )
-    return quantize_price(calculated_line_total, checkout.currency)
+    return quantize_price(calculated_line_total, checkout_info.checkout.currency)

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -104,10 +104,9 @@ def checkout_line_total(
     """
     address = checkout_info.shipping_address or checkout_info.billing_address
     calculated_line_total = manager.calculate_checkout_line_total(
-        checkout_info.checkout,
+        checkout_info,
         checkout_line_info,
         address,
-        checkout_info.channel,
         discounts or [],
     )
     return quantize_price(calculated_line_total, checkout_info.checkout.currency)

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -164,10 +164,9 @@ def _create_line_for_order(
         translated_variant_name = ""
 
     total_line_price = manager.calculate_checkout_line_total(
-        checkout,
+        checkout_info,
         checkout_line_info,
         address,
-        channel,
         discounts,
     )
     unit_price = manager.calculate_checkout_line_unit_price(

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -312,10 +312,8 @@ def get_prices_of_discounted_specific_product(
         line = line_info.line
         line_total = calculations.checkout_line_total(
             manager=manager,
-            checkout=checkout_info.checkout,
+            checkout_info=checkout_info,
             checkout_line_info=line_info,
-            address=address,
-            channel=checkout_info.channel,
             discounts=discounts,
         ).gross
         line_unit_price = manager.calculate_checkout_line_unit_price(

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -165,12 +165,11 @@ def test_checkout_totals_use_discounts(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout, [checkout_line_info], discounts)
     line_total = calculations.checkout_line_total(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         checkout_line_info=checkout_line_info,
-        address=checkout.shipping_address,
-        channel=channel_USD,
         discounts=discounts,
     )
     assert data["lines"][0]["totalPrice"]["gross"]["amount"] == line_total.gross.amount

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -114,6 +114,10 @@ class CheckoutLine(CountableDjangoObjectType):
                 discounts = DiscountsByDateTimeLoader(info.context).load(
                     info.context.request_time
                 )
+                checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
+                    checkout.token
+                )
+
                 return Promise.all(
                     [
                         checkout,
@@ -124,6 +128,7 @@ class CheckoutLine(CountableDjangoObjectType):
                         collections,
                         channel,
                         discounts,
+                        checkout_info,
                     ]
                 ).then(calculate_line_total_price)
 
@@ -143,6 +148,7 @@ class CheckoutLine(CountableDjangoObjectType):
                 collections,
                 channel,
                 discounts,
+                checkout_info,
             ) = data
             line_info = CheckoutLineInfo(
                 line=root,
@@ -152,10 +158,9 @@ class CheckoutLine(CountableDjangoObjectType):
                 collections=collections,
             )
             return info.context.plugins.calculate_checkout_line_total(
-                checkout=checkout,
+                checkout_info=checkout_info,
                 checkout_line_info=line_info,
                 address=address,
-                channel=channel,
                 discounts=discounts,
             )
 

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -331,10 +331,9 @@ class AvataxPlugin(BasePlugin):
 
     def calculate_checkout_line_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        channel: "Channel",
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
@@ -345,10 +344,12 @@ class AvataxPlugin(BasePlugin):
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout, [checkout_line_info.line]):
+        if not _validate_checkout(checkout_info.checkout, [checkout_line_info.line]):
             return base_total
 
-        taxes_data = get_checkout_tax_data(checkout, discounts, self.config)
+        taxes_data = get_checkout_tax_data(
+            checkout_info.checkout, discounts, self.config
+        )
         if not taxes_data or "error" in taxes_data:
             return base_total
 

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -124,12 +124,14 @@ def test_calculate_checkout_line_total(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], discounts
+    )
 
     total = manager.calculate_checkout_line_total(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
-        channel,
         discounts,
     )
     total = quantize_price(total, total.currency)

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -206,10 +206,9 @@ class BasePlugin:
     # TODO: Add information about this change to `breaking changes in changelog`
     def calculate_checkout_line_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        channel: "Channel",
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -156,10 +156,9 @@ class PluginsManager(PaymentInterface):
     ) -> TaxedMoney:
         line_totals = [
             self.calculate_checkout_line_total(
-                checkout_info.checkout,
+                checkout_info,
                 line_info,
                 address,
-                line_info.channel_listing.channel,
                 discounts,
             )
             for line_info in lines
@@ -242,28 +241,26 @@ class PluginsManager(PaymentInterface):
 
     def calculate_checkout_line_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        channel: "Channel",
         discounts: Iterable["DiscountInfo"],
     ):
         default_value = base_calculations.base_checkout_line_total(
             checkout_line_info,
-            channel,
+            checkout_info.channel,
             discounts,
         )
         return quantize_price(
             self.__run_method_on_plugins(
                 "calculate_checkout_line_total",
                 default_value,
-                checkout,
+                checkout_info,
                 checkout_line_info,
                 address,
-                channel,
                 discounts,
             ),
-            checkout.currency,
+            checkout_info.checkout.currency,
         )
 
     def calculate_checkout_line_unit_price(

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     # flake8: noqa
     from ...account.models import Address
     from ...channel.models import Channel
-    from ...checkout.fetch import CheckoutLineInfo
+    from ...checkout.fetch import CheckoutInfo, CheckoutLineInfo
     from ...checkout.models import Checkout
     from ...discount import DiscountInfo
     from ...order.models import Order, OrderLine
@@ -92,14 +92,13 @@ class PluginSample(BasePlugin):
 
     def calculate_checkout_line_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        channel: "Channel",
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ):
-        price = Money("1.0", currency=checkout.currency)
+        price = Money("1.0", currency=checkout_info.checkout.currency)
         return TaxedMoney(price, price)
 
     def calculate_checkout_line_unit_price(

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -124,11 +124,13 @@ def test_manager_calculates_checkout_line_total(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [discount_info]
+    )
     taxed_total = PluginsManager(plugins=plugins).calculate_checkout_line_total(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
-        channel,
         [discount_info],
     )
     assert TaxedMoney(expected_total, expected_total) == taxed_total

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -167,10 +167,9 @@ class VatlayerPlugin(BasePlugin):
 
     def calculate_checkout_line_total(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
-        channel: "Channel",
         discounts: Iterable["DiscountInfo"],
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
@@ -180,7 +179,7 @@ class VatlayerPlugin(BasePlugin):
             checkout_line_info.variant,
             checkout_line_info.product,
             checkout_line_info.collections,
-            channel,
+            checkout_info.channel,
             checkout_line_info.channel_listing,
             previous_value,
         )

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -390,12 +390,12 @@ def test_calculate_checkout_line_total(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     line_price = manager.calculate_checkout_line_total(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         address,
-        channel,
         [],
     )
 


### PR DESCRIPTION
Use `CheckoutInfo` in plugins methods for calculating checkout line total.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
