### PR TITLE
Add vcr for failing product media tests

### DIFF
--- a/saleor/graphql/core/tests/cassettes/test_get_oembed_data[http:/www.youtube.com/watch?v=dQw4w9WgXcQ-VIDEO].yaml
+++ b/saleor/graphql/core/tests/cassettes/test_get_oembed_data[http:/www.youtube.com/watch?v=dQw4w9WgXcQ-VIDEO].yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.youtube.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://www.youtube.com/oembed?format=json&maxheight=1080&maxwidth=1920&url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
+  response:
+    body:
+      string: '{"title":"Rick Astley - Never Gonna Give You Up (Video)","author_name":"RickAstleyVEVO","author_url":"https://www.youtube.com/user/RickAstleyVEVO","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe
+        width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+    headers:
+      Accept-Ranges:
+      - none
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:22:47 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - X-Origin
+      - Referer
+      - Origin,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/vimeo.com/148751763-VIDEO].yaml
+++ b/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/vimeo.com/148751763-VIDEO].yaml
@@ -1,0 +1,82 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - vimeo.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://vimeo.com/api/oembed.json?format=json&maxheight=1080&maxwidth=1920&url=https%3A%2F%2Fvimeo.com%2F148751763
+  response:
+    body:
+      string: '{"type":"video","version":"1.0","provider_name":"Vimeo","provider_url":"https:\/\/vimeo.com\/","title":"Rick
+        Astley - Never Gonna Give You Up","author_name":"Rick Astley","author_url":"https:\/\/vimeo.com\/user46726126","is_plus":"0","account_type":"basic","html":"<iframe
+        src=\"https:\/\/player.vimeo.com\/video\/148751763?app_id=122963\" width=\"320\"
+        height=\"240\" frameborder=\"0\" allow=\"autoplay; fullscreen; picture-in-picture\"
+        allowfullscreen title=\"Rick Astley - Never Gonna Give You Up\"><\/iframe>","width":320,"height":240,"duration":214,"description":"","thumbnail_url":"https:\/\/i.vimeocdn.com\/video\/547780029_295x166.jpg","thumbnail_width":295,"thumbnail_height":221,"thumbnail_url_with_play_button":"https:\/\/i.vimeocdn.com\/filter\/overlay?src0=https%3A%2F%2Fi.vimeocdn.com%2Fvideo%2F547780029_295x166.jpg&src1=http%3A%2F%2Ff.vimeocdn.com%2Fp%2Fimages%2Fcrawler_play.png","upload_date":"2015-12-12
+        19:51:18","video_id":148751763,"uri":"\/videos\/148751763"}'
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Headers:
+      - X-Requested-With
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '0'
+      Cache-Control:
+      - no-store, no-cache, must-revalidate, post-check=0, pre-check=0
+      Connection:
+      - close
+      Content-Length:
+      - '982'
+      Content-Security-Policy-Report-Only:
+      - 'default-src https: data: blob: wss: ''unsafe-inline'' ''unsafe-eval''; report-uri
+        /_csp'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:22:45 GMT
+      Etag:
+      - '"3d00955b438ddd10b764354ab9578e738318c3b7"'
+      Last-Modified:
+      - Thu, 18 Mar 2021 08:21:04 GMT
+      Server:
+      - nginx
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 varnish, 1.1 varnish, 1.1 varnish
+      X-BApp-Server:
+      - pweb-v9157-nfxnf
+      X-Cache:
+      - MISS, MISS
+      X-Cache-Hits:
+      - 0, 0
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - sameorigin
+      X-Served-By:
+      - cache-bwi5140-BWI, cache-cph20621-CPH
+      X-Timer:
+      - S1616059366.666689,VS0,VE133
+      X-UA-Compatible:
+      - IE=edge
+      X-VServer:
+      - infra-webproxy-a-9
+      X-Varnish-Cache:
+      - '0'
+      X-Vimeo-DC:
+      - ge
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.flickr.com/photos/megane_wakui/31740618232/-IMAGE].yaml
+++ b/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.flickr.com/photos/megane_wakui/31740618232/-IMAGE].yaml
@@ -1,0 +1,110 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.flickr.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://www.flickr.com/services/oembed/?format=json&maxheight=1080&maxwidth=1920&url=https%3A%2F%2Fwww.flickr.com%2Fphotos%2Fmegane_wakui%2F31740618232%2F
+  response:
+    body:
+      string: '{"type":"photo","flickr_type":"photo","title":"","author_name":"Masashi
+        Wakui","author_url":"https:\/\/www.flickr.com\/photos\/megane_wakui\/","width":1024,"height":681,"url":"https:\/\/live.staticflickr.com\/408\/31740618232_e5e8717408_b.jpg","web_page":"https:\/\/www.flickr.com\/photos\/megane_wakui\/31740618232\/","thumbnail_url":"https:\/\/live.staticflickr.com\/408\/31740618232_e5e8717408_q.jpg","thumbnail_width":150,"thumbnail_height":150,"web_page_short_url":"https:\/\/flic.kr\/p\/QmNXYu","license":"All
+        Rights Reserved","license_id":0,"html":"<a data-flickr-embed=\"true\" href=\"https:\/\/www.flickr.com\/photos\/megane_wakui\/31740618232\/\"
+        title=\"Untitled by Masashi Wakui, on Flickr\"><img src=\"https:\/\/live.staticflickr.com\/408\/31740618232_e5e8717408_b.jpg\"
+        width=\"1024\" height=\"681\" alt=\"Untitled\"><\/a><script async src=\"https:\/\/embedr.flickr.com\/assets\/client-code.js\"
+        charset=\"utf-8\"><\/script>","version":"1.0","cache_age":3600,"provider_name":"Flickr","provider_url":"https:\/\/www.flickr.com\/"}
+
+        '
+    headers:
+      Connection:
+      - close
+      Content-Length:
+      - '1043'
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:22:47 GMT
+      Vary:
+      - Accept-Encoding
+      Via:
+      - 1.1 4cb16ea6a84fa64395352e03f53b5e8f.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - GIeXPFey2CCOo4qmsNwyZkLqMXKEcyJyZF-rJ7en4e9kfuLf2YGa4w==
+      X-Amz-Cf-Pop:
+      - WAW50-C1
+      X-Cache:
+      - Miss from cloudfront
+      content-security-policy:
+      - 'default-src ''unsafe-inline'' https://*.flickr.com https://*.staticflickr.com
+        https://*.flickr.net https://*.braintreegateway.com https://*.kaptcha.com
+        https://*.paypal.com http://api.flickr.com https://*.pinterest.com https://connect.facebook.net
+        https://*.facebook.com https://*.maps.api.here.com https://*.maps.cit.api.here.com
+        https://cdn.siftscience.com https://tpc.googlesyndication.com https://securepubads.g.doubleclick.net
+        https://adservice.google.com https://cdn.ampproject.org https://trustarc.mgr.consensu.org/
+        https://*.trustarc.com; img-src data: blob: https://*.flickr.com https://*.flickr.net
+        http://*.flickr.net https://*.staticflickr.com http://*.staticflickr.com https://*.yimg.com
+        https://*.yahoo.com https://image.maps.api.here.com https://*.paypal.com https://*.pinterest.com
+        http://*.static-alpha.flickr.com https://connect.facebook.net https://*.facebook.com
+        https://*.maps.api.here.com https://*.maps.cit.api.here.com https://creativecommons.org
+        https://hexagon-analytics.com https://*.2o7.net https://tagmanager.google.com
+        https://www.googletagmanager.com https://*.google.com https://*.google-analytics.com
+        https://*.googleadservices.com https://*.googlesyndication.com https://*.doubleclick.com
+        https://*.doubleclick.de https://*.doubleclick.net https://*.googletagservices.com
+        https://*.googleadservices.com https://*.googlesyndication.com https://*.googleapis.com
+        https://api.mapbox.com https://*.trustarc.com; script-src ''unsafe-eval''
+        ''unsafe-inline'' https://*.flickr.com http://*.flickr.net https://*.flickr.net
+        https://*.staticflickr.com https://*.analytics.yahoo.com https://yep.video.yahoo.com
+        https://video.media.yql.yahoo.com https://*.yahooapis.com https://*.braintreegateway.com
+        https://*.paypalobjects.com https://connect.facebook.net https://*.facebook.com
+        https://*.maps.api.here.com https://*.maps.cit.api.here.com https://cdn.siftscience.com
+        https://assets.adobedtm.com https://securepubads.g.doubleclick.net https://adservice.google.com
+        https://cdn.ampproject.org https://*.google.com https://*.google-analytics.com
+        https://*.googleadservices.com https://*.googlesyndication.com https://*.doubleclick.com
+        https://*.doubleclick.de https://*.doubleclick.net https://*.googletagservices.com
+        https://*.googleadservices.com https://*.googlesyndication.com https://*.googleapis.com
+        https://consent.trustarc.com https://trustarc.mgr.consensu.org; connect-src
+        https://*.flickr.com https://*.flickr.net http://*.flickr.net https://*.staticflickr.com
+        https://geo.query.yahoo.com https://*.yahooapis.com http://api.flickr.com
+        https://*.pinterest.com http://*.yahoo.com https://*.maps.api.here.com https://*.maps.cit.api.here.com
+        https://cdn.siftscience.com https://*.demdex.net https://securepubads.g.doubleclick.net
+        https://*.trustarc.com; report-uri https://csp.flickr.com/beacon/csp?src=adsecflickr;'
+      server:
+      - Apache/2.4.46 (Ubuntu)
+      set-cookie:
+      - xb=155751; expires=Sun, 16-Mar-2031 09:22:47 GMT; Max-Age=315360000; path=/;
+        domain=.flickr.com
+      - localization=en-us%3Bpl%3Bpl; expires=Thu, 16-Mar-2023 09:22:47 GMT; Max-Age=62899200;
+        path=/; domain=.flickr.com
+      - flrbp=1616059367-dcb1f8826c20722a7f25c4fedb3ef05ec06b488c; expires=Tue, 14-Sep-2021
+        09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbs=1616059367-64a31658cbd8ffacc3b8ef717aafdb6950ca0771; expires=Tue, 14-Sep-2021
+        09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbgrp=1616059367-da72a7a1906fa99538f6d198c01273e1bbe43329; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbgdrp=1616059367-74a58e6d6b59827183922aa0a5080be2c3e5c893; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbgmrp=1616059367-1eeba700dcf9080506867547889c28fd7a81ec32; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbrst=1616059367-c3f79e11fa3406f3d031882174d831a183deb5d0; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrtags=1616059367-e00edec7f689127419c849acee351e6727750be3; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbrp=1616059367-2817d64ff5431e308c3e66138a4ae0be87f64e8b; expires=Tue, 14-Sep-2021
+        09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrbrgs=1616059367-f4c26a08c44ac612c854d15490b5beeb08f0b961; expires=Tue,
+        14-Sep-2021 09:22:47 GMT; Max-Age=15552000; path=/; domain=.flickr.com; HttpOnly
+      - flrb=53; expires=Thu, 18-Mar-2021 10:22:47 GMT; Max-Age=3600; path=/; domain=.flickr.com;
+        HttpOnly
+      - ccc=%7B%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
+        expires=Sat, 17-Apr-2021 09:22:47 GMT; Max-Age=2592000; path=/; domain=.flickr.com
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.youtube.com/watch?v=dQw4w9WgXcQ&ab_channel=TestingChannel-VIDEO].yaml
+++ b/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.youtube.com/watch?v=dQw4w9WgXcQ&ab_channel=TestingChannel-VIDEO].yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.youtube.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://www.youtube.com/oembed?scheme=https&format=json&maxheight=1080&maxwidth=1920&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ%26ab_channel%3DTestingChannel
+  response:
+    body:
+      string: '{"title":"Rick Astley - Never Gonna Give You Up (Video)","author_name":"RickAstleyVEVO","author_url":"https://www.youtube.com/user/RickAstleyVEVO","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe
+        width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+    headers:
+      Accept-Ranges:
+      - none
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:22:45 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - X-Origin
+      - Referer
+      - Origin,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.youtube.com/watch?v=dQw4w9WgXcQ-VIDEO].yaml
+++ b/saleor/graphql/core/tests/cassettes/test_get_oembed_data[https:/www.youtube.com/watch?v=dQw4w9WgXcQ-VIDEO].yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.youtube.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://www.youtube.com/oembed?scheme=https&format=json&maxheight=1080&maxwidth=1920&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
+  response:
+    body:
+      string: '{"title":"Rick Astley - Never Gonna Give You Up (Video)","author_name":"RickAstleyVEVO","author_url":"https://www.youtube.com/user/RickAstleyVEVO","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe
+        width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+    headers:
+      Accept-Ranges:
+      - none
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:22:46 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - X-Origin
+      - Referer
+      - Origin,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/core/tests/test_core.py
+++ b/saleor/graphql/core/tests/test_core.py
@@ -283,6 +283,7 @@ def test_requestor_is_superuser_for_anonymous_user():
     assert result is False
 
 
+@pytest.mark.vcr
 @pytest.mark.parametrize(
     "url, expected_media_type",
     [

--- a/saleor/graphql/product/tests/cassettes/test_product_media_create_mutation_with_media_url.yaml
+++ b/saleor/graphql/product/tests/cassettes/test_product_media_create_mutation_with_media_url.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Connection:
+      - close
+      Host:
+      - www.youtube.com
+      User-Agent:
+      - python-micawber
+    method: GET
+    uri: https://www.youtube.com/oembed?scheme=https&format=json&maxheight=1080&maxwidth=1920&url=https%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3DdQw4w9WgXcQ
+  response:
+    body:
+      string: '{"title":"Rick Astley - Never Gonna Give You Up (Video)","author_name":"RickAstleyVEVO","author_url":"https://www.youtube.com/user/RickAstleyVEVO","type":"video","height":1080,"width":1920,"version":"1.0","provider_name":"YouTube","provider_url":"https://www.youtube.com/","thumbnail_height":360,"thumbnail_width":480,"thumbnail_url":"https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg","html":"\u003ciframe
+        width=\u00221920\u0022 height=\u00221080\u0022 src=\u0022https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\u0022
+        frameborder=\u00220\u0022 allow=\u0022accelerometer; autoplay; clipboard-write;
+        encrypted-media; gyroscope; picture-in-picture\u0022 allowfullscreen\u003e\u003c/iframe\u003e"}'
+    headers:
+      Accept-Ranges:
+      - none
+      Alt-Svc:
+      - h3-29=":443"; ma=2592000,h3-T051=":443"; ma=2592000,h3-Q050=":443"; ma=2592000,h3-Q046=":443";
+        ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"
+      Cache-Control:
+      - private
+      Connection:
+      - close
+      Content-Type:
+      - application/json
+      Date:
+      - Thu, 18 Mar 2021 09:29:04 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - X-Origin
+      - Referer
+      - Origin,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -6182,6 +6182,7 @@ def test_product_media_create_mutation_without_file(
     assert errors[0]["code"] == ProductErrorCode.REQUIRED.name
 
 
+@pytest.mark.vcr
 def test_product_media_create_mutation_with_media_url(
     monkeypatch, staff_api_client, product, permission_manage_products, media_root
 ):
@@ -6205,7 +6206,7 @@ def test_product_media_create_mutation_with_media_url(
     assert media[0]["type"] == ProductMediaTypes.VIDEO
 
     oembed_data = json.loads(media[0]["oembedData"])
-    assert oembed_data["url"] == ("https://www.youtube.com/watch?v=dQw4w9WgXcQ")
+    assert oembed_data["url"] == "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
     assert oembed_data["type"] == "video"
     assert oembed_data["html"] is not None
     assert oembed_data["thumbnail_url"] == (


### PR DESCRIPTION
I want to merge this change because...

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
