### PR TITLE
Raise GraphQLError when too big integer value is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend `Transaction` type with gateway response and `Payment` type with filter - #7062 by @IKarbowiak
 - Fix invalid tax rates for lines - #7058 by @IKarbowiak
 - Allow seeing unconfirmed orders - #7072 by @IKarbowiak
+- Raise GraphQLError when too big integer value is provided - #7076 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -3476,6 +3476,35 @@ def test_variant_stocks_update_stock_duplicated_warehouse(
     assert errors[0]["index"] == 2
 
 
+def test_product_variant_stocks_update_too_big_quantity_value(
+    staff_api_client, variant, warehouse, permission_manage_products
+):
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    second_warehouse = Warehouse.objects.get(pk=warehouse.pk)
+    second_warehouse.slug = "second warehouse"
+    second_warehouse.pk = None
+    second_warehouse.save()
+
+    Stock.objects.create(product_variant=variant, warehouse=warehouse, quantity=10)
+
+    quantity = 99999999999
+    stocks = [
+        {
+            "warehouse": graphene.Node.to_global_id("Warehouse", second_warehouse.id),
+            "quantity": 99999999999,
+        },
+    ]
+    variables = {"variantId": variant_id, "stocks": stocks}
+    response = staff_api_client.post_graphql(VARIANT_STOCKS_UPDATE_MUTATIONS, variables)
+    content = get_graphql_content(response, ignore_errors=True)
+    assert len(content["errors"]) == 1
+    assert (
+        content["errors"][0]["message"]
+        == f"Int cannot represent non 32-bit signed integer value: {quantity}"
+    )
+
+
 VARIANT_STOCKS_DELETE_MUTATION = """
     mutation ProductVariantStocksDelete($variantId: ID!, $warehouseIds: [ID!]!){
         productVariantStocksDelete(

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -29,6 +29,7 @@ from ..core.exceptions import PermissionDenied, ReadOnlyException
 from ..core.utils import is_valid_ipv4, is_valid_ipv6
 
 API_PATH = SimpleLazyObject(lambda: reverse("api"))
+INT_ERROR_MSG = "Int cannot represent non 32-bit signed integer value"
 
 unhandled_errors_logger = logging.getLogger("saleor.graphql.errors.unhandled")
 handled_errors_logger = logging.getLogger("saleor.graphql.errors.handled")
@@ -291,6 +292,11 @@ class GraphQLView(View):
                     return response
             except Exception as e:
                 span.set_tag(opentracing.tags.ERROR, True)
+                # In the graphql-core version that we are using,
+                # the Exception is raised for too big integers value.
+                # As it's a validation error we want to raise GraphQLError instead.
+                if str(e).startswith(INT_ERROR_MSG):
+                    e = GraphQLError(str(e))
                 return ExecutionResult(errors=[e], invalid=True)
 
     @staticmethod


### PR DESCRIPTION
In the `graphql-core` version that we are using, the `Exception` is raised for too big integers value. As it's a validation error we want to raise `GraphQLError` instead. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
