### PR TITLE
Enables opentracing parent calling saleor

### DIFF
--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 import opentracing
 import opentracing.tags
-from opentracing.propagation import Format
 from django.conf import settings
 from django.db import connection
 from django.db.backends.postgresql.base import DatabaseWrapper
@@ -22,6 +21,7 @@ from graphql.error import GraphQLError, GraphQLSyntaxError
 from graphql.error import format_error as format_graphql_error
 from graphql.execution import ExecutionResult
 from jwt.exceptions import PyJWTError
+from opentracing.propagation import Format
 
 from ..core.exceptions import PermissionDenied, ReadOnlyException
 from ..core.utils import is_valid_ipv4, is_valid_ipv6
@@ -134,8 +134,7 @@ class GraphQLView(View):
         tracer = opentracing.global_tracer()
 
         span_context = tracer.extract(
-            format=Format.HTTP_HEADERS,
-            carrier=request.headers
+            format=Format.HTTP_HEADERS, carrier=request.headers
         )
 
         with tracer.start_active_span("http", child_of=span_context) as scope:


### PR DESCRIPTION
I want to merge this change because...

At present saleor assumes that it is the initial request from the UI layer and creates a new jaeger/opentracing span even if a parent span is provided in the HTTP headers.

This PR allows upstream services to pass a opentracing headers in the request and have full tracing across services.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
