### PR TITLE
Update logic to use shipping zones available in given chnnel in checkout module

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -234,7 +234,9 @@ def _create_lines_for_order(
         for variant_translation in variants_translation
     }
 
-    check_stock_quantity_bulk(variants, country_code, quantities)
+    check_stock_quantity_bulk(
+        variants, country_code, quantities, checkout_info.channel.slug
+    )
 
     return [
         _create_line_for_order(

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -386,7 +386,7 @@ def _create_order(
     OrderLine.objects.bulk_create(order_lines)
 
     country_code = checkout_info.get_country()
-    allocate_stocks(order_lines_info, country_code)
+    allocate_stocks(order_lines_info, country_code, checkout_info.channel.slug)
 
     # Add gift cards to the order
     for gift_card in checkout.gift_cards.select_for_update():

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -25,14 +25,16 @@ def test_get_user_checkout(
 
 def test_adding_zero_quantity(checkout, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 0)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 0)
     assert checkout.lines.count() == 0
 
 
 def test_adding_same_variant(checkout, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 1)
-    add_variant_to_checkout(checkout, variant, 2)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
+    add_variant_to_checkout(checkout_info, variant, 2)
     assert checkout.lines.count() == 1
     assert checkout.quantity == 3
     subtotal = TaxedMoney(Money("30.00", "USD"), Money("30.00", "USD"))
@@ -52,29 +54,33 @@ def test_adding_same_variant(checkout, product):
 
 def test_replacing_same_variant(checkout, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 1, replace=True)
-    add_variant_to_checkout(checkout, variant, 2, replace=True)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1, replace=True)
+    add_variant_to_checkout(checkout_info, variant, 2, replace=True)
     assert checkout.lines.count() == 1
     assert checkout.quantity == 2
 
 
 def test_adding_invalid_quantity(checkout, product):
     variant = product.variants.get()
+    checkout_info = fetch_checkout_info(checkout, [], [])
     with pytest.raises(ValueError):
-        add_variant_to_checkout(checkout, variant, -1)
+        add_variant_to_checkout(checkout_info, variant, -1)
 
 
 def test_getting_line(checkout, product):
     variant = product.variants.get()
     assert checkout.get_line(variant) is None
-    add_variant_to_checkout(checkout, variant)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant)
     assert checkout.lines.get() == checkout.get_line(variant)
 
 
 def test_shipping_detection(checkout, product):
     assert not checkout.is_shipping_required()
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, replace=True)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, replace=True)
     assert checkout.is_shipping_required()
 
 
@@ -122,7 +128,8 @@ def test_get_prices_of_discounted_specific_product_only_product(
     channel = checkout.channel
     variant_channel_listing = line.variant.channel_listings.get(channel=channel)
 
-    add_variant_to_checkout(checkout, product2.variants.get(), 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.products.add(product)
 
     manager = get_plugins_manager()
@@ -155,7 +162,8 @@ def test_get_prices_of_discounted_specific_product_only_collection(
     channel = checkout.channel
     variant_channel_listing = line.variant.channel_listings.get(channel=channel)
 
-    add_variant_to_checkout(checkout, product2.variants.get(), 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     product.collections.add(collection)
     voucher.collections.add(collection)
 
@@ -192,7 +200,8 @@ def test_get_prices_of_discounted_specific_product_only_category(
 
     product2.category = category2
     product2.save()
-    add_variant_to_checkout(checkout, product2.variants.get(), 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, product2.variants.get(), 1)
     voucher.categories.add(category)
 
     manager = get_plugins_manager()

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -507,7 +507,9 @@ def test_create_order_insufficient_stock(
     checkout, customer_user, product_without_shipping
 ):
     variant = product_without_shipping.variants.get()
-    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+
+    add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
     checkout.user = customer_user
     checkout.billing_address = customer_user.default_billing_address
     checkout.shipping_address = customer_user.default_billing_address
@@ -749,7 +751,8 @@ def test_create_order_with_variant_tracking_false(
     checkout.tracking_code = ""
     checkout.redirect_url = "https://www.example.com"
     checkout.save()
-    add_variant_to_checkout(checkout, variant, 10, check_quantity=False)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 10, check_quantity=False)
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -108,7 +108,7 @@ def add_variant_to_checkout(
     return checkout
 
 
-def add_variants_to_checkout(checkout, variants, quantities):
+def add_variants_to_checkout(checkout, variants, quantities, channel_slug):
     """Add variants to checkout.
 
     Suitable for new checkouts as it always creates new checkout lines without checking
@@ -117,7 +117,7 @@ def add_variants_to_checkout(checkout, variants, quantities):
 
     # check quantities
     country_code = checkout.get_country()
-    check_stock_quantity_bulk(variants, country_code, quantities)
+    check_stock_quantity_bulk(variants, country_code, quantities, channel_slug)
 
     channel_listings = product_models.ProductChannelListing.objects.filter(
         channel_id=checkout.channel.id,

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -335,6 +335,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
     @classmethod
     @transaction.atomic()
     def save(cls, info, instance: models.Checkout, cleaned_input):
+        channel = cleaned_input["channel"]
         # Create the checkout object
         instance.save()
 
@@ -347,7 +348,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         quantities = cleaned_input.get("quantities")
         if variants and quantities:
             try:
-                add_variants_to_checkout(instance, variants, quantities)
+                add_variants_to_checkout(instance, variants, quantities, channel.slug)
             except InsufficientStock as exc:
                 error = prepare_insufficient_stock_checkout_validation_error(exc)
                 raise ValidationError({"lines": error})

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -15,6 +15,7 @@ from ...checkout.fetch import (
     CheckoutLineInfo,
     fetch_checkout_info,
     fetch_checkout_lines,
+    get_valid_shipping_method_list_for_checkout_info,
     update_checkout_info_shipping_method,
 )
 from ...checkout.utils import (
@@ -106,7 +107,7 @@ def update_checkout_shipping_method_if_invalid(
         checkout.save(update_fields=["shipping_method", "last_change"])
 
 
-def check_lines_quantity(variants, quantities, country):
+def check_lines_quantity(variants, quantities, country, channel_slug):
     """Clean quantities and check if stock is sufficient for each checkout line."""
     for quantity in quantities:
         if quantity < 0:
@@ -129,7 +130,7 @@ def check_lines_quantity(variants, quantities, country):
                 }
             )
     try:
-        check_stock_quantity_bulk(variants, country, quantities)
+        check_stock_quantity_bulk(variants, country, quantities, channel_slug)
     except InsufficientStock as e:
         errors = [
             ValidationError(
@@ -222,7 +223,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
 
     @classmethod
     def clean_checkout_lines(
-        cls, lines, country, channel_id
+        cls, lines, country, channel
     ) -> Tuple[List[product_models.ProductVariant], List[int]]:
         variant_ids = [line["variant_id"] for line in lines]
         variants = cls.get_nodes_or_error(
@@ -235,8 +236,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         )
 
         quantities = [line["quantity"] for line in lines]
-        validate_variants_available_for_purchase(variants, channel_id)
-        check_lines_quantity(variants, quantities, country)
+        validate_variants_available_for_purchase(variants, channel.id)
+        check_lines_quantity(variants, quantities, country, channel.slug)
         return variants, quantities
 
     @classmethod
@@ -319,7 +320,7 @@ class CheckoutCreate(ModelMutation, I18nMixin):
             (
                 cleaned_input["variants"],
                 cleaned_input["quantities"],
-            ) = cls.clean_checkout_lines(lines, country, cleaned_input["channel"].id)
+            ) = cls.clean_checkout_lines(lines, country, cleaned_input["channel"])
 
         # Use authenticated user's email as default email
         if user.is_authenticated:
@@ -423,12 +424,17 @@ class CheckoutLinesAdd(BaseMutation):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
+        discounts = info.context.discounts
 
         variant_ids = [line.get("variant_id") for line in lines]
         variants = cls.get_nodes_or_error(variant_ids, "variant_id", ProductVariant)
         quantities = [line.get("quantity") for line in lines]
 
-        check_lines_quantity(variants, quantities, checkout.get_country())
+        checkout_info = fetch_checkout_info(checkout, [], discounts)
+
+        check_lines_quantity(
+            variants, quantities, checkout.get_country(), checkout_info.channel.slug
+        )
         validate_variants_available_for_purchase(variants, checkout.channel_id)
 
         if variants and quantities:
@@ -447,7 +453,11 @@ class CheckoutLinesAdd(BaseMutation):
                     )
 
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info.valid_shipping_methods = (
+            get_valid_shipping_method_list_for_checkout_info(
+                checkout_info, checkout_info.shipping_address, lines, discounts
+            )
+        )
 
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         recalculate_checkout_discount(
@@ -597,7 +607,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
 
     @classmethod
     def process_checkout_lines(
-        cls, lines: Iterable["CheckoutLineInfo"], country: str
+        cls, lines: Iterable["CheckoutLineInfo"], country: str, channel_slug: str
     ) -> None:
         variant_ids = [line_info.variant.id for line_info in lines]
         variants = list(
@@ -606,7 +616,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
             ).prefetch_related("product__product_type")
         )  # FIXME: is this prefetch needed?
         quantities = [line_info.line.quantity for line_info in lines]
-        check_lines_quantity(variants, quantities, country)
+        check_lines_quantity(variants, quantities, country, channel_slug)
 
     @classmethod
     def perform_mutation(cls, _root, info, checkout_id, shipping_address):
@@ -652,7 +662,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
 
         # Resolve and process the lines, validating variants quantities
         if lines:
-            cls.process_checkout_lines(lines, country)
+            cls.process_checkout_lines(lines, country, checkout_info.channel.slug)
 
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -442,7 +442,7 @@ class CheckoutLinesAdd(BaseMutation):
             for variant, quantity in zip(variants, quantities):
                 try:
                     checkout = add_variant_to_checkout(
-                        checkout, variant, quantity, replace=replace
+                        checkout_info, variant, quantity, replace=replace
                     )
                 except InsufficientStock as exc:
                     error = prepare_insufficient_stock_checkout_validation_error(exc)

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -23,11 +23,18 @@ def checkout_with_variants(
     product_with_single_variant,
     product_with_two_variants,
 ):
+    checkout_info = fetch_checkout_info(checkout, [], [])
 
-    add_variant_to_checkout(checkout, product_with_default_variant.variants.get(), 1)
-    add_variant_to_checkout(checkout, product_with_single_variant.variants.get(), 10)
-    add_variant_to_checkout(checkout, product_with_two_variants.variants.first(), 3)
-    add_variant_to_checkout(checkout, product_with_two_variants.variants.last(), 5)
+    add_variant_to_checkout(
+        checkout_info, product_with_default_variant.variants.get(), 1
+    )
+    add_variant_to_checkout(
+        checkout_info, product_with_single_variant.variants.get(), 10
+    )
+    add_variant_to_checkout(
+        checkout_info, product_with_two_variants.variants.first(), 3
+    )
+    add_variant_to_checkout(checkout_info, product_with_two_variants.variants.last(), 5)
 
     checkout.save()
     return checkout

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -535,6 +535,35 @@ def test_checkout_create_with_invalid_channel_slug(
     assert error["field"] == "channel"
 
 
+def test_checkout_create_no_channel_shipping_zones(
+    api_client, stock, graphql_address_data, channel_USD
+):
+    """Create checkout object using GraphQL API."""
+    channel_USD.shipping_zones.clear()
+    variant = stock.product_variant
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    test_email = "test@example.com"
+    shipping_address = graphql_address_data
+    variables = {
+        "checkoutInput": {
+            "channel": channel_USD.slug,
+            "lines": [{"quantity": 1, "variantId": variant_id}],
+            "email": test_email,
+            "shippingAddress": shipping_address,
+        }
+    }
+    assert not Checkout.objects.exists()
+    response = api_client.post_graphql(MUTATION_CHECKOUT_CREATE, variables)
+    content = get_graphql_content(response)["data"]["checkoutCreate"]
+
+    new_checkout = Checkout.objects.first()
+    assert new_checkout is None
+    errors = content["checkoutErrors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert errors[0]["field"] == "quantity"
+
+
 def test_checkout_create_multiple_warehouse(
     api_client, variant_with_many_stocks, graphql_address_data, channel_USD
 ):
@@ -1347,6 +1376,31 @@ def test_checkout_lines_add(
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
 
 
+def test_checkout_lines_add_no_channel_shipping_zones(
+    user_api_client, checkout_with_item, stock
+):
+    variant = stock.product_variant
+    checkout = checkout_with_item
+    checkout.channel.shipping_zones.clear()
+    line = checkout.lines.first()
+    assert line.quantity == 3
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    variables = {
+        "checkoutId": checkout_id,
+        "lines": [{"variantId": variant_id, "quantity": 1}],
+        "channelSlug": checkout.channel.slug,
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_ADD, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesAdd"]
+    errors = data["checkoutErrors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert errors[0]["field"] == "quantity"
+
+
 def test_checkout_lines_add_with_unpublished_product(
     user_api_client, checkout_with_item, stock, channel_USD
 ):
@@ -1588,6 +1642,33 @@ def test_checkout_lines_update(
     lines = fetch_checkout_lines(checkout)
     checkout_info = fetch_checkout_info(checkout, lines, [])
     mocked_update_shipping_method.assert_called_once_with(checkout_info, lines)
+
+
+def test_checkout_lines_update_channel_without_shipping_zones(
+    user_api_client, checkout_with_item
+):
+    checkout = checkout_with_item
+    checkout.channel.shipping_zones.clear()
+    assert checkout.lines.count() == 1
+    line = checkout.lines.first()
+    variant = line.variant
+    assert line.quantity == 3
+
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    variables = {
+        "checkoutId": checkout_id,
+        "lines": [{"variantId": variant_id, "quantity": 1}],
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["checkoutLinesUpdate"]
+    errors = data["checkoutErrors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert errors[0]["field"] == "quantity"
 
 
 def test_create_checkout_with_unpublished_product(
@@ -2012,6 +2093,29 @@ def test_checkout_shipping_address_update_insufficient_stocks(
     shipping_address["country"] = "US"
     shipping_address["countryArea"] = "New York"
     shipping_address["postalCode"] = "10001"
+    variables = {"checkoutId": checkout_id, "shippingAddress": shipping_address}
+
+    response = user_api_client.post_graphql(
+        MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutShippingAddressUpdate"]
+    errors = data["checkoutErrors"]
+    assert errors[0]["code"] == CheckoutErrorCode.INSUFFICIENT_STOCK.name
+    assert errors[0]["field"] == "quantity"
+
+
+def test_checkout_shipping_address_update_channel_without_shipping_zones(
+    user_api_client,
+    checkout_with_item,
+    graphql_address_data,
+):
+    checkout = checkout_with_item
+    checkout.channel.shipping_zones.clear()
+    assert checkout.shipping_address is None
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+
+    shipping_address = graphql_address_data
     variables = {"checkoutId": checkout_id, "shippingAddress": shipping_address}
 
     response = user_api_client.post_graphql(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2032,7 +2032,8 @@ def test_checkout_shipping_address_update_changes_checkout_country(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD, currency="USD")
     checkout.set_country("PL", commit=True)
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     assert checkout.shipping_address is None
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
 
@@ -2082,7 +2083,8 @@ def test_checkout_shipping_address_update_insufficient_stocks(
     variant = variant_with_many_stocks_different_shipping_zones
     checkout = Checkout.objects.create(channel=channel_USD)
     checkout.set_country("PL", commit=True)
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     Stock.objects.filter(
         warehouse__shipping_zones__countries__contains="US", product_variant=variant
     ).update(quantity=0)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1236,6 +1236,22 @@ def test_checkout_available_shipping_methods(
     assert data["availableShippingMethods"][0]["name"] == shipping_method.name
 
 
+def test_checkout_available_shipping_methods_shipping_zone_without_channels(
+    api_client, checkout_with_item, address, shipping_zone
+):
+    shipping_zone.channels.clear()
+    checkout_with_item.shipping_address = address
+    checkout_with_item.save()
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"token": checkout_with_item.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    assert len(data["availableShippingMethods"]) == 0
+
+
 def test_checkout_available_shipping_methods_excluded_postal_codes(
     api_client, checkout_with_item, address, shipping_zone
 ):

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -142,8 +142,12 @@ def test_checkout_update_shipping_method(
     content = get_graphql_content(response)
     data = content["data"]["checkoutShippingMethodUpdate"]
 
-    assert data["errors"] == [
-        {"field": "shippingMethod", "message": "This checkout doesn't need shipping"}
+    assert data["checkoutErrors"] == [
+        {
+            "field": "shippingMethod",
+            "message": "This checkout doesn't need shipping",
+            "code": CheckoutErrorCode.SHIPPING_NOT_REQUIRED.name,
+        }
     ]
 
     # Ensure the shipping method was unchanged

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -176,7 +176,8 @@ def test_checkout_lines_update_remove_shipping_if_removed_product_with_shipping(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    add_variant_to_checkout(checkout, digital_variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, digital_variant, 1)
     line = checkout.lines.first()
     variant = line.variant
 
@@ -205,7 +206,8 @@ def test_checkout_line_delete_remove_shipping_if_removed_product_with_shipping(
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.save()
-    add_variant_to_checkout(checkout, digital_variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, digital_variant, 1)
     line = checkout.lines.first()
 
     line_id = graphene.Node.to_global_id("CheckoutLine", line.pk)

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -378,7 +378,7 @@ class DraftOrderComplete(BaseMutation):
                     line=line, quantity=line.quantity, variant=line.variant
                 )
                 try:
-                    allocate_stocks([line_data], country)
+                    allocate_stocks([line_data], country, order.channel.slug)
                 except InsufficientStock as exc:
                     errors = prepare_insufficient_stock_order_validation_errors(exc)
                     raise ValidationError({"lines": errors})

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -485,8 +485,10 @@ def test_order_query_in_pln_channel(
     staff_api_client,
     permission_manage_orders,
     order_with_lines_channel_PLN,
+    shipping_zone,
     channel_PLN,
 ):
+    shipping_zone.channels.add(channel_PLN)
     order = order_with_lines_channel_PLN
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post_graphql(ORDERS_QUERY)

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -80,7 +80,9 @@ def validate_order_lines(order, country):
             )
         if line.variant.track_inventory:
             try:
-                check_stock_quantity(line.variant, country, line.quantity)
+                check_stock_quantity(
+                    line.variant, country, order.channel.slug, line.quantity
+                )
             except InsufficientStock as exc:
                 errors = prepare_insufficient_stock_order_validation_errors(exc)
                 raise ValidationError({"lines": errors})

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -269,7 +269,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         if root.channel_slug:
             channel_slug = str(root.channel_slug)
             stocks = (
-                stocks.for_country(country_code, channel_slug)
+                stocks.for_country_and_channel(country_code, channel_slug)
                 if country_code
                 else stocks.for_channel(channel_slug)
             )

--- a/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
@@ -45,6 +45,7 @@ def test_shipping_method_channel_listing_create_as_staff_user(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -172,6 +173,7 @@ def test_shipping_method_channel_listing_update_with_negative_price(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     staff_api_client.user.user_permissions.add(permission_manage_shipping)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
@@ -212,6 +214,7 @@ def test_shipping_method_channel_listing_update_with_negative_min_value(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     staff_api_client.user.user_permissions.add(permission_manage_shipping)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
@@ -252,6 +255,7 @@ def test_shipping_method_channel_listing_update_with_negative_max_value(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     staff_api_client.user.user_permissions.add(permission_manage_shipping)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
@@ -290,6 +294,7 @@ def test_shipping_method_channel_listing_update_with_max_less_than_min(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -334,6 +339,7 @@ def test_shipping_method_channel_listing_create_without_price(
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -376,6 +382,7 @@ def test_shipping_method_channel_listing_update_with_to_many_decimal_places_in_p
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -420,6 +427,7 @@ def test_shipping_method_channel_listing_update_with_to_many_decimal_places_in_m
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -464,6 +472,7 @@ def test_shipping_method_channel_listing_update_with_to_many_decimal_places_in_m
     channel_PLN,
 ):
     # given
+    shipping_method.shipping_zone.channels.add(channel_PLN)
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
@@ -497,5 +506,52 @@ def test_shipping_method_channel_listing_update_with_to_many_decimal_places_in_m
 
     # then
     assert data["shippingErrors"][0]["field"] == "maximumOrderPrice"
+    assert data["shippingErrors"][0]["code"] == ShippingErrorCode.INVALID.name
+    assert data["shippingErrors"][0]["channels"] == [channel_id]
+
+
+def test_shipping_method_channel_listing_create_channel_not_valid(
+    staff_api_client,
+    shipping_method,
+    permission_manage_shipping,
+    channel_PLN,
+):
+    # given
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.pk
+    )
+    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    price = 1
+    min_value = 2
+    max_value = 3
+
+    variables = {
+        "id": shipping_method_id,
+        "input": {
+            "addChannels": [
+                {
+                    "channelId": channel_id,
+                    "price": price,
+                    "minimumOrderPrice": min_value,
+                    "maximumOrderPrice": max_value,
+                }
+            ]
+        },
+    }
+
+    # when
+
+    response = staff_api_client.post_graphql(
+        SHIPPING_METHOD_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_shipping,),
+    )
+    content = get_graphql_content(response)
+
+    # then
+    data = content["data"]["shippingMethodChannelListingUpdate"]
+
+    # then
+    assert data["shippingErrors"][0]["field"] == "addChannels"
     assert data["shippingErrors"][0]["code"] == ShippingErrorCode.INVALID.name
     assert data["shippingErrors"][0]["channels"] == [channel_id]

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -246,7 +246,7 @@ def test_stock_quantity_is_sum_of_quantities_from_warehouses_that_support_countr
 
     # Create another warehouse with a different shipping zone that supports PL. As
     # a result there should be two shipping zones and two warehouses that support PL.
-    stocks = variant.stocks.for_country("PL")
+    stocks = variant.stocks.for_country("PL", channel_USD.slug)
     warehouse = Warehouse.objects.create(
         address=address.get_copy(),
         name="WarehousePL",
@@ -256,7 +256,7 @@ def test_stock_quantity_is_sum_of_quantities_from_warehouses_that_support_countr
     warehouse.shipping_zones.add(shipping_zone)
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
-    stocks = variant.stocks.for_country("PL")
+    stocks = variant.stocks.for_country("PL", channel_USD.slug)
     sum_quantities = sum([stock.quantity for stock in stocks])
 
     variables = {

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -246,7 +246,7 @@ def test_stock_quantity_is_sum_of_quantities_from_warehouses_that_support_countr
 
     # Create another warehouse with a different shipping zone that supports PL. As
     # a result there should be two shipping zones and two warehouses that support PL.
-    stocks = variant.stocks.for_country("PL", channel_USD.slug)
+    stocks = variant.stocks.for_country_and_channel("PL", channel_USD.slug)
     warehouse = Warehouse.objects.create(
         address=address.get_copy(),
         name="WarehousePL",
@@ -256,7 +256,7 @@ def test_stock_quantity_is_sum_of_quantities_from_warehouses_that_support_countr
     warehouse.shipping_zones.add(shipping_zone)
     Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
 
-    stocks = variant.stocks.for_country("PL", channel_USD.slug)
+    stocks = variant.stocks.for_country_and_channel("PL", channel_USD.slug)
     sum_quantities = sum([stock.quantity for stock in stocks])
 
     variables = {

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -194,13 +194,12 @@ def test_calculate_checkout_total_uses_default_calculation(
     product_with_single_variant.charge_taxes = False
     product_with_single_variant.category = non_default_category
     product_with_single_variant.save()
-    add_variant_to_checkout(
-        checkout_with_item, product_with_single_variant.variants.get()
-    )
-
     discounts = [discount_info] if with_discount else None
     lines = fetch_checkout_lines(checkout_with_item)
     checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+    add_variant_to_checkout(checkout_info, product_with_single_variant.variants.get())
+    lines = fetch_checkout_lines(checkout_with_item)
+
     total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(
@@ -265,13 +264,10 @@ def test_calculate_checkout_total(
     product_with_single_variant.charge_taxes = False
     product_with_single_variant.category = non_default_category
     product_with_single_variant.save()
-    add_variant_to_checkout(
-        checkout_with_item, product_with_single_variant.variants.get()
-    )
-
     discounts = [discount_info] if with_discount else None
+    checkout_info = fetch_checkout_info(checkout_with_item, [], discounts)
+    add_variant_to_checkout(checkout_info, product_with_single_variant.variants.get())
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
     total = manager.calculate_checkout_total(
         checkout_info, lines, ship_to_pl_address, discounts
     )
@@ -358,9 +354,11 @@ def test_calculate_checkout_subtotal(
     checkout_with_item.save()
 
     discounts = [discount_info] if with_discount else None
-    add_variant_to_checkout(checkout_with_item, variant, 2)
+
+    checkout_info = fetch_checkout_info(checkout_with_item, [], discounts)
+    add_variant_to_checkout(checkout_info, variant, 2)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+
     total = manager.calculate_checkout_subtotal(
         checkout_info, lines, address, discounts
     )

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -295,9 +295,9 @@ def test_calculate_checkout_subtotal(
     product.save()
 
     discounts = [discount_info] if with_discount else None
-    add_variant_to_checkout(checkout_with_item, variant, 2)
+    checkout_info = fetch_checkout_info(checkout_with_item, [], discounts)
+    add_variant_to_checkout(checkout_info, variant, 2)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
     total = manager.calculate_checkout_subtotal(
         checkout_info, lines, address, discounts
     )

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -120,6 +120,7 @@ class ShippingMethodQueryset(models.QuerySet):
         """
         qs = self.filter(
             shipping_zone__countries__contains=country_code,
+            shipping_zone__channels__id=channel_id,
             channel_listings__currency=price.currency,
             channel_listings__channel_id=channel_id,
         )

--- a/saleor/shipping/tests/test_shipping.py
+++ b/saleor/shipping/tests/test_shipping.py
@@ -265,6 +265,7 @@ def test_use_default_shipping_zone(shipping_zone, channel_USD):
     default_zone.countries = get_countries_without_shipping_zone()
     default_zone.save(update_fields=["countries"])
 
+    default_zone.channels.add(channel_USD)
     weight_method = default_zone.shipping_methods.create(
         minimum_order_weight=Weight(kg=1),
         maximum_order_weight=Weight(kg=10),

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -35,6 +35,7 @@ from ..attribute.models import (
     AttributeValueTranslation,
 )
 from ..attribute.utils import associate_attribute_values_to_instance
+from ..checkout.fetch import fetch_checkout_info
 from ..checkout.models import Checkout
 from ..checkout.utils import add_variant_to_checkout
 from ..core import JobStatus
@@ -258,7 +259,8 @@ def checkout(db, channel_USD):
 @pytest.fixture
 def checkout_with_item(checkout, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 3)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
 
@@ -316,7 +318,8 @@ def checkout_ready_to_complete(checkout_with_item, address, shipping_method, gif
 def checkout_with_digital_item(checkout, digital_content):
     """Create a checkout with a digital line."""
     variant = digital_content.product_variant
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     checkout.email = "customer@example.com"
     checkout.save()
     return checkout
@@ -326,7 +329,8 @@ def checkout_with_digital_item(checkout, digital_content):
 def checkout_with_shipping_required(checkout_with_item, product):
     checkout = checkout_with_item
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 3)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 3)
     checkout.save()
     return checkout
 
@@ -350,7 +354,8 @@ def other_shipping_method(shipping_zone, channel_USD):
 @pytest.fixture
 def checkout_without_shipping_required(checkout, product_without_shipping):
     variant = product_without_shipping.variants.get()
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     checkout.save()
     return checkout
 
@@ -358,7 +363,8 @@ def checkout_without_shipping_required(checkout, product_without_shipping):
 @pytest.fixture
 def checkout_with_single_item(checkout, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     checkout.save()
     return checkout
 
@@ -368,7 +374,8 @@ def checkout_with_variant_without_inventory_tracking(
     checkout, variant_without_inventory_tracking, address, shipping_method
 ):
     variant = variant_without_inventory_tracking
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.billing_address = address
@@ -381,10 +388,11 @@ def checkout_with_variant_without_inventory_tracking(
 @pytest.fixture
 def checkout_with_items(checkout, product_list, product):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 1)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 1)
     for prod in product_list:
         variant = prod.variants.get()
-        add_variant_to_checkout(checkout, variant, 1)
+        add_variant_to_checkout(checkout_info, variant, 1)
     checkout.refresh_from_db()
     return checkout
 
@@ -392,7 +400,8 @@ def checkout_with_items(checkout, product_list, product):
 @pytest.fixture
 def checkout_with_voucher(checkout, product, voucher):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 3)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 3)
     checkout.voucher_code = voucher.code
     checkout.discount = Money("20.00", "USD")
     checkout.save()
@@ -402,7 +411,8 @@ def checkout_with_voucher(checkout, product, voucher):
 @pytest.fixture
 def checkout_with_voucher_percentage(checkout, product, voucher_percentage):
     variant = product.variants.get()
-    add_variant_to_checkout(checkout, variant, 3)
+    checkout_info = fetch_checkout_info(checkout, [], [])
+    add_variant_to_checkout(checkout_info, variant, 3)
     checkout.voucher_code = voucher_percentage.code
     checkout.discount = Money("3.00", "USD")
     checkout.save()
@@ -543,9 +553,10 @@ def user_checkout_PLN(customer_user, channel_PLN):
 
 @pytest.fixture
 def user_checkout_with_items(user_checkout, product_list):
+    checkout_info = fetch_checkout_info(user_checkout, [], [])
     for product in product_list:
         variant = product.variants.get()
-        add_variant_to_checkout(user_checkout, variant, 1)
+        add_variant_to_checkout(checkout_info, variant, 1)
     user_checkout.refresh_from_db()
     return user_checkout
 

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -52,7 +52,7 @@ def check_stock_quantity_bulk(
     :raises InsufficientStock: when there is not enough items in stock for a variant.
     """
     all_variants_stocks = (
-        Stock.objects.for_country(country_code, channel_slug)
+        Stock.objects.for_country_and_channel(country_code, channel_slug)
         .filter(product_variant__in=variants)
         .annotate_available_quantity()
     )

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -22,14 +22,18 @@ def _get_available_quantity(stocks: StockQuerySet) -> int:
     return max(total_quantity - quantity_allocated, 0)
 
 
-def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity: int):
+def check_stock_quantity(
+    variant: "ProductVariant", country_code: str, channel_slug: str, quantity: int
+):
     """Validate if there is stock available for given variant in given country.
 
     If so - returns None. If there is less stock then required raise InsufficientStock
     exception.
     """
     if variant.track_inventory:
-        stocks = Stock.objects.get_variant_stocks_for_country(country_code, variant)
+        stocks = Stock.objects.get_variant_stocks_for_country(
+            country_code, channel_slug, variant
+        )
         if not stocks:
             raise InsufficientStock([InsufficientStockData(variant=variant)])
 

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -37,13 +37,13 @@ def check_stock_quantity(variant: "ProductVariant", country_code: str, quantity:
             raise InsufficientStock([InsufficientStockData(variant=variant)])
 
 
-def check_stock_quantity_bulk(variants, country_code, quantities):
+def check_stock_quantity_bulk(variants, country_code, quantities, channel_slug=None):
     """Validate if there is stock available for given variants in given country.
 
     :raises InsufficientStock: when there is not enough items in stock for a variant.
     """
     all_variants_stocks = (
-        Stock.objects.for_country(country_code)
+        Stock.objects.for_country(country_code, channel_slug)
         .filter(product_variant__in=variants)
         .annotate_available_quantity()
     )
@@ -63,8 +63,7 @@ def check_stock_quantity_bulk(variants, country_code, quantities):
                     variant=variant, available_quantity=available_quantity
                 )
             )
-
-        if variant.track_inventory:
+        elif variant.track_inventory:
             if quantity > available_quantity:
                 insufficient_stocks.append(
                     InsufficientStockData(

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -39,7 +39,7 @@ def allocate_stocks(
 
     stocks = list(
         Stock.objects.select_for_update(of=("self",))
-        .for_country(country_code, channel_slug)
+        .for_country_and_channel(country_code, channel_slug)
         .filter(product_variant__in=variants)
         .order_by("pk")
         .values("id", "product_variant", "pk", "quantity")

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -17,7 +17,9 @@ StockData = namedtuple("StockData", ["pk", "quantity"])
 
 
 @transaction.atomic
-def allocate_stocks(order_lines_info: Iterable["OrderLineData"], country_code: str):
+def allocate_stocks(
+    order_lines_info: Iterable["OrderLineData"], country_code: str, channel_slug: str
+):
     """Allocate stocks for given `order_lines` in given country.
 
     Function lock for update all stocks and allocations for variants in
@@ -37,7 +39,7 @@ def allocate_stocks(order_lines_info: Iterable["OrderLineData"], country_code: s
 
     stocks = list(
         Stock.objects.select_for_update(of=("self",))
-        .for_country(country_code)
+        .for_country(country_code, channel_slug)
         .filter(product_variant__in=variants)
         .order_by("pk")
         .values("id", "product_variant", "pk", "quantity")

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -72,7 +72,7 @@ class StockQuerySet(models.QuerySet):
             warehouse__in=query_warehouse
         )
 
-    def for_country(self, country_code: str, channel_slug):
+    def for_country_and_channel(self, country_code: str, channel_slug):
         filter_lookup = {"shipping_zones__countries__contains": country_code}
         if channel_slug is not None:
             filter_lookup["shipping_zones__channels__slug"] = channel_slug
@@ -90,14 +90,14 @@ class StockQuerySet(models.QuerySet):
 
         Note it will raise a 'Stock.DoesNotExist' exception if no such stock is found.
         """
-        return self.for_country(country_code, channel_slug).filter(
+        return self.for_country_and_channel(country_code, channel_slug).filter(
             product_variant=product_variant
         )
 
     def get_product_stocks_for_country_and_channel(
         self, country_code: str, channel_slug: str, product: Product
     ):
-        return self.for_country(country_code, channel_slug).filter(
+        return self.for_country_and_channel(country_code, channel_slug).filter(
             product_variant__product_id=product.pk
         )
 

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -84,13 +84,15 @@ class StockQuerySet(models.QuerySet):
         )
 
     def get_variant_stocks_for_country(
-        self, country_code: str, product_variant: ProductVariant
+        self, country_code: str, channel_slug: str, product_variant: ProductVariant
     ):
         """Return the stock information about the a stock for a given country.
 
         Note it will raise a 'Stock.DoesNotExist' exception if no such stock is found.
         """
-        return self.for_country(country_code).filter(product_variant=product_variant)
+        return self.for_country(country_code, channel_slug).filter(
+            product_variant=product_variant
+        )
 
     def get_product_stocks_for_country_and_channel(
         self, country_code: str, channel_slug: str, product: Product

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -72,7 +72,7 @@ class StockQuerySet(models.QuerySet):
             warehouse__in=query_warehouse
         )
 
-    def for_country(self, country_code: str, channel_slug=None):
+    def for_country(self, country_code: str, channel_slug):
         filter_lookup = {"shipping_zones__countries__contains": country_code}
         if channel_slug is not None:
             filter_lookup["shipping_zones__channels__slug"] = channel_slug

--- a/saleor/warehouse/tests/test_stock.py
+++ b/saleor/warehouse/tests/test_stock.py
@@ -3,10 +3,10 @@ from ..models import Stock
 COUNTRY_CODE = "US"
 
 
-def test_stocks_for_country(variant_with_many_stocks):
+def test_stocks_for_country(variant_with_many_stocks, channel_USD):
     [stock1, stock2] = (
         Stock.objects.filter(product_variant=variant_with_many_stocks)
-        .for_country(COUNTRY_CODE)
+        .for_country(COUNTRY_CODE, channel_USD.slug)
         .order_by("pk")
         .all()
     )
@@ -18,12 +18,12 @@ def test_stocks_for_country(variant_with_many_stocks):
     assert COUNTRY_CODE in warehouse2.countries
 
 
-def test_stock_for_country_does_not_exists(product, warehouse):
+def test_stock_for_country_does_not_exists(product, warehouse, channel_PLN):
     shipping_zone = warehouse.shipping_zones.first()
     shipping_zone.countries = [COUNTRY_CODE]
     shipping_zone.save(update_fields=["countries"])
     warehouse.refresh_from_db()
     fake_country_code = "PL"
     assert fake_country_code not in warehouse.countries
-    stock_qs = Stock.objects.for_country(fake_country_code)
+    stock_qs = Stock.objects.for_country(fake_country_code, channel_PLN.slug)
     assert not stock_qs.exists()

--- a/saleor/warehouse/tests/test_stock.py
+++ b/saleor/warehouse/tests/test_stock.py
@@ -6,7 +6,7 @@ COUNTRY_CODE = "US"
 def test_stocks_for_country(variant_with_many_stocks, channel_USD):
     [stock1, stock2] = (
         Stock.objects.filter(product_variant=variant_with_many_stocks)
-        .for_country(COUNTRY_CODE, channel_USD.slug)
+        .for_country_and_channel(COUNTRY_CODE, channel_USD.slug)
         .order_by("pk")
         .all()
     )
@@ -25,5 +25,7 @@ def test_stock_for_country_does_not_exists(product, warehouse, channel_PLN):
     warehouse.refresh_from_db()
     fake_country_code = "PL"
     assert fake_country_code not in warehouse.countries
-    stock_qs = Stock.objects.for_country(fake_country_code, channel_PLN.slug)
+    stock_qs = Stock.objects.for_country_and_channel(
+        fake_country_code, channel_PLN.slug
+    )
     assert not stock_qs.exists()

--- a/saleor/warehouse/tests/test_stock_availability.py
+++ b/saleor/warehouse/tests/test_stock_availability.py
@@ -10,39 +10,61 @@ from ..availability import (
 COUNTRY_CODE = "US"
 
 
-def test_check_stock_quantity(variant_with_many_stocks):
-    assert check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 7) is None
+def test_check_stock_quantity(variant_with_many_stocks, channel_USD):
+    assert (
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 7
+        )
+        is None
+    )
 
 
-def test_check_stock_quantity_out_of_stock(variant_with_many_stocks):
+def test_check_stock_quantity_out_of_stock(variant_with_many_stocks, channel_USD):
     with pytest.raises(InsufficientStock):
-        check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 8)
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 8
+        )
 
 
 def test_check_stock_quantity_with_allocations(
     variant_with_many_stocks,
     order_line_with_allocation_in_many_stocks,
     order_line_with_one_allocation,
+    channel_USD,
 ):
-    assert check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 3) is None
+    assert (
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 3
+        )
+        is None
+    )
 
 
 def test_check_stock_quantity_with_allocations_out_of_stock(
-    variant_with_many_stocks, order_line_with_allocation_in_many_stocks
+    variant_with_many_stocks, order_line_with_allocation_in_many_stocks, channel_USD
 ):
     with pytest.raises(InsufficientStock):
-        check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 5)
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 5
+        )
 
 
-def test_check_stock_quantity_without_stocks(variant_with_many_stocks):
+def test_check_stock_quantity_without_stocks(variant_with_many_stocks, channel_USD):
     variant_with_many_stocks.stocks.all().delete()
     with pytest.raises(InsufficientStock):
-        check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 1)
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 1
+        )
 
 
-def test_check_stock_quantity_without_one_stock(variant_with_many_stocks):
+def test_check_stock_quantity_without_one_stock(variant_with_many_stocks, channel_USD):
     variant_with_many_stocks.stocks.get(quantity=3).delete()
-    assert check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 4) is None
+    assert (
+        check_stock_quantity(
+            variant_with_many_stocks, COUNTRY_CODE, channel_USD.slug, 4
+        )
+        is None
+    )
 
 
 def test_check_stock_quantity_bulk(variant_with_many_stocks, channel_USD):

--- a/saleor/warehouse/tests/test_stock_availability.py
+++ b/saleor/warehouse/tests/test_stock_availability.py
@@ -45,7 +45,7 @@ def test_check_stock_quantity_without_one_stock(variant_with_many_stocks):
     assert check_stock_quantity(variant_with_many_stocks, COUNTRY_CODE, 4) is None
 
 
-def test_check_stock_quantity_bulk(variant_with_many_stocks):
+def test_check_stock_quantity_bulk(variant_with_many_stocks, channel_USD):
     variant = variant_with_many_stocks
     country_code = "US"
     available_quantity = _get_available_quantity(variant.stocks.all())
@@ -53,7 +53,7 @@ def test_check_stock_quantity_bulk(variant_with_many_stocks):
     # test that it doesn't raise error for available quantity
     assert (
         check_stock_quantity_bulk(
-            [variant_with_many_stocks], country_code, [available_quantity]
+            [variant_with_many_stocks], country_code, [available_quantity], channel_USD
         )
         is None
     )
@@ -61,12 +61,29 @@ def test_check_stock_quantity_bulk(variant_with_many_stocks):
     # test that it raises an error for exceeded quantity
     with pytest.raises(InsufficientStock):
         check_stock_quantity_bulk(
-            [variant_with_many_stocks], country_code, [available_quantity + 1]
+            [variant_with_many_stocks],
+            country_code,
+            [available_quantity + 1],
+            channel_USD,
         )
 
     # test that it raises an error if no stocks are found
     variant.stocks.all().delete()
     with pytest.raises(InsufficientStock):
         check_stock_quantity_bulk(
-            [variant_with_many_stocks], country_code, [available_quantity]
+            [variant_with_many_stocks], country_code, [available_quantity], channel_USD
+        )
+
+
+def test_check_stock_quantity_bulk_no_channel_shipping_zones(
+    variant_with_many_stocks, channel_USD
+):
+    variant = variant_with_many_stocks
+    country_code = "US"
+    available_quantity = _get_available_quantity(variant.stocks.all())
+    channel_USD.shipping_zones.clear()
+
+    with pytest.raises(InsufficientStock):
+        check_stock_quantity_bulk(
+            [variant_with_many_stocks], country_code, [available_quantity], channel_USD
         )

--- a/saleor/warehouse/tests/test_stock_management.py
+++ b/saleor/warehouse/tests/test_stock_management.py
@@ -18,13 +18,13 @@ from ..models import Allocation
 COUNTRY_CODE = "US"
 
 
-def test_allocate_stocks(order_line, stock):
+def test_allocate_stocks(order_line, stock, channel_USD):
     stock.quantity = 100
     stock.save(update_fields=["quantity"])
 
     line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=50)
 
-    allocate_stocks([line_data], COUNTRY_CODE)
+    allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -32,7 +32,7 @@ def test_allocate_stocks(order_line, stock):
     assert allocation.quantity_allocated == 50
 
 
-def test_allocate_stocks_multiply_lines(order_line, order, product, stock):
+def test_allocate_stocks_multiply_lines(order_line, order, product, stock, channel_USD):
     stock.quantity = 100
     stock.save(update_fields=["quantity"])
 
@@ -56,7 +56,7 @@ def test_allocate_stocks_multiply_lines(order_line, order, product, stock):
         line=order_line_2, variant=variant_2, quantity=quantity_2
     )
 
-    allocate_stocks([line_data_1, line_data_2], COUNTRY_CODE)
+    allocate_stocks([line_data_1, line_data_2], COUNTRY_CODE, channel_USD.slug)
 
     stock.refresh_from_db()
     assert stock.quantity == 100
@@ -68,12 +68,12 @@ def test_allocate_stocks_multiply_lines(order_line, order, product, stock):
     assert allocation.quantity_allocated == quantity_2
 
 
-def test_allocate_stock_many_stocks(order_line, variant_with_many_stocks):
+def test_allocate_stock_many_stocks(order_line, variant_with_many_stocks, channel_USD):
     variant = variant_with_many_stocks
     stocks = variant.stocks.all()
 
     line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=5)
-    allocate_stocks([line_data], COUNTRY_CODE)
+    allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
 
     allocations = Allocation.objects.filter(order_line=order_line, stock__in=stocks)
     assert allocations[0].quantity_allocated == 4
@@ -84,13 +84,14 @@ def test_allocate_stock_many_stocks_partially_allocated(
     order_line,
     order_line_with_allocation_in_many_stocks,
     order_line_with_one_allocation,
+    channel_USD,
 ):
     allocated_line = order_line_with_allocation_in_many_stocks
     variant = allocated_line.variant
     stocks = variant.stocks.all()
 
     line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=3)
-    allocate_stocks([line_data], COUNTRY_CODE)
+    allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
 
     allocations = Allocation.objects.filter(order_line=order_line, stock__in=stocks)
     assert allocations[0].quantity_allocated == 1
@@ -98,7 +99,7 @@ def test_allocate_stock_many_stocks_partially_allocated(
 
 
 def test_allocate_stock_partially_allocated_insufficient_stocks(
-    order_line, order_line_with_allocation_in_many_stocks
+    order_line, order_line_with_allocation_in_many_stocks, channel_USD
 ):
     allocated_line = order_line_with_allocation_in_many_stocks
     variant = allocated_line.variant
@@ -106,20 +107,33 @@ def test_allocate_stock_partially_allocated_insufficient_stocks(
 
     line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=6)
     with pytest.raises(InsufficientStock):
-        allocate_stocks([line_data], COUNTRY_CODE)
+        allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
 
     assert not Allocation.objects.filter(
         order_line=order_line, stock__in=stocks
     ).exists()
 
 
-def test_allocate_stock_insufficient_stocks(order_line, variant_with_many_stocks):
+def test_allocate_stocks_no_channel_shipping_zones(order_line, stock, channel_USD):
+    channel_USD.shipping_zones.clear()
+
+    stock.quantity = 100
+    stock.save(update_fields=["quantity"])
+
+    line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=50)
+    with pytest.raises(InsufficientStock):
+        allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
+
+
+def test_allocate_stock_insufficient_stocks(
+    order_line, variant_with_many_stocks, channel_USD
+):
     variant = variant_with_many_stocks
     stocks = variant.stocks.all()
 
     line_data = OrderLineData(line=order_line, variant=order_line.variant, quantity=10)
     with pytest.raises(InsufficientStock):
-        allocate_stocks([line_data], COUNTRY_CODE)
+        allocate_stocks([line_data], COUNTRY_CODE, channel_USD.slug)
 
     assert not Allocation.objects.filter(
         order_line=order_line, stock__in=stocks
@@ -127,7 +141,7 @@ def test_allocate_stock_insufficient_stocks(order_line, variant_with_many_stocks
 
 
 def test_allocate_stock_insufficient_stocks_for_multiply_lines(
-    order_line, variant_with_many_stocks, product
+    order_line, variant_with_many_stocks, product, channel_USD
 ):
     variant = variant_with_many_stocks
     stocks = variant.stocks.all()
@@ -152,7 +166,7 @@ def test_allocate_stock_insufficient_stocks_for_multiply_lines(
     )
 
     with pytest.raises(InsufficientStock) as exc:
-        allocate_stocks([line_data_1, line_data_2], COUNTRY_CODE)
+        allocate_stocks([line_data_1, line_data_2], COUNTRY_CODE, channel_USD.slug)
 
     assert set(item.variant for item in exc._excinfo[1].items) == {variant, variant_2}
 

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -305,9 +305,7 @@ def generate_fulfillment_payload(fulfillment: Fulfillment):
     if fulfillment_line and fulfillment_line.stock:
         warehouse = fulfillment_line.stock.warehouse
     else:
-        warehouse = Warehouse.objects.for_country(
-            order_country, order.channel.slug
-        ).first()
+        warehouse = Warehouse.objects.for_country(order_country).first()
     fulfillment_data = serializer.serialize(
         [fulfillment],
         fields=fulfillment_fields,

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -299,12 +299,15 @@ def generate_fulfillment_payload(fulfillment: Fulfillment):
 
     # fulfillment fields to serialize
     fulfillment_fields = ("status", "tracking_code", "order__user_email")
-    order_country = get_order_country(fulfillment.order)
+    order = fulfillment.order
+    order_country = get_order_country(order)
     fulfillment_line = fulfillment.lines.first()
     if fulfillment_line and fulfillment_line.stock:
         warehouse = fulfillment_line.stock.warehouse
     else:
-        warehouse = Warehouse.objects.for_country(order_country).first()
+        warehouse = Warehouse.objects.for_country(
+            order_country, order.channel.slug
+        ).first()
     fulfillment_data = serializer.serialize(
         [fulfillment],
         fields=fulfillment_fields,


### PR DESCRIPTION
Return data based on available warehouses for a given channel in checkout-related methods.
Update:
- `check_stock_quantity_bulk` method
- `allocate_stocks`
- `check_variant_in_stock`
- update quantity validation in `CheckoutCreate`, `CheckoutLinesAdd`, `CheckoutLinesUpdate`
- add channel validation in `ShippingMethodChannelListingUpdate`





<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
