### PR TITLE
Re-added query for fetching a specific gateway clientToken.

### DIFF
--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -1,3 +1,5 @@
+import graphene
+
 from ...payment import gateway as payment_gateway
 from ...payment import models
 from ...payment.utils import fetch_customer_id
@@ -7,8 +9,10 @@ PAYMENT_SEARCH_FIELDS = ["id"]
 
 
 def resolve_client_token(user, gateway: str):
-    customer_id = fetch_customer_id(user, gateway)
-    return payment_gateway.get_client_token(gateway, customer_id)
+    gateway_customer_id = fetch_customer_id(user, gateway)
+    customer_id = gateway_customer_id if gateway_customer_id else graphene.Node.to_global_id(
+        "User", user.id) if user.id else None
+    return {'clientToken': payment_gateway.get_client_token(gateway, customer_id)}
 
 
 def resolve_payments(info, query):

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -4,8 +4,8 @@ from ...core.permissions import OrderPermissions
 from ..core.fields import PrefetchingConnectionField
 from ..decorators import permission_required
 from .mutations import PaymentCapture, PaymentInitialize, PaymentRefund, PaymentVoid
-from .resolvers import resolve_payments
-from .types import Payment
+from .resolvers import resolve_payments, resolve_client_token
+from .types import Payment, PaymentClientToken
 
 
 class PaymentQueries(graphene.ObjectType):
@@ -17,6 +17,11 @@ class PaymentQueries(graphene.ObjectType):
         ),
     )
     payments = PrefetchingConnectionField(Payment, description="List of payments.")
+    payment_client_token = graphene.Field(
+        PaymentClientToken,
+        args={'gateway': graphene.String()},
+        required=True
+    )
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_payment(self, info, **data):
@@ -25,6 +30,10 @@ class PaymentQueries(graphene.ObjectType):
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_payments(self, info, query=None, **_kwargs):
         return resolve_payments(info, query)
+
+    def resolve_payment_client_token(self, info, gateway=None):
+        user = info.context.user if info.context.user.is_authenticated else None
+        return resolve_client_token(user=user, gateway=gateway)
 
 
 class PaymentMutations(graphene.ObjectType):

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -61,6 +61,16 @@ class PaymentSource(graphene.ObjectType):
     )
 
 
+class PaymentClientToken(graphene.ObjectType):
+    class Meta:
+        description = (
+            "Represents a client token for a specific payment gateway "
+            "to be used on frontend"
+        )
+
+    clientToken = graphene.String(description="Gateway specific client token", required=True)
+
+
 class Payment(CountableDjangoObjectType):
     charge_status = PaymentChargeStatusEnum(
         description="Internal payment status.", required=True


### PR DESCRIPTION
I want to merge this change because the payment gateway `get_client_token` generation was no longer exposed in the payments query. This also makes sure that the `user_id` is passed to the `get_client_token` even if there is no gateway specific user_id in the private meta

I've hit this issue while developing a payment gateway for [primer.io](https://primer.io) 
The use-case here is that the frontend needs to use a specific `client_token` that gets generated on the backend. This client token can be user-specific so it later allows fetching of user specific stored payment methods. 

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
