### PR TITLE
change_currency: remove queries referencing deprecated currency field

### DIFF
--- a/saleor/core/management/commands/change_currency.py
+++ b/saleor/core/management/commands/change_currency.py
@@ -42,12 +42,8 @@ class Command(BaseCommand):
                 )
 
         Checkout.objects.update(currency=currency)
-        Voucher.objects.update(currency=currency)
         GiftCard.objects.update(currency=currency)
         Order.objects.update(currency=currency)
         OrderLine.objects.update(currency=currency)
         Payment.objects.update(currency=currency)
         Transaction.objects.update(currency=currency)
-        Product.objects.update(currency=currency)
-        ProductVariant.objects.update(currency=currency)
-        ShippingMethod.objects.update(currency=currency)


### PR DESCRIPTION
I want to merge this change because...

these queries reference deprecated currency fields.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
