### PR TITLE
Refactor checkout get_total_weight method

### DIFF
--- a/saleor/checkout/models.py
+++ b/saleor/checkout/models.py
@@ -116,19 +116,11 @@ class Checkout(ModelWithMetadata):
             return zero_money(currency=self.currency)
         return Money(balance, self.currency)
 
-    def get_total_weight(
-        self, lines: Optional[Iterable["CheckoutLineInfo"]] = None
-    ) -> "Weight":
-        # Cannot use `sum` as it parses an empty Weight to an int
+    def get_total_weight(self, lines: Iterable["CheckoutLineInfo"]) -> "Weight":
         weights = zero_weight()
-        # TODO: we should use new data structure for lines in order like in checkout
-        if lines is None:
-            for line in self:
-                weights += line.variant.get_weight() * line.quantity
-        else:
-            for checkout_line_info in lines:
-                line = checkout_line_info.line
-                weights += line.variant.get_weight() * line.quantity
+        for checkout_line_info in lines:
+            line = checkout_line_info.line
+            weights += line.variant.get_weight() * line.quantity
         return weights
 
     def get_line(self, variant: "ProductVariant") -> Optional["CheckoutLine"]:

--- a/saleor/checkout/tests/test_cart.py
+++ b/saleor/checkout/tests/test_cart.py
@@ -271,4 +271,5 @@ def test_get_total_weight(checkout_with_item):
     variant.save()
     line.quantity = 6
     line.save()
-    assert checkout_with_item.get_total_weight() == Weight(kg=60)
+    lines = fetch_checkout_lines(checkout_with_item)
+    assert checkout_with_item.get_total_weight(lines) == Weight(kg=60)


### PR DESCRIPTION
Force using `CheckoutLineInfo` in checkout `get_total_weight` method.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
