### PR TITLE
Fix order address resolves for orders without address

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -4347,6 +4347,27 @@ def test_query_draft_order_by_token_as_anonymous_customer(api_client, draft_orde
     assert not content["data"]["orderByToken"]
 
 
+def test_query_order_without_addresess(order, user_api_client, channel_USD):
+    # given
+    query = ORDER_BY_TOKEN_QUERY
+
+    order = Order.objects.create(
+        token=str(uuid.uuid4()),
+        channel=channel_USD,
+        user=user_api_client.user,
+    )
+
+    # when
+    response = user_api_client.post_graphql(query, {"token": order.token})
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["orderByToken"]
+    assert data["userEmail"] == user_api_client.user.email
+    assert data["billingAddress"] is None
+    assert data["shippingAddress"] is None
+
+
 MUTATION_ORDER_BULK_CANCEL = """
 mutation CancelManyOrders($ids: [ID]!) {
     orderBulkCancel(ids: $ids) {

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -692,6 +692,8 @@ class Order(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_billing_address(root: models.Order, info):
+        if not root.shipping_address_id:
+            return
         requester = get_user_or_app_from_context(info.context)
         if requestor_has_access(requester, root.user, OrderPermissions.MANAGE_ORDERS):
             return AddressByIdLoader(info.context).load(root.billing_address_id)
@@ -703,6 +705,8 @@ class Order(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_shipping_address(root: models.Order, info):
+        if not root.shipping_address_id:
+            return
         requester = get_user_or_app_from_context(info.context)
         if requestor_has_access(requester, root.user, OrderPermissions.MANAGE_ORDERS):
             return AddressByIdLoader(info.context).load(root.shipping_address_id)


### PR DESCRIPTION
I want to merge this change because fixing order address resolves for orders without address

In PR #7083  we add dataloaders to order address resolvers, but we miss that address on draft orders can be `None`. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
