### PR TITLE
Fix total count on connection resolver without first or last to 2.11

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,11 +31,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: "3.8"
-
     - name: Install system dependencies
       run: apt-get install -y libpq-dev
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable, unreleased changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+- Fix total count on connection resolver without first or last - #6976 by @fowczarek
+
 # 2.11.8
 
 - Deprecate `Shop.geolocalization` query - #6828 by @maarcingebala

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -158,6 +158,10 @@ def _get_edges_for_connection(edge_type, qs, args, sorting_fields):
     cursor = after or before
     requested_count = first or last
 
+    # If we don't receive `first` and `last` we shouldn't build `edges` and `page_info`
+    if not first and not last:
+        return [], {}
+
     if last:
         start_slice, end_slice = 1, None
     else:
@@ -218,7 +222,10 @@ def connection_from_queryset_slice(
     qs = qs[:end_margin]
     edges, page_info = _get_edges_for_connection(edge_type, qs, args, sorting_fields)
 
-    return connection_type(edges=edges, page_info=pageinfo_type(**page_info),)
+    return connection_type(
+        edges=edges,
+        page_info=pageinfo_type(**page_info),
+    )
 
 
 class NonNullConnection(Connection):


### PR DESCRIPTION
I want to merge this change because fixing the total count on connection resolver without first or last.

Currently, if a user sends a request for `totalCount` for any `ConnectionField` we unnecessary build `edges` and `pageInfo` for QS with all objects from the database.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
