### PR TITLE
Add optional support for reporting resource limits via a stub field in shop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix variant resolver on `DigitalContent` - #6983 by @fowczarek
 - Fix race condition on `send_fulfillment-confirmation` - #6988 by @fowczarek
 - Fix resolver by id and slug for product and product variant - #6985 by @d-wysocki
+- Add optional support for reporting resource limits via a stub field in `shop` - #6967 by @NyanKiyoshi
+
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2328,6 +2328,19 @@ type LanguageDisplay {
   language: String!
 }
 
+type LimitInfo {
+  currentUsage: Limits!
+  allowedUsage: Limits!
+}
+
+type Limits {
+  channels: Int
+  orders: Int
+  productVariants: Int
+  staffUsers: Int
+  warehouses: Int
+}
+
 type Manifest {
   identifier: String!
   version: String!
@@ -5049,6 +5062,7 @@ type Shop {
   companyAddress: Address
   customerSetPasswordUrl: String
   staffNotificationRecipients: [StaffNotificationRecipient]
+  limits: LimitInfo!
   version: String!
 }
 

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -26,6 +26,21 @@ COUNTRIES_QUERY = """
     }
 """
 
+LIMIT_INFO_QUERY = """
+    {
+      shop {
+        limits {
+          currentUsage {
+            channels
+          }
+          allowedUsage {
+            channels
+          }
+        }
+      }
+    }
+"""
+
 
 def test_query_countries(user_api_client):
     response = user_api_client.post_graphql(COUNTRIES_QUERY % {"attributes": ""})
@@ -1297,3 +1312,25 @@ def test_version_query_as_staff_user(staff_api_client):
     response = staff_api_client.post_graphql(API_VERSION_QUERY)
     content = get_graphql_content(response)
     assert content["data"]["shop"]["version"] == __version__
+
+
+def test_cannot_get_shop_limit_info_when_not_staff(user_api_client):
+    query = LIMIT_INFO_QUERY
+    response = user_api_client.post_graphql(query)
+    assert_no_permission(response)
+
+
+def test_get_shop_limit_info_returns_null_by_default(staff_api_client):
+    query = LIMIT_INFO_QUERY
+    response = staff_api_client.post_graphql(query)
+    content = get_graphql_content(response)
+    assert content == {
+        "data": {
+            "shop": {
+                "limits": {
+                    "currentUsage": {"channels": None},
+                    "allowedUsage": {"channels": None},
+                }
+            }
+        }
+    }

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -77,8 +77,16 @@ class Limits(graphene.ObjectType):
 
 
 class LimitInfo(graphene.ObjectType):
-    current_usage = graphene.Field(Limits, required=True)
-    allowed_usage = graphene.Field(Limits, required=True)
+    current_usage = graphene.Field(
+        Limits,
+        required=True,
+        description="Defines the current resource usage.",
+    )
+    allowed_usage = graphene.Field(
+        Limits,
+        required=True,
+        description="Defines the allowed maximum resource usage, null means unlimited.",
+    )
 
 
 class Shop(graphene.ObjectType):


### PR DESCRIPTION
Allows a Saleor instance to specify custom maximum and current usage of limitations, does nothing out of the box apart from returning `null` (i.e. unlimited).


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
