### PR TITLE
Fix available shipping methods for weight based methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable, unreleased changes to this project will be documented in this file.
 ## [Unreleased]
 
 - Fix total count on connection resolver without first or last - #6976 by @fowczarek
+- Fix available shipping methods for weight based methods - #7097 by @IKarbowiak
 
 # 2.11.8
 

--- a/saleor/shipping/models.py
+++ b/saleor/shipping/models.py
@@ -28,10 +28,13 @@ if TYPE_CHECKING:
 def _applicable_weight_based_methods(weight, qs):
     """Return weight based shipping methods that are applicable for the total weight."""
     qs = qs.weight_based()
-    min_weight_matched = Q(minimum_order_weight__lte=weight)
-    no_weight_limit = Q(maximum_order_weight__isnull=True)
-    max_weight_matched = Q(maximum_order_weight__gte=weight)
-    return qs.filter(min_weight_matched & (no_weight_limit | max_weight_matched))
+    min_weight_matched = Q(minimum_order_weight__lte=weight) | Q(
+        minimum_order_weight__isnull=True
+    )
+    max_weight_matched = Q(maximum_order_weight__gte=weight) | Q(
+        maximum_order_weight__isnull=True
+    )
+    return qs.filter(min_weight_matched & max_weight_matched)
 
 
 def _applicable_price_based_methods(price: Money, qs):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -594,6 +594,16 @@ def shipping_method(shipping_zone):
 
 
 @pytest.fixture
+def shipping_method_weight_based(shipping_zone):
+    method = ShippingMethod.objects.create(
+        name="weight based method",
+        type=ShippingMethodType.WEIGHT_BASED,
+        shipping_zone=shipping_zone,
+    )
+    return method
+
+
+@pytest.fixture
 def color_attribute(db):  # pylint: disable=W0613
     attribute = Attribute.objects.create(slug="color", name="Color")
     AttributeValue.objects.create(attribute=attribute, name="Red", slug="red")


### PR DESCRIPTION
Apply changes from #7021.
Fixes #6925

Previously, shipping methods without a lower weight limit set didn't return in available shipping methods on `Checkout` and `Order`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
