### PR TITLE
Fix available shipping methods - return also weight methods without weight limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Allow to use `Bearer` as an authorization prefix - #6996 by @korycins
 - Update checkout quantity when checkout lines are deleted - #7002 by @IKarbowiak
 - Raise an error when the user is trying to sort products by rank without search - #7013 by @IKarbowiak
+- Fix available shipping methods - return also weight methods without weight limits - #7021 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -10,6 +10,7 @@ import pytest
 from django.core.exceptions import ValidationError
 from django.test import override_settings
 from django_countries.fields import Country
+from measurement.measures import Weight
 from prices import Money, TaxedMoney
 
 from ....account.models import User
@@ -28,7 +29,7 @@ from ....payment import TransactionKind
 from ....payment.interface import GatewayResponse
 from ....plugins.manager import PluginsManager, get_plugins_manager
 from ....plugins.tests.sample_plugins import ActiveDummyPaymentGateway
-from ....product.models import ProductChannelListing
+from ....product.models import ProductChannelListing, ProductVariant
 from ....shipping import models as shipping_models
 from ....warehouse.models import Stock
 from ...tests.utils import assert_no_permission, get_graphql_content
@@ -1208,6 +1209,67 @@ def test_checkout_available_shipping_methods(
 
     shipping_method = shipping_zone.shipping_methods.first()
     assert data["availableShippingMethods"][0]["name"] == shipping_method.name
+
+
+@pytest.mark.parametrize("minimum_order_weight_value", [0, 2, None])
+def test_checkout_available_shipping_methods_with_weight_based_shipping_method(
+    api_client,
+    checkout_with_item,
+    address,
+    shipping_method_weight_based,
+    minimum_order_weight_value,
+):
+    checkout_with_item.shipping_address = address
+    checkout_with_item.save()
+
+    shipping_method = shipping_method_weight_based
+    if minimum_order_weight_value is not None:
+        weight = Weight(kg=minimum_order_weight_value)
+        shipping_method.minimum_order_weight = weight
+        variant = checkout_with_item.lines.first().variant
+        variant.weight = weight
+        variant.save(update_fields=["weight"])
+    else:
+        shipping_method.minimum_order_weight = minimum_order_weight_value
+
+    shipping_method.save(update_fields=["minimum_order_weight"])
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"token": checkout_with_item.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
+    assert shipping_method.name in shipping_methods
+
+
+def test_checkout_available_shipping_methods_weight_method_with_higher_minimal_weigh(
+    api_client, checkout_with_item, address, shipping_method_weight_based
+):
+    checkout_with_item.shipping_address = address
+    checkout_with_item.save()
+
+    shipping_method = shipping_method_weight_based
+    weight_value = 5
+    shipping_method.minimum_order_weight = Weight(kg=weight_value)
+    shipping_method.save(update_fields=["minimum_order_weight"])
+
+    variants = []
+    for line in checkout_with_item.lines.all():
+        variant = line.variant
+        variant.weight = Weight(kg=1)
+        variants.append(variant)
+    ProductVariant.objects.bulk_update(variants, ["weight"])
+
+    query = GET_CHECKOUT_AVAILABLE_SHIPPING_METHODS
+    variables = {"token": checkout_with_item.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    shipping_methods = [method["name"] for method in data["availableShippingMethods"]]
+    assert shipping_method.name not in shipping_methods
 
 
 def test_checkout_available_shipping_methods_excluded_postal_codes(

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -9,6 +9,7 @@ import pytest
 from django.contrib.auth.models import AnonymousUser
 from django.core.exceptions import ValidationError
 from freezegun import freeze_time
+from measurement.measures import Weight
 from prices import Money, TaxedMoney
 
 from ....account.models import CustomerEvent
@@ -562,6 +563,62 @@ def test_order_query_without_available_shipping_methods(
     content = get_graphql_content(response)
     order_data = content["data"]["orders"]["edges"][0]["node"]
     assert len(order_data["availableShippingMethods"]) == 0
+
+
+@pytest.mark.parametrize("minimum_order_weight_value", [0, 2, None])
+def test_order_available_shipping_methods_with_weight_based_shipping_method(
+    staff_api_client,
+    order_line,
+    shipping_method_weight_based,
+    permission_manage_orders,
+    minimum_order_weight_value,
+):
+
+    shipping_method = shipping_method_weight_based
+    order = order_line.order
+    if minimum_order_weight_value is not None:
+        weight = Weight(kg=minimum_order_weight_value)
+        shipping_method.minimum_order_weight = weight
+        order.weight = weight
+        order.save(update_fields=["weight"])
+    else:
+        shipping_method.minimum_order_weight = minimum_order_weight_value
+
+    shipping_method.save(update_fields=["minimum_order_weight"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+
+    shipping_methods = [
+        method["name"] for method in order_data["availableShippingMethods"]
+    ]
+    assert shipping_method.name in shipping_methods
+
+
+def test_order_available_shipping_methods_weight_method_with_higher_minimal_weigh(
+    staff_api_client, order_line, shipping_method_weight_based, permission_manage_orders
+):
+    order = order_line.order
+
+    shipping_method = shipping_method_weight_based
+    weight_value = 5
+    shipping_method.minimum_order_weight = Weight(kg=weight_value)
+    shipping_method.save(update_fields=["minimum_order_weight"])
+
+    order.weight = Weight(kg=1)
+    order.save(update_fields=["weight"])
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDERS_QUERY_SHIPPING_METHODS)
+    content = get_graphql_content(response)
+    order_data = content["data"]["orders"]["edges"][0]["node"]
+
+    shipping_methods = [
+        method["name"] for method in order_data["availableShippingMethods"]
+    ]
+    assert shipping_method.name not in shipping_methods
 
 
 def test_order_query_shipping_methods_excluded_postal_codes(

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -31,10 +31,13 @@ if TYPE_CHECKING:
 def _applicable_weight_based_methods(weight, qs):
     """Return weight based shipping methods that are applicable for the total weight."""
     qs = qs.weight_based()
-    min_weight_matched = Q(minimum_order_weight__lte=weight)
-    no_weight_limit = Q(maximum_order_weight__isnull=True)
-    max_weight_matched = Q(maximum_order_weight__gte=weight)
-    return qs.filter(min_weight_matched & (no_weight_limit | max_weight_matched))
+    min_weight_matched = Q(minimum_order_weight__lte=weight) | Q(
+        minimum_order_weight__isnull=True
+    )
+    max_weight_matched = Q(maximum_order_weight__gte=weight) | Q(
+        maximum_order_weight__isnull=True
+    )
+    return qs.filter(min_weight_matched & max_weight_matched)
 
 
 def _applicable_price_based_methods(price: Money, qs, channel_id):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -716,6 +716,24 @@ def shipping_method(shipping_zone, channel_USD):
 
 
 @pytest.fixture
+def shipping_method_weight_based(shipping_zone, channel_USD):
+    method = ShippingMethod.objects.create(
+        name="weight based method",
+        type=ShippingMethodType.WEIGHT_BASED,
+        shipping_zone=shipping_zone,
+        maximum_delivery_days=10,
+        minimum_delivery_days=5,
+    )
+    ShippingMethodChannelListing.objects.create(
+        shipping_method=method,
+        channel=channel_USD,
+        minimum_order_price=Money(0, "USD"),
+        price=Money(10, "USD"),
+    )
+    return method
+
+
+@pytest.fixture
 def shipping_method_excluded_by_postal_code(shipping_method):
     shipping_method.postal_code_rules.create(start="HB2", end="HB6")
     return shipping_method


### PR DESCRIPTION
Previously, shipping methods without a lower weight limit set didn't return in available shipping methods on `Checkout` and `Order`.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
