### PR TITLE
Allow seeing unconfirmed orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Added support for querying objects by metadata fields - #6683 by @LeOndaz
 - Avoid using `get_plugins_manager` method - #7052 by @IKarbowiak
 - Extend `Transaction` type with gateway response and `Payment` type with filter - #7062 by @IKarbowiak
+- Allow seeing unconfirmed orders - #7072 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -20,6 +20,7 @@ from ....account.models import Address, User
 from ....checkout import AddressType
 from ....core.jwt import create_token
 from ....core.permissions import AccountPermissions, OrderPermissions
+from ....order import OrderStatus
 from ....order.models import FulfillmentStatus, Order
 from ....product.tests.utils import create_image
 from ...core.utils import str_to_enum
@@ -85,8 +86,13 @@ FULL_USER_QUERY = """
                 isDefaultShippingAddress
                 isDefaultBillingAddress
             }
-            orders {
+            orders(first: 10) {
                 totalCount
+                edges {
+                    node {
+                        id
+                    }
+                }
             }
             dateJoined
             lastLogin
@@ -225,6 +231,43 @@ def test_query_customer_user(
     assert address["phone"] == user_address.phone.as_e164
     assert address["isDefaultShippingAddress"] is None
     assert address["isDefaultBillingAddress"] is None
+
+
+def test_query_customer_user_with_orders(
+    staff_api_client, customer_user, order_list, permission_manage_users
+):
+    # given
+    query = FULL_USER_QUERY
+    order_unfulfilled = order_list[0]
+    order_unfulfilled.user = customer_user
+
+    order_unconfirmed = order_list[1]
+    order_unconfirmed.status = OrderStatus.UNCONFIRMED
+    order_unconfirmed.user = customer_user
+
+    order_draft = order_list[2]
+    order_draft.status = OrderStatus.DRAFT
+    order_draft.user = customer_user
+
+    Order.objects.bulk_update(
+        [order_unconfirmed, order_draft, order_unfulfilled], ["user", "status"]
+    )
+
+    id = graphene.Node.to_global_id("User", customer_user.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    user = content["data"]["user"]
+    assert {order["node"]["id"] for order in user["orders"]["edges"]} == {
+        graphene.Node.to_global_id("Order", order.pk)
+        for order in [order_unfulfilled, order_unconfirmed]
+    }
 
 
 def test_query_customer_user_app(
@@ -371,6 +414,85 @@ def test_query_staff_user(
     assert {perm["code"].lower() for perm in data["permissions"]} == set(
         all_permissions.values_list("codename", flat=True)
     )
+
+
+def test_query_staff_user_with_order_and_without_manage_orders_perm(
+    staff_api_client,
+    staff_user,
+    order_list,
+    permission_manage_staff,
+):
+    # given
+    staff_user.user_permissions.add(permission_manage_staff)
+
+    order_unfulfilled = order_list[0]
+    order_unfulfilled.user = staff_user
+
+    order_unconfirmed = order_list[1]
+    order_unconfirmed.status = OrderStatus.UNCONFIRMED
+    order_unconfirmed.user = staff_user
+
+    order_draft = order_list[2]
+    order_draft.status = OrderStatus.DRAFT
+    order_draft.user = staff_user
+
+    Order.objects.bulk_update(
+        [order_unconfirmed, order_draft, order_unfulfilled], ["user", "status"]
+    )
+
+    query = FULL_USER_QUERY
+    user_id = graphene.Node.to_global_id("User", staff_user.pk)
+    variables = {"id": user_id}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["user"]
+
+    assert data["email"] == staff_user.email
+    assert data["orders"]["totalCount"] == 2
+    assert {node["node"]["id"] for node in data["orders"]["edges"]} == {
+        graphene.Node.to_global_id("Order", order.pk)
+        for order in [order_unfulfilled, order_unconfirmed]
+    }
+
+
+def test_query_staff_user_with_orders_and_manage_orders_perm(
+    staff_api_client,
+    staff_user,
+    order_list,
+    permission_manage_staff,
+    permission_manage_orders,
+):
+    # given
+    staff_user.user_permissions.add(permission_manage_staff, permission_manage_orders)
+
+    order_unfulfilled = order_list[0]
+    order_unfulfilled.user = staff_user
+
+    order_unconfirmed = order_list[1]
+    order_unconfirmed.status = OrderStatus.UNCONFIRMED
+    order_unconfirmed.user = staff_user
+
+    order_draft = order_list[2]
+    order_draft.status = OrderStatus.DRAFT
+    order_draft.user = staff_user
+
+    Order.objects.bulk_update(
+        [order_unconfirmed, order_draft, order_unfulfilled], ["user", "status"]
+    )
+
+    query = FULL_USER_QUERY
+    user_id = graphene.Node.to_global_id("User", staff_user.pk)
+    variables = {"id": user_id}
+    response = staff_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["user"]
+
+    assert data["email"] == staff_user.email
+    assert data["orders"]["totalCount"] == 3
+    assert {node["node"]["id"] for node in data["orders"]["edges"]} == {
+        graphene.Node.to_global_id("Order", order.pk)
+        for order in [order_unfulfilled, order_unconfirmed, order_draft]
+    }
 
 
 USER_QUERY = """

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -333,8 +333,8 @@ class User(CountableDjangoObjectType):
     def resolve_orders(root: models.User, info, **_kwargs):
         viewer = info.context.user
         if viewer.has_perm(OrderPermissions.MANAGE_ORDERS):
-            return root.orders.all()  # type: ignore
-        return root.orders.confirmed()  # type: ignore
+            return root.orders.all()
+        return root.orders.non_draft()
 
     @staticmethod
     def resolve_avatar(root: models.User, info, size=None, **_kwargs):


### PR DESCRIPTION
Users without `manage_orders` permission shouldn't see only draft orders.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
