### PR TITLE
Use is_shipping_required utils method where it ce be done

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -628,7 +628,8 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
                 }
             )
 
-        if not checkout.is_shipping_required():
+        lines = fetch_checkout_lines(checkout)
+        if not is_shipping_required(lines):
             raise ValidationError(
                 {
                     "shipping_address": ValidationError(
@@ -641,9 +642,8 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         shipping_address = cls.validate_address(
             shipping_address, instance=checkout.shipping_address, info=info
         )
-        discounts = info.context.discounts
 
-        lines = fetch_checkout_lines(checkout)
+        discounts = info.context.discounts
         checkout_info = fetch_checkout_info(checkout, lines, discounts)
 
         country = get_user_country_context(

--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -14,6 +14,7 @@ from django.core.cache import cache
 from requests.auth import HTTPBasicAuth
 
 from ...checkout import base_calculations
+from ...checkout.utils import is_shipping_required
 from ...core.taxes import TaxError
 from ...order.utils import get_total_order_discount
 
@@ -157,7 +158,7 @@ def _validate_checkout(
         return False
 
     shipping_address = checkout_info.shipping_address
-    shipping_required = checkout_info.checkout.is_shipping_required()
+    shipping_required = is_shipping_required(lines)
     address = shipping_address or checkout_info.billing_address
     return _validate_adddress_details(
         shipping_address, shipping_required, address, checkout_info.shipping_method


### PR DESCRIPTION
Update places where the non-optimized checkout model method was used instead of `is_shipping_required` utils that use `CheckoutLineInfo`. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
