### PR TITLE
Remove corresponding ShippingMethodChannelListings when shipping zone is removed from channel

### DIFF
--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -125,6 +125,9 @@ class ChannelUpdate(ModelMutation):
         remove_shipping_zones = cleaned_data.get("remove_shipping_zones")
         if remove_shipping_zones:
             instance.shipping_zones.remove(*remove_shipping_zones)
+            instance.shipping_method_listings.filter(
+                shipping_method__shipping_zone__in=remove_shipping_zones
+            ).delete()
 
 
 class ChannelDeleteInput(graphene.InputObjectType):

--- a/saleor/graphql/channel/tests/test_channel_update_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_update_mutations.py
@@ -257,9 +257,8 @@ def test_channel_update_mutation_remove_shipping_zone(
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
     name = "newName"
     slug = "new_slug"
-    remove_shipping_zone = graphene.Node.to_global_id(
-        "ShippingZone", shipping_zones[0].pk
-    )
+    shipping_zone = shipping_zones[0].pk
+    remove_shipping_zone = graphene.Node.to_global_id("ShippingZone", shipping_zone)
     variables = {
         "id": channel_id,
         "input": {
@@ -268,6 +267,9 @@ def test_channel_update_mutation_remove_shipping_zone(
             "removeShippingZones": [remove_shipping_zone],
         },
     }
+    assert channel_USD.shipping_method_listings.filter(
+        shipping_method__shipping_zone=shipping_zone
+    )
 
     # when
     response = staff_api_client.post_graphql(
@@ -288,6 +290,9 @@ def test_channel_update_mutation_remove_shipping_zone(
     zones = [zone["id"] for zone in channel_data["shippingZones"]]
     assert len(zones) == len(shipping_zones) - 1
     assert remove_shipping_zone not in zones
+    assert not channel_USD.shipping_method_listings.filter(
+        shipping_method__shipping_zone=shipping_zone
+    )
 
 
 def test_channel_update_mutation_add_and_remove_shipping_zone(

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -175,6 +175,9 @@ class ShippingZoneMixin:
         remove_channels = cleaned_data.get("remove_channels")
         if remove_channels:
             instance.channels.remove(*remove_channels)
+            models.ShippingMethodChannelListing.objects.filter(
+                shipping_method__shipping_zone=instance, channel__in=remove_channels
+            ).delete()
 
 
 class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -2,6 +2,7 @@ import graphene
 import pytest
 
 from ....shipping.error_codes import ShippingErrorCode
+from ....shipping.models import ShippingMethodChannelListing
 from ....shipping.utils import get_countries_without_shipping_zone
 from ...core.enums import WeightUnitsEnum
 from ...tests.utils import get_graphql_content
@@ -461,7 +462,11 @@ def test_update_shipping_zone_remove_channels(
 ):
     shipping_zone.channels.add(channel_USD, channel_PLN)
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
-    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.pk)
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
+
+    assert ShippingMethodChannelListing.objects.filter(
+        shipping_method__shipping_zone=shipping_zone, channel=channel_USD
+    )
 
     variables = {
         "id": shipping_id,
@@ -477,7 +482,10 @@ def test_update_shipping_zone_remove_channels(
     data = content["data"]["shippingZoneUpdate"]["shippingZone"]
     assert len(data["channels"]) == 1
     assert data["channels"][0]["id"] == graphene.Node.to_global_id(
-        "Channel", channel_USD.pk
+        "Channel", channel_PLN.pk
+    )
+    assert not ShippingMethodChannelListing.objects.filter(
+        shipping_method__shipping_zone=shipping_zone, channel=channel_USD
     )
 
 


### PR DESCRIPTION
- Update `ChannelUpdate` mutation
- Update `ShippingZoneUpdate` mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
