### PR TITLE
Fix incorrect argument for call of update_order_pirces

### DIFF
--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -280,7 +280,11 @@ class OrderUpdateShipping(BaseMutation):
                 "shipping_tax_rate",
             ]
         )
-        update_order_prices(order, info.context.plugins, info.context.site.settings)
+        update_order_prices(
+            order,
+            info.context.plugins,
+            info.context.site.settings.include_taxes_in_prices,
+        )
         # Post-process the results
         order_shipping_updated(order)
         return OrderUpdateShipping(order=order)

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -490,7 +490,9 @@ def test_update_order_prices(
     ).price
     shipping_price = TaxedMoney(net=shipping_price, gross=shipping_price)
 
-    update_order_prices(order_with_lines, manager, site_settings)
+    update_order_prices(
+        order_with_lines, manager, site_settings.include_taxes_in_prices
+    )
 
     line_1.refresh_from_db()
     line_2.refresh_from_db()
@@ -534,7 +536,9 @@ def test_update_order_prices_tax_included(order_with_lines, vatlayer, site_setti
         channel_id=order_with_lines.channel_id
     ).price
 
-    update_order_prices(order_with_lines, manager, site_settings)
+    update_order_prices(
+        order_with_lines, manager, site_settings.include_taxes_in_prices
+    )
 
     line_1.refresh_from_db()
     line_2.refresh_from_db()

--- a/saleor/order/utils.py
+++ b/saleor/order/utils.py
@@ -1,7 +1,7 @@
 import copy
 from decimal import Decimal
 from functools import partial, wraps
-from typing import Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Tuple, Union
 
 from django.conf import settings
 from django.db import transaction
@@ -22,6 +22,9 @@ from ..shipping.models import ShippingMethod
 from ..warehouse.management import deallocate_stock, increase_stock
 from ..warehouse.models import Warehouse
 from . import events
+
+if TYPE_CHECKING:
+    from ..plugins.manager import PluginsManager
 
 
 def get_order_country(order: Order) -> str:
@@ -193,7 +196,7 @@ def update_taxes_for_order_line(
 
 
 def update_taxes_for_order_lines(
-    lines: List[OrderLine], order: "Order", manager, tax_included
+    lines: Iterable[OrderLine], order: "Order", manager, tax_included
 ):
     for line in lines:
         update_taxes_for_order_line(line, order, manager, tax_included=tax_included)
@@ -209,7 +212,7 @@ def update_taxes_for_order_lines(
     )
 
 
-def update_order_prices(order, manager, tax_included):
+def update_order_prices(order: Order, manager: "PluginsManager", tax_included: bool):
     """Update prices in order with given discounts and proper taxes."""
 
     update_taxes_for_order_lines(order.lines.all(), order, manager, tax_included)


### PR DESCRIPTION
I want to merge this change because there is an issue with incorrect call of the method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
