### PR TITLE
Feature/add saleor header for authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix exporting product description to xlsx - #6959 by @IKarbowiak
 - Add `Shop.version` field to query API version - #6980 by @maarcingebala
 - Return empty results when filtering by non-existing attribute - #7025 by @maarcingebala
+- Add new authorization header `Authorization-Bearer` - #6998 by @korycins
 
 # 2.11.1
 

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -15,7 +15,10 @@ from .permissions import (
 )
 
 JWT_ALGORITHM = "HS256"
-JWT_AUTH_HEADER = "HTTP_AUTHORIZATION"
+
+SALEOR_AUTH_HEADER = "HTTP_AUTHORIZATION_BEARER"
+DEFAULT_AUTH_HEADER = "HTTP_AUTHORIZATION"
+
 AUTH_HEADER_PREFIXES = ["JWT", "BEARER"]
 JWT_ACCESS_TYPE = "access"
 JWT_REFRESH_TYPE = "refresh"
@@ -113,11 +116,14 @@ def create_refresh_token(
 
 
 def get_token_from_request(request: WSGIRequest) -> Optional[str]:
-    auth = request.META.get(JWT_AUTH_HEADER, "").split(maxsplit=1)
+    auth_token = request.META.get(SALEOR_AUTH_HEADER)
 
-    if len(auth) != 2 or auth[0].upper() not in AUTH_HEADER_PREFIXES:
-        return None
-    return auth[1]
+    if not auth_token:
+        auth = request.META.get(DEFAULT_AUTH_HEADER, "").split(maxsplit=1)
+
+        if len(auth) == 2 and auth[0].upper() in AUTH_HEADER_PREFIXES:
+            auth_token = auth[1]
+    return auth_token
 
 
 def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:

--- a/saleor/core/tests/test_auth_backend_default_header.py
+++ b/saleor/core/tests/test_auth_backend_default_header.py
@@ -17,6 +17,17 @@ from ..jwt import (
 from ..permissions import get_permissions_from_names
 
 
+def test_use_default_header_as_a_fallback(rf, staff_user, customer_user):
+    customer_access_token = create_access_token(customer_user)
+
+    request = rf.request(
+        HTTP_AUTHORIZATION_BEARER="", HTTP_AUTHORIZATION=f"JWT {customer_access_token}"
+    )
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == customer_user
+
+
 @pytest.mark.parametrize("prefix", ["JWT", "Bearer"])
 def test_user_authenticated(prefix, rf, staff_user):
     access_token = create_access_token(staff_user)

--- a/saleor/core/tests/test_auth_backend_saleor_header.py
+++ b/saleor/core/tests/test_auth_backend_saleor_header.py
@@ -1,0 +1,211 @@
+import jwt
+import pytest
+from django.contrib.auth.models import Permission
+from freezegun import freeze_time
+from jwt import ExpiredSignatureError, InvalidSignatureError, InvalidTokenError
+
+from ..auth_backend import JSONWebTokenBackend
+from ..jwt import (
+    JWT_ACCESS_TYPE,
+    JWT_ALGORITHM,
+    create_access_token,
+    create_access_token_for_app,
+    create_refresh_token,
+    jwt_encode,
+    jwt_user_payload,
+)
+from ..permissions import get_permissions_from_names
+
+
+def test_use_saleor_header_as_a_first_try(rf, staff_user, customer_user):
+    staff_access_token = create_access_token(staff_user)
+    customer_access_token = create_access_token(customer_user)
+
+    request = rf.request(
+        HTTP_AUTHORIZATION_BEARER=f"{staff_access_token}",
+        HTTP_AUTHORIZATION=f"JWT {customer_access_token}",
+    )
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == staff_user
+
+
+def test_user_authenticated(rf, staff_user):
+    access_token = create_access_token(staff_user)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == staff_user
+
+
+def test_user_deactivated(rf, staff_user):
+    staff_user.is_active = False
+    staff_user.save()
+    access_token = create_access_token(staff_user)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_incorect_type_of_token(rf, staff_user):
+    token = create_refresh_token(staff_user)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_saleor_is_not_owner_of_token(rf, staff_user, settings):
+    payload = jwt_user_payload(
+        staff_user,
+        JWT_ACCESS_TYPE,
+        settings.JWT_TTL_ACCESS,
+        token_owner="mirumee.custom.auth.plugin",
+    )
+    token = jwt_encode(payload)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{token}")
+    backend = JSONWebTokenBackend()
+
+    assert backend.authenticate(request) is None
+
+
+def test_raises_error_when_owner_field_is_missing(rf, staff_user, settings):
+    payload = jwt_user_payload(
+        staff_user,
+        JWT_ACCESS_TYPE,
+        settings.JWT_TTL_ACCESS,
+        token_owner=None,  # type: ignore
+    )
+    token = jwt_encode(payload)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_incorrect_token(rf, staff_user, settings):
+    payload = jwt_user_payload(
+        staff_user,
+        JWT_ACCESS_TYPE,
+        settings.JWT_TTL_ACCESS,
+    )
+    token = jwt.encode(
+        payload,
+        "Wrong secret",
+        JWT_ALGORITHM,
+    )
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidSignatureError):
+        backend.authenticate(request)
+
+
+def test_missing_token(rf, staff_user):
+    request = rf.request(HTTP_AUTHORIZATION_BEARER="")
+    backend = JSONWebTokenBackend()
+    assert backend.authenticate(request) is None
+
+
+def test_missing_header(rf, staff_user):
+    request = rf.request()
+    backend = JSONWebTokenBackend()
+    assert backend.authenticate(request) is None
+
+
+def test_token_expired(rf, staff_user):
+    with freeze_time("2019-03-18 12:00:00"):
+        access_token = create_access_token(staff_user)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(ExpiredSignatureError):
+        backend.authenticate(request)
+
+
+def test_user_doesnt_exist(rf, staff_user):
+    access_token = create_access_token(staff_user)
+    staff_user.delete()
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_user_deactivated_token(rf, staff_user):
+    access_token = create_access_token(staff_user)
+    staff_user.jwt_token_key = "New key"
+    staff_user.save()
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)
+
+
+def test_user_doesnt_have_permissions_from_token(staff_user, app, rf):
+    staff_user.user_permissions.set(
+        Permission.objects.filter(codename__in=["manage_checkouts", "manage_orders"])
+    )
+    app.permissions.set(
+        Permission.objects.filter(codename__in=["manage_apps", "manage_checkouts"])
+    )
+    access_token_for_app = create_access_token_for_app(app, staff_user)
+
+    expected_permissions = Permission.objects.filter(codename__in=["manage_checkouts"])
+
+    # user doesn't have the same permissions as in the token
+    staff_user.user_permissions.set(expected_permissions)
+
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token_for_app}")
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == staff_user
+    assert set(user.effective_permissions) == set(expected_permissions)
+
+
+@pytest.mark.parametrize(
+    "user_permissions, app_permissions, expected_limited_permissions",
+    [
+        (
+            ["manage_apps", "manage_checkouts"],
+            ["manage_checkouts"],
+            ["MANAGE_CHECKOUTS"],
+        ),
+        ([], ["manage_checkouts"], []),
+        ([], [], []),
+        (["manage_apps"], ["manage_checkouts"], []),
+        (["manage_checkouts"], [], []),
+        (
+            ["manage_orders", "manage_checkouts", "manage_apps"],
+            ["manage_checkouts", "manage_apps"],
+            ["MANAGE_CHECKOUTS", "MANAGE_APPS"],
+        ),
+    ],
+)
+def test_user_with_limited_permissions(
+    user_permissions, app_permissions, expected_limited_permissions, rf, staff_user, app
+):
+    staff_user.user_permissions.set(
+        Permission.objects.filter(codename__in=user_permissions)
+    )
+    app.permissions.set(Permission.objects.filter(codename__in=app_permissions))
+    access_token_for_app = create_access_token_for_app(app, staff_user)
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token_for_app}")
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == staff_user
+    user_permissions = user.effective_permissions
+    limited_permissions = get_permissions_from_names(expected_limited_permissions)
+    assert set(user_permissions) == set(limited_permissions)
+
+
+def test_user_payload_doesnt_have_user_token(rf, staff_user, settings):
+    access_payload = jwt_user_payload(
+        staff_user, JWT_ACCESS_TYPE, settings.JWT_TTL_ACCESS
+    )
+    del access_payload["token"]
+    access_token = jwt_encode(access_payload)
+
+    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{access_token}")
+    backend = JSONWebTokenBackend()
+    with pytest.raises(InvalidTokenError):
+        backend.authenticate(request)

--- a/saleor/core/tests/test_auth_backend_saleor_header.py
+++ b/saleor/core/tests/test_auth_backend_saleor_header.py
@@ -70,20 +70,6 @@ def test_saleor_is_not_owner_of_token(rf, staff_user, settings):
     assert backend.authenticate(request) is None
 
 
-def test_raises_error_when_owner_field_is_missing(rf, staff_user, settings):
-    payload = jwt_user_payload(
-        staff_user,
-        JWT_ACCESS_TYPE,
-        settings.JWT_TTL_ACCESS,
-        token_owner=None,  # type: ignore
-    )
-    token = jwt_encode(payload)
-    request = rf.request(HTTP_AUTHORIZATION_BEARER=f"{token}")
-    backend = JSONWebTokenBackend()
-    with pytest.raises(InvalidTokenError):
-        backend.authenticate(request)
-
-
 def test_incorrect_token(rf, staff_user, settings):
     payload = jwt_user_payload(
         staff_user,

--- a/saleor/core/tests/test_auth_backend_saleor_header.py
+++ b/saleor/core/tests/test_auth_backend_saleor_header.py
@@ -17,6 +17,20 @@ from ..jwt import (
 from ..permissions import get_permissions_from_names
 
 
+@pytest.mark.parametrize("token_type", ["Basic", "Bearer"])
+def test_use_authorization_bearer_header_when_authorization_is_provided(
+    token_type, rf, staff_user, customer_user
+):
+    staff_access_token = create_access_token(staff_user)
+    request = rf.request(
+        HTTP_AUTHORIZATION_BEARER=f"{staff_access_token}",
+        HTTP_AUTHORIZATION=f"{token_type} ABC1234",
+    )
+    backend = JSONWebTokenBackend()
+    user = backend.authenticate(request)
+    assert user == staff_user
+
+
 def test_use_saleor_header_as_a_first_try(rf, staff_user, customer_user):
     staff_access_token = create_access_token(staff_user)
     customer_access_token = create_access_token(customer_user)


### PR DESCRIPTION
I want to merge this change because it introduces a new header responsible for authorizing a user's request.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
