### PR TITLE
Add Shop.version field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Change the `app` query to return info about the currently authenticated app - #6928 by @d-wysocki
 - Add default sorting by rank for search products - #6936 by @d-wysocki
 - Fix exporting product description to xlsx - #6959 by @IKarbowiak
+- Add `Shop.version` field to query API version - #6980 by @maarcingebala
 
 # 2.11.1
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5049,6 +5049,7 @@ type Shop {
   companyAddress: Address
   customerSetPasswordUrl: String
   staffNotificationRecipients: [StaffNotificationRecipient]
+  version: String!
 }
 
 type ShopAddressUpdate {

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -4,6 +4,7 @@ import graphene
 import pytest
 from django_countries import countries
 
+from .... import __version__
 from ....account.models import Address
 from ....core.error_codes import ShopErrorCode
 from ....core.permissions import get_permissions_codename
@@ -1265,3 +1266,34 @@ def test_order_settings_query_as_staff(
 def test_order_settings_query_as_user(user_api_client, site_settings):
     response = user_api_client.post_graphql(ORDER_SETTINGS_QUERY)
     assert_no_permission(response)
+
+
+API_VERSION_QUERY = """
+    query {
+        shop {
+            version
+        }
+    }
+"""
+
+
+def test_version_query_as_anonymous_user(api_client):
+    response = api_client.post_graphql(API_VERSION_QUERY)
+    assert_no_permission(response)
+
+
+def test_version_query_as_customer(user_api_client):
+    response = user_api_client.post_graphql(API_VERSION_QUERY)
+    assert_no_permission(response)
+
+
+def test_version_query_as_app(app_api_client):
+    response = app_api_client.post_graphql(API_VERSION_QUERY)
+    content = get_graphql_content(response)
+    assert content["data"]["shop"]["version"] == __version__
+
+
+def test_version_query_as_staff_user(staff_api_client):
+    response = staff_api_client.post_graphql(API_VERSION_QUERY)
+    content = get_graphql_content(response)
+    assert content["data"]["shop"]["version"] == __version__

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -7,6 +7,7 @@ from django_countries import countries
 from django_prices_vatlayer.models import VAT
 from phonenumbers import COUNTRY_CODE_TO_REGION_CODE
 
+from ... import __version__
 from ...account import models as account_models
 from ...core.permissions import SitePermissions, get_permissions
 from ...plugins.manager import get_plugins_manager
@@ -18,7 +19,7 @@ from ..core.connection import CountableDjangoObjectType
 from ..core.enums import WeightUnitsEnum
 from ..core.types.common import CountryDisplay, LanguageDisplay, Permission
 from ..core.utils import str_to_enum
-from ..decorators import permission_required
+from ..decorators import permission_required, staff_member_or_app_required
 from ..menu.dataloaders import MenuByIdLoader
 from ..menu.types import Menu
 from ..shipping.types import ShippingMethod
@@ -170,6 +171,7 @@ class Shop(graphene.ObjectType):
         description="List of staff notification recipients.",
         required=False,
     )
+    version = graphene.String(description="Saleor API version.", required=True)
 
     class Meta:
         description = (
@@ -333,3 +335,8 @@ class Shop(graphene.ObjectType):
     @permission_required(SitePermissions.MANAGE_SETTINGS)
     def resolve_staff_notification_recipients(_, info):
         return account_models.StaffNotificationRecipient.objects.all()
+
+    @staticmethod
+    @staff_member_or_app_required
+    def resolve_version(_, _info):
+        return __version__


### PR DESCRIPTION
This PR adds `Shop.version` field to query the currently running API version. The field is restricted to staff users and apps.

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
