### PR TITLE
Use channel in filtering by product availability

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -131,9 +131,10 @@ def filter_products_by_collections(qs, collections):
     return qs.filter(collections__in=collections)
 
 
-def filter_products_by_stock_availability(qs, stock_availability):
+def filter_products_by_stock_availability(qs, stock_availability, channel_slug):
     total_stock = (
-        Stock.objects.select_related("product_variant")
+        Stock.objects.for_channel(channel_slug)
+        .select_related("product_variant")
         .values("product_variant__product_id")
         .annotate(
             total_quantity_allocated=Coalesce(Sum("allocations__quantity_allocated"), 0)
@@ -203,9 +204,9 @@ def _filter_minimal_price(qs, _, value, channel_slug):
     return qs
 
 
-def filter_stock_availability(qs, _, value):
+def _filter_stock_availability(qs, _, value, channel_slug):
     if value:
-        qs = filter_products_by_stock_availability(qs, value)
+        qs = filter_products_by_stock_availability(qs, value, channel_slug)
     return qs
 
 
@@ -326,7 +327,7 @@ class ProductFilter(django_filters.FilterSet):
         method=filter_attributes,
     )
     stock_availability = EnumFilter(
-        input_class=StockAvailability, method=filter_stock_availability
+        input_class=StockAvailability, method="filter_stock_availability"
     )
     product_type = GlobalIDFilter()  # Deprecated
     product_types = GlobalIDMultipleChoiceFilter(field_name="product_type")
@@ -359,6 +360,10 @@ class ProductFilter(django_filters.FilterSet):
     def filter_is_published(self, queryset, name, value):
         channel_slug = get_channel_slug_from_filter_data(self.data)
         return _filter_is_published(queryset, name, value, channel_slug)
+
+    def filter_stock_availability(self, queryset, name, value):
+        channel_slug = get_channel_slug_from_filter_data(self.data)
+        return _filter_stock_availability(queryset, name, value, channel_slug)
 
 
 class ProductVariantFilter(django_filters.FilterSet):

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -68,7 +68,7 @@ def resolve_products(
 ) -> ChannelQsContext:
     qs = models.Product.objects.visible_to_user(requestor, channel_slug)
     if stock_availability:
-        qs = filter_products_by_stock_availability(qs, stock_availability)
+        qs = filter_products_by_stock_availability(qs, stock_availability, channel_slug)
     if not requestor_is_staff_member_or_app(requestor):
         qs = qs.annotate_visible_in_listings(channel_slug).exclude(
             visible_in_listings=False

--- a/saleor/graphql/product/tests/test_product_pagination.py
+++ b/saleor/graphql/product/tests/test_product_pagination.py
@@ -695,9 +695,11 @@ def test_products_pagination_with_filtering(
     staff_api_client,
     permission_manage_products,
     products_for_pagination,
+    channel_USD,
 ):
     page_size = 2
 
+    filter_by["channel"] = channel_USD.slug
     variables = {"first": page_size, "after": None, "filter": filter_by}
     response = staff_api_client.post_graphql(
         QUERY_PRODUCTS_PAGINATION,


### PR DESCRIPTION
Filter products by stock availability should return only products available in shipping zones for a given channel.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
