### PR TITLE
Fix doubling price in checkout for products without tax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ All notable, unreleased changes to this project will be documented in this file.
 - Remove triggering a webhook event `PRODUCT_UPDATED`  when calling `ProductVariantCreate` mutation.  Use `PRODUCT_VARIANT_CREATED` instead - #6963 by @piotrgrundas
 - Remove triggering a webhook event `PRODUCT_UPDATED` when calling  `ProductVariantChannelListingUpdate` mutation. Use `PRODUCT_VARIANT_UPDATED` instead - #6963 by @piotrgrundas
 - Refactor listing payment gateways - #7050 by @maarcingebala. Breaking changes in plugin methods: removed `get_payment_gateway` and `get_payment_gateway_for_checkout`; instead `get_payment_gateways` was added.
+- Fix doubling price in checkout for products without tax - #7056 by @IKarbowiak
+  - Introduce changes in plugins method:
+    - `calculate_checkout_subtotal` has been dropped from plugins, for correct subtotal calculation, `calculate_checkout_line_total` must be set (manager method for calculating checkout subtotal uses `calculate_checkout_line_total` method)
 
 ### Other
 

--- a/saleor/checkout/base_calculations.py
+++ b/saleor/checkout/base_calculations.py
@@ -5,7 +5,7 @@ manager.
 """
 
 from decimal import Decimal
-from typing import TYPE_CHECKING, Iterable, List, Optional
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from prices import TaxedMoney
 
@@ -15,16 +15,8 @@ from ..discount import DiscountInfo
 from .fetch import CheckoutLineInfo
 
 if TYPE_CHECKING:
-    # flake8: noqa
     from ..channel.models import Channel
     from ..checkout.fetch import CheckoutInfo
-    from ..product.models import (
-        Collection,
-        Product,
-        ProductVariant,
-        ProductVariantChannelListing,
-    )
-    from .models import Checkout, CheckoutLine
 
 
 def base_checkout_shipping_price(
@@ -50,11 +42,6 @@ def base_checkout_shipping_price(
     return quantize_price(
         TaxedMoney(net=shipping_price, gross=shipping_price), shipping_price.currency
     )
-
-
-def base_checkout_subtotal(line_totals: List[TaxedMoney], currency: str) -> TaxedMoney:
-    """Return the total cost of all checkout lines."""
-    return sum(line_totals, zero_taxed_money(currency))
 
 
 def base_checkout_total(

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -163,21 +163,6 @@ class BasePlugin:
         """
         return NotImplemented
 
-    def calculate_checkout_subtotal(
-        self,
-        checkout_info: "CheckoutInfo",
-        lines: List["CheckoutLineInfo"],
-        address: Optional["Address"],
-        discounts: List["DiscountInfo"],
-        previous_value: TaxedMoney,
-    ) -> TaxedMoney:
-        """Calculate the subtotal for checkout.
-
-        Overwrite this method if you need to apply specific logic for the calculation
-        of a checkout subtotal. Return TaxedMoney.
-        """
-        return NotImplemented
-
     def calculate_checkout_shipping(
         self,
         checkout_info: "CheckoutInfo",

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -157,18 +157,10 @@ class PluginsManager(PaymentInterface):
             )
             for line_info in lines
         ]
-        default_value = base_calculations.base_checkout_subtotal(
-            line_totals, checkout_info.checkout.currency
-        )
+        currency = checkout_info.checkout.currency
+        total = sum(line_totals, zero_taxed_money(currency))
         return quantize_price(
-            self.__run_method_on_plugins(
-                "calculate_checkout_subtotal",
-                default_value,
-                checkout_info,
-                lines,
-                address,
-                discounts,
-            ),
+            total,
             checkout_info.checkout.currency,
         )
 

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -74,12 +74,6 @@ class PluginSample(BasePlugin):
         total = Money("1.0", currency=checkout_info.checkout.currency)
         return TaxedMoney(total, total)
 
-    def calculate_checkout_subtotal(
-        self, checkout_info, lines, address, discounts, previous_value
-    ):
-        subtotal = Money("1.0", currency=checkout_info.checkout.currency)
-        return TaxedMoney(subtotal, subtotal)
-
     def calculate_checkout_shipping(
         self, checkout_info, lines, address, discounts, previous_value
     ):


### PR DESCRIPTION
The problem was caused by `_calculate_checkout_subtotal` in avatax plugin. I decided to drop `calculate_checkout_subtotal` from plugins and left it only in `manager` as it was anyway calculated by the manager with the use of `calculate_checkout_line_total`. The plugin method `calculate_checkout_subtotal` was run only when all checkout lines have products with no charge taxes.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
