### PR TITLE
Change the way of handling external tokens

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -141,11 +141,7 @@ def is_saleor_token(token: str) -> bool:
     except jwt.PyJWTError:
         return False
     owner = payload.get(JWT_OWNER_FIELD)
-    if not owner:
-        raise jwt.InvalidTokenError(
-            "Invalid token. Create new one by using tokenCreate mutation."
-        )
-    if owner != JWT_SALEOR_OWNER_NAME:
+    if not owner or owner != JWT_SALEOR_OWNER_NAME:
         return False
     return True
 

--- a/saleor/core/tests/test_auth_backend.py
+++ b/saleor/core/tests/test_auth_backend.py
@@ -62,7 +62,7 @@ def test_saleor_is_not_owner_of_token(prefix, rf, staff_user, settings):
 
 
 @pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
-def test_raises_error_when_owner_field_is_missing(prefix, rf, staff_user, settings):
+def test_owner_field_is_missing(prefix, rf, staff_user, settings):
     payload = jwt_user_payload(
         staff_user,
         JWT_ACCESS_TYPE,
@@ -72,8 +72,7 @@ def test_raises_error_when_owner_field_is_missing(prefix, rf, staff_user, settin
     token = jwt_encode(payload)
     request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {token}")
     backend = JSONWebTokenBackend()
-    with pytest.raises(InvalidTokenError):
-        backend.authenticate(request)
+    assert backend.authenticate(request) is None
 
 
 @pytest.mark.parametrize("prefix", ["JWT", "Bearer"])


### PR DESCRIPTION
I want to merge this change because currently, we're blocking the external tokens which don't have a structure prepared by Saleor. This can complicate using an external auth interface as we can't use access token prepared by different services. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
