### PR TITLE
Fix resolver by id and slug for product and product variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop `data` field from checkout line model - #6961 by @fowczarek
 - Fix `totalCount` on connection resolver without `first` or `last` - #6975 by @fowczarek
 - Fix variant resolver on `DigitalContent` - #6983 by @fowczarek
+- Fix resolver by id and slug for product and product variant - #6985 by @d-wysocki
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -989,7 +989,6 @@ class ProductVariantDelete(ModelDeleteMutation):
         )
 
         response = super().perform_mutation(_root, info, **data)
-
         # delete order lines for deleted variant
         order_models.OrderLine.objects.filter(pk__in=line_pks).delete()
 

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -302,11 +302,19 @@ class ProductQueries(graphene.ObjectType):
         if id:
             _, id = graphene.Node.from_global_id(id)
             product = resolve_product_by_id(
-                info, id, channel_slug=channel, requestor=requestor
+                info,
+                id,
+                channel_slug=channel,
+                requestor=requestor,
+                requestor_has_access_to_all=is_staff,
             )
         else:
             product = resolve_product_by_slug(
-                info, product_slug=slug, channel_slug=channel, requestor=requestor
+                info,
+                product_slug=slug,
+                channel_slug=channel,
+                requestor=requestor,
+                requestor_has_access_to_all=is_staff,
             )
         return ChannelContext(node=product, channel_slug=channel) if product else None
 
@@ -337,7 +345,11 @@ class ProductQueries(graphene.ObjectType):
         if id:
             _, id = graphene.Node.from_global_id(id)
             variant = resolve_variant_by_id(
-                info, id, channel_slug=channel, requestor=requestor
+                info,
+                id,
+                channel_slug=channel,
+                requestor=requestor,
+                requestor_has_access_to_all=is_staff,
             )
         else:
             variant = resolve_product_variant_by_sku(

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -320,9 +320,16 @@ class ProductQueries(graphene.ObjectType):
 
     def resolve_products(self, info, channel=None, **kwargs):
         requestor = get_user_or_app_from_context(info.context)
-        if channel is None and not requestor_is_staff_member_or_app(requestor):
+        if_staff = requestor_is_staff_member_or_app(requestor)
+        if channel is None and not if_staff:
             channel = get_default_channel_slug_or_graphql_error()
-        return resolve_products(info, requestor, channel_slug=channel, **kwargs)
+        return resolve_products(
+            info,
+            requestor,
+            requestor_has_access_to_all=if_staff,
+            channel_slug=channel,
+            **kwargs,
+        )
 
     def resolve_product_type(self, info, id, **_kwargs):
         return graphene.Node.get_node_from_global_id(info, id, ProductType)

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -6373,6 +6373,144 @@ def test_product_update_variants_names(mock__update_variants_names, product_type
     assert mock__update_variants_names.call_count == 1
 
 
+def test_unavailable_product_by_id_as_staff(staff_api_client, product, channel_USD):
+    query = """
+        query getProduct($id: ID!, $channel: String) {
+            product(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {"id": product_id, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+    assert data["id"] == product_id
+
+
+def test_unavailable_product_by_id_as_user(user_api_client, product, channel_USD):
+    query = """
+        query getProduct($id: ID!, $channel: String) {
+            product(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {"id": product_id, "channel": channel_USD.slug}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["product"] is None
+
+
+def test_unavailable_product_by_slug_as_staff(staff_api_client, product, channel_USD):
+    query = """
+        query getProduct($slug: String!, $channel: String) {
+            product(slug: $slug, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {"slug": product.slug, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+    assert data["id"] == product_id
+
+
+def test_unavailable_product_by_slug_as_user(user_api_client, product, channel_USD):
+    query = """
+        query getProduct($slug: String!, $channel: String) {
+            product(slug: $slug, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+
+    variables = {"slug": product.slug, "channel": channel_USD.slug}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["product"] is None
+
+
+def test_unavailable_product_variant_by_id_as_staff(
+    staff_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = variant.product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_unavailable_product_variant_by_id_as_user(
+    user_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = variant.product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["productVariant"] is None
+
+
 def test_product_variants_by_ids(staff_api_client, variant, channel_USD):
     query = """
         query getProduct($ids: [ID!], $channel: String) {

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -6396,6 +6396,29 @@ def test_unavailable_product_by_id_as_staff(staff_api_client, product, channel_U
     assert data["id"] == product_id
 
 
+def test_unavailable_product_by_id_as_app(app_api_client, product, channel_USD):
+    query = """
+        query getProduct($id: ID!, $channel: String) {
+            product(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {"id": product_id, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+    assert data["id"] == product_id
+
+
 def test_unavailable_product_by_id_as_user(user_api_client, product, channel_USD):
     query = """
         query getProduct($id: ID!, $channel: String) {
@@ -6436,6 +6459,29 @@ def test_unavailable_product_by_slug_as_staff(staff_api_client, product, channel
 
     variables = {"slug": product.slug, "channel": channel_USD.slug}
     response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["product"]
+    assert data["id"] == product_id
+
+
+def test_unavailable_product_by_slug_as_app(app_api_client, product, channel_USD):
+    query = """
+        query getProduct($slug: String!, $channel: String) {
+            product(slug: $slug, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {"slug": product.slug, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["product"]
     assert data["id"] == product_id
@@ -6482,6 +6528,29 @@ def test_unavailable_product_variant_by_id_as_staff(
 
     variables = {"id": variant_id, "channel": channel_USD.slug}
     response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_unavailable_product_variant_by_id_as_app(app_api_client, variant, channel_USD):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+            }
+        }
+    """
+    product_channel_listing = variant.product.channel_listings.filter(
+        channel__slug=channel_USD.slug
+    ).first()
+    product_channel_listing.visible_in_listings = False
+    product_channel_listing.save()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["productVariant"]
     assert data["id"] == variant_id


### PR DESCRIPTION
I want to merge this change because...I want to fix resolvers by id and slug for product and product variant.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
