### PR TITLE
Update logic to use shipping zones available in given channel in order and shop module

### DIFF
--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -18,10 +18,25 @@ FRAGMENT_DISCOUNTS = """
     }
 """
 
+FRAGMENT_AVAILABLE_SHIPPING_METHODS = """
+    fragment AvailableShippingMethods on ShippingMethod {
+        id
+        price {
+            amount
+        }
+        minimumOrderPrice {
+            amount
+            currency
+        }
+        type
+    }
+"""
+
 FRAGMENT_ORDER_DETAILS = (
     FRAGMENT_ADDRESS
     + FRAGMENT_PRODUCT_VARIANT
     + FRAGMENT_DISCOUNTS
+    + FRAGMENT_AVAILABLE_SHIPPING_METHODS
     + """
         fragment OrderDetail on Order {
           userEmail
@@ -47,6 +62,9 @@ FRAGMENT_ORDER_DETAILS = (
               currency
               ...Price
             }
+          }
+          availableShippingMethods {
+            ...AvailableShippingMethods
           }
           subtotal {
             ...Price

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2366,6 +2366,33 @@ def test_draft_order_complete_with_inactive_channel(
     assert data["orderErrors"][0]["field"] == "channel"
 
 
+def test_draft_order_complete_channel_without_shipping_zones(
+    staff_api_client,
+    permission_manage_orders,
+    staff_user,
+    draft_order,
+):
+    order = draft_order
+    order.channel.shipping_zones.clear()
+
+    # Ensure no events were created
+    assert not OrderEvent.objects.exists()
+
+    # Ensure no allocation were created
+    assert not Allocation.objects.filter(order_line__order=order).exists()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_COMPLETE_MUTATION, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]
+    assert len(data["orderErrors"]) == 1
+    assert data["orderErrors"][0]["code"] == OrderErrorCode.INSUFFICIENT_STOCK.name
+    assert data["orderErrors"][0]["field"] == "lines"
+
+
 def test_draft_order_complete_product_without_inventory_tracking(
     staff_api_client,
     shipping_method,

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -566,6 +566,35 @@ def test_order_query_without_available_shipping_methods(
     assert len(order_data["availableShippingMethods"]) == 0
 
 
+def test_order_query_shipping_zones_with_available_shipping_methods(
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+    shipping_zone,
+    channel_USD,
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    assert len(order_data["availableShippingMethods"]) == 1
+
+
+def test_order_query_shipping_zones_without_channel(
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+    shipping_zone,
+    channel_USD,
+):
+    channel_USD.shipping_zones.clear()
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+    assert len(order_data["availableShippingMethods"]) == 0
+
+
 def test_order_query_shipping_methods_excluded_postal_codes(
     staff_api_client,
     permission_manage_orders,

--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -6,7 +6,8 @@ from ..channel import ChannelContext
 
 def resolve_available_shipping_methods(info, channel_slug: str, address):
     available = ShippingMethod.objects.filter(
-        channel_listings__channel__slug=channel_slug
+        shipping_zone__channels__slug=channel_slug,
+        channel_listings__channel__slug=channel_slug,
     )
     if address and address.country:
         available = available.filter(

--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -5,10 +5,7 @@ from ..channel import ChannelContext
 
 
 def resolve_available_shipping_methods(info, channel_slug: str, address):
-    available = ShippingMethod.objects.filter(
-        shipping_zone__channels__slug=channel_slug,
-        channel_listings__channel__slug=channel_slug,
-    )
+    available = ShippingMethod.objects.for_channel(channel_slug)
     if address and address.country:
         available = available.filter(
             shipping_zone__countries__contains=address.country,

--- a/saleor/graphql/shop/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/shop/tests/benchmark/test_homepage.py
@@ -1,17 +1,23 @@
 import pytest
 
+from ....order.tests.benchmark.test_order import FRAGMENT_AVAILABLE_SHIPPING_METHODS
 from ....tests.utils import get_graphql_content
 
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_retrieve_shop(api_client, count_queries):
-    query = """
-        query getShop {
+def test_retrieve_shop(api_client, channel_USD, count_queries):
+    query = (
+        FRAGMENT_AVAILABLE_SHIPPING_METHODS
+        + """
+        query getShop($channel: String!) {
           shop {
             defaultCountry {
               code
               country
+            }
+            availableShippingMethods(channel: $channel) {
+              ...AvailableShippingMethods
             }
             countries {
               country
@@ -20,5 +26,8 @@ def test_retrieve_shop(api_client, count_queries):
           }
         }
     """
+    )
 
-    get_graphql_content(api_client.post_graphql(query))
+    get_graphql_content(
+        api_client.post_graphql(query, variables={"channel": channel_USD.slug})
+    )

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -680,12 +680,30 @@ def test_query_available_shipping_methods_no_address(
     # then
     content = get_graphql_content(response)
     data = content["data"]["shop"]["availableShippingMethods"]
+    assert len(data) > 0
     assert {ship_meth["id"] for ship_meth in data} == {
         graphene.Node.to_global_id("ShippingMethod", ship_meth.pk)
         for ship_meth in ShippingMethod.objects.filter(
-            channel_listings__channel__slug=channel_USD.slug
+            shipping_zone__channels__slug=channel_USD.slug,
+            channel_listings__channel__slug=channel_USD.slug,
         )
     }
+
+
+def test_query_available_shipping_methods_no_channel_shipping_zones(
+    staff_api_client, shipping_method, shipping_method_channel_PLN, channel_USD
+):
+    # given
+    query = AVAILABLE_SHIPPING_METHODS_QUERY
+    channel_USD.shipping_zones.clear()
+
+    # when
+    response = staff_api_client.post_graphql(query, {"channel": channel_USD.slug})
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["shop"]["availableShippingMethods"]
+    assert len(data) == 0
 
 
 def test_query_available_shipping_methods_for_given_address(

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -729,7 +729,7 @@ def test_query_available_shipping_methods_for_given_address(
     data = content["data"]["shop"]["availableShippingMethods"]
     assert len(data) == shipping_method_count - 1
     assert graphene.Node.to_global_id(
-        "ShippingMethod", shipping_zone_without_countries.pk
+        "ShippingMethod", shipping_zone_without_countries.shipping_methods.first().pk
     ) not in {ship_meth["id"] for ship_meth in data}
 
 

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -374,7 +374,10 @@ def automatically_fulfill_digital_lines(order: "Order"):
 
 
 def _create_fulfillment_lines(
-    fulfillment: Fulfillment, warehouse_pk: str, lines_data: List[Dict]
+    fulfillment: Fulfillment,
+    warehouse_pk: str,
+    lines_data: List[Dict],
+    channel_slug: str,
 ) -> List[FulfillmentLine]:
     """Modify stocks and allocations. Return list of unsaved FulfillmentLines.
 
@@ -390,6 +393,7 @@ def _create_fulfillment_lines(
                     },
                     ...
                 ]
+        channel_slug (str): Channel for which fulfillment lines should be created.
 
     Return:
         List[FulfillmentLine]: Unsaved fulfillmet lines created for this fulfillment
@@ -401,9 +405,11 @@ def _create_fulfillment_lines(
     """
     lines = [line_data["order_line"] for line_data in lines_data]
     variants = [line.variant for line in lines]
-    stocks = Stock.objects.filter(
-        warehouse_id=warehouse_pk, product_variant__in=variants
-    ).select_related("product_variant")
+    stocks = (
+        Stock.objects.for_channel(channel_slug)
+        .filter(warehouse_id=warehouse_pk, product_variant__in=variants)
+        .select_related("product_variant")
+    )
 
     variant_to_stock: Dict[str, List[Stock]] = defaultdict(list)
     for stock in stocks:
@@ -502,6 +508,7 @@ def create_fulfillments(
                 fulfillment,
                 warehouse_pk,
                 fulfillment_lines_for_warehouses[warehouse_pk],
+                order.channel.slug,
             )
         )
 

--- a/saleor/order/tests/test_fulfullments_actions.py
+++ b/saleor/order/tests/test_fulfullments_actions.py
@@ -105,10 +105,10 @@ def test_create_fulfillments_without_notification(
 def test_create_fulfillments_many_warehouses(
     staff_user,
     order_with_lines,
-    warehouses,
+    warehouses_with_shipping_zone,
 ):
     order = order_with_lines
-    warehouse1, warehouse2 = warehouses
+    warehouse1, warehouse2 = warehouses_with_shipping_zone
     order_line1, order_line2 = order.lines.all()
 
     stock_w1_l1 = Stock(

--- a/saleor/order/tests/test_order_utils.py
+++ b/saleor/order/tests/test_order_utils.py
@@ -3,7 +3,11 @@ import pytest
 from .. import OrderStatus
 from ..events import OrderEvents
 from ..models import Order, OrderEvent
-from ..utils import change_order_line_quantity, match_orders_with_new_user
+from ..utils import (
+    change_order_line_quantity,
+    get_valid_shipping_methods_for_order,
+    match_orders_with_new_user,
+)
 
 
 @pytest.mark.parametrize(
@@ -74,3 +78,76 @@ def test_match_draft_order_with_new_user(customer_user, channel_USD):
 
     order.refresh_from_db()
     assert order.user is None
+
+
+def test_get_valid_shipping_methods_for_order(order_line_with_one_allocation, address):
+    # given
+    order = order_line_with_one_allocation.order
+    order_line_with_one_allocation.is_shipping_required = True
+    order_line_with_one_allocation.save(update_fields=["is_shipping_required"])
+
+    order.currency = "USD"
+    order.shipping_address = address
+    order.save(update_fields=["shipping_address"])
+
+    # when
+    valid_shipping_methods = get_valid_shipping_methods_for_order(order)
+
+    # then
+    assert len(valid_shipping_methods) == 1
+
+
+def test_get_valid_shipping_methods_for_order_no_channel_shipping_zones(
+    order_line_with_one_allocation, address
+):
+    # given
+    order = order_line_with_one_allocation.order
+    order.channel.shipping_zones.clear()
+    order_line_with_one_allocation.is_shipping_required = True
+    order_line_with_one_allocation.save(update_fields=["is_shipping_required"])
+
+    order.currency = "USD"
+    order.shipping_address = address
+    order.save(update_fields=["shipping_address"])
+
+    # when
+    valid_shipping_methods = get_valid_shipping_methods_for_order(order)
+
+    # then
+    assert len(valid_shipping_methods) == 0
+
+
+def test_get_valid_shipping_methods_for_order_no_shipping_address(
+    order_line_with_one_allocation, address
+):
+    # given
+    order = order_line_with_one_allocation.order
+    order_line_with_one_allocation.is_shipping_required = True
+    order_line_with_one_allocation.save(update_fields=["is_shipping_required"])
+
+    order.currency = "USD"
+
+    # when
+    valid_shipping_methods = get_valid_shipping_methods_for_order(order)
+
+    # then
+    assert valid_shipping_methods is None
+
+
+def test_get_valid_shipping_methods_for_order_shipping_not_required(
+    order_line_with_one_allocation, address
+):
+    # given
+    order = order_line_with_one_allocation.order
+    order_line_with_one_allocation.is_shipping_required = False
+    order_line_with_one_allocation.save(update_fields=["is_shipping_required"])
+
+    order.currency = "USD"
+    order.shipping_address = address
+    order.save(update_fields=["shipping_address"])
+
+    # when
+    valid_shipping_methods = get_valid_shipping_methods_for_order(order)
+
+    # then
+    assert valid_shipping_methods is None

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -95,6 +95,12 @@ class ShippingMethodQueryset(models.QuerySet):
     def weight_based(self):
         return self.filter(type=ShippingMethodType.WEIGHT_BASED)
 
+    def for_channel(self, channel_slug: str):
+        return self.filter(
+            shipping_zone__channels__slug=channel_slug,
+            channel_listings__channel__slug=channel_slug,
+        )
+
     @staticmethod
     def applicable_shipping_methods_by_channel(shipping_methods, channel_id):
         query = ShippingMethodChannelListing.objects.filter(


### PR DESCRIPTION
**Order:**
- Ensure that `draftOrderComplete` cannot be done, for the shipping method with shipping zone not available in order channel
- Ensure that `order.availableShippingMethods` returns only methods with shipping zones available in the order channel
- Update `_create_fulfillment_lines` method - get stocks for given channel
  - Ensure that only stocks for a given channel are used in `orderFulfill`
- Ensure that in `orderUpdateShipping` only shipping method available in the order channel can be used
- Ensure `get_valid_shipping_methods_for_order` returns only shipping methods with shipping zone available in the order channel

**Shop**
- Update `shop.availableShippingMethods` - return only shipping methods with shipping zones available in given channel

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
