### PR TITLE
Remove version number from docs link

### DIFF
--- a/templates/home/index.html
+++ b/templates/home/index.html
@@ -155,7 +155,7 @@
     <div class="container">
       <nav class="nav">
         {% include "home/images/logo.svg" %}
-        <span> <a href="https://docs.saleor.io/docs/" target="_blank">View documentation</a> for Saleor 2.10 </span>
+        <span> <a href="https://docs.saleor.io/docs/" target="_blank">View documentation</a></span>
       </nav>
       <div class="inner-container">
         <div class="content-container">


### PR DESCRIPTION
This PR removes the version number from the index.html template. The version number is currently outdated. I think there is no need to maintain that and this PR removes it at all, while keeping the link to the docs as "View documentation".

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
