### PR TITLE
Fix race condition on send_fulfillment-confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Drop `data` field from checkout line model - #6961 by @fowczarek
 - Fix `totalCount` on connection resolver without `first` or `last` - #6975 by @fowczarek
 - Fix variant resolver on `DigitalContent` - #6983 by @fowczarek
+- Fix race condition on `send_fulfillment-confirmation` - #6988 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -175,6 +175,7 @@ def order_returned(
     manager.order_updated(order)
 
 
+@transaction.atomic
 def order_fulfilled(
     fulfillments: List["Fulfillment"],
     user: "User",
@@ -506,11 +507,13 @@ def create_fulfillments(
         )
 
     FulfillmentLine.objects.bulk_create(fulfillment_lines)
-    order_fulfilled(
-        fulfillments,
-        requester,
-        fulfillment_lines,
-        notify_customer,
+    transaction.on_commit(
+        lambda: order_fulfilled(
+            fulfillments,
+            requester,
+            fulfillment_lines,
+            notify_customer,
+        )
     )
     return fulfillments
 

--- a/saleor/order/tests/test_fulfullments_actions.py
+++ b/saleor/order/tests/test_fulfullments_actions.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from ...core.exceptions import InsufficientStock
+from ...tests.utils import flush_post_commit_hooks
 from ...warehouse.models import Allocation, Stock
 from ..actions import create_fulfillments
 from ..models import FulfillmentLine, OrderStatus
@@ -27,6 +28,7 @@ def test_create_fulfillments(
     [fulfillment] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, True
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(
@@ -75,6 +77,7 @@ def test_create_fulfillments_without_notification(
     [fulfillment] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, False
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(
@@ -132,6 +135,7 @@ def test_create_fulfillments_many_warehouses(
     [fulfillment1, fulfillment2] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, False
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(
@@ -179,6 +183,7 @@ def test_create_fulfillments_with_one_line_empty_quantity(
     [fulfillment] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, True
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(
@@ -224,6 +229,7 @@ def test_create_fulfillments_with_variant_without_inventory_tracking(
     [fulfillment] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, True
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(
@@ -266,6 +272,7 @@ def test_create_fulfillments_without_allocations(
     [fulfillment] = create_fulfillments(
         staff_user, order, fulfillment_lines_for_warehouses, True
     )
+    flush_post_commit_hooks()
 
     order.refresh_from_db()
     fulfillment_lines = FulfillmentLine.objects.filter(


### PR DESCRIPTION
I want to merge this change because of fixing race condition on send_fulfillment-confirmation. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
