### PR TITLE
Fix duplicate creation event when opening pull requests

### DIFF
--- a/.github/workflows/test-env-deploy.yml
+++ b/.github/workflows/test-env-deploy.yml
@@ -3,7 +3,7 @@ name: TEST-ENV-DEPLOYMENT
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, labeled]
+    types: [reopened, synchronize, labeled]
     branches: ["*"]
 
 jobs:


### PR DESCRIPTION
When a pull request is opened with a label filled in the creation form, it causes to trigger two events: opened and labeled.

This then causes to attempt to create the environment twice around one second apart.

Instead, we will now only build with the first event: labeled instead of opened.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
