### PR TITLE
Fix variant resolver for staff user with and without providing channel

### DIFF
--- a/saleor/graphql/product/dataloaders/__init__.py
+++ b/saleor/graphql/product/dataloaders/__init__.py
@@ -5,7 +5,7 @@ from .attributes import (
     VariantAttributesByProductTypeIdLoader,
 )
 from .products import (
-    AvailableProductVariantsByProductVariantIdAndChannel,
+    AvailableProductVariantsByProductIdAndChannel,
     CategoryByIdLoader,
     CollectionByIdLoader,
     CollectionChannelListingByCollectionIdAndChannelSlugLoader,
@@ -28,6 +28,7 @@ from .products import (
     ProductTypeByVariantIdLoader,
     ProductVariantByIdLoader,
     ProductVariantChannelListingByIdLoader,
+    ProductVariantsByProductIdAndChannel,
     ProductVariantsByProductIdLoader,
     VariantChannelListingByVariantIdAndChannelIdLoader,
     VariantChannelListingByVariantIdAndChannelSlugLoader,
@@ -67,5 +68,6 @@ __all__ = [
     "VariantChannelListingByVariantIdAndChannelIdLoader",
     "VariantChannelListingByVariantIdLoader",
     "VariantsChannelListingByProductIdAndChannelSlugLoader",
-    "AvailableProductVariantsByProductVariantIdAndChannel",
+    "ProductVariantsByProductIdAndChannel",
+    "AvailableProductVariantsByProductIdAndChannel",
 ]

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -135,6 +135,9 @@ QUERY_FETCH_ALL_PRODUCTS = """
                 node {
                     id
                     name
+                    variants {
+                        id
+                    }
                 }
             }
         }
@@ -1068,6 +1071,51 @@ def test_fetch_all_products_available_as_staff_user(
     num_products = Product.objects.count()
     assert content["data"]["products"]["totalCount"] == num_products
     assert len(content["data"]["products"]["edges"]) == num_products
+
+
+def test_fetch_all_product_variants_available_as_staff_user_with_channel(
+    staff_api_client, permission_manage_products, product_variant_list, channel_USD
+):
+    variables = {"channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(
+        QUERY_FETCH_ALL_PRODUCTS,
+        variables,
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+    num_products = Product.objects.count()
+    num_variants = ProductVariant.objects.count()
+    assert num_variants > 1
+
+    content = get_graphql_content(response)
+    products = content["data"]["products"]
+    variants = products["edges"][0]["node"]["variants"]
+
+    assert products["totalCount"] == num_products
+    assert len(products["edges"]) == num_products
+    assert len(variants) == num_variants - 1
+
+
+def test_fetch_all_product_variants_available_as_staff_user_without_channel(
+    staff_api_client, permission_manage_products, product_variant_list, channel_USD
+):
+    response = staff_api_client.post_graphql(
+        QUERY_FETCH_ALL_PRODUCTS,
+        permissions=(permission_manage_products,),
+        check_no_permissions=False,
+    )
+
+    num_products = Product.objects.count()
+    num_variants = ProductVariant.objects.count()
+    assert num_variants > 1
+
+    content = get_graphql_content(response)
+    products = content["data"]["products"]
+    variants = products["edges"][0]["node"]["variants"]
+
+    assert products["totalCount"] == num_products
+    assert len(products["edges"]) == num_products
+    assert len(variants) == num_variants
 
 
 def test_fetch_all_products_not_available_as_staff_user(
@@ -7380,10 +7428,10 @@ def test_product_variant_without_price_as_staff(
     stock,
     channel_USD,
 ):
-    product = variant.product
-    ProductVariantChannelListing.objects.filter(
-        channel=channel_USD, variant__product_id=product.pk
-    ).update(price_amount=None)
+
+    variant_channel_listing = variant.channel_listings.first()
+    variant_channel_listing.price_amount = None
+    variant_channel_listing.save()
 
     query = """
         query getProductVariants($id: ID!, $channel: String, $address: AddressInput) {
@@ -7411,8 +7459,12 @@ def test_product_variant_without_price_as_staff(
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     variants_data = content["data"]["product"]["variants"]
+
+    assert variants_data[0]["pricing"] is not None
+
     assert variants_data[1]["id"] == variant_id
     assert variants_data[1]["pricing"] is None
+
     assert len(variants_data) == 2
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1209,7 +1209,7 @@ def product_with_collections(
 
 
 @pytest.fixture
-def product_available_in_many_channels(product, channel_PLN):
+def product_available_in_many_channels(product, channel_PLN, channel_USD):
     ProductChannelListing.objects.create(
         product=product,
         channel=channel_PLN,
@@ -1585,7 +1585,7 @@ def variant_with_many_stocks_different_shipping_zones(
 
 
 @pytest.fixture
-def product_variant_list(product, channel_USD):
+def product_variant_list(product, channel_USD, channel_PLN):
     variants = list(
         ProductVariant.objects.bulk_create(
             [
@@ -1613,10 +1613,10 @@ def product_variant_list(product, channel_USD):
             ),
             ProductVariantChannelListing(
                 variant=variants[2],
-                channel=channel_USD,
+                channel=channel_PLN,
                 cost_price_amount=Decimal(1),
                 price_amount=Decimal(10),
-                currency=channel_USD.currency_code,
+                currency=channel_PLN.currency_code,
             ),
         ]
     )


### PR DESCRIPTION
I want to merge this change because...I want to fix variant resolver for staff with and without providing channel slug.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
