### PR TITLE
Update checkout quantity when checkout lines are deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix resolver by id and slug for product and product variant - #6985 by @d-wysocki
 - Add optional support for reporting resource limits via a stub field in `shop` - #6967 by @NyanKiyoshi
 - Allow to use `Bearer` as an authorization prefix - #6996 by @korycins
+- Update checkout quantity when checkout lines are deleted - #7002 by @IKarbowiak
 
 
 ### Breaking

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -27,6 +27,7 @@ from ...checkout.utils import (
     is_shipping_required,
     recalculate_checkout_discount,
     remove_promo_code_from_checkout,
+    update_checkout_quantity,
 )
 from ...core import analytics
 from ...core.exceptions import InsufficientStock, PermissionDenied, ProductNotPublished
@@ -497,6 +498,7 @@ class CheckoutLineDelete(BaseMutation):
         lines = fetch_checkout_lines(checkout)
         checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
+        update_checkout_quantity(checkout)
         recalculate_checkout_discount(
             info.context.plugins, checkout_info, lines, info.context.discounts
         )


### PR DESCRIPTION
Checkout quantity wasn't updated when the checkout line was deleted with the use of `CheckoutLineDelete` mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
