### PR TITLE
Use checkout info in calculate checkout shipping

### DIFF
--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -25,7 +25,7 @@ def checkout_shipping_price(
     It takes in account all plugins.
     """
     calculated_checkout_shipping = manager.calculate_checkout_shipping(
-        checkout_info.checkout, lines, address, discounts or []
+        checkout_info, lines, address, discounts or []
     )
     return quantize_price(calculated_checkout_shipping, checkout_info.checkout.currency)
 

--- a/saleor/checkout/calculations.py
+++ b/saleor/checkout/calculations.py
@@ -10,13 +10,12 @@ if TYPE_CHECKING:
     from ..account.models import Address
     from ..plugins.manager import PluginsManager
     from .fetch import CheckoutInfo, CheckoutLineInfo
-    from .models import Checkout
 
 
 def checkout_shipping_price(
     *,
     manager: "PluginsManager",
-    checkout: "Checkout",
+    checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
     address: Optional["Address"],
     discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -26,9 +25,9 @@ def checkout_shipping_price(
     It takes in account all plugins.
     """
     calculated_checkout_shipping = manager.calculate_checkout_shipping(
-        checkout, lines, address, discounts or []
+        checkout_info.checkout, lines, address, discounts or []
     )
-    return quantize_price(calculated_checkout_shipping, checkout.currency)
+    return quantize_price(calculated_checkout_shipping, checkout_info.checkout.currency)
 
 
 def checkout_subtotal(

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -142,7 +142,6 @@ def _create_line_for_order(
     :raises InsufficientStock: when there is not enough items in stock for this variant.
     """
     checkout = checkout_info.checkout
-    channel = checkout_info.channel
     checkout_line = checkout_line_info.line
     quantity = checkout_line.quantity
     variant = checkout_line_info.variant
@@ -172,11 +171,10 @@ def _create_line_for_order(
     unit_price = manager.calculate_checkout_line_unit_price(
         total_line_price,
         quantity,
-        checkout,
+        checkout_info,
         checkout_line_info,
         address,
         discounts,
-        channel,
     )
     tax_rate = manager.get_checkout_line_tax_rate(
         checkout, checkout_line_info, address, discounts, unit_price

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -141,7 +141,6 @@ def _create_line_for_order(
 
     :raises InsufficientStock: when there is not enough items in stock for this variant.
     """
-    checkout = checkout_info.checkout
     checkout_line = checkout_line_info.line
     quantity = checkout_line.quantity
     variant = checkout_line_info.variant
@@ -177,7 +176,7 @@ def _create_line_for_order(
         discounts,
     )
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout, checkout_line_info, address, discounts, unit_price
+        checkout_info, checkout_line_info, address, discounts, unit_price
     )
 
     line = OrderLine(
@@ -284,7 +283,7 @@ def _prepare_order_data(
         checkout_info, lines, address, discounts
     )
     shipping_tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout, lines, address, discounts, shipping_total
+        checkout_info, lines, address, discounts, shipping_total
     )
     order_data.update(
         _process_shipping_data_for_order(checkout_info, shipping_total, manager, lines)

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -283,7 +283,7 @@ def _prepare_order_data(
     taxed_total = max(taxed_total, zero_taxed_money(checkout.currency))
 
     shipping_total = manager.calculate_checkout_shipping(
-        checkout, lines, address, discounts
+        checkout_info, lines, address, discounts
     )
     shipping_tax_rate = manager.get_checkout_shipping_tax_rate(
         checkout, lines, address, discounts, shipping_total

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -426,7 +426,7 @@ def test_get_discount_for_checkout_shipping_voucher_all_countries(
     shipping_total = TaxedMoney(Money(10, "USD"), Money(10, "USD"))
     monkeypatch.setattr(
         "saleor.checkout.utils.calculations.checkout_shipping_price",
-        lambda manager, checkout, lines, address, discounts: shipping_total,
+        lambda manager, checkout_info, lines, address, discounts: shipping_total,
     )
     checkout = Mock(
         spec=Checkout,

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -586,7 +586,7 @@ def test_create_order_with_gift_card(
     )
     shipping_price = calculations.checkout_shipping_price(
         manager=manager,
-        checkout=checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -235,7 +235,7 @@ def _get_shipping_voucher_discount_for_checkout(
 
     shipping_price = calculations.checkout_shipping_price(
         manager=manager,
-        checkout=checkout_info.checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=discounts,

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -319,11 +319,10 @@ def get_prices_of_discounted_specific_product(
         line_unit_price = manager.calculate_checkout_line_unit_price(
             line_total,
             line.quantity,
-            checkout_info.checkout,
+            checkout_info,
             line_info,
             address,
             discounts,
-            checkout_info.channel,
         )
         line_prices.extend([line_unit_price] * line.quantity)
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -351,10 +351,10 @@ class Checkout(CountableDjangoObjectType):
     # TODO: We should optimize it in/after PR#5819
     def resolve_shipping_price(root: models.Checkout, info):
         def calculate_shipping_price(data):
-            address, lines, discounts = data
+            address, lines, checkout_info, discounts = data
             return calculations.checkout_shipping_price(
                 manager=info.context.plugins,
-                checkout=root,
+                checkout_info=checkout_info,
                 lines=lines,
                 address=address,
                 discounts=discounts,
@@ -366,10 +366,13 @@ class Checkout(CountableDjangoObjectType):
             else None
         )
         lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(root.token)
+        checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(root.token)
         discounts = DiscountsByDateTimeLoader(info.context).load(
             info.context.request_time
         )
-        return Promise.all([address, lines, discounts]).then(calculate_shipping_price)
+        return Promise.all([address, lines, checkout_info, discounts]).then(
+            calculate_shipping_price
+        )
 
     @staticmethod
     def resolve_lines(root: models.Checkout, info):

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -153,7 +153,7 @@ def get_shipping_data(manager, checkout_info, lines, discounts):
     currency = checkout_info.checkout.currency
     shipping_total = checkout_shipping_price(
         manager=manager,
-        checkout=checkout_info.checkout,
+        checkout_info=checkout_info,
         lines=lines,
         address=address,
         discounts=discounts,

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -157,10 +157,10 @@ class AvataxPlugin(BasePlugin):
         checkout_total = previous_value
 
         if not _validate_checkout(
-            checkout_info.checkout, [line_info.line for line_info in lines]
+            checkout_info, [line_info.line for line_info in lines]
         ):
             return checkout_total
-        response = get_checkout_tax_data(checkout_info.checkout, discounts, self.config)
+        response = get_checkout_tax_data(checkout_info, discounts, self.config)
         if not response or "error" in response:
             return checkout_total
         currency = response.get("currencyCode")
@@ -185,7 +185,7 @@ class AvataxPlugin(BasePlugin):
         base_subtotal: TaxedMoney,
     ) -> TaxedMoney:
         currency = checkout_info.checkout.currency
-        response = get_checkout_tax_data(checkout_info.checkout, discounts, self.config)
+        response = get_checkout_tax_data(checkout_info, discounts, self.config)
         if not response or "error" in response:
             return base_subtotal
 
@@ -216,10 +216,10 @@ class AvataxPlugin(BasePlugin):
 
         base_subtotal = previous_value
         if not _validate_checkout(
-            checkout_info.checkout, [line_info.line for line_info in lines]
+            checkout_info, [line_info.line for line_info in lines]
         ):
             return base_subtotal
-        response = get_checkout_tax_data(checkout_info.checkout, discounts, self.config)
+        response = get_checkout_tax_data(checkout_info, discounts, self.config)
         if not response or "error" in response:
             return base_subtotal
 
@@ -259,11 +259,11 @@ class AvataxPlugin(BasePlugin):
             return base_shipping_price
 
         if not _validate_checkout(
-            checkout_info.checkout, [line_info.line for line_info in lines]
+            checkout_info, [line_info.line for line_info in lines]
         ):
             return base_shipping_price
 
-        response = get_checkout_tax_data(checkout_info.checkout, discounts, self.config)
+        response = get_checkout_tax_data(checkout_info, discounts, self.config)
         if not response or "error" in response:
             return base_shipping_price
 
@@ -346,12 +346,10 @@ class AvataxPlugin(BasePlugin):
         if not checkout_line_info.product.charge_taxes:
             return base_total
 
-        if not _validate_checkout(checkout_info.checkout, [checkout_line_info.line]):
+        if not _validate_checkout(checkout_info, [checkout_line_info.line]):
             return base_total
 
-        taxes_data = get_checkout_tax_data(
-            checkout_info.checkout, discounts, self.config
-        )
+        taxes_data = get_checkout_tax_data(checkout_info, discounts, self.config)
         if not taxes_data or "error" in taxes_data:
             return base_total
 
@@ -377,7 +375,7 @@ class AvataxPlugin(BasePlugin):
         if not checkout_line_info.product.charge_taxes:
             return previous_value
         return self._calculate_unit_price(
-            checkout_info.checkout,
+            checkout_info,
             checkout_line_info.line,
             checkout_line_info.variant,
             previous_value,
@@ -401,7 +399,7 @@ class AvataxPlugin(BasePlugin):
 
     def _calculate_unit_price(
         self,
-        instance: Union["Checkout", "Order"],
+        instance: Union["CheckoutInfo", "Order"],
         line: Union["CheckoutLine", "OrderLine"],
         variant: "ProductVariant",
         base_value: TaxedMoney,
@@ -463,14 +461,14 @@ class AvataxPlugin(BasePlugin):
 
     def get_checkout_line_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
         previous_value: Decimal,
     ) -> Decimal:
         return self._get_unit_tax_rate(
-            checkout, previous_value, False, discounts, [checkout_line_info.line]
+            checkout_info, previous_value, False, discounts, [checkout_line_info.line]
         )
 
     def get_order_line_tax_rate(
@@ -484,14 +482,14 @@ class AvataxPlugin(BasePlugin):
 
     def get_checkout_shipping_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
         previous_value: Decimal,
     ):
         return self._get_shipping_tax_rate(
-            checkout,
+            checkout_info,
             previous_value,
             False,
             discounts,
@@ -503,7 +501,7 @@ class AvataxPlugin(BasePlugin):
 
     def _get_unit_tax_rate(
         self,
-        instance: Union["Order", "Checkout"],
+        instance: Union["Order", "CheckoutInfo"],
         base_rate: Decimal,
         is_order: bool,
         discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -522,7 +520,7 @@ class AvataxPlugin(BasePlugin):
 
     def _get_shipping_tax_rate(
         self,
-        instance: Union["Order", "Checkout"],
+        instance: Union["Order", "CheckoutInfo"],
         base_rate: Decimal,
         is_order: bool,
         discounts: Optional[Iterable[DiscountInfo]] = None,
@@ -544,7 +542,7 @@ class AvataxPlugin(BasePlugin):
 
     def _get_tax_data(
         self,
-        instance: Union["Order", "Checkout"],
+        instance: Union["Order", "CheckoutInfo"],
         base_value: Decimal,
         is_order: bool,
         discounts: Optional[Iterable[DiscountInfo]] = None,

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -244,7 +244,7 @@ class AvataxPlugin(BasePlugin):
 
     def calculate_checkout_shipping(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
@@ -258,10 +258,12 @@ class AvataxPlugin(BasePlugin):
         if self._skip_plugin(previous_value):
             return base_shipping_price
 
-        if not _validate_checkout(checkout, [line_info.line for line_info in lines]):
+        if not _validate_checkout(
+            checkout_info.checkout, [line_info.line for line_info in lines]
+        ):
             return base_shipping_price
 
-        response = get_checkout_tax_data(checkout, discounts, self.config)
+        response = get_checkout_tax_data(checkout_info.checkout, discounts, self.config)
         if not response or "error" in response:
             return base_shipping_price
 

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -368,17 +368,16 @@ class AvataxPlugin(BasePlugin):
 
     def calculate_checkout_line_unit_price(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        channel: "Channel",
         previous_value: TaxedMoney,
     ):
         if not checkout_line_info.product.charge_taxes:
             return previous_value
         return self._calculate_unit_price(
-            checkout,
+            checkout_info.checkout,
             checkout_line_info.line,
             checkout_line_info.variant,
             previous_value,

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[False].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[False].yaml
@@ -1,0 +1,77 @@
+interactions:
+- request:
+    body: '{"createTransactionModel": {"companyCode": "DEFAULT", "type": "SalesOrder",
+      "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
+      true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
+      "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
+      "description": null}], "code": "9a83989e-e9be-4eda-bf3a-601925f3b388", "date":
+      "2021-02-26", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
+      Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":
+      "92614"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
+      "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
+      "USD", "email": ""}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Basic Og==
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '761'
+      User-Agent:
+      - python-requests/2.25.1
+    method: POST
+    uri: https://rest.avatax.com/api/v2/transactions/createoradjust
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEA+1XbW/iRhD+K5E/B+Q3CPCNkosUKYUokJ501X1Y7AX2amy6u05DT/nv98y+OOaA
+        u7RVT6pUxAd7ZnZ25pnZZ8efA5EHo/AyyKqcB6NgyAbJcDDkHT5c8k7Kc9ZZrhLW6YfRMO6tkmUy
+        GARkvd2xcn+LtXEaD696l0HONDmIwzjqhHEn7sNsx/ZbXurrEyqlma4VFiz4dldJJvew1/sd+Ziz
+        gquZzLmEbMl0tpnY6GjnWkpeZnsneZxfQ8ifsw0r1/wBG01OGWS10tWWy0fF1nxhd6F1pRZ6/6h4
+        27+1/IWXeSWdPDQbW0VLxJ8Ru55WCBkGkmdVmYmCA5QVKxS/DIoqY1pU5at7yZGsFuX67ki1qyWy
+        UNwk/up0xSnfVoSK0Nlxqdp+daVZMd5WdamDUZJ2kyHQJNk7EyNK3EWRjeRaqMzavcoW7DkY9br9
+        yNngnS0L1KLtCsIJK7K6AMrI0Zqz/BOwpSo/cIaQgMW00mMjhZXB4LcWJE8IHIgEI2zVLtu71Ypn
+        WjzxU83SNsRKSoVvmSgs8NsqFyvB86OViygZ9fqjtN/tx/1hlMQfEI+3RtWl6d9BgtZG3uz52EEY
+        jsyfFhai5GjYXz/7I6MlKxVD0FVJjhAUmUzr7RKNOwoirHl73+VcZVLsyBnWLrjSFztZ5XWm4SZ3
+        JfMFNoWz3XdCNOFSu4AOO1SoW823TW21rNGjAiLXn1GcuDy919h20u81MycF/UDYS76KLPR4iv2T
+        a+wjEOES2Pp+wSN11lcbQHrcWiS05342tD/rioSUXy9JqadP1M3a3ZZZUefUezbTnGv0zLkS3qF2
+        DrXjwpoDA4oaBfd3cC752tbJvJ0oxKdaCuWCNzZGMGVborf72d14SrRFHMjHSol1yXN/4o2lo6jJ
+        dAEzI8mFaTSvoANsKLOsysUhpKY5pKHcsBsnIX5vq4DzPav1rqauA7LzeklSwiWYWZFLYq5ZmTOZ
+        XxDnWs241ptKglD9khTXAhXxiDQoOreb9wMXXupwm0NUl0LPVj8xJeiquOfSs/sjFNALNa3Ke6bU
+        YiPrhnaFuuEA2pFwQ7kOJ1oKb661Gy0cHRpYHD1fWx51aw9VWOa7u/EG2XHahWBLUTiAkM+cFwWo
+        4uXjZYAyUhp6I6t6vbluOhWqjW8k5JtVSt+WqgbzZPxGcrHegO9NOE9MNw0376Dus07nkTCEwnKS
+        L0v4cvlWDotpzzffnT+IpuYbsdvhCkVsRLieSiIDwytVmWvi71GV8aQPj5V1D2G7rt7QIX/zEMZh
+        FNK4QIaOp9KrQWoEZ6jxf54CjOZnUPKzyhn4HW+8jaU+cFn9RYYyJfVUhENKLlBPL3GVpoHgXyQn
+        22wNm/xDbrIpeSb7ipqM8gcyEwp9c56ZwHcszyVX6nuz1hJXIC6g/R1/4jQIfhC7nmMEGk4WPPuz
+        +oNdXDmZG1OIMBKoIc1AxHh6/zCb3I3fQ9Dc6njegWhZ4YrdS+j7h5a4a9eNATjjD2YSoPsxDntR
+        iDkS07HQGDvsJkVVrpvXb/Lu1/mMLQzYlWKmlGJAd/EzE+XFXEvO6f4j1dnMbuUT1LBqEpuM8XaQ
+        2jDuRymEr5mZO+MgszSMrtIQHxSt1JKk2x+kVxF95bVz7ETRVXfQi9LB0Nxrqt5u6duOxubXPU4M
+        UQdjTzPdGKmrwvk5CtEezB7BiCaPk9MVTM8TCDA+HHLa9OEJAEaOEuDLfiS50+pGrpNUdnRp4MJf
+        +PXmCNop0oyVeKdW+e/h5Yc5T7ktzLwK/dLg5kewb86qbeTsJ+f3oPv48gUbwmYU1hAAAA==
+    headers:
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 26 Feb 2021 13:56:46 GMT
+      Location:
+      - /api/v2/companies/242975/transactions/0
+      Server:
+      - Kestrel
+      ServerDuration:
+      - '00:00:00.0238854'
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[True].yaml
+++ b/saleor/plugins/avatax/tests/cassettes/test_calculate_checkout_line_unit_price[True].yaml
@@ -4,8 +4,8 @@ interactions:
       "lines": [{"quantity": 3, "amount": "30.00", "taxCode": "O9999999", "taxIncluded":
       true, "itemCode": "123", "description": "Test product"}, {"quantity": 1, "amount":
       "10.000", "taxCode": "FR020100", "taxIncluded": true, "itemCode": "Shipping",
-      "description": null}], "code": "868fdaa2-a02f-4695-8f7d-118edf742477", "date":
-      "2021-01-25", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
+      "description": null}], "code": "51772547-85b5-4fec-8c33-9bb3019aec71", "date":
+      "2021-02-26", "customerCode": 0, "addresses": {"shipFrom": {"line1": "2000 Main
       Street", "line2": "", "city": "Irvine", "region": "CA", "country": "US", "postalCode":
       "92614"}, "shipTo": {"line1": "T\u0119czowa 7", "line2": "", "city": "WROC\u0141AW",
       "region": "", "country": "PL", "postalCode": "53-601"}}, "commit": false, "currencyCode":
@@ -28,30 +28,30 @@ interactions:
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAEA+1X227jNhD9lUDPcaCbr2+uswECpHYQO10gxT4wEm1zK0sqSaVxF/n3PcOLLcfO
-        btqiCxSo4QdpOBzOnBmeGX0JRB6MwvMgq3IejIJBb7DMGYs7LIyXnbQ37HYGy37eiaIBz5f9NE77
-        /YC0NzUrt9fYG6fxsN89D3KmyUAcxlEnjDpxF2o12254qS9PLCnNdKOwYcE3dSWZ3EJfb2uyMWcF
-        VzOZcwnZI9PZemK9o5MbKXmZbZ3kfn4JIX/O1qxc8TscNDmlkDVKVxsu7xVb8YU9hfaVWujtveJt
-        +1bzF17mlXTy0BxsF1oi/gzf9bSCy1CQPKvKTBQcoCxZofh5UFQZ06Iq9+YlR7BalKubo6W6kYhC
-        cRP43uiSU7wtDxWhU3Op2nZ1pVkx3lRNqYNRkl4kQ6BJsg/GR6T4Akk2kkuhMqu3ly3YczDqXvQi
-        p4N39lggF21TEE5YkTUFUEaMVp3ln4EtZfmOM7gELKaVHhsptAwGv7UgeYLjQCQY4ah22j4slzzT
-        4omfKpa2InZSKHzDRGGB31S5WAqeH+1cRMkoGY6S/sUgSsIkiR7gj9dG1qWp30ESDWPEzZ6PDYTh
-        yPxpYyFKjoL99Yu/MlqyUjE4XZVkCE6RyrTZPKJwR0GEPe+vu5yrTIqajGHvgit9VssqbzINM7lL
-        mU+wSZytvhOiCZfaOXRYoUJda77Z5VbLBjUqIHL1GcWJi9NbjW0l/d4wc1NQD4S95MvIQo+n2D+5
-        wj4CESaBra8XPFJlvToA0uPSIqG997Oh/VlTJKT4uklKNX0ib1bvusyKJqfas5HmXKNm3krhDXLn
-        UDtOrLkwoKhRcHsD45KvbJ7M24lEfG6kUM55o2MEU7Yherud3YynRFvEgXyslFiVPPc33mg6ippM
-        F1AzklyYQvMLdIENZZZVuTiE1BSHNJQbXsRJiN/7MuBszxpdN1R1QHbePJKUcAlmVuSCmGtW5kzm
-        Z8S5dmXc6HUlQah+S4q2QEk8Ig3yzp3m7cCElzrc5hA1pdCz5U9MCWoVt1x6dr/HAtaFmlblLVNq
-        sZbNjnaFuuIA2pHwjnIdTrQV1lxp71Zh6FDB4uj52vKo23u4hG2+unfWIDsOuxDsURQOIMQz50UB
-        qnj5dB4gjRSGXsuqWa0vd5WKpbUvJMSbVUpfl6oB82T8SnKxWoPvjTtPTO8Kbt5B3medzj1hiAXL
-        ST4t4cv5ezkspjPf3Tt/EE3N16Ku0ULhGxGup5LIwLCnKtMm/h5VGUv68FpZ8xC28+oVHfJXd2Ec
-        RiGNC6ToeCrtD1IjeIMa/+cpwGh+BiU/q7wBv+ON97HUA5fVX2Qok1JPRbikZAL59BKXaRoI/kVy
-        ssW2Y5N/yE02JM9kr6jJLP5AZkKir95mJvAdy3PJlfrerPWIFogGtL3hT5wGwQdR0ycHMQINJwue
-        /Vn9wc7oa4VkbkyhxwTLkGYgYjx9vJtNbsYfIdh1dTzXIFpWuGR3k04vNOOca7tuDMAdvzOTAPXH
-        OOxGIeZITMdCY+ywhxRVudq9fpN3X8cztjA49ymkGNCd/cxEeTbXknPqf9+M7Fo+Idp2YJPx69CG
-        cS9KIdwPOKZnHESWhlE/DfFB0QotSS56g7Qf9ciJVoz4UMS03Y3SwdD0NdVsNvRtR2Pz/owTQ9TB
-        2LObbozUZeHtOQreHswewYgmj5PTFVTfJhBgfDjktOnDEwCUHCXAlv1IcrfVjVwnqeyoaaDhL/x+
-        cwXtFGnGSrxTqfz38PLDnKfcFmZ+CfWyw82PYN+cVdvI2U/O70H36eUruNPNQtYQAAA=
+        H4sIAAAAAAAEA+1X227bRhD9FYPPlsCrbm+qHAMGXMmw5AZIkYcVuZI2pUh1d+naDfLvObMXmbKk
+        xG3RAAUq6IGcmZ2dOTN7dvg5EEUwCi+DvC54MAqyqN+Ps7TfGWTLrJOueN4Z5EnSGS6XSRgNGc/7
+        UUDW2x2rnm+wNk7jYT+7DAqmyUEcxlEnjDtxD2Y79rzllb46oVKa6UZhwYJvd7Vk8hn2+nlHPuas
+        5GomCy4hWzKdbyY2Otq5kZJX+bOTPMyvIORP+YZVa36PjSanDPJG6XrL5YNia76wu9C6Sgv9/KB4
+        27+1/IVXRS2dPDQbW0VLxJ8Qu57WCBkGkud1lYuSA5QVKxW/DMo6Z1rU1Yt7yZGsFtX69ki1aySy
+        UNwk/uJ0xSnfVoSK0Nlxqdp+da1ZOd7WTaWDUZJ2kyHQJNk7EyNK3EWRjeRKqNzavcgW7CkYZd1e
+        5GzwzpYlatF2BeGElXlTAmXkaM1Z8QnYUpXvOUNIwGJa67GRwspg8FsLkkcEDkSCEbZql+3dCr2m
+        xSM/1SxtQ6ykVPiWidICv60LsRK8OFq5iJJR1hulvW6Whf1BFn9APN4aVZemfwdJNIyRN3s6dhCG
+        I/OnhaWoOBr218/+yGjJKsUQdF2RIwRFJtNmu0TjjgJzTt7cdwVXuRQ7coa1C670xU7WRZNrbF24
+        kvkCm8LZ7jshmnCpXUCHHSrUjebbfW21bNCjAiLXn1GcuDy919h20u8NMycF/UDYS76KLPR4iv2T
+        a+wjEOES2Pp+wSN11qsNID1uLRLacz8b2p91RULKL0tS6ukTdbN2N1VeNgX1ns204Bo9c66Et6id
+        Q+24sObAgKJGwd0tnEu+tnUybycK8amRQrngjY0RTNmW6O1udjueEm0RB/KxUmJd8cKfeGPpKGoy
+        XcDMSAphGs0r6AAbyqzqanEIqWkOaSg37MZJiN/bKuB8zxq9a6jrgOy8WZKUcAlmVuSSmGtWFUwW
+        F8S5VjNu9KaWIFS/JMW1QEU8Ig2Kzu3m/cCFlzrc5hA1ldCz1U9MCboq7rj07P4ABfRCTevqjim1
+        2MhmT7tCXXMA7Uh4T7kOJ1oKb66191o4OjSwOHq+tjzq1h6qsMx3994bZMdpl4ItRekAQj5zXpag
+        ii8fLwOUkdLQG1k3683VvlOh2vhGQr55rfRNpRowT86vJRfrDfjehPPI9L7h5h3UfdbpPBCGUFhO
+        8mUJv1y+lcNi2vPtHPZjaGq+EbsdrlDERoTrqSQyMLxQlbkm/h5VGU/68FhZ9xC26+oNHfLX92Ec
+        RiGNC2ToeCrtD1IjOEON//MUYDQ/g5KfVc7A73jjbSz1gcv6LzKUKamnIhxScoF6eomrNA0E/yI5
+        2Wbbs8k/5CabkmeyV9RklD+QmVDo6/PMBL5jRSG5Ut+btZa4AnEBPd/yR06D4Aexyxwj0HCy4Pmf
+        9R/sou9kbkwhwkighjQHEePp/f1scjt+D8H+VsfzDkTLSlfsLOn0QvvZY69dNwbgjN+bSYDuxzjM
+        ohBzJKZjoTF22E3KulrvX7/Ju6/zGVsYXPiUUgzoLn5morqYa8k53X+UztnMbuQj1O3EJuPXqQ3j
+        XpRC+DLgmDvjILM0jPppiA+KVmpJ0u0N0n5EX3ntHDtR1O8OsigdDM29pprtlr7taGx+2ePEEHUw
+        9uynGyN1VTg/RyHag9kjGNHkcXK6gul5AgHGh0NOmz48AcDIUQJ82Y8kd1rdyHWSyo4uDVz4C7/e
+        HEE7RZqxEu/UKv89vPww5ym3hZlXoV/2uPkR7Juzahs5+8n5Peg+fvkKHVbWiNYQAAA=
     headers:
       Connection:
       - keep-alive
@@ -60,13 +60,13 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Mon, 25 Jan 2021 13:39:37 GMT
+      - Fri, 26 Feb 2021 13:56:46 GMT
       Location:
       - /api/v2/companies/242975/transactions/0
       Server:
       - Kestrel
       ServerDuration:
-      - '00:00:00.0267833'
+      - '00:00:00.0235982'
       Transfer-Encoding:
       - chunked
       Vary:

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -305,8 +305,9 @@ def test_calculate_checkout_shipping(
     checkout_with_item.shipping_method = shipping_zone.shipping_methods.get()
     checkout_with_item.save()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
     shipping_price = manager.calculate_checkout_shipping(
-        checkout_with_item, lines, address, [discount_info]
+        checkout_info, lines, address, [discount_info]
     )
     shipping_price = quantize_price(shipping_price, shipping_price.currency)
     assert shipping_price == TaxedMoney(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -11,6 +11,7 @@ from requests import RequestException
 
 from ....account.models import Address
 from ....checkout.fetch import (
+    CheckoutInfo,
     CheckoutLineInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
@@ -652,10 +653,20 @@ def test_get_checkout_line_tax_rate(
         product=variant.product,
         collections=[],
     )
+    checkout_info = CheckoutInfo(
+        checkout=checkout_with_item,
+        shipping_method=checkout_with_item.shipping_method,
+        shipping_address=address,
+        billing_address=None,
+        channel=checkout_with_item.channel,
+        user=None,
+        shipping_method_channel_listings=None,
+        valid_shipping_methods=[],
+    )
 
     # when
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -692,10 +703,11 @@ def test_get_checkout_line_tax_rate_checkout_not_valid_default_value_returned(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     # when
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -733,10 +745,11 @@ def test_get_checkout_line_tax_rate_error_in_response(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     # when
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -871,10 +884,20 @@ def test_get_checkout_shipping_tax_rate(
         product=variant.product,
         collections=[],
     )
+    checkout_info = CheckoutInfo(
+        checkout=checkout_with_item,
+        shipping_method=checkout_with_item.shipping_method,
+        shipping_address=address,
+        billing_address=None,
+        channel=checkout_with_item.channel,
+        user=None,
+        shipping_method_channel_listings=None,
+        valid_shipping_methods=[],
+    )
 
     # when
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [],
@@ -911,10 +934,11 @@ def test_get_checkout_shipping_tax_rate_checkout_not_valid_default_value_returne
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     # when
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [],
@@ -952,10 +976,11 @@ def test_get_checkout_shipping_tax_rate_error_in_response(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     # when
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [],
@@ -997,10 +1022,11 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     # when
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [],

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -445,7 +445,8 @@ def test_calculate_checkout_line_unit_price(
         net=Money("10.00", "USD") * 3, gross=Money("10.00", "USD") * 3
     )
 
-    checkout_line = fetch_checkout_lines(checkout_with_item)[0]
+    lines = fetch_checkout_lines(checkout_with_item)
+    checkout_line = lines[0]
     product = checkout_line.variant.product
     product.charge_taxes = charge_taxes
     product.save(update_fields=["charge_taxes"])
@@ -458,20 +459,18 @@ def test_calculate_checkout_line_unit_price(
     checkout.shipping_method = method
     checkout.save()
 
-    channel = checkout.channel
-
     site_settings.company_address = address_usa
     site_settings.include_taxes_in_prices = True
     site_settings.save()
 
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     line_price = manager.calculate_checkout_line_unit_price(
         total_price,
         checkout_line.line.quantity,
-        checkout,
+        checkout_info,
         checkout_line,
         checkout.shipping_address,
         [],
-        channel,
     )
     line_price = quantize_price(line_price, line_price.currency)
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -180,7 +180,7 @@ class BasePlugin:
 
     def calculate_checkout_shipping(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: List["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: List["DiscountInfo"],

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -221,11 +221,10 @@ class BasePlugin:
 
     def calculate_checkout_line_unit_price(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        channel: "Channel",
         previous_value: TaxedMoney,
     ):
         """Calculate checkout line unit price."""

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -249,7 +249,7 @@ class BasePlugin:
 
     def get_checkout_line_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
@@ -268,7 +268,7 @@ class BasePlugin:
 
     def get_checkout_shipping_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -130,7 +130,7 @@ class PluginsManager(PaymentInterface):
                 checkout_info, lines, address, discounts
             ),
             shipping_price=self.calculate_checkout_shipping(
-                checkout_info.checkout, lines, address, discounts
+                checkout_info, lines, address, discounts
             ),
             discount=checkout_info.checkout.discount,
             currency=checkout_info.checkout.currency,
@@ -180,22 +180,24 @@ class PluginsManager(PaymentInterface):
 
     def calculate_checkout_shipping(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
     ) -> TaxedMoney:
-        default_value = base_calculations.base_checkout_shipping_price(checkout, lines)
+        default_value = base_calculations.base_checkout_shipping_price(
+            checkout_info.checkout, lines
+        )
         return quantize_price(
             self.__run_method_on_plugins(
                 "calculate_checkout_shipping",
                 default_value,
-                checkout,
+                checkout_info,
                 lines,
                 address,
                 discounts,
             ),
-            checkout.currency,
+            checkout_info.checkout.currency,
         )
 
     def calculate_order_shipping(self, order: "Order") -> TaxedMoney:

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -186,7 +186,7 @@ class PluginsManager(PaymentInterface):
         discounts: Iterable[DiscountInfo],
     ) -> TaxedMoney:
         default_value = base_calculations.base_checkout_shipping_price(
-            checkout_info.checkout, lines
+            checkout_info, lines
         )
         return quantize_price(
             self.__run_method_on_plugins(

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -219,7 +219,7 @@ class PluginsManager(PaymentInterface):
 
     def get_checkout_shipping_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
@@ -229,7 +229,7 @@ class PluginsManager(PaymentInterface):
         return self.__run_method_on_plugins(
             "get_checkout_shipping_tax_rate",
             default_value,
-            checkout,
+            checkout_info,
             lines,
             address,
             discounts,
@@ -312,7 +312,7 @@ class PluginsManager(PaymentInterface):
 
     def get_checkout_line_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable[DiscountInfo],
@@ -322,7 +322,7 @@ class PluginsManager(PaymentInterface):
         return self.__run_method_on_plugins(
             "get_checkout_line_tax_rate",
             default_value,
-            checkout,
+            checkout_info,
             checkout_line_info,
             address,
             discounts,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -269,11 +269,10 @@ class PluginsManager(PaymentInterface):
         self,
         total_line_price: TaxedMoney,
         quantity: int,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        channel: "Channel",
     ):
         default_value = base_calculations.base_checkout_line_unit_price(
             total_line_price, quantity
@@ -282,11 +281,10 @@ class PluginsManager(PaymentInterface):
             self.__run_method_on_plugins(
                 "calculate_checkout_line_unit_price",
                 default_value,
-                checkout,
+                checkout_info,
                 checkout_line_info,
                 address,
                 discounts,
-                channel,
             ),
             total_line_price.currency,
         )

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -181,7 +181,7 @@ class PluginSample(BasePlugin):
 
     def get_checkout_line_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
@@ -200,7 +200,7 @@ class PluginSample(BasePlugin):
 
     def get_checkout_shipping_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -103,14 +103,13 @@ class PluginSample(BasePlugin):
 
     def calculate_checkout_line_unit_price(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        channel: "Channel",
         previous_value: TaxedMoney,
     ):
-        currency = checkout.currency
+        currency = checkout_info.checkout.currency
         price = Money("10.0", currency)
         return TaxedMoney(price, price)
 

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -81,9 +81,9 @@ class PluginSample(BasePlugin):
         return TaxedMoney(subtotal, subtotal)
 
     def calculate_checkout_shipping(
-        self, checkout, lines, address, discounts, previous_value
+        self, checkout_info, lines, address, discounts, previous_value
     ):
-        price = Money("1.0", currency=checkout.currency)
+        price = Money("1.0", currency=checkout_info.checkout.currency)
         return TaxedMoney(price, price)
 
     def calculate_order_shipping(self, order, previous_value):

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -45,7 +45,7 @@ def test_manager_calculates_checkout_total(
     expected_total = Money(total_amount, currency)
     manager = PluginsManager(plugins=plugins)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
     taxed_total = manager.calculate_checkout_total(
         checkout_info, lines, None, [discount_info]
     )
@@ -62,7 +62,7 @@ def test_manager_calculates_checkout_subtotal(
     currency = checkout_with_item.currency
     expected_subtotal = Money(subtotal_amount, currency)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
     taxed_subtotal = PluginsManager(plugins=plugins).calculate_checkout_subtotal(
         checkout_info, lines, None, [discount_info]
     )
@@ -152,9 +152,12 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [discount_info]
+    )
 
     tax_rate = PluginsManager(plugins=plugins).get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [discount_info],
@@ -182,8 +185,11 @@ def test_manager_get_checkout_line_tax_rate_no_plugins(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [discount_info]
+    )
     tax_rate = PluginsManager(plugins=[]).get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [discount_info],
@@ -244,9 +250,12 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [discount_info]
+    )
 
     tax_rate = PluginsManager(plugins=plugins).get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [discount_info],
@@ -274,8 +283,12 @@ def test_manager_get_checkout_shipping_tax_rate_no_plugins(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [discount_info]
+    )
+
     tax_rate = PluginsManager(plugins=[]).get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [discount_info],

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -79,8 +79,9 @@ def test_manager_calculates_checkout_shipping(
     currency = checkout_with_item.currency
     expected_shipping_price = Money(shipping_amount, currency)
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
     taxed_shipping_price = PluginsManager(plugins=plugins).calculate_checkout_shipping(
-        checkout_with_item, lines, None, [discount_info]
+        checkout_info, lines, None, [discount_info]
     )
     assert (
         TaxedMoney(expected_shipping_price, expected_shipping_price)

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -348,15 +348,15 @@ def test_manager_calculates_checkout_line_unit_price(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     taxed_total = PluginsManager(plugins=plugins).calculate_checkout_line_unit_price(
         total_line_price,
         quantity,
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         address,
         [],
-        channel,
     )
     currency = total_line_price.net.currency
     expected_net = Money(

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -191,11 +191,10 @@ class VatlayerPlugin(BasePlugin):
 
     def calculate_checkout_line_unit_price(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
-        channel: "Channel",
         previous_value: TaxedMoney,
     ) -> TaxedMoney:
         unit_price = self.__calculate_checkout_line_unit_price(
@@ -204,7 +203,7 @@ class VatlayerPlugin(BasePlugin):
             checkout_line_info.variant,
             checkout_line_info.product,
             checkout_line_info.collections,
-            channel,
+            checkout_info.channel,
             checkout_line_info.channel_listing,
             previous_value,
         )

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -128,7 +128,7 @@ class VatlayerPlugin(BasePlugin):
 
     def calculate_checkout_shipping(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: List["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: List["DiscountInfo"],
@@ -141,10 +141,10 @@ class VatlayerPlugin(BasePlugin):
         taxes = None
         if address:
             taxes = self._get_taxes_for_country(address.country)
-        if not checkout.shipping_method:
+        if not checkout_info.shipping_method:
             return previous_value
-        shipping_price = checkout.shipping_method.channel_listings.get(
-            channel_id=checkout.channel_id
+        shipping_price = checkout_info.shipping_method.channel_listings.get(
+            channel_id=checkout_info.channel.id
         ).price
         return get_taxed_shipping_price(shipping_price, taxes)
 

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -141,11 +141,12 @@ class VatlayerPlugin(BasePlugin):
         taxes = None
         if address:
             taxes = self._get_taxes_for_country(address.country)
-        if not checkout_info.shipping_method:
+        if (
+            not checkout_info.shipping_method
+            or not checkout_info.shipping_method_channel_listings
+        ):
             return previous_value
-        shipping_price = checkout_info.shipping_method.channel_listings.get(
-            channel_id=checkout_info.channel.id
-        ).price
+        shipping_price = checkout_info.shipping_method_channel_listings.price
         return get_taxed_shipping_price(shipping_price, taxes)
 
     def calculate_order_shipping(

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -248,7 +248,7 @@ class VatlayerPlugin(BasePlugin):
 
     def get_checkout_line_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         checkout_line_info: "CheckoutLineInfo",
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],
@@ -280,7 +280,7 @@ class VatlayerPlugin(BasePlugin):
 
     def get_checkout_shipping_tax_rate(
         self,
-        checkout: "Checkout",
+        checkout_info: "CheckoutInfo",
         lines: Iterable["CheckoutLineInfo"],
         address: Optional["Address"],
         discounts: Iterable["DiscountInfo"],

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -103,7 +103,7 @@ class VatlayerPlugin(BasePlugin):
             )
             + calculations.checkout_shipping_price(
                 manager=manager,
-                checkout=checkout_info.checkout,
+                checkout_info=checkout_info,
                 lines=lines,
                 address=address,
                 discounts=discounts,

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -435,15 +435,15 @@ def test_calculate_checkout_line_unit_price(
         product=line.variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     line_price = manager.calculate_checkout_line_unit_price(
         total_price,
         line.quantity,
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         address,
         [],
-        channel,
     )
 
     assert line_price == TaxedMoney(

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -652,8 +652,9 @@ def test_get_checkout_line_tax_rate(
         collections=[],
     )
 
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -688,9 +689,10 @@ def test_get_checkout_line_tax_rate_order_not_valid(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     tax_rate = manager.get_checkout_line_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -784,9 +786,10 @@ def test_get_checkout_shipping_tax_rate(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         [checkout_line_info],
         checkout_with_item.shipping_address,
         [],
@@ -821,9 +824,10 @@ def test_get_checkout_shipping_tax_rate_no_address(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],
@@ -865,9 +869,10 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
         product=variant.product,
         collections=[],
     )
+    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
-        checkout_with_item,
+        checkout_info,
         checkout_line_info,
         checkout_with_item.shipping_address,
         [],

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -594,9 +594,10 @@ def test_calculations_checkout_shipping_price_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     checkout_shipping_price = calculations.checkout_shipping_price(
         manager=manager,
-        checkout=checkout_with_item,
+        checkout_info=checkout_info,
         lines=lines,
         address=checkout_with_item.shipping_address,
     )


### PR DESCRIPTION
Use `CheckoutInfo` in the following plugins methods:
- `calculate_checkout_shipping`
- `get_checkout_shipping_tax_rate`
- `calculate_checkout_line_unit_price`
- `get_checkout_line_tax_rate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
