### PR TITLE
Refactor listing payment gateways

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ All notable, unreleased changes to this project will be documented in this file.
   To get proper taxes we should always send the whole checkout to Avalara.
 - Remove triggering a webhook event `PRODUCT_UPDATED`  when calling `ProductVariantCreate` mutation.  Use `PRODUCT_VARIANT_CREATED` instead - #6963 by @piotrgrundas
 - Remove triggering a webhook event `PRODUCT_UPDATED` when calling  `ProductVariantChannelListingUpdate` mutation. Use `PRODUCT_VARIANT_UPDATED` instead - #6963 by @piotrgrundas
+- Refactor listing payment gateways - #7050 by @maarcingebala. Breaking changes in plugin methods: removed `get_payment_gateway` and `get_payment_gateway_for_checkout`; instead `get_payment_gateways` was added.
 
 ### Other
 

--- a/saleor/core/payments.py
+++ b/saleor/core/payments.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     # flake8: noqa
+    from ..checkout.models import Checkout
     from ..payment.interface import (
         CustomerSource,
         GatewayResponse,
@@ -17,6 +18,7 @@ class PaymentInterface(ABC):
     def list_payment_gateways(
         self,
         currency: Optional[str] = None,
+        checkout: Optional["Checkout"] = None,
         active_only: bool = True,
     ) -> List["PaymentGateway"]:
         pass

--- a/saleor/core/payments.py
+++ b/saleor/core/payments.py
@@ -3,8 +3,6 @@ from typing import TYPE_CHECKING, List, Optional
 
 if TYPE_CHECKING:
     # flake8: noqa
-    from ..checkout.models import Checkout, CheckoutLine
-    from ..discount import DiscountInfo
     from ..payment.interface import (
         CustomerSource,
         GatewayResponse,
@@ -17,14 +15,9 @@ if TYPE_CHECKING:
 class PaymentInterface(ABC):
     @abstractmethod
     def list_payment_gateways(
-        self, currency: Optional[str] = None, active_only: bool = True
-    ) -> List["PaymentGateway"]:
-        pass
-
-    @abstractmethod
-    def checkout_available_payment_gateways(
         self,
-        checkout: "Checkout",
+        currency: Optional[str] = None,
+        active_only: bool = True,
     ) -> List["PaymentGateway"]:
         pass
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -425,7 +425,7 @@ class Checkout(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_available_payment_gateways(root: models.Checkout, info):
-        return info.context.plugins.checkout_available_payment_gateways(checkout=root)
+        return info.context.plugins.list_payment_gateways(currency=root.currency)
 
     @staticmethod
     def resolve_gift_cards(root: models.Checkout, _info):

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -425,7 +425,9 @@ class Checkout(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_available_payment_gateways(root: models.Checkout, info):
-        return info.context.plugins.list_payment_gateways(currency=root.currency)
+        return info.context.plugins.list_payment_gateways(
+            currency=root.currency, checkout=root
+        )
 
     @staticmethod
     def resolve_gift_cards(root: models.Checkout, _info):

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -256,30 +256,34 @@ class AdyenGatewayPlugin(BasePlugin):
     def get_payment_gateways(
         self, currency: Optional[str], checkout: Optional["Checkout"], previous_value
     ) -> List["PaymentGateway"]:
-        if not checkout:
-            return []
+        local_config = self._get_gateway_config()
+        config = [
+            {
+                "field": "client_key",
+                "value": local_config.connection_params["client_key"],
+            }
+        ]
 
-        config = self._get_gateway_config()
-        request = request_data_for_gateway_config(
-            checkout, config.connection_params["merchant_account"]
-        )
-        with opentracing.global_tracer().start_active_span(
-            "adyen.checkout.payment_methods"
-        ) as scope:
-            span = scope.span
-            span.set_tag(opentracing.tags.COMPONENT, "payment")
-            span.set_tag("service.name", "adyen")
-            response = api_call(request, self.adyen.checkout.payment_methods)
+        if checkout:
+            # If checkout is available, fetch available payment methods from Adyen API
+            # and append them to the config object returned for the gateway.
+            request = request_data_for_gateway_config(
+                checkout, local_config.connection_params["merchant_account"]
+            )
+            with opentracing.global_tracer().start_active_span(
+                "adyen.checkout.payment_methods"
+            ) as scope:
+                span = scope.span
+                span.set_tag(opentracing.tags.COMPONENT, "payment")
+                span.set_tag("service.name", "adyen")
+                response = api_call(request, self.adyen.checkout.payment_methods)
+                adyen_payment_methods = json.dumps(response.message)
+                config.append({"field": "config", "value": adyen_payment_methods})
+
         gateway = PaymentGateway(
             id=self.PLUGIN_ID,
             name=self.PLUGIN_NAME,
-            config=[
-                {
-                    "field": "client_key",
-                    "value": config.connection_params["client_key"],
-                },
-                {"field": "config", "value": json.dumps(response.message)},
-            ],
+            config=config,
             currencies=self.get_supported_currencies([]),
         )
         return [gateway]

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -253,11 +253,11 @@ class AdyenGatewayPlugin(BasePlugin):
         return previous_value
 
     @require_active_plugin
-    def get_payment_gateway_for_checkout(
-        self,
-        checkout: "Checkout",
-        previous_value,
-    ) -> Optional["PaymentGateway"]:
+    def get_payment_gateways(
+        self, currency: Optional[str], checkout: Optional["Checkout"], previous_value
+    ) -> List["PaymentGateway"]:
+        if not checkout:
+            return []
 
         config = self._get_gateway_config()
         request = request_data_for_gateway_config(
@@ -270,7 +270,7 @@ class AdyenGatewayPlugin(BasePlugin):
             span.set_tag(opentracing.tags.COMPONENT, "payment")
             span.set_tag("service.name", "adyen")
             response = api_call(request, self.adyen.checkout.payment_methods)
-        return PaymentGateway(
+        gateway = PaymentGateway(
             id=self.PLUGIN_ID,
             name=self.PLUGIN_NAME,
             config=[
@@ -282,6 +282,7 @@ class AdyenGatewayPlugin(BasePlugin):
             ],
             currencies=self.get_supported_currencies([]),
         )
+        return [gateway]
 
     @property
     def order_auto_confirmation(self):

--- a/saleor/payment/gateways/adyen/tests/test_plugin.py
+++ b/saleor/payment/gateways/adyen/tests/test_plugin.py
@@ -58,9 +58,9 @@ def test_get_payment_gateway_for_checkout(
     checkout_with_single_item.billing_address = address
     checkout_with_single_item.save()
     adyen_plugin = adyen_plugin()
-    response = adyen_plugin.get_payment_gateway_for_checkout(
-        checkout_with_single_item, None
-    )
+    response = adyen_plugin.get_payment_gateways(
+        currency=None, checkout=checkout_with_single_item, previous_value=None
+    )[0]
     assert response.id == adyen_plugin.PLUGIN_ID
     assert response.name == adyen_plugin.PLUGIN_NAME
     config = response.config

--- a/saleor/payment/gateways/authorize_net/tests/test_plugin.py
+++ b/saleor/payment/gateways/authorize_net/tests/test_plugin.py
@@ -12,9 +12,9 @@ def test_get_payment_gateway_for_checkout(
 ):
     checkout_with_single_item.billing_address = address
     checkout_with_single_item.save()
-    response = authorize_net_plugin.get_payment_gateway_for_checkout(
-        checkout_with_single_item, None
-    )
+    response = authorize_net_plugin.get_payment_gateways(
+        currency=None, checkout=checkout_with_single_item, previous_value=None
+    )[0]
     assert response.id == authorize_net_plugin.PLUGIN_ID
     assert response.name == authorize_net_plugin.PLUGIN_NAME
     config = response.config
@@ -41,8 +41,9 @@ def test_get_payment_gateway_for_checkout_inactive(
     authorize_net_plugin, checkout_with_single_item
 ):
     authorize_net_plugin.active = False
-    response = authorize_net_plugin.get_payment_gateway_for_checkout(
-        checkout_with_single_item, None
+    currency = checkout_with_single_item.currency
+    response = authorize_net_plugin.get_payment_gateways(
+        currency=currency, checkout=checkout_with_single_item, previous_value=None
     )
     assert not response
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -613,28 +613,22 @@ class BasePlugin:
     def token_is_required_as_payment_input(self, previous_value):
         return previous_value
 
-    def get_payment_gateway(
-        self, currency: Optional[str], previous_value
-    ) -> Optional["PaymentGateway"]:
+    def get_payment_gateways(
+        self, currency: Optional[str], checkout: Optional["Checkout"], previous_value
+    ) -> List["PaymentGateway"]:
         payment_config = self.get_payment_config(previous_value)
         payment_config = payment_config if payment_config != NotImplemented else []
         currencies = self.get_supported_currencies(previous_value=[])
         currencies = currencies if currencies != NotImplemented else []
         if currency and currency not in currencies:
-            return None
-        return PaymentGateway(
+            return []
+        gateway = PaymentGateway(
             id=self.PLUGIN_ID,
             name=self.PLUGIN_NAME,
             config=payment_config,
             currencies=currencies,
         )
-
-    def get_payment_gateway_for_checkout(
-        self,
-        checkout: "Checkout",
-        previous_value,
-    ) -> Optional["PaymentGateway"]:
-        return self.get_payment_gateway(checkout.currency, previous_value)
+        return [gateway]
 
     @classmethod
     def _update_config_items(

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -593,15 +593,19 @@ class PluginsManager(PaymentInterface):
         }
 
     def list_payment_gateways(
-        self, currency: Optional[str] = None, active_only: bool = True
+        self,
+        currency: Optional[str] = None,
+        active_only: bool = True,
     ) -> List["PaymentGateway"]:
         payment_plugins = self.list_payment_plugin(active_only=active_only)
         # if currency is given return only gateways which support given currency
         gateways = []
         for plugin in payment_plugins.values():
-            gateway = plugin.get_payment_gateway(currency=currency, previous_value=None)
-            if gateway:
-                gateways.append(gateway)
+            gateways.extend(
+                plugin.get_payment_gateways(
+                    currency=currency, checkout=None, previous_value=None
+                )
+            )
         return gateways
 
     def list_external_authentications(self, active_only: bool = True) -> List[dict]:
@@ -614,20 +618,6 @@ class PluginsManager(PaymentInterface):
             for plugin in plugins
             if auth_basic_method in type(plugin).__dict__
         ]
-
-    def checkout_available_payment_gateways(
-        self,
-        checkout: "Checkout",
-    ) -> List["PaymentGateway"]:
-        payment_plugins = self.list_payment_plugin(active_only=True)
-        gateways = []
-        for plugin in payment_plugins.values():
-            gateway = plugin.get_payment_gateway_for_checkout(
-                checkout, previous_value=None
-            )
-            if gateway:
-                gateways.append(gateway)
-        return gateways
 
     def __run_payment_method(
         self,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -595,6 +595,7 @@ class PluginsManager(PaymentInterface):
     def list_payment_gateways(
         self,
         currency: Optional[str] = None,
+        checkout: Optional["Checkout"] = None,
         active_only: bool = True,
     ) -> List["PaymentGateway"]:
         payment_plugins = self.list_payment_plugin(active_only=active_only)
@@ -603,7 +604,7 @@ class PluginsManager(PaymentInterface):
         for plugin in payment_plugins.values():
             gateways.extend(
                 plugin.get_payment_gateways(
-                    currency=currency, checkout=None, previous_value=None
+                    currency=currency, checkout=checkout, previous_value=None
                 )
             )
         return gateways


### PR DESCRIPTION
An attempt to unify plugin manager's methods to list payment gateways.

Now we have two methods in plugin manager for listing payment gateways: `checkout_available_payment_gateways`  and `list_payment_gateways`. These methods can be merged into one with an optional `checkout` parameter. When checkout is provided, the method will return gateways suitable for that checkout. Otherwise, it will return all available gateways. This PR refactors the plugin manager to have only one method.

Similar change is made in `BasePlugin` - instead of two: `get_payment_gateway_for_checkout` and `get_payment_gateway` we will have one `get_payment_gateways`. This method will also return multiple gateways instead of one, which will be used in a new feature where we will have payment gateways implemented as apps/webhooks.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
