### PR TITLE
Update logic to use shipping zones available in given chnnel in product module

### DIFF
--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -62,6 +62,7 @@ class ChannelCreate(ModelMutation):
         return cleaned_input
 
     @classmethod
+    @transaction.atomic
     def _save_m2m(cls, info, instance, cleaned_data):
         super()._save_m2m(info, instance, cleaned_data)
         shipping_zones = cleaned_data.get("add_shipping_zones")
@@ -115,6 +116,7 @@ class ChannelUpdate(ModelMutation):
         return cleaned_input
 
     @classmethod
+    @transaction.atomic
     def _save_m2m(cls, info, instance, cleaned_data):
         super()._save_m2m(info, instance, cleaned_data)
         add_shipping_zones = cleaned_data.get("add_shipping_zones")

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -257,6 +257,68 @@ def test_get_product_variant_channel_listing_as_anonymous(
     assert_no_permission(response)
 
 
+QUERY_PRODUCT_VARIANT_STOCKS = """
+    query ProductVariantDetails($id: ID!, $channel: String) {
+        productVariant(id: $id, channel: $channel) {
+            id
+            stocks{
+                id
+                quantity
+                warehouse{
+                    slug
+                }
+            }
+        }
+    }
+"""
+
+
+def test_get_product_variant_stocks(
+    staff_api_client, variant_with_many_stocks, channel_USD, permission_manage_products
+):
+    # given
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PRODUCT_VARIANT_STOCKS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    stocks_count = variant.stocks.count()
+    data = content["data"]["productVariant"]
+    assert len(data["stocks"]) == stocks_count
+
+
+def test_get_product_variant_stocks_no_channel_shipping_zones(
+    staff_api_client, variant_with_many_stocks, channel_USD, permission_manage_products
+):
+    # given
+    channel_USD.shipping_zones.clear()
+    variant = variant_with_many_stocks
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_PRODUCT_VARIANT_STOCKS,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    content = get_graphql_content(response)
+
+    # then
+    stocks_count = variant.stocks.count()
+    data = content["data"]["productVariant"]
+    assert data["stocks"] == []
+    assert stocks_count > 0
+
+
 CREATE_VARIANT_MUTATION = """
       mutation createVariant (
             $productId: ID!,

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -265,9 +265,15 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                 address, info.context.site.settings.company_address
             )
 
-        if not country_code:
-            return root.node.stocks.annotate_available_quantity()
-        return root.node.stocks.for_country(country_code).annotate_available_quantity()
+        stocks = root.node.stocks
+        if root.channel_slug:
+            channel_slug = str(root.channel_slug)
+            stocks = (
+                stocks.for_country(country_code, channel_slug)
+                if country_code
+                else stocks.for_channel(channel_slug)
+            )
+        return stocks.annotate_available_quantity()
 
     @staticmethod
     def resolve_quantity_available(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -697,7 +697,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
         def calculate_is_available(product_channel_listing):
-            in_stock = is_product_in_stock(root.node, country_code)
+            in_stock = is_product_in_stock(root.node, country_code, channel_slug)
             is_visible = False
             if product_channel_listing:
                 is_visible = product_channel_listing.is_available_for_purchase()

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -67,7 +67,7 @@ from ...utils import (
 )
 from ...utils.filters import reporting_period_to_date
 from ...warehouse.dataloaders import (
-    AvailableQuantityByProductVariantIdAndCountryCodeLoader,
+    AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader,
 )
 from ...warehouse.types import Stock
 from ..dataloaders import (
@@ -284,9 +284,9 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         if not root.node.track_inventory:
             return settings.MAX_CHECKOUT_LINE_QUANTITY
 
-        return AvailableQuantityByProductVariantIdAndCountryCodeLoader(
+        return AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
             info.context
-        ).load((root.node.id, country_code))
+        ).load((root.node.id, country_code, root.channel_slug))
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -4,7 +4,6 @@ from typing import DefaultDict, Iterable, List, Optional, Tuple
 from django.conf import settings
 
 from ...warehouse.models import Stock
-from ..channel.dataloaders import ChannelBySlugLoader
 from ..core.dataloaders import DataLoader
 
 CountryCode = Optional[str]
@@ -24,91 +23,80 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
     context_key = "stock_by_productvariant_and_country"
 
     def batch_load(self, keys):
-        def with_channels(channels):
-            # Split the list of keys by country first. A typical query will only touch
-            # a handful of unique countries but may access thousands of product variants
-            # so it's cheaper to execute one query per country.
-            variants_by_country_and_channel: DefaultDict[
-                CountryCode, List[int]
-            ] = defaultdict(list)
-            for variant_id, country_code, channel_slug in keys:
-                variants_by_country_and_channel[(country_code, channel_slug)].append(
-                    variant_id
-                )
-
-            channel_map = {channel.slug: channel for channel in channels}
-
-            # For each country code execute a single query for all product variants.
-            quantity_by_variant_and_country: DefaultDict[
-                VariantIdAndCountryCode, int
-            ] = defaultdict(int)
-            for key, variant_ids in variants_by_country_and_channel.items():
-                country_code, channel_slug = key
-                quantities = batch_load_country(
-                    country_code, channel_map[channel_slug], variant_ids
-                )
-                for variant_id, quantity in quantities:
-                    quantity_by_variant_and_country[
-                        (variant_id, country_code, channel_slug)
-                    ] = quantity
-
-            return [quantity_by_variant_and_country[key] for key in keys]
-
-        def batch_load_country(
-            country_code: CountryCode, channel, variant_ids: Iterable[int]
-        ) -> Iterable[Tuple[int, int]]:
-            # get stocks only for warehouses assigned to the shipping zones
-            # that are available in the given channel
-            channel_shipping_zones = channel.shipping_zones.values_list("id", flat=True)
-            results = Stock.objects.filter(product_variant_id__in=variant_ids).filter(
-                warehouse__shipping_zones__id__in=channel_shipping_zones
-            )
-            if country_code:
-                results = results.filter(
-                    warehouse__shipping_zones__countries__contains=country_code
-                )
-            results = results.annotate_available_quantity()
-            results = results.values_list(
-                "product_variant_id", "warehouse__shipping_zones", "available_quantity"
+        # Split the list of keys by country first. A typical query will only touch
+        # a handful of unique countries but may access thousands of product variants
+        # so it's cheaper to execute one query per country.
+        variants_by_country_and_channel: DefaultDict[
+            CountryCode, List[int]
+        ] = defaultdict(list)
+        for variant_id, country_code, channel_slug in keys:
+            variants_by_country_and_channel[(country_code, channel_slug)].append(
+                variant_id
             )
 
-            # A single country code (or a missing country code) can return results from
-            # multiple shipping zones. We want to combine all quantities within a single
-            # zone and then find out which zone contains the highest total.
-            quantity_by_shipping_zone_by_product_variant: DefaultDict[
-                int, DefaultDict[int, int]
-            ] = defaultdict(lambda: defaultdict(int))
-            for variant_id, shipping_zone_id, quantity in results:
-                quantity_by_shipping_zone_by_product_variant[variant_id][
-                    shipping_zone_id
-                ] += quantity
-            quantity_map: DefaultDict[int, int] = defaultdict(int)
-            for (
-                variant_id,
-                quantity_by_shipping_zone,
-            ) in quantity_by_shipping_zone_by_product_variant.items():
-                quantity_values = quantity_by_shipping_zone.values()
-                if country_code:
-                    # When country code is known, return the sum of quantities from all
-                    # shipping zones supporting given country.
-                    quantity_map[variant_id] = sum(quantity_values)
-                else:
-                    # When country code is unknown, return the highest known quantity.
-                    quantity_map[variant_id] = max(quantity_values)
+        # For each country code execute a single query for all product variants.
+        quantity_by_variant_and_country: DefaultDict[
+            VariantIdAndCountryCode, int
+        ] = defaultdict(int)
+        for key, variant_ids in variants_by_country_and_channel.items():
+            country_code, channel_slug = key
+            quantities = self.batch_load_country(
+                country_code, channel_slug, variant_ids
+            )
+            for variant_id, quantity in quantities:
+                quantity_by_variant_and_country[
+                    (variant_id, country_code, channel_slug)
+                ] = quantity
 
-            # Return the quantities after capping them at the maximum quantity allowed
-            # in checkout. This prevent users from tracking the store's precise
-            # stock levels.
-            return [
-                (
-                    variant_id,
-                    min(quantity_map[variant_id], settings.MAX_CHECKOUT_LINE_QUANTITY),
-                )
-                for variant_id in variant_ids
-            ]
+        return [quantity_by_variant_and_country[key] for key in keys]
 
-        return (
-            ChannelBySlugLoader(self.context)
-            .load_many({slug for _, _, slug in keys})
-            .then(with_channels)
+    def batch_load_country(
+        self, country_code: CountryCode, channel_slug: str, variant_ids: Iterable[int]
+    ) -> Iterable[Tuple[int, int]]:
+        # get stocks only for warehouses assigned to the shipping zones
+        # that are available in the given channel
+        results = Stock.objects.filter(product_variant_id__in=variant_ids).filter(
+            warehouse__shipping_zones__channels__slug=channel_slug
         )
+        if country_code:
+            results = results.filter(
+                warehouse__shipping_zones__countries__contains=country_code
+            )
+        results = results.annotate_available_quantity()
+        results = results.values_list(
+            "product_variant_id", "warehouse__shipping_zones", "available_quantity"
+        )
+
+        # A single country code (or a missing country code) can return results from
+        # multiple shipping zones. We want to combine all quantities within a single
+        # zone and then find out which zone contains the highest total.
+        quantity_by_shipping_zone_by_product_variant: DefaultDict[
+            int, DefaultDict[int, int]
+        ] = defaultdict(lambda: defaultdict(int))
+        for variant_id, shipping_zone_id, quantity in results:
+            quantity_by_shipping_zone_by_product_variant[variant_id][
+                shipping_zone_id
+            ] += quantity
+        quantity_map: DefaultDict[int, int] = defaultdict(int)
+        for (
+            variant_id,
+            quantity_by_shipping_zone,
+        ) in quantity_by_shipping_zone_by_product_variant.items():
+            quantity_values = quantity_by_shipping_zone.values()
+            if country_code:
+                # When country code is known, return the sum of quantities from all
+                # shipping zones supporting given country.
+                quantity_map[variant_id] = sum(quantity_values)
+            else:
+                # When country code is unknown, return the highest known quantity.
+                quantity_map[variant_id] = max(quantity_values)
+
+        # Return the quantities after capping them at the maximum quantity allowed in
+        # checkout. This prevent users from tracking the store's precise stock levels.
+        return [
+            (
+                variant_id,
+                min(quantity_map[variant_id], settings.MAX_CHECKOUT_LINE_QUANTITY),
+            )
+            for variant_id in variant_ids
+        ]

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -4,13 +4,14 @@ from typing import DefaultDict, Iterable, List, Optional, Tuple
 from django.conf import settings
 
 from ...warehouse.models import Stock
+from ..channel.dataloaders import ChannelBySlugLoader
 from ..core.dataloaders import DataLoader
 
 CountryCode = Optional[str]
 VariantIdAndCountryCode = Tuple[int, CountryCode]
 
 
-class AvailableQuantityByProductVariantIdAndCountryCodeLoader(
+class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
     DataLoader[VariantIdAndCountryCode, int]
 ):
     """Calculates available variant quantity based on variant ID and country code.
@@ -23,67 +24,91 @@ class AvailableQuantityByProductVariantIdAndCountryCodeLoader(
     context_key = "stock_by_productvariant_and_country"
 
     def batch_load(self, keys):
-        # Split the list of keys by country first. A typical query will only touch
-        # a handful of unique countries but may access thousands of product variants
-        # so it's cheaper to execute one query per country.
-        variants_by_country: DefaultDict[CountryCode, List[int]] = defaultdict(list)
-        for variant_id, country_code in keys:
-            variants_by_country[country_code].append(variant_id)
+        def with_channels(channels):
+            # Split the list of keys by country first. A typical query will only touch
+            # a handful of unique countries but may access thousands of product variants
+            # so it's cheaper to execute one query per country.
+            variants_by_country_and_channel: DefaultDict[
+                CountryCode, List[int]
+            ] = defaultdict(list)
+            for variant_id, country_code, channel_slug in keys:
+                variants_by_country_and_channel[(country_code, channel_slug)].append(
+                    variant_id
+                )
 
-        # For each country code execute a single query for all product variants.
-        quantity_by_variant_and_country: DefaultDict[
-            VariantIdAndCountryCode, int
-        ] = defaultdict(int)
-        for country_code, variant_ids in variants_by_country.items():
-            quantities = self.batch_load_country(country_code, variant_ids)
-            for variant_id, quantity in quantities:
-                quantity_by_variant_and_country[(variant_id, country_code)] = quantity
+            channel_map = {channel.slug: channel for channel in channels}
 
-        return [quantity_by_variant_and_country[key] for key in keys]
+            # For each country code execute a single query for all product variants.
+            quantity_by_variant_and_country: DefaultDict[
+                VariantIdAndCountryCode, int
+            ] = defaultdict(int)
+            for key, variant_ids in variants_by_country_and_channel.items():
+                country_code, channel_slug = key
+                quantities = batch_load_country(
+                    country_code, channel_map[channel_slug], variant_ids
+                )
+                for variant_id, quantity in quantities:
+                    quantity_by_variant_and_country[
+                        (variant_id, country_code, channel_slug)
+                    ] = quantity
 
-    def batch_load_country(
-        self, country_code: CountryCode, variant_ids: Iterable[int]
-    ) -> Iterable[Tuple[int, int]]:
-        results = Stock.objects.filter(product_variant_id__in=variant_ids)
-        if country_code:
-            results = results.filter(
-                warehouse__shipping_zones__countries__contains=country_code
+            return [quantity_by_variant_and_country[key] for key in keys]
+
+        def batch_load_country(
+            country_code: CountryCode, channel, variant_ids: Iterable[int]
+        ) -> Iterable[Tuple[int, int]]:
+            # get stocks only for warehouses assigned to the shipping zones
+            # that are available in the given channel
+            channel_shipping_zones = channel.shipping_zones.values_list("id", flat=True)
+            results = Stock.objects.filter(product_variant_id__in=variant_ids).filter(
+                warehouse__shipping_zones__id__in=channel_shipping_zones
             )
-        results = results.annotate_available_quantity()
-        results = results.values_list(
-            "product_variant_id", "warehouse__shipping_zones", "available_quantity"
-        )
-
-        # A single country code (or a missing country code) can return results from
-        # multiple shipping zones. We want to combine all quantities within a single
-        # zone and then find out which zone contains the highest total.
-        quantity_by_shipping_zone_by_product_variant: DefaultDict[
-            int, DefaultDict[int, int]
-        ] = defaultdict(lambda: defaultdict(int))
-        for variant_id, shipping_zone_id, quantity in results:
-            quantity_by_shipping_zone_by_product_variant[variant_id][
-                shipping_zone_id
-            ] += quantity
-        quantity_map: DefaultDict[int, int] = defaultdict(int)
-        for (
-            variant_id,
-            quantity_by_shipping_zone,
-        ) in quantity_by_shipping_zone_by_product_variant.items():
-            quantity_values = quantity_by_shipping_zone.values()
             if country_code:
-                # When country code is known, return the sum of quantities from all
-                # shipping zones supporting given country.
-                quantity_map[variant_id] = sum(quantity_values)
-            else:
-                # When country code is unknown, return the highest known quantity.
-                quantity_map[variant_id] = max(quantity_values)
-
-        # Return the quantities after capping them at the maximum quantity allowed in
-        # checkout. This prevent users from tracking the store's precise stock levels.
-        return [
-            (
-                variant_id,
-                min(quantity_map[variant_id], settings.MAX_CHECKOUT_LINE_QUANTITY),
+                results = results.filter(
+                    warehouse__shipping_zones__countries__contains=country_code
+                )
+            results = results.annotate_available_quantity()
+            results = results.values_list(
+                "product_variant_id", "warehouse__shipping_zones", "available_quantity"
             )
-            for variant_id in variant_ids
-        ]
+
+            # A single country code (or a missing country code) can return results from
+            # multiple shipping zones. We want to combine all quantities within a single
+            # zone and then find out which zone contains the highest total.
+            quantity_by_shipping_zone_by_product_variant: DefaultDict[
+                int, DefaultDict[int, int]
+            ] = defaultdict(lambda: defaultdict(int))
+            for variant_id, shipping_zone_id, quantity in results:
+                quantity_by_shipping_zone_by_product_variant[variant_id][
+                    shipping_zone_id
+                ] += quantity
+            quantity_map: DefaultDict[int, int] = defaultdict(int)
+            for (
+                variant_id,
+                quantity_by_shipping_zone,
+            ) in quantity_by_shipping_zone_by_product_variant.items():
+                quantity_values = quantity_by_shipping_zone.values()
+                if country_code:
+                    # When country code is known, return the sum of quantities from all
+                    # shipping zones supporting given country.
+                    quantity_map[variant_id] = sum(quantity_values)
+                else:
+                    # When country code is unknown, return the highest known quantity.
+                    quantity_map[variant_id] = max(quantity_values)
+
+            # Return the quantities after capping them at the maximum quantity allowed
+            # in checkout. This prevent users from tracking the store's precise
+            # stock levels.
+            return [
+                (
+                    variant_id,
+                    min(quantity_map[variant_id], settings.MAX_CHECKOUT_LINE_QUANTITY),
+                )
+                for variant_id in variant_ids
+            ]
+
+        return (
+            ChannelBySlugLoader(self.context)
+            .load_many({slug for _, _, slug in keys})
+            .then(with_channels)
+        )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -610,6 +610,7 @@ def shipping_zone(db, channel_USD):  # pylint: disable=W0613
     shipping_zone = ShippingZone.objects.create(
         name="Europe", countries=[code for code, name in countries]
     )
+    shipping_zone.channels.add(channel_USD)
     method = shipping_zone.shipping_methods.create(
         name="DHL",
         type=ShippingMethodType.PRICE_BASED,
@@ -633,6 +634,10 @@ def shipping_zones(db, channel_USD, channel_PLN):
             ShippingZone(name="USA", countries=["US"]),
         ]
     )
+
+    shipping_zone_poland.channels.add(channel_PLN, channel_USD)
+    shipping_zone_usa.channels.add(channel_PLN, channel_USD)
+
     method = shipping_zone_poland.shipping_methods.create(
         name="DHL",
         type=ShippingMethodType.PRICE_BASED,

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -84,9 +84,11 @@ def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:
     return _get_available_quantity(stocks)
 
 
-def is_product_in_stock(product: "Product", country_code: str) -> bool:
+def is_product_in_stock(
+    product: "Product", country_code: str, channel_slug: str
+) -> bool:
     """Check if there is any variant of given product available in given country."""
-    stocks = Stock.objects.get_product_stocks_for_country(
-        country_code, product
+    stocks = Stock.objects.get_product_stocks_for_country_and_channel(
+        country_code, channel_slug, product
     ).annotate_available_quantity()
     return any(stocks.values_list("available_quantity", flat=True))

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -76,14 +76,6 @@ def check_stock_quantity_bulk(variants, country_code, quantities):
         raise InsufficientStock(insufficient_stocks)
 
 
-def get_available_quantity(variant: "ProductVariant", country_code: str) -> int:
-    """Return available quantity for given product in given country."""
-    stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
-    if not stocks:
-        return 0
-    return _get_available_quantity(stocks)
-
-
 def is_product_in_stock(
     product: "Product", country_code: str, channel_slug: str
 ) -> bool:

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -62,6 +62,16 @@ class StockQuerySet(models.QuerySet):
             - Coalesce(Sum("allocations__quantity_allocated"), 0)
         )
 
+    def for_channel(self, channel_slug: str):
+        query_warehouse = models.Subquery(
+            Warehouse.objects.filter(
+                shipping_zones__channels__slug=channel_slug
+            ).values("pk")
+        )
+        return self.select_related("product_variant", "warehouse").filter(
+            warehouse__in=query_warehouse
+        )
+
     def for_country(self, country_code: str, channel_slug=None):
         filter_lookup = {"shipping_zones__countries__contains": country_code}
         if channel_slug is not None:

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -62,11 +62,12 @@ class StockQuerySet(models.QuerySet):
             - Coalesce(Sum("allocations__quantity_allocated"), 0)
         )
 
-    def for_country(self, country_code: str):
+    def for_country(self, country_code: str, channel_slug=None):
+        filter_lookup = {"shipping_zones__countries__contains": country_code}
+        if channel_slug is not None:
+            filter_lookup["shipping_zones__channels__slug"] = channel_slug
         query_warehouse = models.Subquery(
-            Warehouse.objects.filter(
-                shipping_zones__countries__contains=country_code
-            ).values("pk")
+            Warehouse.objects.filter(**filter_lookup).values("pk")
         )
         return self.select_related("product_variant", "warehouse").filter(
             warehouse__in=query_warehouse
@@ -81,8 +82,10 @@ class StockQuerySet(models.QuerySet):
         """
         return self.for_country(country_code).filter(product_variant=product_variant)
 
-    def get_product_stocks_for_country(self, country_code: str, product: Product):
-        return self.for_country(country_code).filter(
+    def get_product_stocks_for_country_and_channel(
+        self, country_code: str, channel_slug: str, product: Product
+    ):
+        return self.for_country(country_code, channel_slug).filter(
             product_variant__product_id=product.pk
         )
 

--- a/saleor/warehouse/tests/test_stock_availability.py
+++ b/saleor/warehouse/tests/test_stock_availability.py
@@ -2,11 +2,10 @@ import pytest
 
 from ...core.exceptions import InsufficientStock
 from ..availability import (
+    _get_available_quantity,
     check_stock_quantity,
     check_stock_quantity_bulk,
-    get_available_quantity,
 )
-from ..models import Allocation
 
 COUNTRY_CODE = "US"
 
@@ -46,36 +45,10 @@ def test_check_stock_quantity_without_one_stock(variant_with_many_stocks):
     assert check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 4) is None
 
 
-def test_get_available_quantity_without_allocation(order_line, stock):
-    assert not Allocation.objects.filter(order_line=order_line, stock=stock).exists()
-    available_quantity = get_available_quantity(order_line.variant, COUNTRY_CODE)
-    assert available_quantity == stock.quantity
-
-
-def test_get_available_quantity(variant_with_many_stocks):
-    available_quantity = get_available_quantity(variant_with_many_stocks, COUNTRY_CODE)
-    assert available_quantity == 7
-
-
-def test_get_available_quantity_with_allocations(
-    variant_with_many_stocks,
-    order_line_with_allocation_in_many_stocks,
-    order_line_with_one_allocation,
-):
-    available_quantity = get_available_quantity(variant_with_many_stocks, COUNTRY_CODE)
-    assert available_quantity == 3
-
-
-def test_get_available_quantity_without_stocks(variant_with_many_stocks):
-    variant_with_many_stocks.stocks.all().delete()
-    available_quantity = get_available_quantity(variant_with_many_stocks, COUNTRY_CODE)
-    assert available_quantity == 0
-
-
 def test_check_stock_quantity_bulk(variant_with_many_stocks):
     variant = variant_with_many_stocks
     country_code = "US"
-    available_quantity = get_available_quantity(variant, country_code)
+    available_quantity = _get_available_quantity(variant.stocks.all())
 
     # test that it doesn't raise error for available quantity
     assert (


### PR DESCRIPTION
Return data based on available warehouses for a given channel.
Update:
- `ProductVariant.quantityAvailable`
- `Product.isAvailable`
- `ProductVariant.stocks`

Drop unused `get_available_quantity` method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
