### PR TITLE
Make quantity field on StockInput required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix doubling price in checkout for products without tax - #7056 by @IKarbowiak
   - Introduce changes in plugins method:
     - `calculate_checkout_subtotal` has been dropped from plugins, for correct subtotal calculation, `calculate_checkout_line_total` must be set (manager method for calculating checkout subtotal uses `calculate_checkout_line_total` method)
+- Make quantity field on `StockInput` required - #7082 by @IKarbowiak
 
 ### Other
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -497,7 +497,9 @@ class StockInput(graphene.InputObjectType):
     warehouse = graphene.ID(
         required=True, description="Warehouse in which stock is located."
     )
-    quantity = graphene.Int(description="Quantity of items available for sell.")
+    quantity = graphene.Int(
+        required=True, description="Quantity of items available for sell."
+    )
 
 
 class ProductCreateInput(ProductInput):

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5336,7 +5336,7 @@ input StockFilterInput {
 
 input StockInput {
   warehouse: ID!
-  quantity: Int
+  quantity: Int!
 }
 
 enum TaxRateType {


### PR DESCRIPTION
Field `quantity` on `StockInput` should be required.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
