### PR TITLE
Make subtotal a required parameter in get_valid_shipping_methods_for_checkout

### DIFF
--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -36,8 +36,9 @@ def test_adding_same_variant(checkout, product):
     assert checkout.lines.count() == 1
     assert checkout.quantity == 3
     subtotal = TaxedMoney(Money("30.00", "USD"), Money("30.00", "USD"))
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     manager = get_plugins_manager()
     assert (
         calculations.checkout_subtotal(
@@ -96,7 +97,7 @@ def test_get_prices_of_discounted_specific_product(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -127,7 +128,7 @@ def test_get_prices_of_discounted_specific_product_only_product(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -161,7 +162,7 @@ def test_get_prices_of_discounted_specific_product_only_collection(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -197,7 +198,7 @@ def test_get_prices_of_discounted_specific_product_only_category(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )
@@ -223,7 +224,7 @@ def test_get_prices_of_discounted_specific_product_all_products(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     prices = utils.get_prices_of_discounted_specific_product(
         manager, checkout_info, lines, voucher
     )

--- a/saleor/checkout/tests/test_checkout.py
+++ b/saleor/checkout/tests/test_checkout.py
@@ -38,21 +38,22 @@ def test_is_valid_shipping_method(checkout_with_item, address, shipping_zone):
     checkout = checkout_with_item
     checkout.shipping_address = address
     checkout.save()
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     # no shipping method assigned
     assert not is_valid_shipping_method(checkout_info)
     shipping_method = shipping_zone.shipping_methods.first()
     checkout.shipping_method = shipping_method
     checkout.save()
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     assert is_valid_shipping_method(checkout_info)
 
     zone = ShippingZone.objects.create(name="DE", countries=["DE"])
     shipping_method.shipping_zone = zone
     shipping_method.save()
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     assert not is_valid_shipping_method(checkout_info)
 
@@ -60,7 +61,8 @@ def test_is_valid_shipping_method(checkout_with_item, address, shipping_zone):
 def test_clear_shipping_method(checkout, shipping_method):
     checkout.shipping_method = shipping_method
     checkout.save()
-    checkout_info = fetch_checkout_info(checkout, [], [])
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, [], [], manager)
     clear_shipping_method(checkout_info)
     checkout.refresh_from_db()
     assert not checkout.shipping_method
@@ -152,8 +154,9 @@ def test_get_discount_for_checkout_value_voucher(
 def test_get_voucher_discount_for_checkout_voucher_validation(
     mock_validate_voucher, voucher, checkout_with_voucher
 ):
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_voucher)
-    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
     manager = get_plugins_manager()
     address = checkout_with_voucher.shipping_address
     get_voucher_discount_for_checkout(manager, voucher, checkout_info, lines, address)
@@ -257,7 +260,7 @@ def test_get_discount_for_checkout_specific_products_voucher(
         voucher.products.add(product)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_items)
-    checkout_info = fetch_checkout_info(checkout_with_items, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     discount = get_voucher_discount_for_checkout(
         manager, voucher, checkout_info, lines, None, []
     )
@@ -658,7 +661,8 @@ def test_get_discount_for_checkout_shipping_voucher_not_applicable(
 
 
 def test_get_voucher_for_checkout(checkout_with_voucher, voucher):
-    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [])
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [], manager)
     checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher == voucher
 
@@ -667,13 +671,15 @@ def test_get_voucher_for_checkout_expired_voucher(checkout_with_voucher, voucher
     date_yesterday = timezone.now() - datetime.timedelta(days=1)
     voucher.end_date = date_yesterday
     voucher.save()
-    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [])
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout_with_voucher, [], [], manager)
     checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher is None
 
 
 def test_get_voucher_for_checkout_no_voucher_code(checkout):
-    checkout_info = fetch_checkout_info(checkout, [], [])
+    manager = get_plugins_manager()
+    checkout_info = fetch_checkout_info(checkout, [], [], manager)
     checkout_voucher = get_voucher_for_checkout(checkout_info)
     assert checkout_voucher is None
 
@@ -696,7 +702,7 @@ def test_recalculate_checkout_discount(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_voucher)
-    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
 
     recalculate_checkout_discount(manager, checkout_info, lines, None)
     assert (
@@ -711,7 +717,7 @@ def test_recalculate_checkout_discount_with_sale(
     checkout = checkout_with_voucher_percentage
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     recalculate_checkout_discount(manager, checkout_info, lines, [discount_info])
     assert checkout.discount == Money("1.50", "USD")
@@ -735,7 +741,7 @@ def test_recalculate_checkout_discount_voucher_not_applicable(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
     assert not checkout.voucher_code
@@ -751,7 +757,7 @@ def test_recalculate_checkout_discount_expired_voucher(checkout_with_voucher, vo
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
     assert not checkout.voucher_code
@@ -768,7 +774,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     channel_listing = shipping_method.channel_listings.get(channel_id=channel_USD.id)
     channel_listing.price = (
         calculations.checkout_subtotal(
@@ -781,7 +787,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_less_than_shipping
     )
     channel_listing.save()
 
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
     assert checkout.discount == channel_listing.price
@@ -810,7 +816,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     checkout = checkout_with_voucher_percentage_and_shipping
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     channel_listing = shipping_method.channel_listings.get(channel=channel_USD)
     channel_listing.price = (
         calculations.checkout_subtotal(
@@ -823,7 +829,7 @@ def test_recalculate_checkout_discount_free_shipping_subtotal_bigger_than_shippi
     )
     channel_listing.save()
 
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
     assert checkout.discount == channel_listing.price
@@ -849,7 +855,7 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
     checkout = checkout_with_voucher_percentage
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     recalculate_checkout_discount(manager, checkout_info, lines, None)
 
     assert not checkout.discount_name
@@ -858,9 +864,10 @@ def test_recalculate_checkout_discount_free_shipping_for_checkout_without_shippi
 
 
 def test_change_address_in_checkout(checkout, address):
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout_info, address, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    change_shipping_address_in_checkout(checkout_info, address, lines, [], manager)
     change_billing_address_in_checkout(checkout, address)
 
     checkout.refresh_from_db()
@@ -874,9 +881,10 @@ def test_change_address_in_checkout_to_none(checkout, address):
     checkout.billing_address = address.get_copy()
     checkout.save()
 
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout_info, None, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    change_shipping_address_in_checkout(checkout_info, None, lines, [], manager)
     change_billing_address_in_checkout(checkout, None)
 
     checkout.refresh_from_db()
@@ -892,9 +900,10 @@ def test_change_address_in_checkout_to_same(checkout, address):
     shipping_address_id = checkout.shipping_address.id
     billing_address_id = checkout.billing_address.id
 
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout_info, address, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    change_shipping_address_in_checkout(checkout_info, address, lines, [], manager)
     change_billing_address_in_checkout(checkout, address)
 
     checkout.refresh_from_db()
@@ -910,9 +919,12 @@ def test_change_address_in_checkout_to_other(checkout, address):
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
 
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout_info, other_address, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    change_shipping_address_in_checkout(
+        checkout_info, other_address, lines, [], manager
+    )
     change_billing_address_in_checkout(checkout, other_address)
 
     checkout.refresh_from_db()
@@ -932,9 +944,12 @@ def test_change_address_in_checkout_from_user_address_to_other(
     checkout.save(update_fields=["shipping_address", "billing_address"])
     other_address = Address.objects.create(country=Country("DE"))
 
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
-    change_shipping_address_in_checkout(checkout_info, other_address, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    change_shipping_address_in_checkout(
+        checkout_info, other_address, lines, [], manager
+    )
     change_billing_address_in_checkout(checkout, other_address)
 
     checkout.refresh_from_db()
@@ -948,7 +963,7 @@ def test_add_voucher_to_checkout(checkout_with_item, voucher):
     assert checkout_with_item.voucher_code is None
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     assert checkout_with_item.voucher_code == voucher.code
 
@@ -958,7 +973,7 @@ def test_add_voucher_to_checkout_fail(
 ):
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     with pytest.raises(NotApplicable):
         add_voucher_to_checkout(
             manager,
@@ -1035,7 +1050,7 @@ def test_is_fully_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -1057,7 +1072,7 @@ def test_is_fully_paid_many_payments(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -1087,7 +1102,7 @@ def test_is_fully_paid_partially_paid(checkout_with_item, payment_dummy):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -1109,7 +1124,7 @@ def test_is_fully_paid_no_payment(checkout_with_item):
     checkout = checkout_with_item
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     is_paid = is_fully_paid(manager, checkout_info, lines, None)
     assert not is_paid
 

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -43,7 +43,7 @@ def test_create_order_captured_payment_creates_expected_events(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
         order_data=_prepare_order_data(
@@ -183,7 +183,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
         order_data=_prepare_order_data(
@@ -315,7 +315,7 @@ def test_create_order_preauth_payment_creates_expected_events(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
         order_data=_prepare_order_data(
@@ -426,7 +426,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     # Place checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
         order_data=_prepare_order_data(
@@ -516,7 +516,7 @@ def test_create_order_insufficient_stock(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     with pytest.raises(InsufficientStock):
         _prepare_order_data(
             manager=manager,
@@ -540,7 +540,7 @@ def test_create_order_doesnt_duplicate_order(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     order_data = _prepare_order_data(
         manager=manager, checkout_info=checkout_info, lines=lines, discounts=None
     )
@@ -576,7 +576,7 @@ def test_create_order_with_gift_card(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -625,7 +625,7 @@ def test_create_order_with_gift_card_partial_use(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
@@ -678,7 +678,7 @@ def test_create_order_with_many_gift_cards(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     price_without_gift_card = calculations.checkout_total(
         manager=manager,
@@ -725,7 +725,7 @@ def test_note_in_created_order(checkout_with_item, address, customer_user):
     checkout_with_item.save()
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     order = _create_order(
         checkout_info=checkout_info,
         order_data=_prepare_order_data(
@@ -753,7 +753,7 @@ def test_create_order_with_variant_tracking_false(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     order_data = _prepare_order_data(
         manager=manager, checkout_info=checkout_info, lines=lines, discounts=None
@@ -785,7 +785,7 @@ def test_create_order_use_tanslations(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     variant = lines[0].variant
     product = lines[0].product

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -24,7 +24,7 @@ from ..giftcard.utils import (
     add_gift_card_code_to_checkout,
     remove_gift_card_code_from_checkout,
 )
-from ..plugins.manager import PluginsManager, get_plugins_manager
+from ..plugins.manager import PluginsManager
 from ..product import models as product_models
 from ..shipping.models import ShippingMethod
 from ..warehouse.availability import check_stock_quantity, check_stock_quantity_bulk
@@ -193,7 +193,13 @@ def change_billing_address_in_checkout(checkout, address):
         checkout.save(update_fields=["billing_address", "last_change"])
 
 
-def change_shipping_address_in_checkout(checkout_info, address, lines, discounts):
+def change_shipping_address_in_checkout(
+    checkout_info: "CheckoutInfo",
+    address: "Address",
+    lines: Iterable["CheckoutLineInfo"],
+    discounts: Iterable[DiscountInfo],
+    manager: "PluginsManager",
+):
     """Save shipping address in checkout if changed.
 
     Remove previously saved address if not connected to any user.
@@ -204,9 +210,11 @@ def change_shipping_address_in_checkout(checkout_info, address, lines, discounts
     )
     if changed:
         if remove:
-            checkout.shipping_address.delete()
+            checkout.shipping_address.delete()  # type: ignore
         checkout.shipping_address = address
-        update_checkout_info_shipping_address(checkout_info, address, lines, discounts)
+        update_checkout_info_shipping_address(
+            checkout_info, address, lines, discounts, manager
+        )
         checkout.save(update_fields=["shipping_address", "last_change"])
 
 
@@ -552,21 +560,13 @@ def remove_voucher_from_checkout(checkout: Checkout):
 def get_valid_shipping_methods_for_checkout(
     checkout_info: "CheckoutInfo",
     lines: Iterable["CheckoutLineInfo"],
-    discounts: Iterable[DiscountInfo],
+    subtotal: "TaxedMoney",
     country_code: Optional[str] = None,
-    subtotal: Optional["TaxedMoney"] = None,
 ):
     if not is_shipping_required(lines):
         return None
     if not checkout_info.shipping_address:
         return None
-    # TODO: subtotal should comes from arg instead of calculate it in this function
-    # use info.context.plugins from resolver
-    if subtotal is None:
-        manager = get_plugins_manager()
-        subtotal = manager.calculate_checkout_subtotal(
-            checkout_info, lines, checkout_info.shipping_address, discounts
-        )
     return ShippingMethod.objects.applicable_shipping_methods_for_instance(
         checkout_info.checkout,
         channel_id=checkout_info.checkout.channel_id,

--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -230,8 +230,9 @@ def test_specific_products_voucher_checkout_discount(
         discount=Money(discount_value, channel_USD.currency_code),
     )
     checkout = checkout_with_item
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     manager = get_plugins_manager()
     discount = get_voucher_discount_for_checkout(
         manager, voucher, checkout_info, lines, checkout.shipping_address, discounts

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -447,14 +447,17 @@ class CheckoutLinesAdd(BaseMutation):
                         code=exc.code,
                     )
 
+        manager = info.context.plugins
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
 
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         recalculate_checkout_discount(
-            info.context.plugins, checkout_info, lines, info.context.discounts
+            manager, checkout_info, lines, info.context.discounts
         )
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutLinesAdd(checkout=checkout)
 
 
@@ -495,14 +498,17 @@ class CheckoutLineDelete(BaseMutation):
         if line and line in checkout.lines.all():
             line.delete()
 
+        manager = info.context.plugins
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
         update_checkout_shipping_method_if_invalid(checkout_info, lines)
         update_checkout_quantity(checkout)
         recalculate_checkout_discount(
-            info.context.plugins, checkout_info, lines, info.context.discounts
+            manager, checkout_info, lines, info.context.discounts
         )
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutLineDelete(checkout=checkout)
 
 
@@ -644,7 +650,9 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         )
 
         discounts = info.context.discounts
-        checkout_info = fetch_checkout_info(checkout, lines, discounts)
+        manager = info.context.plugins
+        lines = fetch_checkout_lines(checkout)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
         country = get_user_country_context(
             destination_address=shipping_address,
@@ -661,13 +669,11 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         with transaction.atomic():
             shipping_address.save()
             change_shipping_address_in_checkout(
-                checkout_info, shipping_address, lines, discounts
+                checkout_info, shipping_address, lines, discounts, manager
             )
-        recalculate_checkout_discount(
-            info.context.plugins, checkout_info, lines, discounts
-        )
+        recalculate_checkout_discount(manager, checkout_info, lines, discounts)
 
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutShippingAddressUpdate(checkout=checkout)
 
 
@@ -742,8 +748,11 @@ class CheckoutShippingMethodUpdate(BaseMutation):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
+        manager = info.context.plugins
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
         if not is_shipping_required(lines):
             raise ValidationError(
                 {
@@ -782,9 +791,9 @@ class CheckoutShippingMethodUpdate(BaseMutation):
         checkout.shipping_method = shipping_method
         checkout.save(update_fields=["shipping_method", "last_change"])
         recalculate_checkout_discount(
-            info.context.plugins, checkout_info, lines, info.context.discounts
+            manager, checkout_info, lines, info.context.discounts
         )
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutShippingMethodUpdate(checkout=checkout)
 
 
@@ -874,10 +883,13 @@ class CheckoutComplete(BaseMutation):
                     )
                 raise e
 
+            manager = info.context.plugins
             lines = fetch_checkout_lines(checkout)
-            checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+            checkout_info = fetch_checkout_info(
+                checkout, lines, info.context.discounts, manager
+            )
             order, action_required, action_data = complete_checkout(
-                manager=info.context.plugins,
+                manager=manager,
                 checkout_info=checkout_info,
                 lines=lines,
                 payment_data=data.get("payment_data", {}),
@@ -918,16 +930,19 @@ class CheckoutAddPromoCode(BaseMutation):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
+        manager = info.context.plugins
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
         add_promo_code_to_checkout(
-            info.context.plugins,
+            manager,
             checkout_info,
             lines,
             promo_code,
             info.context.discounts,
         )
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutAddPromoCode(checkout=checkout)
 
 
@@ -952,7 +967,10 @@ class CheckoutRemovePromoCode(BaseMutation):
         checkout = cls.get_node_or_error(
             info, checkout_id, only_type=Checkout, field="checkout_id"
         )
-        checkout_info = fetch_checkout_info(checkout, [], info.context.discounts)
+        manager = info.context.plugins
+        checkout_info = fetch_checkout_info(
+            checkout, [], info.context.discounts, manager
+        )
         remove_promo_code_from_checkout(checkout_info, promo_code)
-        info.context.plugins.checkout_updated(checkout)
+        manager.checkout_updated(checkout)
         return CheckoutRemovePromoCode(checkout=checkout)

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -68,7 +68,7 @@ def checkout_with_voucher(checkout_with_billing_address, voucher):
     checkout = checkout_with_billing_address
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     return checkout
 
@@ -76,8 +76,9 @@ def checkout_with_voucher(checkout_with_billing_address, voucher):
 @pytest.fixture()
 def checkout_with_charged_payment(checkout_with_voucher):
     checkout = checkout_with_voucher
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_voucher, lines, [], manager)
     manager = get_plugins_manager()
     taxed_total = calculations.checkout_total(
         manager=manager,

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -491,8 +491,11 @@ def test_checkout_payment_charge(
         }
     """
 
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_billing_address)
-    checkout_info = fetch_checkout_info(checkout_with_billing_address, lines, [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_billing_address, lines, [], manager
+    )
     manager = get_plugins_manager()
     total = calculations.checkout_total(
         manager=manager,

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -131,7 +131,7 @@ def test_checkout_complete_with_inactive_channel(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager=manager,
@@ -188,7 +188,7 @@ def test_checkout_complete(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )
@@ -297,7 +297,7 @@ def test_checkout_with_voucher_complete(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -367,7 +367,7 @@ def test_checkout_complete_without_inventory_tracking(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -442,7 +442,7 @@ def test_checkout_complete_error_in_gateway_response_for_dummy_credit_card(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )
@@ -516,7 +516,7 @@ def test_checkout_complete_does_not_delete_checkout_after_unsuccessful_payment(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     taxed_total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -606,7 +606,7 @@ def test_checkout_complete_confirmation_needed(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -660,7 +660,7 @@ def test_checkout_confirm(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -705,7 +705,7 @@ def test_checkout_complete_insufficient_stock(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -751,7 +751,7 @@ def test_checkout_complete_insufficient_stock_payment_refunded(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -806,7 +806,7 @@ def test_checkout_complete_insufficient_stock_payment_voided(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -860,7 +860,7 @@ def test_checkout_complete_without_redirect_url(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )
@@ -925,7 +925,7 @@ def test_checkout_complete_payment_payment_total_different_than_checkout(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -994,7 +994,7 @@ def test_create_order_raises_insufficient_stock(
     mocked_create_order.side_effect = InsufficientStock(
         [InsufficientStockData(variant=lines[0].variant)]
     )
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, checkout.shipping_address
     )
@@ -1038,7 +1038,7 @@ def test_checkout_complete_with_digital(
     # Create a dummy payment to charge
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -1096,7 +1096,7 @@ def test_checkout_complete_0_total_value(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )

--- a/saleor/graphql/checkout/tests/test_checkout_digital.py
+++ b/saleor/graphql/checkout/tests/test_checkout_digital.py
@@ -7,6 +7,7 @@ from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
 from ....checkout.models import Checkout
 from ....checkout.utils import add_variant_to_checkout
+from ....plugins.manager import get_plugins_manager
 from ...checkout.mutations import update_checkout_shipping_method_if_invalid
 from ...tests.utils import get_graphql_content
 from .test_checkout import (
@@ -160,8 +161,9 @@ def test_remove_shipping_method_if_only_digital_in_checkout(
     checkout.save()
 
     assert checkout.shipping_method
+    manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     update_checkout_shipping_method_if_invalid(checkout_info, lines)
 
     checkout.refresh_from_db()

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -25,7 +25,7 @@ def test_checkout_lines_delete_with_not_applicable_voucher(
 ):
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     subtotal = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -35,7 +35,7 @@ def test_checkout_lines_delete_with_not_applicable_voucher(
     voucher.channel_listings.filter(channel=channel_USD).update(
         min_spent_amount=subtotal.gross.amount
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
 
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     assert checkout_with_item.voucher_code == voucher.code
@@ -76,7 +76,7 @@ def test_checkout_shipping_address_update_with_not_applicable_voucher(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     add_voucher_to_checkout(manager, checkout_info, lines, voucher)
     assert checkout_with_item.voucher_code == voucher.code
 
@@ -146,7 +146,7 @@ def test_checkout_totals_use_discounts(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -165,7 +165,9 @@ def test_checkout_totals_use_discounts(
         product=line.variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout, [checkout_line_info], discounts)
+    checkout_info = fetch_checkout_info(
+        checkout, [checkout_line_info], discounts, manager
+    )
     line_total = calculations.checkout_line_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -276,9 +278,9 @@ def test_checkout_add_voucher_code(api_client, checkout_with_item, voucher):
 def test_checkout_add_voucher_code_checkout_with_sale(
     api_client, checkout_with_item, voucher_percentage, discount_info
 ):
-    lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     address = checkout_with_item.shipping_address
     subtotal = calculations.checkout_subtotal(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
@@ -309,7 +311,7 @@ def test_checkout_add_specific_product_voucher_code_checkout_with_sale(
     expected_discount = Decimal(1.5)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -317,7 +319,7 @@ def test_checkout_add_specific_product_voucher_code_checkout_with_sale(
         lines=lines,
         address=checkout.shipping_address,
     )
-    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info], manager)
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -348,9 +350,9 @@ def test_checkout_add_products_voucher_code_checkout_with_sale(
     voucher.save()
     voucher.products.add(product)
 
-    lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -359,7 +361,7 @@ def test_checkout_add_products_voucher_code_checkout_with_sale(
         address=checkout.shipping_address,
     )
 
-    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info], manager)
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -389,16 +391,16 @@ def test_checkout_add_collection_voucher_code_checkout_with_sale(
     voucher.save()
     voucher.collections.add(collection)
 
-    lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     subtotal = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
         lines=lines,
         address=checkout.shipping_address,
     )
-    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info], manager)
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -427,9 +429,9 @@ def test_checkout_add_category_code_checkout_with_sale(
     voucher.save()
     voucher.categories.add(category)
 
-    lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
 
     subtotal = calculations.checkout_subtotal(
         manager=manager,
@@ -437,7 +439,7 @@ def test_checkout_add_category_code_checkout_with_sale(
         lines=lines,
         address=checkout.shipping_address,
     )
-    checkout_info = fetch_checkout_info(checkout, lines, [discount_info])
+    checkout_info = fetch_checkout_info(checkout, lines, [discount_info], manager)
     subtotal_discounted = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -516,9 +518,9 @@ def test_checkout_add_many_gift_card_code(
 
 
 def test_checkout_get_total_with_gift_card(api_client, checkout_with_item, gift_card):
-    lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout_with_item)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -540,9 +542,9 @@ def test_checkout_get_total_with_gift_card(api_client, checkout_with_item, gift_
 def test_checkout_get_total_with_many_gift_card(
     api_client, checkout_with_gift_card, gift_card_created_by_staff
 ):
-    lines = fetch_checkout_lines(checkout_with_gift_card)
-    checkout_info = fetch_checkout_info(checkout_with_gift_card, lines, [])
     manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout_with_gift_card)
+    checkout_info = fetch_checkout_info(checkout_with_gift_card, lines, [], manager)
     taxed_total = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -394,7 +394,6 @@ class Checkout(CountableDjangoObjectType):
             available = get_valid_shipping_methods_for_checkout(
                 checkout_info,
                 lines,
-                discounts,
                 subtotal=subtotal,
                 country_code=address.country.code,
             )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -128,13 +128,16 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
         cls.validate_token(info.context.plugins, gateway, data)
         cls.validate_return_url(data)
 
+        manager = info.context.plugins
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, info.context.discounts)
+        checkout_info = fetch_checkout_info(
+            checkout, lines, info.context.discounts, manager
+        )
         address = (
             checkout.shipping_address or checkout.billing_address
         )  # FIXME: check which address we need here
         checkout_total = calculate_checkout_total_with_gift_cards(
-            manager=info.context.plugins,
+            manager=manager,
             checkout_info=checkout_info,
             lines=lines,
             address=address,

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -115,7 +115,7 @@ def test_checkout_add_payment_without_shipping_method_and_not_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -156,7 +156,7 @@ def test_checkout_add_payment_without_shipping_method_with_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -188,7 +188,7 @@ def test_checkout_add_payment_with_shipping_method_and_shipping_required(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -229,7 +229,7 @@ def test_checkout_add_payment(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -273,7 +273,7 @@ def test_checkout_add_payment_default_amount(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -307,7 +307,7 @@ def test_checkout_add_payment_bad_amount(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -358,7 +358,7 @@ def test_use_checkout_billing_address_as_payment_billing(
     checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -407,7 +407,7 @@ def test_create_payment_for_checkout_with_active_payments(
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )

--- a/saleor/payment/gateways/adyen/tests/conftest.py
+++ b/saleor/payment/gateways/adyen/tests/conftest.py
@@ -73,7 +73,7 @@ def payment_adyen_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.save()
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_items)
-    checkout_info = fetch_checkout_info(checkout_with_items, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_items, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -157,7 +157,7 @@ def test_handle_authorization_for_checkout(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )
@@ -204,7 +204,7 @@ def test_handle_authorization_with_adyen_auto_capture(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )
@@ -398,7 +398,7 @@ def test_handle_capture_for_checkout(
     payment = payment_adyen_for_checkout
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, [])
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     total = calculations.calculate_checkout_total_with_gift_cards(
         manager, checkout_info, lines, address
     )

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -190,7 +190,7 @@ def append_klarna_data(payment_information: "PaymentData", payment_data: dict):
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout)
     discounts = fetch_active_discounts()
-    checkout_info = fetch_checkout_info(checkout, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     currency = payment_information.currency
     country_code = checkout.get_country()
 
@@ -264,7 +264,7 @@ def request_data_for_gateway_config(
     address = checkout.billing_address or checkout.shipping_address
     discounts = fetch_active_discounts()
     lines = fetch_checkout_lines(checkout)
-    checkout_info = fetch_checkout_info(checkout, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
     total = checkout_total(
         manager=manager,
         checkout_info=checkout_info,

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -156,7 +156,7 @@ def create_order(payment, checkout):
     try:
         discounts = fetch_active_discounts()
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(checkout, lines, discounts)
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
         order, _, _ = complete_checkout(
             manager=manager,
             checkout_info=checkout_info,

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -88,7 +88,7 @@ def test_create_payment(checkout_with_item, address):
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )
@@ -128,7 +128,7 @@ def test_create_payment_from_checkout_requires_billing_address(checkout_with_ite
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=None
     )
@@ -170,7 +170,7 @@ def test_create_payment_information_for_checkout_payment(address, checkout_with_
 
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     total = checkout_total(
         manager=manager, checkout_info=checkout_info, lines=lines, address=address
     )

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -45,7 +45,9 @@ def test_manager_calculates_checkout_total(
     expected_total = Money(total_amount, currency)
     manager = PluginsManager(plugins=plugins)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, lines, [discount_info], manager
+    )
     taxed_total = manager.calculate_checkout_total(
         checkout_info, lines, None, [discount_info]
     )
@@ -61,8 +63,11 @@ def test_manager_calculates_checkout_subtotal(
 ):
     currency = checkout_with_item.currency
     expected_subtotal = Money(subtotal_amount, currency)
+    manager = PluginsManager(plugins=plugins)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, lines, [discount_info], manager
+    )
     taxed_subtotal = PluginsManager(plugins=plugins).calculate_checkout_subtotal(
         checkout_info, lines, None, [discount_info]
     )
@@ -78,8 +83,11 @@ def test_manager_calculates_checkout_shipping(
 ):
     currency = checkout_with_item.currency
     expected_shipping_price = Money(shipping_amount, currency)
+    manager = PluginsManager(plugins=plugins)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [discount_info])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, lines, [discount_info], manager
+    )
     taxed_shipping_price = PluginsManager(plugins=plugins).calculate_checkout_shipping(
         checkout_info, lines, None, [discount_info]
     )
@@ -118,6 +126,7 @@ def test_manager_calculates_checkout_line_total(
     channel_listing = line.variant.channel_listings.get(channel=channel)
     currency = checkout_with_item.currency
     expected_total = Money(amount, currency)
+    manager = get_plugins_manager()
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=line.variant,
@@ -126,7 +135,7 @@ def test_manager_calculates_checkout_line_total(
         collections=[],
     )
     checkout_info = fetch_checkout_info(
-        checkout_with_item, [checkout_line_info], [discount_info]
+        checkout_with_item, [checkout_line_info], [discount_info], manager
     )
     taxed_total = PluginsManager(plugins=plugins).calculate_checkout_line_total(
         checkout_info,
@@ -145,6 +154,7 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(
     unit_price = TaxedMoney(Money(12, "USD"), Money(15, "USD"))
 
     variant = line.variant
+    manager = get_plugins_manager()
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=variant,
@@ -153,7 +163,7 @@ def test_manager_get_checkout_line_tax_rate_sample_plugin(
         collections=[],
     )
     checkout_info = fetch_checkout_info(
-        checkout_with_item, [checkout_line_info], [discount_info]
+        checkout_with_item, [checkout_line_info], [discount_info], manager
     )
 
     tax_rate = PluginsManager(plugins=plugins).get_checkout_line_tax_rate(
@@ -178,6 +188,7 @@ def test_manager_get_checkout_line_tax_rate_no_plugins(
 ):
     line = checkout_with_item.lines.all()[0]
     variant = line.variant
+    manager = get_plugins_manager()
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=variant,
@@ -186,7 +197,7 @@ def test_manager_get_checkout_line_tax_rate_no_plugins(
         collections=[],
     )
     checkout_info = fetch_checkout_info(
-        checkout_with_item, [checkout_line_info], [discount_info]
+        checkout_with_item, [checkout_line_info], [discount_info], manager
     )
     tax_rate = PluginsManager(plugins=[]).get_checkout_line_tax_rate(
         checkout_info,
@@ -243,6 +254,7 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(
     shipping_price = TaxedMoney(Money(12, "USD"), Money(14, "USD"))
 
     variant = line.variant
+    manager = get_plugins_manager()
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=variant,
@@ -251,7 +263,7 @@ def test_manager_get_checkout_shipping_tax_rate_sample_plugin(
         collections=[],
     )
     checkout_info = fetch_checkout_info(
-        checkout_with_item, [checkout_line_info], [discount_info]
+        checkout_with_item, [checkout_line_info], [discount_info], manager
     )
 
     tax_rate = PluginsManager(plugins=plugins).get_checkout_shipping_tax_rate(
@@ -276,6 +288,7 @@ def test_manager_get_checkout_shipping_tax_rate_no_plugins(
 ):
     line = checkout_with_item.lines.all()[0]
     variant = line.variant
+    manager = get_plugins_manager()
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=variant,
@@ -284,7 +297,7 @@ def test_manager_get_checkout_shipping_tax_rate_no_plugins(
         collections=[],
     )
     checkout_info = fetch_checkout_info(
-        checkout_with_item, [checkout_line_info], [discount_info]
+        checkout_with_item, [checkout_line_info], [discount_info], manager
     )
 
     tax_rate = PluginsManager(plugins=[]).get_checkout_shipping_tax_rate(
@@ -354,6 +367,7 @@ def test_manager_calculates_checkout_line_unit_price(
     channel = checkout_with_item.channel
     channel_listing = line.variant.channel_listings.get(channel=channel)
 
+    manager = PluginsManager(plugins=plugins)
     checkout_line_info = CheckoutLineInfo(
         line=line,
         variant=line.variant,
@@ -361,7 +375,9 @@ def test_manager_calculates_checkout_line_unit_price(
         product=line.variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     taxed_total = PluginsManager(plugins=plugins).calculate_checkout_line_unit_price(
         total_line_price,

--- a/saleor/plugins/vatlayer/tests/test_vatlayer.py
+++ b/saleor/plugins/vatlayer/tests/test_vatlayer.py
@@ -249,7 +249,7 @@ def test_calculate_checkout_total(
 
     discounts = [discount_info] if with_discount else None
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     total = manager.calculate_checkout_total(checkout_info, lines, address, discounts)
     total = quantize_price(total, total.currency)
     assert total == TaxedMoney(
@@ -297,7 +297,7 @@ def test_calculate_checkout_subtotal(
     discounts = [discount_info] if with_discount else None
     add_variant_to_checkout(checkout_with_item, variant, 2)
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts)
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, discounts, manager)
     total = manager.calculate_checkout_subtotal(
         checkout_info, lines, address, discounts
     )
@@ -390,7 +390,9 @@ def test_calculate_checkout_line_total(
         product=line.variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     line_price = manager.calculate_checkout_line_total(
         checkout_info,
@@ -435,7 +437,9 @@ def test_calculate_checkout_line_unit_price(
         product=line.variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     line_price = manager.calculate_checkout_line_unit_price(
         total_price,
@@ -558,7 +562,7 @@ def test_calculations_checkout_total_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_subtotal = calculations.checkout_total(
         manager=manager,
         checkout_info=checkout_info,
@@ -576,7 +580,7 @@ def test_calculations_checkout_subtotal_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_subtotal = calculations.checkout_subtotal(
         manager=manager,
         checkout_info=checkout_info,
@@ -594,7 +598,7 @@ def test_calculations_checkout_shipping_price_with_vatlayer(
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
-    checkout_info = fetch_checkout_info(checkout_with_item, lines, [])
+    checkout_info = fetch_checkout_info(checkout_with_item, lines, [], manager)
     checkout_shipping_price = calculations.checkout_shipping_price(
         manager=manager,
         checkout_info=checkout_info,
@@ -652,7 +656,9 @@ def test_get_checkout_line_tax_rate(
         collections=[],
     )
 
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
     tax_rate = manager.get_checkout_line_tax_rate(
         checkout_info,
         checkout_line_info,
@@ -689,7 +695,9 @@ def test_get_checkout_line_tax_rate_order_not_valid(
         product=variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     tax_rate = manager.get_checkout_line_tax_rate(
         checkout_info,
@@ -786,7 +794,9 @@ def test_get_checkout_shipping_tax_rate(
         product=variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
         checkout_info,
@@ -824,7 +834,9 @@ def test_get_checkout_shipping_tax_rate_no_address(
         product=variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
         checkout_info,
@@ -869,7 +881,9 @@ def test_get_checkout_shipping_tax_rate_skip_plugin(
         product=variant.product,
         collections=[],
     )
-    checkout_info = fetch_checkout_info(checkout_with_item, [checkout_line_info], [])
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [checkout_line_info], [], manager
+    )
 
     tax_rate = manager.get_checkout_shipping_tax_rate(
         checkout_info,


### PR DESCRIPTION
Require `subtotal` parameter in `get_valid_shipping_methods_for_checkout` utils method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
