### PR TITLE
Filter channel listings without price for update_product_discounted_price_task

### DIFF
--- a/saleor/product/tests/test_product_minimal_variant_price.py
+++ b/saleor/product/tests/test_product_minimal_variant_price.py
@@ -26,6 +26,25 @@ def test_update_product_discounted_price(product, channel_USD):
     assert product_channel_listing.discounted_price == variant_channel_listing.price
 
 
+def test_update_product_discounted_price_without_price(
+    product, channel_USD, channel_PLN
+):
+    variant = product.variants.first()
+    variant_channel_listing = variant.channel_listings.get(channel_id=channel_USD.id)
+    product_channel_listing = product.channel_listings.get(channel_id=channel_USD.id)
+    second_product_channel_listing = product.channel_listings.create(
+        channel=channel_PLN
+    )
+
+    assert product_channel_listing.discounted_price == Money("10", "USD")
+
+    update_product_discounted_price(product)
+
+    product_channel_listing.refresh_from_db()
+    assert product_channel_listing.discounted_price == variant_channel_listing.price
+    assert second_product_channel_listing.discounted_price is None
+
+
 def test_update_products_discounted_prices_of_catalogues_for_product(
     product, channel_USD
 ):

--- a/saleor/product/utils/variant_prices.py
+++ b/saleor/product/utils/variant_prices.py
@@ -13,7 +13,7 @@ from ..models import Product, ProductChannelListing, ProductVariantChannelListin
 def _get_variant_prices_in_channels_dict(product):
     prices_dict = defaultdict(list)
     for variant_channel_listing in ProductVariantChannelListing.objects.filter(
-        variant__product_id=product
+        variant__product_id=product, price_amount__isnull=False
     ):
         channel_id = variant_channel_listing.channel_id
         prices_dict[channel_id].append(variant_channel_listing.price)
@@ -44,7 +44,9 @@ def update_product_discounted_price(product, discounts=None):
     changed_products_channels_to_update = []
     for product_channel_listing in product.channel_listings.all():
         channel_id = product_channel_listing.channel_id
-        variant_prices_dict = variant_prices_in_channels_dict[channel_id]
+        variant_prices_dict = variant_prices_in_channels_dict.get(channel_id)
+        if not variant_prices_dict:
+            continue
         product_discounted_price = _get_product_discounted_price(
             variant_prices_dict,
             product,


### PR DESCRIPTION
I want to merge this change because...I want to use only channel listing with price for update_product_discounted_price_task

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
