### PR TITLE
Remove redundant Opentracing spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow to use `Bearer` as an authorization prefix - #6996 by @korycins
 - Update checkout quantity when checkout lines are deleted - #7002 by @IKarbowiak
 - Raise an error when the user is trying to sort products by rank without search - #7013 by @IKarbowiak
+- Remove redundant Opentracing spans - #6994 by @fowczarek
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -94,21 +94,12 @@ class PluginsManager(PaymentInterface):
         method. If plugin doesn't have own implementation of expected method_name, it
         will return previous_value.
         """
-        plugin_id = getattr(plugin, "PLUGIN_ID", "")
         plugin_method = getattr(plugin, method_name, NotImplemented)
         if plugin_method == NotImplemented:
             return previous_value
-        with opentracing.global_tracer().start_active_span(
-            f"{plugin_id}.{method_name}", finish_on_close=False
-        ) as scope:
-            returned_value = plugin_method(
-                *args, **kwargs, previous_value=previous_value
-            )
-            if returned_value == NotImplemented:
-                return previous_value
-            # We should create spans for plugin_method with return data instead of
-            # `NotImplemented`
-            scope.span.finish()
+        returned_value = plugin_method(*args, **kwargs, previous_value=previous_value)
+        if returned_value == NotImplemented:
+            return previous_value
         return returned_value
 
     def change_user_address(


### PR DESCRIPTION
I want to merge this change because of removing redundant spans.

We shouldn't create spans for:
~~1. plugin_method with return data instead of `NotImplemented`~~ We should refactor plugins manager(sperate task)
2. metadata resolver
3. default context resolvers
3. each plugin from `__run_method_on_single_plugin`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
