### PR TITLE
Benchmark tests for order address resolvers

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -3,4 +3,5 @@ pytest_plugins = [
     "saleor.plugins.tests.fixtures",
     "saleor.graphql.tests.fixtures",
     "saleor.graphql.channel.tests.fixtures",
+    "saleor.graphql.order.tests.benchmark.fixtures",
 ]

--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -1,0 +1,22 @@
+import uuid
+
+import pytest
+from prices import Money, TaxedMoney
+
+from .....order.models import Order
+
+
+@pytest.fixture
+def orders_for_benchmarks(channel_USD, address, customer_user):
+    orders = [
+        Order(
+            token=str(uuid.uuid4()),
+            channel=channel_USD,
+            billing_address=address.get_copy(),
+            shipping_address=address.get_copy(),
+            user=customer_user,
+            total=TaxedMoney(net=Money(i, "USD"), gross=Money(i, "USD")),
+        )
+        for i in range(10)
+    ]
+    return Order.objects.bulk_create(orders)

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -152,3 +152,36 @@ def test_staff_order_details(
     }
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     get_graphql_content(staff_api_client.post_graphql(query, variables))
+
+
+MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY = """
+  query orders {
+    orders(first: 10) {
+      edges {
+        node {
+          id
+          shippingAddress {
+            id
+          }
+          billingAddress {
+            id
+          }
+        }
+      }
+    }
+  }
+"""
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_staff_multiple_orders_address_resolving(
+    staff_api_client,
+    permission_manage_orders,
+    orders_for_benchmarks,
+    count_queries,
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    get_graphql_content(
+        staff_api_client.post_graphql(MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY)
+    )

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -182,6 +182,7 @@ def test_staff_multiple_orders_address_resolving(
     count_queries,
 ):
     staff_api_client.user.user_permissions.add(permission_manage_orders)
-    get_graphql_content(
+    content = get_graphql_content(
         staff_api_client.post_graphql(MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY)
     )
+    assert content["data"]["orders"] is not None


### PR DESCRIPTION
I want to merge this change because it adds benchmark tests for order address resolvers

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
