### PR TITLE
Validate available variants in channel for order and checkout

### DIFF
--- a/saleor/checkout/error_codes.py
+++ b/saleor/checkout/error_codes.py
@@ -24,3 +24,4 @@ class CheckoutErrorCode(Enum):
     ZERO_QUANTITY = "zero_quantity"
     MISSING_CHANNEL_SLUG = "missing_channel_slug"
     CHANNEL_INACTIVE = "channel_inactive"
+    UNAVAILABLE_VARIANT_IN_CHANNEL = "unavailable_variant_in_channel"

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -220,8 +220,7 @@ def test_checkout_create_with_unavailable_variant(
 ):
 
     variant = stock.product_variant
-    variant.channel_listings.filter(channel=channel_USD).delete()
-    variant.channel_listings.create(channel=channel_USD)
+    variant.channel_listings.filter(channel=channel_USD).update(price_amount=None)
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
     test_email = "test@example.com"
     shipping_address = graphql_address_data
@@ -1385,8 +1384,9 @@ def test_checkout_lines_add_with_unavailable_variant(
     user_api_client, checkout_with_item, stock
 ):
     variant = stock.product_variant
-    variant.channel_listings.filter(channel=checkout_with_item.channel).delete()
-    variant.channel_listings.create(channel=checkout_with_item.channel)
+    variant.channel_listings.filter(channel=checkout_with_item.channel).update(
+        price_amount=None
+    )
     checkout = checkout_with_item
     line = checkout.lines.first()
     assert line.quantity == 3
@@ -1660,8 +1660,9 @@ def test_checkout_lines_update_with_unavailable_variant(
     assert checkout.lines.count() == 1
     line = checkout.lines.first()
     variant = line.variant
-    variant.channel_listings.filter(channel=checkout_with_item.channel).delete()
-    variant.channel_listings.create(channel=checkout_with_item.channel)
+    variant.channel_listings.filter(channel=checkout_with_item.channel).update(
+        price_amount=None
+    )
     assert line.quantity == 3
 
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -247,27 +247,24 @@ def test_checkout_complete(
 def test_checkout_complete_with_unavailable_variant(
     site_settings,
     user_api_client,
-    checkout_with_gift_card,
+    checkout_with_item,
     gift_card,
     payment_dummy,
     address,
     shipping_method,
 ):
 
-    assert not gift_card.last_used_on
-
-    checkout = checkout_with_gift_card
+    checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.shipping_method = shipping_method
     checkout.billing_address = address
-    checkout.store_value_in_metadata(items={"accepted": "true"})
-    checkout.store_value_in_private_metadata(items={"accepted": "false"})
     checkout.save()
 
     checkout_line = checkout.lines.first()
     checkout_line_variant = checkout_line.variant
-    checkout_line_variant.channel_listings.filter(channel=checkout.channel).delete()
-    checkout_line_variant.channel_listings.create(channel=checkout.channel)
+    checkout_line_variant.channel_listings.filter(channel=checkout.channel).update(
+        price_amount=None
+    )
 
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     variant_id = graphene.Node.to_global_id("ProductVariant", checkout_line_variant.pk)

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -30,6 +30,7 @@ MUTATION_CHECKOUT_COMPLETE = """
             checkoutErrors {
                 field,
                 message,
+                variants,
                 code
             }
             confirmationNeeded
@@ -241,6 +242,44 @@ def test_checkout_complete(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
     order_confirmed_mock.assert_called_once_with(order)
+
+
+def test_checkout_complete_with_unavailable_variant(
+    site_settings,
+    user_api_client,
+    checkout_with_gift_card,
+    gift_card,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+
+    assert not gift_card.last_used_on
+
+    checkout = checkout_with_gift_card
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.store_value_in_metadata(items={"accepted": "true"})
+    checkout.store_value_in_private_metadata(items={"accepted": "false"})
+    checkout.save()
+
+    checkout_line = checkout.lines.first()
+    checkout_line_variant = checkout_line.variant
+    checkout_line_variant.channel_listings.filter(channel=checkout.channel).delete()
+    checkout_line_variant.channel_listings.create(channel=checkout.channel)
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    variant_id = graphene.Node.to_global_id("ProductVariant", checkout_line_variant.pk)
+    redirect_url = "https://www.example.com"
+    variables = {"checkoutId": checkout_id, "redirectUrl": redirect_url}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    errors = content["data"]["checkoutComplete"]["checkoutErrors"]
+    assert errors[0]["code"] == CheckoutErrorCode.UNAVAILABLE_VARIANT_IN_CHANNEL.name
+    assert errors[0]["field"] == "lines"
+    assert errors[0]["variants"] == [variant_id]
 
 
 @patch("saleor.plugins.manager.PluginsManager.order_confirmed")

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2582,6 +2582,30 @@ def test_draft_order_lines_create(
     assert data["orderErrors"][0]["field"] == "quantity"
 
 
+def test_draft_order_lines_create_with_unavailable_variant(
+    draft_order, permission_manage_orders, staff_api_client
+):
+    query = DRAFT_ORDER_LINES_CREATE_MUTATION
+    order = draft_order
+    channel = order.channel
+    line = order.lines.first()
+    variant = line.variant
+    variant.channel_listings.filter(channel=channel).update(price_amount=None)
+    quantity = 1
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {"orderId": order_id, "variantId": variant_id, "quantity": quantity}
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    error = content["data"]["draftOrderLinesCreate"]["orderErrors"][0]
+    assert error["code"] == OrderErrorCode.NOT_AVAILABLE_IN_CHANNEL.name
+    assert error["field"] == "input"
+    assert error["variants"] == [variant_id]
+
+
 def test_draft_order_lines_create_with_product_and_variant_not_assigned_to_channel(
     draft_order, permission_manage_orders, staff_api_client, variant
 ):

--- a/saleor/graphql/order/utils.py
+++ b/saleor/graphql/order/utils.py
@@ -138,7 +138,7 @@ def validate_variant_channel_listings(variants, channel):
         )
     variant_ids = set([variant.id for variant in variants])
     variant_channel_listings = ProductVariantChannelListing.objects.filter(
-        channel=channel, variant_id__in=variant_ids
+        channel=channel, variant_id__in=variant_ids, price_amount__isnull=False
     )
     variant_ids_in_channel = set(
         [

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -6682,9 +6682,146 @@ def test_product_update_variants_names(mock__update_variants_names, product_type
     assert mock__update_variants_names.call_count == 1
 
 
+def test_product_variant_without_price_by_id_as_staff(
+    staff_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_id_as_app(
+    app_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_id_as_user(
+    user_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($id: ID!, $channel: String) {
+            productVariant(id: $id, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data is None
+
+
+def test_product_variant_without_price_by_sku_as_staff(
+    staff_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($sku: String!, $channel: String) {
+            productVariant(sku: $sku, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"sku": variant.sku, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_sku_as_app(
+    app_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($sku: String!, $channel: String) {
+            productVariant(sku: $sku, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"sku": variant.sku, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_sku_as_user(
+    user_api_client, variant, channel_USD
+):
+    query = """
+        query getProductVariant($sku: String!, $channel: String) {
+            productVariant(sku: $sku, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+
+    variables = {"sku": variant.sku, "channel": channel_USD.slug}
+    response = user_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data is None
+
+
 def test_product_variants_by_ids(staff_api_client, variant, channel_USD):
     query = """
-        query getProduct($ids: [ID!], $channel: String) {
+        query getProductVariants($ids: [ID!], $channel: String) {
             productVariants(ids: $ids, first: 1, channel: $channel) {
                 edges {
                     node {
@@ -6722,7 +6859,7 @@ def test_product_variants_without_price_by_ids_as_staff(
     staff_api_client, variant, channel_USD
 ):
     query = """
-        query getProduct($ids: [ID!], $channel: String) {
+        query getProductVariants($ids: [ID!], $channel: String) {
             productVariants(ids: $ids, first: 1, channel: $channel) {
                 edges {
                     node {
@@ -6762,7 +6899,7 @@ def test_product_variants_without_price_by_ids_as_user(
     user_api_client, variant, channel_USD
 ):
     query = """
-        query getProduct($ids: [ID!], $channel: String) {
+        query getProductVariants($ids: [ID!], $channel: String) {
             productVariants(ids: $ids, first: 1, channel: $channel) {
                 edges {
                     node {
@@ -6789,7 +6926,7 @@ def test_product_variants_without_price_by_ids_as_app(
     app_api_client, variant, channel_USD
 ):
     query = """
-        query getProduct($ids: [ID!], $channel: String) {
+        query getProductVariants($ids: [ID!], $channel: String) {
             productVariants(ids: $ids, first: 1, channel: $channel) {
                 edges {
                     node {
@@ -6827,7 +6964,7 @@ def test_product_variants_without_price_by_ids_as_app(
 
 def test_product_variants_by_customer(user_api_client, variant, channel_USD):
     query = """
-        query getProduct($ids: [ID!], $channel: String) {
+        query getProductVariants($ids: [ID!], $channel: String) {
             productVariants(ids: $ids, first: 1, channel: $channel) {
                 edges {
                     node {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -971,6 +971,7 @@ enum CheckoutErrorCode {
   ZERO_QUANTITY
   MISSING_CHANNEL_SLUG
   CHANNEL_INACTIVE
+  UNAVAILABLE_VARIANT_IN_CHANNEL
 }
 
 type CheckoutLine implements Node {


### PR DESCRIPTION
I want to merge this change because...I want to use only variants with price for `CheckcoutCreate`, `CheckoutComplete`, `checkoutLinesAdd`, `checkoutLinesUpdate` and `draftOrderLinesCreate`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
