### PR TITLE
Remove html tags from product description_plaintext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix invalid tax rates for lines - #7058 by @IKarbowiak
 - Allow seeing unconfirmed orders - #7072 by @IKarbowiak
 - Raise GraphQLError when too big integer value is provided - #7076 by @IKarbowiak
+- Remove html tags from product description_plaintext - #7094 by @d-wysocki
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/core/tests/test_editorjs.py
+++ b/saleor/core/tests/test_editorjs.py
@@ -2,6 +2,7 @@ import warnings
 from unittest import mock
 
 import pytest
+from django.utils.html import strip_tags
 
 from ..utils.editorjs import clean_editor_js
 
@@ -34,7 +35,7 @@ def test_clean_editor_js(text):
     result = clean_editor_js(data, to_string=True)
 
     # then
-    assert result == text
+    assert result == strip_tags(text)
 
 
 def test_clean_editor_js_no_blocks():
@@ -137,7 +138,7 @@ def test_clean_editor_js_for_list():
     result = clean_editor_js(data, to_string=True)
 
     # then
-    assert result == (
+    assert result == strip_tags(
         "The Saleor Winter Sale is snowed "
         '<a href="https://docs.saleor.io/docs/">. Test.'
         "It is a block-styled editor "

--- a/saleor/core/utils/editorjs.py
+++ b/saleor/core/utils/editorjs.py
@@ -2,6 +2,7 @@ import re
 import warnings
 from typing import Dict, Optional
 
+from django.utils.html import strip_tags
 from urllib3.util import parse_url
 
 BLACKLISTED_URL_SCHEMES = ("javascript",)
@@ -38,7 +39,7 @@ def clean_editor_js(definitions: Optional[Dict], *, to_string: bool = False):
                     continue
                 new_text = clean_text_data(item)
                 if to_string:
-                    string += new_text
+                    string += strip_tags(new_text)
                 else:
                     blocks[index]["data"]["items"][item_index] = new_text
         else:
@@ -47,7 +48,7 @@ def clean_editor_js(definitions: Optional[Dict], *, to_string: bool = False):
                 continue
             new_text = clean_text_data(text)
             if to_string:
-                string += new_text
+                string += strip_tags(new_text)
             else:
                 blocks[index]["data"]["text"] = new_text
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -7,6 +7,7 @@ import graphene
 import pytest
 from django.core.exceptions import ValidationError
 from django.utils.dateparse import parse_datetime
+from django.utils.html import strip_tags
 from django.utils.text import slugify
 from freezegun import freeze_time
 from graphql_relay import to_global_id
@@ -3959,6 +3960,9 @@ def test_update_product(
     color_attribute,
 ):
     query = MUTATION_UPDATE_PRODUCT
+    expected_other_description_json = other_description_json
+    text = expected_other_description_json["blocks"][0]["data"]["text"]
+    expected_other_description_json["blocks"][0]["data"]["text"] = strip_tags(text)
     other_description_json = json.dumps(other_description_json)
 
     product_id = graphene.Node.to_global_id("Product", product.pk)
@@ -3998,7 +4002,7 @@ def test_update_product(
     assert data["productErrors"] == []
     assert data["product"]["name"] == product_name
     assert data["product"]["slug"] == product_slug
-    assert data["product"]["description"] == other_description_json
+    assert data["product"]["description"] == json.dumps(expected_other_description_json)
     assert data["product"]["chargeTaxes"] == product_charge_taxes
     assert data["product"]["taxType"]["taxCode"] == product_tax_rate
     assert not data["product"]["category"]["name"] == category.name

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3472,7 +3472,7 @@ def other_description_json():
             {
                 "key": "",
                 "data": {
-                    "text": "A GRAPHQL-FIRST ECOMMERCE PLATFORM FOR PERFECTIONISTS",
+                    "text": "A GRAPHQL-FIRST <b>ECOMMERCE</b> PLATFORM FOR PERFECTIONISTS",
                 },
                 "text": "A GRAPHQL-FIRST ECOMMERCE PLATFORM FOR PERFECTIONISTS",
                 "type": "header-two",


### PR DESCRIPTION
I want to merge this change because...I want to remove html tags from product description_plaintext

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
