### PR TITLE
update the way of calculating the order discount

### DIFF
--- a/saleor/graphql/order/tests/test_discount_order.py
+++ b/saleor/graphql/order/tests/test_discount_order.py
@@ -135,7 +135,7 @@ def test_add_percentage_order_discount_to_order(
 ):
     total_before_order_discount = draft_order.total
     reason = "The reason of the discount"
-    value = Decimal("10")
+    value = Decimal("10.000")
     variables = {
         "orderId": graphene.Node.to_global_id("Order", draft_order.pk),
         "input": {
@@ -152,7 +152,9 @@ def test_add_percentage_order_discount_to_order(
     draft_order.refresh_from_db()
 
     discount = partial(percentage_discount, percentage=value)
-    expected_total = discount(total_before_order_discount)
+    expected_net_total = discount(total_before_order_discount.net)
+    expected_gross_total = discount(total_before_order_discount.gross)
+    expected_total = TaxedMoney(expected_net_total, expected_gross_total)
 
     errors = data["orderErrors"]
     assert len(errors) == 0
@@ -212,7 +214,7 @@ def test_update_percentage_order_discount_to_order(
     current_undiscounted_total = draft_order.undiscounted_total
 
     reason = "The reason of the discount"
-    value = Decimal("10")
+    value = Decimal("10.000")
     variables = {
         "discountId": graphene.Node.to_global_id("OrderDiscount", order_discount.pk),
         "input": {
@@ -229,7 +231,9 @@ def test_update_percentage_order_discount_to_order(
     draft_order.refresh_from_db()
 
     discount = partial(percentage_discount, percentage=value)
-    expected_total = discount(current_undiscounted_total)
+    expected_net_total = discount(current_undiscounted_total.net)
+    expected_gross_total = discount(current_undiscounted_total.gross)
+    expected_total = TaxedMoney(expected_net_total, expected_gross_total)
 
     errors = data["orderErrors"]
     assert len(errors) == 0
@@ -262,7 +266,7 @@ def test_update_fixed_order_discount_to_order(
     order_discount = draft_order_with_fixed_discount_order.discounts.get()
     current_undiscounted_total = draft_order.undiscounted_total
 
-    value = Decimal("50")
+    value = Decimal("50.000")
     variables = {
         "discountId": graphene.Node.to_global_id("OrderDiscount", order_discount.pk),
         "input": {

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -514,6 +514,17 @@ def order_discount_event(
     )
 
 
+def order_discounts_automatically_updated_event(
+    order: Order, changed_order_discounts: List[Tuple["OrderDiscount", "OrderDiscount"]]
+):
+    for previous_order_discount, current_order_discount in changed_order_discounts:
+        order_discount_automatically_updated_event(
+            order=order,
+            order_discount=current_order_discount,
+            old_order_discount=previous_order_discount,
+        )
+
+
 def order_discount_automatically_updated_event(
     order: Order, order_discount: "OrderDiscount", old_order_discount: "OrderDiscount"
 ):


### PR DESCRIPTION
I want to merge this change because it introduces the proper way of calculating the percentage discount when the price has taxes

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
