### PR TITLE
Use proper configuration in validation of AdminEmail. Add missing timeout

### DIFF
--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -193,11 +193,13 @@ class AdminEmailPlugin(BasePlugin):
             username=configuration["username"] or settings.EMAIL_HOST_USER,
             password=configuration["password"] or settings.EMAIL_HOST_PASSWORD,
             sender_name=configuration["sender_name"],
-            sender_address=configuration["sender_address"]
-            or settings.DEFAULT_FROM_EMAIL,
+            sender_address=(
+                configuration["sender_address"] or settings.DEFAULT_FROM_EMAIL
+            ),
             use_tls=configuration["use_tls"] or settings.EMAIL_USE_TLS,
             use_ssl=configuration["use_ssl"] or settings.EMAIL_USE_SSL,
         )
+
         self.templates = AdminTemplate(
             csv_export_failed=configuration[constants.CSV_EXPORT_FAILED_TEMPLATE_FIELD],
             csv_product_export_success=configuration[
@@ -231,7 +233,25 @@ class AdminEmailPlugin(BasePlugin):
     @classmethod
     def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
         """Validate if provided configuration is correct."""
-        validate_default_email_configuration(plugin_configuration)
+
+        configuration = plugin_configuration.configuration
+        configuration = {item["name"]: item["value"] for item in configuration}
+
+        configuration["host"] = configuration["host"] or settings.EMAIL_HOST
+        configuration["port"] = configuration["port"] or settings.EMAIL_PORT
+        configuration["username"] = (
+            configuration["username"] or settings.EMAIL_HOST_USER
+        )
+        configuration["password"] = (
+            configuration["password"] or settings.EMAIL_HOST_PASSWORD
+        )
+        configuration["sender_address"] = (
+            configuration["sender_address"] or settings.DEFAULT_FROM_EMAIL
+        )
+        configuration["use_tls"] = configuration["use_tls"] or settings.EMAIL_USE_TLS
+        configuration["use_ssl"] = configuration["use_ssl"] or settings.EMAIL_USE_SSL
+
+        validate_default_email_configuration(plugin_configuration, configuration)
         validate_format_of_provided_templates(
             plugin_configuration, constants.TEMPLATE_FIELDS
         )

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -32,6 +32,7 @@ DEFAULT_TEMPLATE_HELP_TEXT = (
 )
 DEFAULT_SUBJECT_HELP_TEXT = "An email subject built with Handlebars template language."
 DEFAULT_EMAIL_VALUE = "DEFAULT"
+DEFAULT_EMAIL_TIMEOUT = 5
 
 
 @dataclass
@@ -192,6 +193,7 @@ def send_email(
         password=config.password,
         use_ssl=config.use_ssl,
         use_tls=config.use_tls,
+        timeout=DEFAULT_EMAIL_TIMEOUT,
     )
     compiler = pybars.Compiler()
     template = compiler.compile(template_str)
@@ -224,6 +226,7 @@ def validate_email_config(config: EmailConfig):
         use_ssl=config.use_ssl,
         use_tls=config.use_tls,
         fail_silently=False,
+        timeout=DEFAULT_EMAIL_TIMEOUT,
     )
     try:
         email_backend.open()
@@ -233,11 +236,10 @@ def validate_email_config(config: EmailConfig):
         email_backend.close()
 
 
-def validate_default_email_configuration(plugin_configuration: "PluginConfiguration"):
+def validate_default_email_configuration(
+    plugin_configuration: "PluginConfiguration", configuration: dict
+):
     """Validate if provided configuration is correct."""
-
-    configuration = plugin_configuration.configuration
-    configuration = {item["name"]: item["value"] for item in configuration}
 
     if not plugin_configuration.active:
         return

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -427,5 +427,8 @@ class UserEmailPlugin(BasePlugin):
     @classmethod
     def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
         """Validate if provided configuration is correct."""
-        validate_default_email_configuration(plugin_configuration)
+        configuration = plugin_configuration.configuration
+        configuration = {item["name"]: item["value"] for item in configuration}
+
+        validate_default_email_configuration(plugin_configuration, configuration)
         validate_format_of_provided_templates(plugin_configuration, TEMPLATE_FIELDS)


### PR DESCRIPTION
I want to merge this change because it improves the way of validation for admin email configuration, it also adds a timeout for email backend.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
