### PR TITLE
Add `check_for_duplicates` validator

### DIFF
--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -1077,7 +1077,7 @@ def test_permission_group_update_mutation_user_in_list_to_add_and_remove(
 
     assert len(errors) == 1
     assert errors[0]["code"] == PermissionGroupErrorCode.DUPLICATED_INPUT_ITEM.name
-    assert errors[0]["field"] is None
+    assert errors[0]["field"] == "users"
     assert errors[0]["permissions"] is None
     assert errors[0]["users"] == [staff_user2_id]
 
@@ -1124,7 +1124,7 @@ def test_permission_group_update_mutation_permissions_in_list_to_add_and_remove(
 
     assert len(errors) == 1
     assert errors[0]["code"] == PermissionGroupErrorCode.DUPLICATED_INPUT_ITEM.name
-    assert errors[0]["field"] is None
+    assert errors[0]["field"] == "permissions"
     assert set(errors[0]["permissions"]) == set(permissions)
     assert errors[0]["users"] is None
 
@@ -1180,7 +1180,7 @@ def test_permission_group_update_mutation_permissions_and_users_duplicated(
     assert {error["code"] for error in errors} == {
         PermissionGroupErrorCode.DUPLICATED_INPUT_ITEM.name
     }
-    assert {error["field"] for error in errors} == {None}
+    assert {error["field"] for error in errors} == {"users", "permissions"}
     assert set(permissions) in [
         set(error["permissions"]) if error["permissions"] else None for error in errors
     ]

--- a/saleor/graphql/utils/validators.py
+++ b/saleor/graphql/utils/validators.py
@@ -1,0 +1,25 @@
+from django.core.exceptions import ValidationError
+
+from ..core.utils import get_duplicates_ids
+
+
+def check_for_duplicates(
+    input_data: dict, add_field: str, remove_field: str, error_class_field: str
+):
+    """Check if any items are on both input field.
+
+    Raise error if some of items are duplicated.
+    """
+    error = None
+    duplicated_ids = get_duplicates_ids(
+        input_data.get(add_field), input_data.get(remove_field)
+    )
+    if duplicated_ids:
+        # add error
+        error_msg = (
+            "The same object cannot be in both list" "for adding and removing items."
+        )
+        params = {error_class_field: list(duplicated_ids)}
+        error = ValidationError(message=error_msg, params=params)
+
+    return error


### PR DESCRIPTION
Add validator for checking duplicates for `add` and `remove` lists. Get rid of duplicates in code.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
