### PR TITLE
Feature/extend manager to use channel slug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,12 @@ All notable, unreleased changes to this project will be documented in this file.
 - Make `order` property of invoice webhook payload contain order instead of order lines - #7081 by @pdblaszczyk
   - Affected webhook events: `INVOICE_REQUESTED`, `INVOICE_SENT`, `INVOICE_DELETED`
 - Make quantity field on `StockInput` required - #7082 by @IKarbowiak
+- Extend plugins manager to configure plugins for each plugins:
+  - Introduce changes in API:
+    - `paymentInitialize` - add `channel` parameter. Optional when only one  channel exists.
+    - `pluginUpdate` - add `channel` parameter.
+    - `availablePaymentGateways` - add `channel` parameter.
+    - `storedPaymentSources` - add `channel` parameter.
 
 ### Other
 

--- a/saleor/checkout/checkout_cleaner.py
+++ b/saleor/checkout/checkout_cleaner.py
@@ -74,7 +74,9 @@ def clean_checkout_payment(
 ):
     clean_billing_address(checkout_info, error_code)
     if not is_fully_paid(manager, checkout_info, lines, discounts):
-        gateway.payment_refund_or_void(last_payment, manager)
+        gateway.payment_refund_or_void(
+            last_payment, manager, channel_slug=checkout_info.channel.slug
+        )
         raise ValidationError(
             "Provided payment methods can not cover the checkout's total amount",
             code=error_code.CHECKOUT_NOT_FULLY_PAID.value,

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -512,11 +512,17 @@ def _process_payment(
     payment_data: Optional[dict],
     order_data: dict,
     manager: "PluginsManager",
+    channel_slug: str,
 ) -> Transaction:
     """Process the payment assigned to checkout."""
     try:
         if payment.to_confirm:
-            txn = gateway.confirm(payment, manager, additional_data=payment_data)
+            txn = gateway.confirm(
+                payment,
+                manager,
+                additional_data=payment_data,
+                channel_slug=channel_slug,
+            )
         else:
             txn = gateway.process_payment(
                 payment=payment,
@@ -524,6 +530,7 @@ def _process_payment(
                 manager=manager,
                 store_source=store_source,
                 additional_data=payment_data,
+                channel_slug=channel_slug,
             )
         payment.refresh_from_db()
         if not txn.is_success:
@@ -553,6 +560,7 @@ def complete_checkout(
     :raises ValidationError
     """
     checkout = checkout_info.checkout
+    channel_slug = checkout_info.channel.slug
     payment = checkout.get_last_active_payment()
     _prepare_checkout(
         manager=manager,
@@ -567,7 +575,7 @@ def complete_checkout(
     try:
         order_data = _get_order_data(manager, checkout_info, lines, discounts)
     except ValidationError as exc:
-        gateway.payment_refund_or_void(payment, manager)
+        gateway.payment_refund_or_void(payment, manager, channel_slug=channel_slug)
         raise exc
 
     txn = _process_payment(
@@ -576,6 +584,7 @@ def complete_checkout(
         payment_data=payment_data,
         order_data=order_data,
         manager=manager,
+        channel_slug=channel_slug,
     )
 
     if txn.customer_id and user.is_authenticated:
@@ -598,7 +607,7 @@ def complete_checkout(
             checkout.delete()
         except InsufficientStock as e:
             release_voucher_usage(order_data)
-            gateway.payment_refund_or_void(payment, manager)
+            gateway.payment_refund_or_void(payment, manager, channel_slug=channel_slug)
             error = prepare_insufficient_stock_checkout_validation_error(e)
             raise error
     return order, action_required, action_data

--- a/saleor/core/payments.py
+++ b/saleor/core/payments.py
@@ -19,56 +19,61 @@ class PaymentInterface(ABC):
         self,
         currency: Optional[str] = None,
         checkout: Optional["Checkout"] = None,
+        channel_slug: Optional[str] = None,
         active_only: bool = True,
     ) -> List["PaymentGateway"]:
         pass
 
     @abstractmethod
     def authorize_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
     def capture_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
     def refund_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
     def void_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
     def confirm_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
-    def token_is_required_as_payment_input(self, gateway) -> bool:
+    def token_is_required_as_payment_input(
+        self, gateway: str, channel_slug: str
+    ) -> bool:
         pass
 
     @abstractmethod
     def process_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         pass
 
     @abstractmethod
-    def get_client_token(self, gateway: str, token_config: "TokenConfig") -> str:
+    def get_client_token(
+        self, gateway: str, token_config: "TokenConfig", channel_slug: str
+    ) -> str:
         pass
 
     @abstractmethod
     def list_payment_sources(
-        self, gateway: str, customer_id: str
+        self, gateway: str, customer_id: str, channel_slug: str
     ) -> List["CustomerSource"]:
         pass

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -549,19 +549,19 @@ def create_fake_payment(mock_notify, order):
     manager = get_plugins_manager()
 
     # Create authorization transaction
-    gateway.authorize(payment, payment.token, manager)
+    gateway.authorize(payment, payment.token, manager, order.channel.slug)
     # 20% chance to void the transaction at this stage
     if random.choice([0, 0, 0, 0, 1]):
-        gateway.void(payment, manager)
+        gateway.void(payment, manager, order.channel.slug)
         return payment
     # 25% to end the payment at the authorization stage
     if not random.choice([1, 1, 1, 0]):
         return payment
     # Create capture transaction
-    gateway.capture(payment, manager)
+    gateway.capture(payment, manager, order.channel.slug)
     # 25% to refund the payment
     if random.choice([0, 0, 0, 1]):
-        gateway.refund(payment, manager)
+        gateway.refund(payment, manager, order.channel.slug)
     return payment
 
 
@@ -681,7 +681,9 @@ def create_fake_order(discounts, max_order_lines=5):
     )
     shipping_method = shipping_method_chanel_listing.shipping_method
     shipping_price = shipping_method_chanel_listing.price
-    shipping_price = manager.apply_taxes_to_shipping(shipping_price, address)
+    shipping_price = manager.apply_taxes_to_shipping(
+        shipping_price, address, channel_slug=channel.slug
+    )
     order_data.update(
         {
             "channel": channel,

--- a/saleor/demo/management/commands/populatedb.py
+++ b/saleor/demo/management/commands/populatedb.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from ....channel.models import Channel
 from ....core.management.commands.populatedb import Command as PopulateDBCommand
 from ....payment.gateways.braintree.plugin import BraintreeGatewayPlugin
 from ....plugins.manager import get_plugins_manager
@@ -13,19 +14,22 @@ def configure_braintree():
     if not (braintree_api_key and braintree_merchant_id and braintree_secret):
         return False
 
+    channels = Channel.objects.all()
     manager = get_plugins_manager()
-    manager.save_plugin_configuration(
-        BraintreeGatewayPlugin.PLUGIN_ID,
-        {
-            "active": True,
-            "configuration": [
-                {"name": "Public API key", "value": braintree_api_key},
-                {"name": "Merchant ID", "value": braintree_merchant_id},
-                {"name": "Secret API key", "value": braintree_secret},
-                {"name": "Use sandbox", "value": True},
-            ],
-        },
-    )
+    for channel in channels:
+        manager.save_plugin_configuration(
+            BraintreeGatewayPlugin.PLUGIN_ID,
+            channel.slug,
+            {
+                "active": True,
+                "configuration": [
+                    {"name": "Public API key", "value": braintree_api_key},
+                    {"name": "Merchant ID", "value": braintree_merchant_id},
+                    {"name": "Secret API key", "value": braintree_secret},
+                    {"name": "Use sandbox", "value": True},
+                ],
+            },
+        )
     return True
 
 

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -111,17 +111,19 @@ def resolve_address_validation_rules(
     )
 
 
-def resolve_payment_sources(info, user: models.User):
+def resolve_payment_sources(info, user: models.User, channel_slug: str):
     manager = info.context.plugins
     stored_customer_accounts = (
         (gtw.id, fetch_customer_id(user, gtw.id))
-        for gtw in gateway.list_gateways(manager)
+        for gtw in gateway.list_gateways(manager, channel_slug)
     )
     return list(
         chain(
             *[
                 prepare_graphql_payment_sources_type(
-                    gateway.list_payment_sources(gtw, customer_id, manager)
+                    gateway.list_payment_sources(
+                        gtw, customer_id, manager, channel_slug
+                    )
                 )
                 for gtw, customer_id in stored_customer_accounts
                 if customer_id is not None

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -241,6 +241,9 @@ class User(CountableDjangoObjectType):
     stored_payment_sources = graphene.List(
         "saleor.graphql.payment.types.PaymentSource",
         description="List of stored payment sources.",
+        channel=graphene.String(
+            description="Slug of a channel for which the data should be returned."
+        ),
     )
     language_code = graphene.Field(
         LanguageCodeEnum, description="User language code.", required=True
@@ -352,11 +355,11 @@ class User(CountableDjangoObjectType):
             )
 
     @staticmethod
-    def resolve_stored_payment_sources(root: models.User, info):
+    def resolve_stored_payment_sources(root: models.User, info, channel=None):
         from .resolvers import resolve_payment_sources
 
         if root == info.context.user:
-            return resolve_payment_sources(info, root)
+            return resolve_payment_sources(info, root, channel_slug=channel)
         raise PermissionDenied()
 
     @staticmethod

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1330,7 +1330,9 @@ def test_checkout_available_shipping_methods_with_price_displayed(
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
 
-    apply_taxes_to_shipping_mock.assert_called_once_with(shipping_price, mock.ANY)
+    apply_taxes_to_shipping_mock.assert_called_once_with(
+        shipping_price, mock.ANY, checkout_with_item.channel.slug
+    )
     assert data["availableShippingMethods"] == [
         {"name": "DHL", "price": {"amount": expected_price}}
     ]

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -779,7 +779,9 @@ def test_checkout_complete_insufficient_stock_payment_refunded(
     assert data["checkoutErrors"][0]["message"] == "Insufficient product stock: 123"
     assert orders_count == Order.objects.count()
 
-    gateway_refund_mock.assert_called_once_with(payment, ANY)
+    gateway_refund_mock.assert_called_once_with(
+        payment, ANY, channel_slug=checkout_info.channel.slug
+    )
 
 
 @patch("saleor.checkout.complete_checkout.gateway.void")
@@ -834,7 +836,9 @@ def test_checkout_complete_insufficient_stock_payment_voided(
     assert data["checkoutErrors"][0]["message"] == "Insufficient product stock: 123"
     assert orders_count == Order.objects.count()
 
-    gateway_void_mock.assert_called_once_with(payment, ANY)
+    gateway_void_mock.assert_called_once_with(
+        payment, ANY, channel_slug=checkout_info.channel.slug
+    )
 
 
 def test_checkout_complete_without_redirect_url(
@@ -956,7 +960,9 @@ def test_checkout_complete_payment_payment_total_different_than_checkout(
     )
     assert orders_count == Order.objects.count()
 
-    gateway_refund_or_void_mock.assert_called_with(payment, ANY)
+    gateway_refund_or_void_mock.assert_called_with(
+        payment, ANY, channel_slug=checkout_info.channel.slug
+    )
 
 
 def test_order_already_exists(

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -384,7 +384,7 @@ class Checkout(CountableDjangoObjectType):
                     for shipping in shippings:
                         shipping_channel_listing = channel_listing_map[shipping.id]
                         taxed_price = info.context.plugins.apply_taxes_to_shipping(
-                            shipping_channel_listing.price, address
+                            shipping_channel_listing.price, address, channel_slug
                         )
                         if display_gross:
                             shipping.price = taxed_price.gross
@@ -431,7 +431,7 @@ class Checkout(CountableDjangoObjectType):
     @staticmethod
     def resolve_available_payment_gateways(root: models.Checkout, info):
         return info.context.plugins.list_payment_gateways(
-            currency=root.currency, checkout=root
+            currency=root.currency, checkout=root, channel_slug=root.channel.slug
         )
 
     @staticmethod

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -463,7 +463,8 @@ class OrderCapture(BaseMutation):
             gateway.capture,
             payment,
             info.context.plugins,
-            amount,
+            amount=amount,
+            channel_slug=order.channel.slug,
         )
         # Confirm that we changed the status to capture. Some payment can receive
         # asynchronous webhook with update status
@@ -499,6 +500,7 @@ class OrderVoid(BaseMutation):
             gateway.void,
             payment,
             info.context.plugins,
+            channel_slug=order.channel.slug,
         )
         # Confirm that we changed the status to void. Some payment can receive
         # asynchronous webhook with update status
@@ -545,7 +547,8 @@ class OrderRefund(BaseMutation):
             gateway.refund,
             payment,
             info.context.plugins,
-            amount,
+            amount=amount,
+            channel_slug=order.channel.slug,
         )
 
         # Confirm that we changed the status to refund. Some payment can receive
@@ -603,8 +606,16 @@ class OrderConfirm(ModelMutation):
         payment = order.get_last_payment()
         manager = info.context.plugins
         if payment and payment.is_authorized and payment.can_capture():
-            gateway.capture(payment, info.context.plugins)
-            order_captured(order, info.context.user, payment.total, payment, manager)
+            gateway.capture(
+                payment, info.context.plugins, channel_slug=order.channel.slug
+            )
+            order_captured(
+                order,
+                info.context.user,
+                payment.total,
+                payment,
+                manager,
+            )
         order_confirmed(order, info.context.user, manager, send_confirmation_email=True)
         return OrderConfirm(order=order)
 

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -695,7 +695,9 @@ def test_order_available_shipping_methods_query(
     order_data = content["data"]["orders"]["edges"][0]["node"]
     method = order_data["availableShippingMethods"][0]
 
-    apply_taxes_to_shipping_mock.assert_called_once_with(shipping_price, ANY)
+    apply_taxes_to_shipping_mock.assert_called_once_with(
+        shipping_price, ANY, fulfilled_order.channel.slug
+    )
     assert expected_price == method["price"]["amount"]
 
 
@@ -821,7 +823,9 @@ def test_order_confirm(
         parameters__amount=payment_txn_preauth.get_total().amount,
     ).exists()
 
-    capture_mock.assert_called_once_with(payment_txn_preauth, ANY)
+    capture_mock.assert_called_once_with(
+        payment_txn_preauth, ANY, channel_slug=order_unconfirmed.channel.slug
+    )
     expected_payload = {
         "order": get_default_order_payload(order_unconfirmed, ""),
         "recipient_email": order_unconfirmed.user.email,
@@ -830,7 +834,8 @@ def test_order_confirm(
         "domain": "mirumee.com",
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMED, expected_payload
+        NotifyEventType.ORDER_CONFIRMED,
+        expected_payload,
     )
 
 
@@ -3375,6 +3380,7 @@ def test_order_cancel_as_app(
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")
 def test_order_capture(
     mocked_notify,
+    channel_USD,
     staff_api_client,
     permission_manage_orders,
     payment_txn_preauth,

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -897,6 +897,7 @@ class Order(CountableDjangoObjectType):
         available_shipping_methods = []
         manager = info.context.plugins
         display_gross = display_gross_prices()
+        channel_slug = root.channel.slug
         for shipping_method in available:
             # Ignore typing check because it is checked in
             # get_valid_shipping_methods_for_order
@@ -907,14 +908,13 @@ class Order(CountableDjangoObjectType):
                 taxed_price = manager.apply_taxes_to_shipping(
                     shipping_channel_listing.price,
                     root.shipping_address,  # type: ignore
-                    root.channel.slug,
+                    channel_slug,
                 )
                 if display_gross:
                     shipping_method.price = taxed_price.gross
                 else:
                     shipping_method.price = taxed_price.net
                 available_shipping_methods.append(shipping_method)
-        channel_slug = root.channel.slug
         instances = [
             ChannelContext(node=shipping, channel_slug=channel_slug)
             for shipping in available_shipping_methods

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -907,6 +907,7 @@ class Order(CountableDjangoObjectType):
                 taxed_price = manager.apply_taxes_to_shipping(
                     shipping_channel_listing.price,
                     root.shipping_address,  # type: ignore
+                    root.channel.slug,
                 )
                 if display_gross:
                     shipping_method.price = taxed_price.gross

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -881,7 +881,7 @@ def set_dummy_customer_id(customer_user, dummy_customer_id):
 
 
 def test_list_payment_sources(
-    mocker, dummy_customer_id, set_dummy_customer_id, user_api_client
+    mocker, dummy_customer_id, set_dummy_customer_id, user_api_client, channel_USD
 ):
     gateway = DUMMY_GATEWAY
     query = """
@@ -905,7 +905,7 @@ def test_list_payment_sources(
     )
     response = user_api_client.post_graphql(query)
 
-    mock_get_source_list.assert_called_once_with(gateway, dummy_customer_id, ANY)
+    mock_get_source_list.assert_called_once_with(gateway, dummy_customer_id, ANY, None)
     content = get_graphql_content(response)["data"]["me"]["storedPaymentSources"]
     assert content is not None and len(content) == 1
     assert content[0] == {"gateway": gateway, "creditCardInfo": {"lastDigits": "5678"}}
@@ -943,8 +943,9 @@ def test_stored_payment_sources_restriction(
 
 
 PAYMENT_INITIALIZE_MUTATION = """
-mutation PaymentInitialize($gateway: String!, $paymentData: JSONString){
-      paymentInitialize(gateway: $gateway, paymentData: $paymentData)
+mutation PaymentInitialize(
+    $gateway: String!,$channel: String!, $paymentData: JSONString){
+      paymentInitialize(gateway: $gateway, channel: $channel, paymentData: $paymentData)
       {
         initializedPayment{
           gateway
@@ -961,7 +962,7 @@ mutation PaymentInitialize($gateway: String!, $paymentData: JSONString){
 
 
 @patch.object(PluginsManager, "initialize_payment")
-def test_payment_initialize(mocked_initialize_payment, api_client):
+def test_payment_initialize(mocked_initialize_payment, api_client, channel_USD):
     exected_initialize_payment_response = InitializedPaymentResponse(
         gateway="gateway.id",
         name="PaymentPluginName",
@@ -976,6 +977,7 @@ def test_payment_initialize(mocked_initialize_payment, api_client):
     query = PAYMENT_INITIALIZE_MUTATION
     variables = {
         "gateway": exected_initialize_payment_response.gateway,
+        "channel": channel_USD.slug,
         "paymentData": json.dumps(
             {"paymentMethod": "applepay", "validationUrl": "https://127.0.0.1/valid"}
         ),
@@ -991,10 +993,11 @@ def test_payment_initialize(mocked_initialize_payment, api_client):
     )
 
 
-def test_payment_initialize_gateway_doesnt_exist(api_client):
+def test_payment_initialize_gateway_doesnt_exist(api_client, channel_USD):
     query = PAYMENT_INITIALIZE_MUTATION
     variables = {
         "gateway": "wrong.gateway",
+        "channel": channel_USD.slug,
         "paymentData": json.dumps(
             {"paymentMethod": "applepay", "validationUrl": "https://127.0.0.1/valid"}
         ),
@@ -1005,13 +1008,16 @@ def test_payment_initialize_gateway_doesnt_exist(api_client):
 
 
 @patch.object(PluginsManager, "initialize_payment")
-def test_payment_initialize_plugin_raises_error(mocked_initialize_payment, api_client):
+def test_payment_initialize_plugin_raises_error(
+    mocked_initialize_payment, api_client, channel_USD
+):
     error_msg = "Missing paymentMethod field."
     mocked_initialize_payment.side_effect = PaymentError(error_msg)
 
     query = PAYMENT_INITIALIZE_MUTATION
     variables = {
         "gateway": "gateway.id",
+        "channel": channel_USD.slug,
         "paymentData": json.dumps({"validationUrl": "https://127.0.0.1/valid"}),
     }
     response = api_client.post_graphql(query, variables)

--- a/saleor/graphql/plugins/mutations.py
+++ b/saleor/graphql/plugins/mutations.py
@@ -31,6 +31,10 @@ class PluginUpdate(BaseMutation):
 
     class Arguments:
         id = graphene.ID(required=True, description="ID of plugin to update.")
+        channel = graphene.String(
+            required=False,
+            description="Slug of a channel for which the data should be modified.",
+        )
         input = PluginUpdateInput(
             description="Fields required to update a plugin configuration.",
             required=True,
@@ -45,6 +49,7 @@ class PluginUpdate(BaseMutation):
     @classmethod
     def perform_mutation(cls, root, info, **data):
         plugin_id = data.get("id")
+        channel_slug = data.get("channel")
         data = data.get("input")
         manager = info.context.plugins
         plugin = manager.get_plugin(plugin_id)
@@ -56,5 +61,5 @@ class PluginUpdate(BaseMutation):
                     )
                 }
             )
-        instance = manager.save_plugin_configuration(plugin_id, data)
+        instance = manager.save_plugin_configuration(plugin_id, channel_slug, data)
         return PluginUpdate(plugin=instance)

--- a/saleor/graphql/plugins/resolvers.py
+++ b/saleor/graphql/plugins/resolvers.py
@@ -23,7 +23,7 @@ def resolve_plugins(manager, sort_by=None, **kwargs):
     search_query = plugin_filter.get("search")
     filter_active = plugin_filter.get("active")
 
-    plugins = manager.plugins
+    plugins = manager.all_plugins
 
     if filter_active is not None:
         plugins = [plugin for plugin in plugins if plugin.active is filter_active]

--- a/saleor/graphql/plugins/tests/test_plugins.py
+++ b/saleor/graphql/plugins/tests/test_plugins.py
@@ -113,6 +113,7 @@ def test_query_plugins_hides_secret_fields(
             conf_field["value"] = cert
     manager.save_plugin_configuration(
         PluginSample.PLUGIN_ID,
+        None,
         {
             "active": True,
             "configuration": configuration,
@@ -191,6 +192,7 @@ def test_query_plugin_hides_secret_fields(
             conf_field["value"] = api_key
     manager.save_plugin_configuration(
         PluginSample.PLUGIN_ID,
+        None,
         {
             "active": True,
             "configuration": configuration,

--- a/saleor/graphql/plugins/types.py
+++ b/saleor/graphql/plugins/types.py
@@ -53,7 +53,14 @@ class Plugin(CountableDjangoObjectType):
         description = "Plugin."
         model = models.PluginConfiguration
         interfaces = [graphene.relay.Node]
-        only_fields = ["id", "name", "description", "active", "configuration"]
+        only_fields = [
+            "id",
+            "name",
+            "description",
+            "active",
+            "channel",
+            "configuration",
+        ]
 
     def resolve_id(self: models.PluginConfiguration, _info):
         return self.identifier

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2694,7 +2694,7 @@ type Mutation {
   paymentCapture(amount: PositiveDecimal, paymentId: ID!): PaymentCapture
   paymentRefund(amount: PositiveDecimal, paymentId: ID!): PaymentRefund
   paymentVoid(paymentId: ID!): PaymentVoid
-  paymentInitialize(gateway: String!, paymentData: JSONString): PaymentInitialize
+  paymentInitialize(channel: String, gateway: String!, paymentData: JSONString): PaymentInitialize
   pageCreate(input: PageCreateInput!): PageCreate
   pageDelete(id: ID!): PageDelete
   pageBulkDelete(ids: [ID]!): PageBulkDelete
@@ -2763,7 +2763,7 @@ type Mutation {
   giftCardCreate(input: GiftCardCreateInput!): GiftCardCreate
   giftCardDeactivate(id: ID!): GiftCardDeactivate
   giftCardUpdate(id: ID!, input: GiftCardUpdateInput!): GiftCardUpdate
-  pluginUpdate(id: ID!, input: PluginUpdateInput!): PluginUpdate
+  pluginUpdate(channel: String, id: ID!, input: PluginUpdateInput!): PluginUpdate
   saleCreate(input: SaleInput!): SaleCreate
   saleDelete(id: ID!): SaleDelete
   saleBulkDelete(ids: [ID]!): SaleBulkDelete
@@ -3759,6 +3759,7 @@ enum PaymentErrorCode {
   SHIPPING_METHOD_NOT_SET
   PAYMENT_ERROR
   NOT_SUPPORTED_GATEWAY
+  CHANNEL_INACTIVE
 }
 
 input PaymentFilterInput {
@@ -3900,6 +3901,7 @@ input PermissionGroupUpdateInput {
 type Plugin implements Node {
   id: ID!
   name: String!
+  channel: Channel
   description: String!
   active: Boolean!
   configuration: [ConfigurationItem]
@@ -5096,7 +5098,7 @@ input ShippingZoneUpdateInput {
 }
 
 type Shop {
-  availablePaymentGateways(currency: String): [PaymentGateway!]!
+  availablePaymentGateways(currency: String, channel: String): [PaymentGateway!]!
   availableExternalAuthentications: [ExternalAuthentication!]!
   availableShippingMethods(channel: String!, address: AddressInput): [ShippingMethod]
   countries(languageCode: LanguageCodeEnum): [CountryDisplay!]!
@@ -5521,7 +5523,7 @@ type User implements Node & ObjectWithMetadata {
   editableGroups: [Group]
   avatar(size: Int): Image
   events: [CustomerEvent]
-  storedPaymentSources: [PaymentSource]
+  storedPaymentSources(channel: String): [PaymentSource]
   languageCode: LanguageCodeEnum!
 }
 

--- a/saleor/graphql/shop/resolvers.py
+++ b/saleor/graphql/shop/resolvers.py
@@ -29,7 +29,9 @@ def resolve_available_shipping_methods(info, channel_slug: str, address):
     )
     for shipping_method in available:
         shipping_price = shipping_mapping[shipping_method.pk]
-        taxed_price = manager.apply_taxes_to_shipping(shipping_price, address)
+        taxed_price = manager.apply_taxes_to_shipping(
+            shipping_price, address, channel_slug
+        )
         if display_gross:
             shipping_method.price = taxed_price.gross
         else:

--- a/saleor/graphql/shop/tests/test_shop.py
+++ b/saleor/graphql/shop/tests/test_shop.py
@@ -628,7 +628,7 @@ AVAILABLE_PAYMENT_GATEWAYS_QUERY = """
 """
 
 
-def test_query_available_payment_gateways(user_api_client, sample_gateway):
+def test_query_available_payment_gateways(user_api_client, sample_gateway, channel_USD):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query)
     content = get_graphql_content(response)
@@ -644,7 +644,7 @@ def test_query_available_payment_gateways(user_api_client, sample_gateway):
 
 
 def test_query_available_payment_gateways_specified_currency_USD(
-    user_api_client, sample_gateway
+    user_api_client, sample_gateway, channel_USD
 ):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query, {"currency": "USD"})
@@ -661,7 +661,7 @@ def test_query_available_payment_gateways_specified_currency_USD(
 
 
 def test_query_available_payment_gateways_specified_currency_EUR(
-    user_api_client, sample_gateway
+    user_api_client, sample_gateway, channel_USD
 ):
     query = AVAILABLE_PAYMENT_GATEWAYS_QUERY
     response = user_api_client.post_graphql(query, {"currency": "EUR"})

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -92,7 +92,16 @@ class Shop(graphene.ObjectType):
         graphene.NonNull(PaymentGateway),
         currency=graphene.Argument(
             graphene.String,
-            description="A currency for which gateways will be returned.",
+            description=(
+                "DEPRECATED: use `channel` argument instead. This argument will be "
+                "removed in Saleor 4.0."
+                "A currency for which gateways will be returned."
+            ),
+            required=False,
+        ),
+        channel=graphene.Argument(
+            graphene.String,
+            description="Slug of a channel for which the data should be returned.",
             required=False,
         ),
         description="List of available payment gateways.",
@@ -207,8 +216,12 @@ class Shop(graphene.ObjectType):
         )
 
     @staticmethod
-    def resolve_available_payment_gateways(_, info, currency: Optional[str] = None):
-        return info.context.plugins.list_payment_gateways(currency=currency)
+    def resolve_available_payment_gateways(
+        _, info, currency: Optional[str] = None, channel: Optional[str] = None
+    ):
+        return info.context.plugins.list_payment_gateways(
+            currency=currency, channel_slug=channel
+        )
 
     @staticmethod
     def resolve_available_external_authentications(_, info):

--- a/saleor/payment/error_codes.py
+++ b/saleor/payment/error_codes.py
@@ -14,3 +14,4 @@ class PaymentErrorCode(Enum):
     SHIPPING_METHOD_NOT_SET = "shipping_method_not_set"
     PAYMENT_ERROR = "payment_error"
     NOT_SUPPORTED_GATEWAY = "not_supported_gateway"
+    CHANNEL_INACTIVE = "channel_inactive"

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -53,6 +53,7 @@ ADDITIONAL_ACTION_PATH = "/additional-actions"
 class AdyenGatewayPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.payments.adyen"
     PLUGIN_NAME = GATEWAY_NAME
+    CONFIGURATION_PER_CHANNEL = True
     DEFAULT_CONFIGURATION = [
         {"name": "merchant-account", "value": None},
         {"name": "api-key", "value": None},

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -169,7 +169,7 @@ def create_order(payment, checkout, manager):
             user=checkout.user or AnonymousUser(),
         )
     except ValidationError:
-        payment_refund_or_void(payment, manager)
+        payment_refund_or_void(payment, manager, checkout_info.channel.slug)
         return None
     # Refresh the payment to assign the newly created order
     payment.refresh_from_db()

--- a/saleor/payment/gateways/authorize_net/plugin.py
+++ b/saleor/payment/gateways/authorize_net/plugin.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 class AuthorizeNetGatewayPlugin(BasePlugin):
     PLUGIN_NAME = GATEWAY_NAME
     PLUGIN_ID = "mirumee.payments.authorize_net"
+    CONFIGURATION_PER_CHANNEL = True
 
     DEFAULT_CONFIGURATION = [
         {"name": "api_login_id", "value": None},

--- a/saleor/payment/gateways/authorize_net/tests/conftest.py
+++ b/saleor/payment/gateways/authorize_net/tests/conftest.py
@@ -33,7 +33,7 @@ def authorize_net_payment(payment_dummy):
     "saleor.payment.gateways.authorize_net.plugin.AuthorizeNetGatewayPlugin"
     ".validate_plugin_configuration"
 )
-def authorize_net_plugin(_, settings, authorize_net_gateway_config):
+def authorize_net_plugin(_, settings, channel_USD, authorize_net_gateway_config):
     settings.PLUGINS = [
         "saleor.payment.gateways.authorize_net.plugin.AuthorizeNetGatewayPlugin"
     ]
@@ -43,6 +43,7 @@ def authorize_net_plugin(_, settings, authorize_net_gateway_config):
 
     manager.save_plugin_configuration(
         AuthorizeNetGatewayPlugin.PLUGIN_ID,
+        channel_USD.slug,
         {
             "active": True,
             "configuration": [
@@ -70,4 +71,4 @@ def authorize_net_plugin(_, settings, authorize_net_gateway_config):
     )
 
     manager = get_plugins_manager()
-    return manager.plugins[0]
+    return manager.plugins_per_channel[channel_USD.slug][0]

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 class BraintreeGatewayPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.payments.braintree"
     PLUGIN_NAME = GATEWAY_NAME
+    CONFIGURATION_PER_CHANNEL = True
+
     DEFAULT_CONFIGURATION = [
         {"name": "Public API key", "value": None},
         {"name": "Secret API key", "value": None},

--- a/saleor/payment/tests/test_gateway.py
+++ b/saleor/payment/tests/test_gateway.py
@@ -87,11 +87,14 @@ def test_process_payment(fake_payment_interface, payment_txn_preauth):
     fake_payment_interface.process_payment.return_value = PROCESS_PAYMENT_RESPONSE
 
     transaction = gateway.process_payment(
-        payment=payment_txn_preauth, token=TOKEN, manager=fake_payment_interface
+        payment=payment_txn_preauth,
+        token=TOKEN,
+        manager=fake_payment_interface,
+        channel_slug=payment_txn_preauth.order.channel.slug,
     )
 
     fake_payment_interface.process_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_preauth.order.channel.slug
     )
     assert transaction.amount == PROCESS_PAYMENT_RESPONSE.amount
     assert transaction.kind == TransactionKind.CAPTURE
@@ -112,10 +115,11 @@ def test_store_source_when_processing_payment(
         token=TOKEN,
         manager=fake_payment_interface,
         store_source=True,
+        channel_slug=payment_txn_preauth.order.channel.slug,
     )
 
     fake_payment_interface.process_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_preauth.order.channel.slug
     )
     assert transaction.customer_id == PROCESS_PAYMENT_RESPONSE.customer_id
 
@@ -127,11 +131,14 @@ def test_authorize_payment(fake_payment_interface, payment_dummy):
     fake_payment_interface.authorize_payment.return_value = AUTHORIZE_RESPONSE
 
     transaction = gateway.authorize(
-        payment=payment_dummy, token=TOKEN, manager=fake_payment_interface
+        payment=payment_dummy,
+        token=TOKEN,
+        manager=fake_payment_interface,
+        channel_slug=payment_dummy.order.channel.slug,
     )
 
     fake_payment_interface.authorize_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_dummy.order.channel.slug
     )
     assert transaction.amount == AUTHORIZE_RESPONSE.amount
     assert transaction.kind == TransactionKind.AUTH
@@ -147,11 +154,13 @@ def test_capture_payment(fake_payment_interface, payment_txn_preauth):
     fake_payment_interface.capture_payment.return_value = PROCESS_PAYMENT_RESPONSE
 
     transaction = gateway.capture(
-        payment=payment_txn_preauth, manager=fake_payment_interface
+        payment=payment_txn_preauth,
+        manager=fake_payment_interface,
+        channel_slug=payment_txn_preauth.order.channel.slug,
     )
 
     fake_payment_interface.capture_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_preauth.order.channel.slug
     )
     assert transaction.amount == PROCESS_PAYMENT_RESPONSE.amount
     assert transaction.kind == TransactionKind.CAPTURE
@@ -165,6 +174,7 @@ def test_refund_for_manual_payment(payment_txn_captured):
         payment=payment_txn_captured,
         manager=get_plugins_manager(),
         amount=PARTIAL_REFUND_AMOUNT,
+        channel_slug=payment_txn_captured.order.channel.slug,
     )
     payment_txn_captured.refresh_from_db()
     assert payment_txn_captured.charge_status == ChargeStatus.PARTIALLY_REFUNDED
@@ -185,9 +195,10 @@ def test_partial_refund_payment(fake_payment_interface, payment_txn_captured):
         payment=payment_txn_captured,
         manager=fake_payment_interface,
         amount=PARTIAL_REFUND_AMOUNT,
+        channel_slug=payment_txn_captured.order.channel.slug,
     )
     fake_payment_interface.refund_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_captured.order.channel.slug
     )
 
     payment_txn_captured.refresh_from_db()
@@ -207,10 +218,12 @@ def test_full_refund_payment(fake_payment_interface, payment_txn_captured):
     )
     fake_payment_interface.refund_payment.return_value = FULL_REFUND_RESPONSE
     transaction = gateway.refund(
-        payment=payment_txn_captured, manager=fake_payment_interface
+        payment=payment_txn_captured,
+        manager=fake_payment_interface,
+        channel_slug=payment_txn_captured.order.channel.slug,
     )
     fake_payment_interface.refund_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_captured.order.channel.slug
     )
 
     payment_txn_captured.refresh_from_db()
@@ -231,11 +244,13 @@ def test_void_payment(fake_payment_interface, payment_txn_preauth):
     fake_payment_interface.void_payment.return_value = VOID_RESPONSE
 
     transaction = gateway.void(
-        payment=payment_txn_preauth, manager=fake_payment_interface
+        payment=payment_txn_preauth,
+        manager=fake_payment_interface,
+        channel_slug=payment_txn_preauth.order.channel.slug,
     )
 
     fake_payment_interface.void_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY, PAYMENT_DATA, channel_slug=payment_txn_preauth.order.channel.slug
     )
     payment_txn_preauth.refresh_from_db()
     assert not payment_txn_preauth.is_active
@@ -255,11 +270,15 @@ def test_confirm_payment(fake_payment_interface, payment_txn_to_confirm):
     fake_payment_interface.confirm_payment.return_value = CONFIRM_RESPONSE
 
     transaction = gateway.confirm(
-        payment=payment_txn_to_confirm, manager=fake_payment_interface
+        payment=payment_txn_to_confirm,
+        manager=fake_payment_interface,
+        channel_slug=payment_txn_to_confirm.order.channel.slug,
     )
 
     fake_payment_interface.confirm_payment.assert_called_once_with(
-        USED_GATEWAY, PAYMENT_DATA
+        USED_GATEWAY,
+        PAYMENT_DATA,
+        channel_slug=payment_txn_to_confirm.order.channel.slug,
     )
     assert transaction.amount == CONFIRM_RESPONSE.amount
     assert transaction.kind == TransactionKind.CONFIRM

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -67,6 +67,7 @@ class AdminEmailPlugin(BasePlugin):
     PLUGIN_NAME = "Admin emails"
     PLUGIN_DESCRIPTION = "Plugin responsible for sending the staff emails."
     DEFAULT_ACTIVE = True
+    CONFIGURATION_PER_CHANNEL = False
 
     DEFAULT_CONFIGURATION = [
         {

--- a/saleor/plugins/admin_email/tests/conftest.py
+++ b/saleor/plugins/admin_email/tests/conftest.py
@@ -66,6 +66,7 @@ def admin_email_plugin(settings):
         ):
             manager.save_plugin_configuration(
                 AdminEmailPlugin.PLUGIN_ID,
+                None,
                 {
                     "active": active,
                     "configuration": [
@@ -121,6 +122,6 @@ def admin_email_plugin(settings):
                 },
             )
         manager = get_plugins_manager()
-        return manager.plugins[0]
+        return manager.global_plugins[0]
 
     return fun

--- a/saleor/plugins/anonymize/plugin.py
+++ b/saleor/plugins/anonymize/plugin.py
@@ -19,6 +19,7 @@ class AnonymizePlugin(BasePlugin):
         "Anonymize customer's personal data in the checkout, such as shipping "
         "or billing address, email and phone number."
     )
+    CONFIGURATION_PER_CHANNEL = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -15,15 +15,15 @@ def vcr_config():
 
 
 @pytest.fixture
-def plugin_configuration(db):
+def plugin_configuration(db, channel_USD):
     def set_configuration(
-        username="test",
-        password="test",
-        sandbox=False,
+        username="test", password="test", sandbox=False, channel=None
     ):
+        channel = channel or channel_USD
         data = {
             "active": True,
             "name": AvataxPlugin.PLUGIN_NAME,
+            "channel": channel,
             "configuration": [
                 {"name": "Username or account", "value": username},
                 {"name": "Password or license", "value": password},

--- a/saleor/plugins/avatax/tests/test_avatax_caching.py
+++ b/saleor/plugins/avatax/tests/test_avatax_caching.py
@@ -21,13 +21,14 @@ def test_calculate_checkout_total_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -64,13 +65,14 @@ def test_calculate_checkout_total_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -108,13 +110,14 @@ def test_calculate_checkout_subtotal_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -151,13 +154,14 @@ def test_calculate_checkout_subtotal_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -195,13 +199,14 @@ def test_calculate_checkout_shipping_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -238,13 +243,14 @@ def test_calculate_checkout_shipping_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -282,13 +288,14 @@ def test_calculate_checkout_line_total_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -326,13 +333,14 @@ def test_calculate_checkout_line_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -371,13 +379,14 @@ def test_calculate_checkout_line_unit_price_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -423,13 +432,14 @@ def test_calculate_checkout_line_unit_price_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -482,13 +492,14 @@ def test_get_checkout_line_tax_rate_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -532,13 +543,14 @@ def test_get_checkout_line_tax_rate_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -588,13 +600,14 @@ def test_get_checkout_shipping_tax_rate_use_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)
@@ -632,13 +645,14 @@ def test_get_checkout_shipping_tax_rate_save_avatax_response_in_cache(
     plugin_configuration,
     avalara_response_for_checkout_with_items_and_shipping,
     monkeypatch,
+    channel_USD,
 ):
     # given
     checkout = checkout_with_items_and_shipping
     checkout_info = checkout_with_items_and_shipping_info
     plugin_configuration()
     manager = get_plugins_manager()
-    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID)
+    plugin = manager.get_plugin(AvataxPlugin.PLUGIN_ID, channel_USD.slug)
     site_settings.company_address = address
     site_settings.save()
     lines = fetch_checkout_lines(checkout)

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -1,4 +1,4 @@
-from copy import copy
+from copy import copy, deepcopy
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
@@ -70,6 +70,7 @@ class BasePlugin:
     PLUGIN_ID = ""
     PLUGIN_DESCRIPTION = ""
     CONFIG_STRUCTURE = None
+    CONFIGURATION_PER_CHANNEL = True
     DEFAULT_CONFIGURATION = []
     DEFAULT_ACTIVE = False
 
@@ -709,7 +710,7 @@ class BasePlugin:
         for config_field in configuration:
             if config_field["name"] not in desired_config_keys:
                 continue
-            updated_configuration.append(config_field)
+            updated_configuration.append(copy(config_field))
 
         configured_keys = set(d["name"] for d in updated_configuration)
         missing_keys = desired_config_keys - configured_keys

--- a/saleor/plugins/invoicing/plugin.py
+++ b/saleor/plugins/invoicing/plugin.py
@@ -15,6 +15,7 @@ class InvoicingPlugin(BasePlugin):
     PLUGIN_NAME = "Invoicing"
     DEFAULT_ACTIVE = True
     PLUGIN_DESCRIPTION = "Built-in saleor plugin that handles invoice creation."
+    CONFIGURATION_PER_CHANNEL = False
 
     def invoice_request(
         self,

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -1,5 +1,16 @@
+from collections import defaultdict
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import opentracing
 from django.conf import settings
@@ -9,6 +20,7 @@ from django.utils.module_loading import import_string
 from django_countries.fields import Country
 from prices import Money, TaxedMoney
 
+from ..channel.models import Channel
 from ..checkout import base_calculations
 from ..core.payments import PaymentInterface
 from ..core.prices import quantize_price
@@ -50,34 +62,66 @@ NotifyEventTypeChoice = str
 class PluginsManager(PaymentInterface):
     """Base manager for handling plugins logic."""
 
-    plugins: List["BasePlugin"] = []
+    plugins_per_channel: Dict[str, List["BasePlugin"]] = {}
+    global_plugins: List["BasePlugin"] = []
+    all_plugins: List["BasePlugin"] = []
+
+    def _load_plugin(self, PluginClass: Type["BasePlugin"], config) -> "BasePlugin":
+
+        if PluginClass.PLUGIN_ID in config:
+            existing_config = config[PluginClass.PLUGIN_ID]
+            plugin_config = existing_config.configuration
+            active = existing_config.active
+        else:
+            plugin_config = PluginClass.DEFAULT_CONFIGURATION
+            active = PluginClass.get_default_active()
+
+        return PluginClass(configuration=plugin_config, active=active)
 
     def __init__(self, plugins: List[str]):
         with opentracing.global_tracer().start_active_span("PluginsManager.__init__"):
-            self.plugins = []
-            all_configs = self._get_all_plugin_configs()
+            self.plugins_per_channel = defaultdict(list)
+            self.all_plugins = []
+            (
+                self._global_config,
+                self._configs_per_channel,
+            ) = self._get_all_plugin_configs()
+            self.global_plugins = []
+            channels = Channel.objects.all()
             for plugin_path in plugins:
+
                 with opentracing.global_tracer().start_active_span(f"{plugin_path}"):
                     PluginClass = import_string(plugin_path)
-                    if PluginClass.PLUGIN_ID in all_configs:
-                        existing_config = all_configs[PluginClass.PLUGIN_ID]
-                        plugin_config = existing_config.configuration
-                        active = existing_config.active
+                    if not getattr(PluginClass, "CONFIGURATION_PER_CHANNEL", False):
+                        plugin = self._load_plugin(PluginClass, self._global_config)
+                        self.global_plugins.append(plugin)
+                        self.all_plugins.append(plugin)
                     else:
-                        plugin_config = PluginClass.DEFAULT_CONFIGURATION
-                        active = PluginClass.get_default_active()
-                    plugin = PluginClass(configuration=plugin_config, active=active)
-                self.plugins.append(plugin)
+                        for channel in channels:
+                            channel_configs = self._configs_per_channel.get(channel, {})
+                            plugin = self._load_plugin(PluginClass, channel_configs)
+                            self.plugins_per_channel[channel.slug].append(plugin)
+                            self.all_plugins.append(plugin)
+
+            for channel in channels:
+                self.plugins_per_channel[channel.slug].extend(self.global_plugins)
 
     def __run_method_on_plugins(
-        self, method_name: str, default_value: Any, *args, **kwargs
+        self,
+        method_name: str,
+        default_value: Any,
+        *args,
+        channel_slug: Optional[str] = None,
+        **kwargs
     ):
         """Try to run a method with the given name on each declared plugin."""
         with opentracing.global_tracer().start_active_span(
             f"PluginsManager.{method_name}"
         ):
             value = default_value
-            for plugin in self.plugins:
+            plugins = self.get_plugins(channel_slug=channel_slug)
+
+            for plugin in plugins:
                 value = self.__run_method_on_single_plugin(
                     plugin, method_name, value, *args, **kwargs
                 )
@@ -139,6 +183,7 @@ class PluginsManager(PaymentInterface):
                 lines,
                 address,
                 discounts,
+                channel_slug=checkout_info.channel.slug,
             ),
             checkout_info.checkout.currency,
         )
@@ -185,6 +230,7 @@ class PluginsManager(PaymentInterface):
                 lines,
                 address,
                 discounts,
+                channel_slug=checkout_info.channel.slug,
             ),
             checkout_info.checkout.currency,
         )
@@ -201,7 +247,10 @@ class PluginsManager(PaymentInterface):
         )
         return quantize_price(
             self.__run_method_on_plugins(
-                "calculate_order_shipping", default_value, order
+                "calculate_order_shipping",
+                default_value,
+                order,
+                channel_slug=order.channel.slug,
             ),
             order.currency,
         )
@@ -222,12 +271,16 @@ class PluginsManager(PaymentInterface):
             lines,
             address,
             discounts,
+            channel_slug=checkout_info.channel.slug,
         ).quantize(Decimal(".0001"))
 
     def get_order_shipping_tax_rate(self, order: "Order", shipping_price: TaxedMoney):
         default_value = base_calculations.base_tax_rate(shipping_price)
         return self.__run_method_on_plugins(
-            "get_order_shipping_tax_rate", default_value, order
+            "get_order_shipping_tax_rate",
+            default_value,
+            order,
+            channel_slug=order.channel.slug,
         ).quantize(Decimal(".0001"))
 
     def calculate_checkout_line_total(
@@ -252,6 +305,7 @@ class PluginsManager(PaymentInterface):
                 checkout_line_info,
                 address,
                 discounts,
+                channel_slug=checkout_info.channel.slug,
             ),
             checkout_info.checkout.currency,
         )
@@ -278,6 +332,7 @@ class PluginsManager(PaymentInterface):
                 checkout_line_info,
                 address,
                 discounts,
+                channel_slug=checkout_info.channel.slug,
             ),
             total_line_price.currency,
         )
@@ -299,6 +354,7 @@ class PluginsManager(PaymentInterface):
                 order_line,
                 variant,
                 product,
+                channel_slug=order.channel.slug,
             ),
             order_line.currency,
         )
@@ -321,6 +377,7 @@ class PluginsManager(PaymentInterface):
             checkout_line_info,
             address,
             discounts,
+            channel_slug=checkout_info.channel.slug,
         ).quantize(Decimal(".0001"))
 
     def get_order_line_tax_rate(
@@ -333,7 +390,13 @@ class PluginsManager(PaymentInterface):
     ) -> Decimal:
         default_value = base_calculations.base_tax_rate(unit_price)
         return self.__run_method_on_plugins(
-            "get_order_line_tax_rate", default_value, order, product, variant, address
+            "get_order_line_tax_rate",
+            default_value,
+            order,
+            product,
+            variant,
+            address,
+            channel_slug=order.channel.slug,
         ).quantize(Decimal(".0001"))
 
     def get_tax_rate_type_choices(self) -> List[TaxType]:
@@ -345,20 +408,25 @@ class PluginsManager(PaymentInterface):
         return self.__run_method_on_plugins("show_taxes_on_storefront", default_value)
 
     def apply_taxes_to_product(
-        self, product: "Product", price: Money, country: Country
+        self, product: "Product", price: Money, country: Country, channel_slug: str
     ):
         default_value = quantize_price(
             TaxedMoney(net=price, gross=price), price.currency
         )
         return quantize_price(
             self.__run_method_on_plugins(
-                "apply_taxes_to_product", default_value, product, price, country
+                "apply_taxes_to_product",
+                default_value,
+                product,
+                price,
+                country,
+                channel_slug=channel_slug,
             ),
             price.currency,
         )
 
     def apply_taxes_to_shipping(
-        self, price: Money, shipping_address: "Address"
+        self, price: Money, shipping_address: "Address", channel_slug: str
     ) -> TaxedMoney:
         default_value = quantize_price(
             TaxedMoney(net=price, gross=price), price.currency
@@ -378,7 +446,12 @@ class PluginsManager(PaymentInterface):
     ):
         default_value = None
         return self.__run_method_on_plugins(
-            "preprocess_order_creation", default_value, checkout_info, discounts, lines
+            "preprocess_order_creation",
+            default_value,
+            checkout_info,
+            discounts,
+            lines,
+            channel_slug=checkout_info.channel.slug,
         )
 
     def customer_created(self, customer: "User"):
@@ -423,59 +496,100 @@ class PluginsManager(PaymentInterface):
 
     def order_created(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_created", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_created", default_value, order, channel_slug=order.channel.slug
+        )
 
     def order_confirmed(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_confirmed", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_confirmed", default_value, order, channel_slug=order.channel.slug
+        )
 
     def invoice_request(
         self, order: "Order", invoice: "Invoice", number: Optional[str]
     ):
         default_value = None
         return self.__run_method_on_plugins(
-            "invoice_request", default_value, order, invoice, number
+            "invoice_request",
+            default_value,
+            order,
+            invoice,
+            number,
+            channel_slug=order.channel.slug,
         )
 
     def invoice_delete(self, invoice: "Invoice"):
         default_value = None
-        return self.__run_method_on_plugins("invoice_delete", default_value, invoice)
+        channel_slug = invoice.order.channel.slug if invoice.order else None
+        return self.__run_method_on_plugins(
+            "invoice_delete",
+            default_value,
+            invoice,
+            channel_slug=channel_slug,
+        )
 
     def invoice_sent(self, invoice: "Invoice", email: str):
         default_value = None
+        channel_slug = invoice.order.channel.slug if invoice.order else None
         return self.__run_method_on_plugins(
-            "invoice_sent", default_value, invoice, email
+            "invoice_sent",
+            default_value,
+            invoice,
+            email,
+            channel_slug=channel_slug,
         )
 
     def order_fully_paid(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_fully_paid", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_fully_paid", default_value, order, channel_slug=order.channel.slug
+        )
 
     def order_updated(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_updated", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_updated", default_value, order, channel_slug=order.channel.slug
+        )
 
     def order_cancelled(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_cancelled", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_cancelled", default_value, order, channel_slug=order.channel.slug
+        )
 
     def order_fulfilled(self, order: "Order"):
         default_value = None
-        return self.__run_method_on_plugins("order_fulfilled", default_value, order)
+        return self.__run_method_on_plugins(
+            "order_fulfilled", default_value, order, channel_slug=order.channel.slug
+        )
 
     def fulfillment_created(self, fulfillment: "Fulfillment"):
         default_value = None
         return self.__run_method_on_plugins(
-            "fulfillment_created", default_value, fulfillment
+            "fulfillment_created",
+            default_value,
+            fulfillment,
+            channel_slug=fulfillment.order.channel.slug,
         )
 
     def checkout_created(self, checkout: "Checkout"):
         default_value = None
-        return self.__run_method_on_plugins("checkout_created", default_value, checkout)
+        return self.__run_method_on_plugins(
+            "checkout_created",
+            default_value,
+            checkout,
+            channel_slug=checkout.channel.slug,
+        )
 
     def checkout_updated(self, checkout: "Checkout"):
         default_value = None
-        return self.__run_method_on_plugins("checkout_updated", default_value, checkout)
+        return self.__run_method_on_plugins(
+            "checkout_updated",
+            default_value,
+            checkout,
+            channel_slug=checkout.channel.slug,
+        )
 
     def page_created(self, page: "Page"):
         default_value = None
@@ -490,11 +604,11 @@ class PluginsManager(PaymentInterface):
         return self.__run_method_on_plugins("page_deleted", default_value, page)
 
     def initialize_payment(
-        self, gateway, payment_data: dict
+        self, gateway, payment_data: dict, channel_slug: str
     ) -> Optional["InitializedPaymentResponse"]:
         method_name = "initialize_payment"
         default_value = None
-        gtw = self.get_plugin(gateway)
+        gtw = self.get_plugin(gateway, channel_slug)
         if not gtw:
             return None
 
@@ -506,45 +620,59 @@ class PluginsManager(PaymentInterface):
         )
 
     def authorize_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "authorize_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
     def capture_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "capture_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
     def refund_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "refund_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
     def void_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "void_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
     def confirm_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "confirm_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
     def process_payment(
-        self, gateway: str, payment_information: "PaymentData"
+        self, gateway: str, payment_information: "PaymentData", channel_slug: str
     ) -> "GatewayResponse":
         method_name = "process_payment"
-        return self.__run_payment_method(gateway, method_name, payment_information)
+        return self.__run_payment_method(
+            gateway, method_name, payment_information, channel_slug=channel_slug
+        )
 
-    def token_is_required_as_payment_input(self, gateway) -> bool:
+    def token_is_required_as_payment_input(
+        self, gateway: str, channel_slug: str
+    ) -> bool:
         method_name = "token_is_required_as_payment_input"
         default_value = True
-        gtw = self.get_plugin(gateway)
+        gtw = self.get_plugin(gateway, channel_slug=channel_slug)
         if gtw is not None:
             return self.__run_method_on_single_plugin(
                 gtw,
@@ -553,35 +681,53 @@ class PluginsManager(PaymentInterface):
             )
         return default_value
 
-    def get_client_token(self, gateway, token_config: "TokenConfig") -> str:
+    def get_client_token(
+        self,
+        gateway,
+        token_config: "TokenConfig",
+        channel_slug: str,
+    ) -> str:
         method_name = "get_client_token"
         default_value = None
-        gtw = self.get_plugin(gateway)
+        gtw = self.get_plugin(gateway, channel_slug=channel_slug)
         return self.__run_method_on_single_plugin(
             gtw, method_name, default_value, token_config=token_config
         )
 
     def list_payment_sources(
-        self, gateway: str, customer_id: str
+        self,
+        gateway: str,
+        customer_id: str,
+        channel_slug: str,
     ) -> List["CustomerSource"]:
         default_value: list = []
-        gtw = self.get_plugin(gateway)
+        gtw = self.get_plugin(gateway, channel_slug=channel_slug)
         if gtw is not None:
             return self.__run_method_on_single_plugin(
                 gtw, "list_payment_sources", default_value, customer_id=customer_id
             )
         raise Exception(f"Payment plugin {gateway} is inaccessible!")
 
-    def get_active_plugins(self, plugins=None) -> List["BasePlugin"]:
-        if plugins is None:
-            plugins = self.plugins
-        return [plugin for plugin in plugins if plugin.active]
+    def get_plugins(
+        self, channel_slug: Optional[str] = None, active_only=False
+    ) -> List["BasePlugin"]:
+        """Return list of plugins for a given channel."""
+        if channel_slug:
+            plugins = self.plugins_per_channel[channel_slug]
+        else:
+            plugins = self.all_plugins
 
-    def list_payment_plugin(self, active_only: bool = False) -> Dict[str, "BasePlugin"]:
-        payment_method = "process_payment"
-        plugins = self.plugins
         if active_only:
-            plugins = self.get_active_plugins()
+            plugins = [plugin for plugin in plugins if plugin.active]
+        return plugins
+
+    def list_payment_plugin(
+        self, active_only: bool = False, channel_slug: Optional["str"] = None
+    ) -> Dict[str, "BasePlugin"]:
+        payment_method = "process_payment"
+
+        plugins = self.get_plugins(channel_slug=channel_slug, active_only=active_only)
+
         return {
             plugin.PLUGIN_ID: plugin
             for plugin in plugins
@@ -592,9 +738,14 @@ class PluginsManager(PaymentInterface):
         self,
         currency: Optional[str] = None,
         checkout: Optional["Checkout"] = None,
+        channel_slug: Optional[str] = None,
         active_only: bool = True,
     ) -> List["PaymentGateway"]:
-        payment_plugins = self.list_payment_plugin(active_only=active_only)
+        channel_slug = checkout.channel.slug if checkout else channel_slug
+
+        payment_plugins = self.list_payment_plugin(
+            active_only=active_only, channel_slug=channel_slug
+        )
         # if currency is given return only gateways which support given currency
         gateways = []
         for plugin in payment_plugins.values():
@@ -606,10 +757,8 @@ class PluginsManager(PaymentInterface):
         return gateways
 
     def list_external_authentications(self, active_only: bool = True) -> List[dict]:
-        plugins = self.plugins
         auth_basic_method = "external_obtain_access_tokens"
-        if active_only:
-            plugins = self.get_active_plugins()
+        plugins = self.get_plugins(active_only=active_only)
         return [
             {"id": plugin.PLUGIN_ID, "name": plugin.PLUGIN_NAME}
             for plugin in plugins
@@ -621,10 +770,11 @@ class PluginsManager(PaymentInterface):
         gateway: str,
         method_name: str,
         payment_information: "PaymentData",
+        channel_slug: str,
         **kwargs,
     ) -> "GatewayResponse":
         default_value = None
-        gtw = self.get_plugin(gateway)
+        gtw = self.get_plugin(gateway, channel_slug)
         if gtw is not None:
             resp = self.__run_method_on_single_plugin(
                 gtw,
@@ -644,10 +794,19 @@ class PluginsManager(PaymentInterface):
     def _get_all_plugin_configs(self):
         with opentracing.global_tracer().start_active_span("_get_all_plugin_configs"):
             if not hasattr(self, "_plugin_configs"):
-                self._plugin_configs = {
-                    pc.identifier: pc for pc in PluginConfiguration.objects.all()
-                }
-            return self._plugin_configs
+                plugin_configurations = PluginConfiguration.objects.prefetch_related(
+                    "channel"
+                ).all()
+                self._plugin_configs_per_channel = defaultdict(dict)
+                self._global_plugin_configs = {}
+                for pc in plugin_configurations:
+                    channel = pc.channel
+                    if channel is None:
+                        self._global_plugin_configs[pc.identifier] = pc
+                    else:
+                        self._plugin_configs_per_channel[channel][pc.identifier] = pc
+
+            return self._global_plugin_configs, self._plugin_configs_per_channel
 
     # FIXME these methods should be more generic
 
@@ -675,11 +834,23 @@ class PluginsManager(PaymentInterface):
             "get_tax_rate_percentage_value", default_value, obj, country
         ).quantize(Decimal("1."))
 
-    def save_plugin_configuration(self, plugin_id, cleaned_data: dict):
-        for plugin in self.plugins:
+    def save_plugin_configuration(
+        self, plugin_id, channel_slug: Optional[str], cleaned_data: dict
+    ):
+        if channel_slug:
+            plugins = self.get_plugins(channel_slug=channel_slug)
+            channel = Channel.objects.filter(slug=channel_slug).first()
+            if not channel:
+                return None
+        else:
+            channel = None
+            plugins = self.global_plugins
+
+        for plugin in plugins:
             if plugin.PLUGIN_ID == plugin_id:
                 plugin_configuration, _ = PluginConfiguration.objects.get_or_create(
                     identifier=plugin_id,
+                    channel=channel,
                     defaults={"configuration": plugin.configuration},
                 )
                 configuration = plugin.save_plugin_configuration(
@@ -689,8 +860,11 @@ class PluginsManager(PaymentInterface):
                 configuration.description = plugin.PLUGIN_DESCRIPTION
                 return configuration
 
-    def get_plugin(self, plugin_id: str) -> Optional["BasePlugin"]:
-        for plugin in self.plugins:
+    def get_plugin(
+        self, plugin_id: str, channel_slug: Optional[str] = None
+    ) -> Optional["BasePlugin"]:
+        plugins = self.get_plugins(channel_slug=channel_slug)
+        for plugin in plugins:
             if plugin.PLUGIN_ID == plugin_id:
                 return plugin
         return None
@@ -705,6 +879,7 @@ class PluginsManager(PaymentInterface):
         if len(split_path) == 2:
             path = split_path[1]
 
+        # FIXME
         default_value = HttpResponseNotFound()
         plugin = self.get_plugin(plugin_id)
         if not plugin:

--- a/saleor/plugins/migrations/0008_pluginconfiguration_channel.py
+++ b/saleor/plugins/migrations/0008_pluginconfiguration_channel.py
@@ -31,7 +31,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ("channel", "0001_initial"),
-        ("plugins", "0006_auto_20200909_1253"),
+        ("plugins", "0007_add_user_emails_configuration"),
     ]
 
     operations = [

--- a/saleor/plugins/sendgrid/plugin.py
+++ b/saleor/plugins/sendgrid/plugin.py
@@ -94,6 +94,7 @@ class SendgridEmailPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.notifications.sendgrid_email"
     PLUGIN_NAME = "Sendgrid"
     DEFAULT_ACTIVE = False
+    CONFIGURATION_PER_CHANNEL = False
 
     DEFAULT_CONFIGURATION = [
         {"name": "sender_name", "value": ""},

--- a/saleor/plugins/sendgrid/tests/conftest.py
+++ b/saleor/plugins/sendgrid/tests/conftest.py
@@ -31,6 +31,7 @@ def sendgrid_email_plugin(settings):
         manager = get_plugins_manager()
         manager.save_plugin_configuration(
             SendgridEmailPlugin.PLUGIN_ID,
+            None,
             {
                 "active": active,
                 "configuration": [
@@ -97,6 +98,6 @@ def sendgrid_email_plugin(settings):
             },
         )
         manager = get_plugins_manager()
-        return manager.plugins[0]
+        return manager.all_plugins[0]
 
     return fun

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -8,12 +8,13 @@ from .sample_plugins import PluginInactive, PluginSample
 
 
 @pytest.fixture
-def plugin_configuration(db):
+def plugin_configuration(db, channel_USD):
     configuration, _ = PluginConfiguration.objects.get_or_create(
         identifier=PluginSample.PLUGIN_ID,
         name=PluginSample.PLUGIN_NAME,
         defaults={
             "active": PluginSample.DEFAULT_ACTIVE,
+            "channel": channel_USD,
             "configuration": PluginSample.DEFAULT_CONFIGURATION,
             "name": PluginSample.PLUGIN_NAME,
         },
@@ -23,12 +24,13 @@ def plugin_configuration(db):
 
 
 @pytest.fixture
-def inactive_plugin_configuration(db):
+def inactive_plugin_configuration(db, channel_USD):
     return PluginConfiguration.objects.get_or_create(
         identifier=PluginSample.PLUGIN_ID,
         name=PluginInactive.PLUGIN_NAME,
         defaults={
             "active": PluginInactive.DEFAULT_ACTIVE,
+            "channel": channel_USD,
             "configuration": PluginInactive.DEFAULT_CONFIGURATION,
             "name": PluginInactive.PLUGIN_NAME,
         },

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -1,20 +1,21 @@
+import copy
+
 import pytest
 from django_prices_vatlayer.models import VAT
 from django_prices_vatlayer.utils import get_tax_for_rate
 
 from ..base_plugin import ConfigurationTypeField
 from ..models import PluginConfiguration
-from .sample_plugins import PluginInactive, PluginSample
+from .sample_plugins import ChannelPluginSample, PluginInactive, PluginSample
 
 
 @pytest.fixture
-def plugin_configuration(db, channel_USD):
+def plugin_configuration(db):
     configuration, _ = PluginConfiguration.objects.get_or_create(
         identifier=PluginSample.PLUGIN_ID,
         name=PluginSample.PLUGIN_NAME,
         defaults={
             "active": PluginSample.DEFAULT_ACTIVE,
-            "channel": channel_USD,
             "configuration": PluginSample.DEFAULT_CONFIGURATION,
             "name": PluginSample.PLUGIN_NAME,
         },
@@ -24,13 +25,40 @@ def plugin_configuration(db, channel_USD):
 
 
 @pytest.fixture
-def inactive_plugin_configuration(db, channel_USD):
+def channel_plugin_configurations(db, channel_USD, channel_PLN):
+    usd_configuration = copy.deepcopy(ChannelPluginSample.DEFAULT_CONFIGURATION)
+    usd_configuration[0]["value"] = channel_USD.slug
+
+    pln_configuration = copy.deepcopy(ChannelPluginSample.DEFAULT_CONFIGURATION)
+    pln_configuration[0]["value"] = channel_PLN.slug
+
+    return PluginConfiguration.objects.bulk_create(
+        [
+            PluginConfiguration(
+                identifier=ChannelPluginSample.PLUGIN_ID,
+                channel=channel_USD,
+                name=ChannelPluginSample.PLUGIN_NAME,
+                active=ChannelPluginSample.DEFAULT_ACTIVE,
+                configuration=usd_configuration,
+            ),
+            PluginConfiguration(
+                identifier=ChannelPluginSample.PLUGIN_ID,
+                channel=channel_PLN,
+                name=ChannelPluginSample.PLUGIN_NAME,
+                active=ChannelPluginSample.DEFAULT_ACTIVE,
+                configuration=pln_configuration,
+            ),
+        ]
+    )
+
+
+@pytest.fixture
+def inactive_plugin_configuration(db):
     return PluginConfiguration.objects.get_or_create(
-        identifier=PluginSample.PLUGIN_ID,
+        identifier=PluginInactive.PLUGIN_ID,
         name=PluginInactive.PLUGIN_NAME,
         defaults={
             "active": PluginInactive.DEFAULT_ACTIVE,
-            "channel": channel_USD,
             "configuration": PluginInactive.DEFAULT_CONFIGURATION,
             "name": PluginInactive.PLUGIN_NAME,
         },

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -212,11 +212,19 @@ class PluginSample(BasePlugin):
 
 
 class ChannelPluginSample(PluginSample):
-    PLUGIN_ID = "plugin.sample"
-    PLUGIN_NAME = "PluginSample"
-    PLUGIN_DESCRIPTION = "Test plugin description"
+    PLUGIN_ID = "channel.plugin.sample"
+    PLUGIN_NAME = "ChannelPluginSample"
+    PLUGIN_DESCRIPTION = "Test channel plugin description"
     DEFAULT_ACTIVE = True
     CONFIGURATION_PER_CHANNEL = True
+    DEFAULT_CONFIGURATION = [{"name": "input-per-channel", "value": None}]
+    CONFIG_STRUCTURE = {
+        "input-per-channel": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Test input",
+            "label": "Input per channel",
+        }
+    }
 
 
 class PluginInactive(BasePlugin):

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -26,6 +26,7 @@ class PluginSample(BasePlugin):
     PLUGIN_NAME = "PluginSample"
     PLUGIN_DESCRIPTION = "Test plugin description"
     DEFAULT_ACTIVE = True
+    CONFIGURATION_PER_CHANNEL = False
     DEFAULT_CONFIGURATION = [
         {"name": "Username", "value": "admin"},
         {"name": "Password", "value": None},
@@ -210,10 +211,19 @@ class PluginSample(BasePlugin):
         return Decimal("0.080").quantize(Decimal(".01"))
 
 
+class ChannelPluginSample(PluginSample):
+    PLUGIN_ID = "plugin.sample"
+    PLUGIN_NAME = "PluginSample"
+    PLUGIN_DESCRIPTION = "Test plugin description"
+    DEFAULT_ACTIVE = True
+    CONFIGURATION_PER_CHANNEL = True
+
+
 class PluginInactive(BasePlugin):
     PLUGIN_ID = "plugin.inactive"
     PLUGIN_NAME = "PluginInactive"
     PLUGIN_DESCRIPTION = "Test plugin description_2"
+    CONFIGURATION_PER_CHANNEL = False
 
     def external_obtain_access_tokens(
         self, data: dict, request: WSGIRequest, previous_value
@@ -228,6 +238,7 @@ class ActivePlugin(BasePlugin):
     PLUGIN_NAME = "Active"
     PLUGIN_DESCRIPTION = "Not working"
     DEFAULT_ACTIVE = True
+    CONFIGURATION_PER_CHANNEL = False
 
 
 class ActivePaymentGateway(BasePlugin):

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -108,6 +108,7 @@ def get_user_event_map():
 class UserEmailPlugin(BasePlugin):
     PLUGIN_ID = constants.PLUGIN_ID
     PLUGIN_NAME = "User emails"
+    CONFIGURATION_PER_CHANNEL = False
 
     DEFAULT_CONFIGURATION = [
         {

--- a/saleor/plugins/user_email/tests/conftest.py
+++ b/saleor/plugins/user_email/tests/conftest.py
@@ -112,6 +112,7 @@ def user_email_plugin(settings):
         ):
             manager.save_plugin_configuration(
                 UserEmailPlugin.PLUGIN_ID,
+                None,
                 {
                     "active": active,
                     "configuration": [
@@ -239,6 +240,6 @@ def user_email_plugin(settings):
                 },
             )
         manager = get_plugins_manager()
-        return manager.plugins[0]
+        return manager.global_plugins[0]
 
     return fun

--- a/saleor/plugins/webhook/plugin.py
+++ b/saleor/plugins/webhook/plugin.py
@@ -31,6 +31,7 @@ class WebhookPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.webhooks"
     PLUGIN_NAME = "Webhooks"
     DEFAULT_ACTIVE = True
+    CONFIGURATION_PER_CHANNEL = False
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -152,6 +152,8 @@ def get_product_availability(
 ) -> ProductAvailability:
     country = country or Country(settings.DEFAULT_COUNTRY)
     with opentracing.global_tracer().start_active_span("get_product_availability"):
+        channel_slug = channel.slug
+
         discounted = None
         discounted_net_range = get_product_price_range(
             product=product,
@@ -164,10 +166,16 @@ def get_product_availability(
         if discounted_net_range is not None:
             discounted = TaxedMoneyRange(
                 start=manager.apply_taxes_to_product(
-                    product, discounted_net_range.start, country
+                    product,
+                    discounted_net_range.start,
+                    country,
+                    channel_slug=channel_slug,
                 ),
                 stop=manager.apply_taxes_to_product(
-                    product, discounted_net_range.stop, country
+                    product,
+                    discounted_net_range.stop,
+                    country,
+                    channel_slug=channel_slug,
                 ),
             )
 
@@ -183,10 +191,16 @@ def get_product_availability(
         if undiscounted_net_range is not None:
             undiscounted = TaxedMoneyRange(
                 start=manager.apply_taxes_to_product(
-                    product, undiscounted_net_range.start, country
+                    product,
+                    undiscounted_net_range.start,
+                    country,
+                    channel_slug=channel_slug,
                 ),
                 stop=manager.apply_taxes_to_product(
-                    product, undiscounted_net_range.stop, country
+                    product,
+                    undiscounted_net_range.stop,
+                    country,
+                    channel_slug=channel_slug,
                 ),
             )
 
@@ -228,6 +242,7 @@ def get_variant_availability(
 ) -> VariantAvailability:
     country = country or Country(settings.DEFAULT_COUNTRY)
     with opentracing.global_tracer().start_active_span("get_variant_availability"):
+        channel_slug = channel.slug
         discounted = plugins.apply_taxes_to_product(
             product,
             get_variant_price(
@@ -239,6 +254,7 @@ def get_variant_availability(
                 channel=channel,
             ),
             country,
+            channel_slug=channel_slug,
         )
         undiscounted = plugins.apply_taxes_to_product(
             product,
@@ -251,6 +267,7 @@ def get_variant_availability(
                 channel=channel,
             ),
             country,
+            channel_slug=channel_slug,
         )
 
         discount = _get_total_discount(undiscounted, discounted)

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -192,10 +192,11 @@ def assert_max_num_queries(capture_queries):
 
 
 @pytest.fixture
-def setup_vatlayer(settings):
+def setup_vatlayer(settings, channel_USD):
     settings.PLUGINS = ["saleor.plugins.vatlayer.plugin.VatlayerPlugin"]
     data = {
         "active": True,
+        "channel": channel_USD,
         "configuration": [
             {"name": "Access key", "value": "vatlayer_access_key"},
         ],


### PR DESCRIPTION
I want to merge this change because it adds logic to plugins manager responsible for distributing the hook calls for plugin assigned to the channels

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
