### PR TITLE
Add possibility to use bearer as an token prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix race condition on `send_fulfillment-confirmation` - #6988 by @fowczarek
 - Fix resolver by id and slug for product and product variant - #6985 by @d-wysocki
 - Add optional support for reporting resource limits via a stub field in `shop` - #6967 by @NyanKiyoshi
+- Allow to use `Bearer` as an authorization prefix - #6996 by @korycins
 
 
 ### Breaking

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -16,7 +16,7 @@ from .permissions import (
 
 JWT_ALGORITHM = "HS256"
 JWT_AUTH_HEADER = "HTTP_AUTHORIZATION"
-JWT_AUTH_HEADER_PREFIX = "JWT"
+AUTH_HEADER_PREFIXES = ["JWT", "BEARER"]
 JWT_ACCESS_TYPE = "access"
 JWT_REFRESH_TYPE = "refresh"
 JWT_THIRDPARTY_ACCESS_TYPE = "thirdparty"
@@ -114,9 +114,8 @@ def create_refresh_token(
 
 def get_token_from_request(request: WSGIRequest) -> Optional[str]:
     auth = request.META.get(JWT_AUTH_HEADER, "").split(maxsplit=1)
-    prefix = JWT_AUTH_HEADER_PREFIX
 
-    if len(auth) != 2 or auth[0].upper() != prefix:
+    if len(auth) != 2 or auth[0].upper() not in AUTH_HEADER_PREFIXES:
         return None
     return auth[1]
 

--- a/saleor/core/tests/test_auth_backend.py
+++ b/saleor/core/tests/test_auth_backend.py
@@ -17,33 +17,37 @@ from ..jwt import (
 from ..permissions import get_permissions_from_names
 
 
-def test_user_authenticated(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_authenticated(prefix, rf, staff_user):
     access_token = create_access_token(staff_user)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     user = backend.authenticate(request)
     assert user == staff_user
 
 
-def test_user_deactivated(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_deactivated(prefix, rf, staff_user):
     staff_user.is_active = False
     staff_user.save()
     access_token = create_access_token(staff_user)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 
-def test_incorect_type_of_token(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_incorect_type_of_token(prefix, rf, staff_user):
     token = create_refresh_token(staff_user)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 
-def test_saleor_is_not_owner_of_token(rf, staff_user, settings):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_saleor_is_not_owner_of_token(prefix, rf, staff_user, settings):
     payload = jwt_user_payload(
         staff_user,
         JWT_ACCESS_TYPE,
@@ -51,13 +55,14 @@ def test_saleor_is_not_owner_of_token(rf, staff_user, settings):
         token_owner="mirumee.custom.auth.plugin",
     )
     token = jwt_encode(payload)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {token}")
     backend = JSONWebTokenBackend()
 
     assert backend.authenticate(request) is None
 
 
-def test_raises_error_when_owner_field_is_missing(rf, staff_user, settings):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_raises_error_when_owner_field_is_missing(prefix, rf, staff_user, settings):
     payload = jwt_user_payload(
         staff_user,
         JWT_ACCESS_TYPE,
@@ -65,13 +70,14 @@ def test_raises_error_when_owner_field_is_missing(rf, staff_user, settings):
         token_owner=None,  # type: ignore
     )
     token = jwt_encode(payload)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 
-def test_incorrect_token(rf, staff_user, settings):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_incorrect_token(prefix, rf, staff_user, settings):
     payload = jwt_user_payload(
         staff_user,
         JWT_ACCESS_TYPE,
@@ -82,14 +88,15 @@ def test_incorrect_token(rf, staff_user, settings):
         "Wrong secret",
         JWT_ALGORITHM,
     )
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidSignatureError):
         backend.authenticate(request)
 
 
-def test_missing_token(rf, staff_user):
-    request = rf.request(HTTP_AUTHORIZATION="JWT ")
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_missing_token(prefix, rf, staff_user):
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} ")
     backend = JSONWebTokenBackend()
     assert backend.authenticate(request) is None
 
@@ -100,35 +107,39 @@ def test_missing_header(rf, staff_user):
     assert backend.authenticate(request) is None
 
 
-def test_token_expired(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_token_expired(prefix, rf, staff_user):
     with freeze_time("2019-03-18 12:00:00"):
         access_token = create_access_token(staff_user)
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(ExpiredSignatureError):
         backend.authenticate(request)
 
 
-def test_user_doesnt_exist(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_doesnt_exist(prefix, rf, staff_user):
     access_token = create_access_token(staff_user)
     staff_user.delete()
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 
-def test_user_deactivated_token(rf, staff_user):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_deactivated_token(prefix, rf, staff_user):
     access_token = create_access_token(staff_user)
     staff_user.jwt_token_key = "New key"
     staff_user.save()
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)
 
 
-def test_user_doesnt_have_permissions_from_token(staff_user, app, rf):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_doesnt_have_permissions_from_token(prefix, staff_user, app, rf):
     staff_user.user_permissions.set(
         Permission.objects.filter(codename__in=["manage_checkouts", "manage_orders"])
     )
@@ -142,7 +153,7 @@ def test_user_doesnt_have_permissions_from_token(staff_user, app, rf):
     # user doesn't have the same permissions as in the token
     staff_user.user_permissions.set(expected_permissions)
 
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token_for_app}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token_for_app}")
     backend = JSONWebTokenBackend()
     user = backend.authenticate(request)
     assert user == staff_user
@@ -185,14 +196,15 @@ def test_user_with_limited_permissions(
     assert set(user_permissions) == set(limited_permissions)
 
 
-def test_user_payload_doesnt_have_user_token(rf, staff_user, settings):
+@pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
+def test_user_payload_doesnt_have_user_token(prefix, rf, staff_user, settings):
     access_payload = jwt_user_payload(
         staff_user, JWT_ACCESS_TYPE, settings.JWT_TTL_ACCESS
     )
     del access_payload["token"]
     access_token = jwt_encode(access_payload)
 
-    request = rf.request(HTTP_AUTHORIZATION=f"JWT {access_token}")
+    request = rf.request(HTTP_AUTHORIZATION=f"{prefix} {access_token}")
     backend = JSONWebTokenBackend()
     with pytest.raises(InvalidTokenError):
         backend.authenticate(request)


### PR DESCRIPTION
I want to merge this change because  we want to use new Authorization prefix (Bearer) as we want to drop `JWT` header in the future (as it is not officially supported in specs)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
