### PR TITLE
Add payment field paymentMethodType to API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `Shop.version` field to query API version - #6980 by @maarcingebala
 - Return empty results when filtering by non-existing attribute - #7025 by @maarcingebala
 - Add new authorization header `Authorization-Bearer` - #6998 by @korycins
+- Add field `paymentMethodType` to `Payment` object - #7073 by @korycins
 
 # 2.11.1
 

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -104,6 +104,7 @@ class Payment(CountableDjangoObjectType):
             "checkout",
             "order",
             "customer_ip_address",
+            "payment_method_type",
         ]
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3676,6 +3676,7 @@ type Payment implements Node {
   token: String!
   checkout: Checkout
   order: Order
+  paymentMethodType: String!
   customerIpAddress: String
   chargeStatus: PaymentChargeStatusEnum!
   actions: [OrderAction]!


### PR DESCRIPTION
I want to merge this change because we would like to give a possibility to provide info about payment method type. `payment_method_type` is a value that comes from PaymentPlugin and defines a type of the non-card payments

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
