### PR TITLE
Fix total count on connection resolver without first or last

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Deprecate API fields `Order.discount`, `Order.discountName`, `Order.translatedDiscountName` - #6874 by @korycins
 - Fix argument validation in page resolver - #6960 by @fowczarek
 - Drop `data` field from checkout line model - #6961 by @fowczarek
+- Fix `totalCount` on connection resolver without `first` or `last` - #6975 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -159,6 +159,10 @@ def _get_edges_for_connection(edge_type, qs, args, sorting_fields):
     cursor = after or before
     requested_count = first or last
 
+    # If we don't receive `first` and `last` we shouldn't build `edges` and `page_info`
+    if not first and not last:
+        return [], {}
+
     if last:
         start_slice, end_slice = 1, None
     else:


### PR DESCRIPTION
I want to merge this change because fixing the total count on connection resolver without first or last.

Currently, if a user sends a request for `totalCount` for any `ConnectionField` we unnecessary build `edges` and `pageInfo` for QS with all objects from the database. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
