### PR TITLE
Add ShipFrom section to Avalara configuration view

### DIFF
--- a/saleor/plugins/avatax/__init__.py
+++ b/saleor/plugins/avatax/__init__.py
@@ -48,6 +48,11 @@ DEFAULT_TAX_DESCRIPTION = "Unmapped Other SKU - taxable default"
 class AvataxConfiguration:
     username_or_account: str
     password_or_license: str
+    from_street_address: str
+    from_city: str
+    from_country: str
+    from_postal_code: str
+    from_country_area: str = ""
     use_sandbox: bool = True
     company_name: str = "DEFAULT"
     autocommit: bool = False
@@ -320,15 +325,6 @@ def generate_request_data(
     config: AvataxConfiguration,
     currency: str,
 ):
-    company_address = Site.objects.get_current().settings.company_address
-    if company_address:
-        company_address = company_address.as_data()
-    else:
-        logging.warning(
-            "To correct calculate taxes by Avatax, company address should be provided "
-            "in dashboard.settings."
-        )
-        company_address = {}
 
     data = {
         "companyCode": config.company_name,
@@ -340,12 +336,12 @@ def generate_request_data(
         "customerCode": 0,
         "addresses": {
             "shipFrom": {
-                "line1": company_address.get("street_address_1"),
-                "line2": company_address.get("street_address_2"),
-                "city": company_address.get("city"),
-                "region": company_address.get("country_area"),
-                "country": company_address.get("country"),
-                "postalCode": company_address.get("postal_code"),
+                "line1": config.from_street_address,
+                "line2": None,
+                "city": config.from_city,
+                "region": config.from_country_area,
+                "country": config.from_country,
+                "postalCode": config.from_postal_code,
             },
             "shipTo": {
                 "line1": address.get("street_address_1"),

--- a/saleor/plugins/avatax/plugin.py
+++ b/saleor/plugins/avatax/plugin.py
@@ -7,6 +7,7 @@ from urllib.parse import urljoin
 import opentracing
 import opentracing.tags
 from django.core.exceptions import ValidationError
+from django_countries import countries
 from prices import Money, TaxedMoney, TaxedMoneyRange
 
 from ...checkout import base_calculations
@@ -61,6 +62,11 @@ class AvataxPlugin(BasePlugin):
         {"name": "Use sandbox", "value": True},
         {"name": "Company name", "value": "DEFAULT"},
         {"name": "Autocommit", "value": False},
+        {"name": "from_street_address", "value": None},
+        {"name": "from_city", "value": None},
+        {"name": "from_country", "value": None},
+        {"name": "from_country_area", "value": None},
+        {"name": "from_postal_code", "value": None},
     ]
     CONFIG_STRUCTURE = {
         "Username or account": {
@@ -92,18 +98,53 @@ class AvataxPlugin(BasePlugin):
             "should be committed by default.",
             "label": "Autocommit",
         },
+        "from_street_address": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "To calculate taxes we need to provide `ship from` details.",
+            "label": "Ship from - street",
+        },
+        "from_city": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "To calculate taxes we need to provide `ship from` details.",
+            "label": "Ship from - city",
+        },
+        "from_country": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "To calculate taxes we need to provide `ship from` details. "
+            "Country code in ISO format. ",
+            "label": "Ship from - country",
+        },
+        "from_country_area": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "To calculate taxes we need to provide `ship from` details.",
+            "label": "Ship from - country area",
+        },
+        "from_postal_code": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "To calculate taxes we need to provide `ship from` details.",
+            "label": "Ship from - postal code",
+        },
     }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # Convert to dict to easier take config elements
         configuration = {item["name"]: item["value"] for item in self.configuration}
+
+        if from_country := configuration["from_country"]:
+            from_country = countries.alpha2(from_country.strip())
+
         self.config = AvataxConfiguration(
             username_or_account=configuration["Username or account"],
             password_or_license=configuration["Password or license"],
             use_sandbox=configuration["Use sandbox"],
             company_name=configuration["Company name"],
             autocommit=configuration["Autocommit"],
+            from_street_address=configuration["from_street_address"],
+            from_city=configuration["from_city"],
+            from_country=from_country,
+            from_country_area=configuration["from_country_area"],
+            from_postal_code=configuration["from_postal_code"],
         )
 
     def _skip_plugin(
@@ -624,6 +665,19 @@ class AvataxPlugin(BasePlugin):
             missing_fields.append("Username or account")
         if not configuration["Password or license"]:
             missing_fields.append("Password or license")
+
+        required_from_address_fields = [
+            "from_street_address",
+            "from_city",
+            "from_country",
+            "from_postal_code",
+        ]
+
+        all_address_fields = all(
+            [configuration[field] for field in required_from_address_fields]
+        )
+        if not all_address_fields:
+            missing_fields.extend(required_from_address_fields)
 
         if plugin_configuration.active:
             if missing_fields:

--- a/saleor/plugins/avatax/tests/conftest.py
+++ b/saleor/plugins/avatax/tests/conftest.py
@@ -17,11 +17,20 @@ def vcr_config():
 @pytest.fixture
 def plugin_configuration(db, channel_USD):
     def set_configuration(
-        username="test", password="test", sandbox=False, channel=None
+        username="test",
+        password="test",
+        sandbox=False,
+        channel=None,
+        active=True,
+        from_street_address="Teczowa 7",
+        from_city="Wroclaw",
+        from_country="PL",
+        from_country_area="",
+        from_postal_code="53-601",
     ):
         channel = channel or channel_USD
         data = {
-            "active": True,
+            "active": active,
             "name": AvataxPlugin.PLUGIN_NAME,
             "channel": channel,
             "configuration": [
@@ -30,6 +39,11 @@ def plugin_configuration(db, channel_USD):
                 {"name": "Use sandbox", "value": sandbox},
                 {"name": "Company name", "value": "DEFAULT"},
                 {"name": "Autocommit", "value": False},
+                {"name": "from_street_address", "value": from_street_address},
+                {"name": "from_city", "value": from_city},
+                {"name": "from_country", "value": from_country},
+                {"name": "from_country_area", "value": from_country_area},
+                {"name": "from_postal_code", "value": from_postal_code},
             ],
         }
         configuration = PluginConfiguration.objects.create(

--- a/saleor/plugins/avatax/tests/test_avatax.py
+++ b/saleor/plugins/avatax/tests/test_avatax.py
@@ -577,7 +577,14 @@ def test_preprocess_order_creation_wrong_data(
 def test_get_cached_tax_codes_or_fetch(monkeypatch):
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", lambda x, y: {})
     config = AvataxConfiguration(
-        username_or_account="test", password_or_license="test", use_sandbox=False
+        username_or_account="test",
+        password_or_license="test",
+        use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     tax_codes = get_cached_tax_codes_or_fetch(config)
     assert len(tax_codes) > 0
@@ -587,7 +594,13 @@ def test_get_cached_tax_codes_or_fetch(monkeypatch):
 def test_get_cached_tax_codes_or_fetch_wrong_response(monkeypatch):
     monkeypatch.setattr("saleor.plugins.avatax.cache.get", lambda x, y: {})
     config = AvataxConfiguration(
-        username_or_account="wrong_data", password_or_license="wrong_data"
+        username_or_account="wrong_data",
+        password_or_license="wrong_data",
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     tax_codes = get_cached_tax_codes_or_fetch(config)
     assert len(tax_codes) == 0
@@ -600,7 +613,13 @@ def test_checkout_needs_new_fetch(
     checkout_with_item.shipping_address = address
     checkout_with_item.shipping_method = shipping_method
     config = AvataxConfiguration(
-        username_or_account="wrong_data", password_or_license="wrong_data"
+        username_or_account="wrong_data",
+        password_or_license="wrong_data",
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
@@ -615,7 +634,13 @@ def test_taxes_need_new_fetch_uses_cached_data(
 
     checkout_with_item.shipping_address = address
     config = AvataxConfiguration(
-        username_or_account="wrong_data", password_or_license="wrong_data"
+        username_or_account="wrong_data",
+        password_or_license="wrong_data",
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_item)
@@ -1234,8 +1259,11 @@ def test_get_plugin_configuration(settings, channel_USD):
 
 
 @patch("saleor.plugins.avatax.plugin.api_get_request")
-def test_save_plugin_configuration(api_get_request_mock, settings, channel_USD):
+def test_save_plugin_configuration(
+    api_get_request_mock, settings, channel_USD, plugin_configuration
+):
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration()
     api_get_request_mock.return_value = {"authenticated": True}
     manager = get_plugins_manager()
     manager.save_plugin_configuration(
@@ -1260,10 +1288,11 @@ def test_save_plugin_configuration(api_get_request_mock, settings, channel_USD):
 
 @patch("saleor.plugins.avatax.plugin.api_get_request")
 def test_save_plugin_configuration_authentication_failed(
-    api_get_request_mock, settings, channel_USD
+    api_get_request_mock, settings, channel_USD, plugin_configuration
 ):
     # given
     settings.PLUGINS = ["saleor.plugins.avatax.plugin.AvataxPlugin"]
+    plugin_configuration(active=False)
     api_get_request_mock.return_value = {"authenticated": False}
     manager = get_plugins_manager()
 
@@ -1311,7 +1340,12 @@ def test_show_taxes_on_storefront(plugin_configuration):
 @override_settings(PLUGINS=["saleor.plugins.avatax.plugin.AvataxPlugin"])
 def test_order_created(api_post_request_task_mock, order, plugin_configuration):
     # given
-    plugin_conf = plugin_configuration()
+    plugin_conf = plugin_configuration(
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-601",
+        from_country="PL",
+    )
     conf = {data["name"]: data["value"] for data in plugin_conf.configuration}
 
     manager = get_plugins_manager()
@@ -1331,19 +1365,19 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
             "customerCode": 0,
             "addresses": {
                 "shipFrom": {
-                    "line1": None,
+                    "line1": "Tęczowa 7",
                     "line2": None,
-                    "city": None,
-                    "region": None,
-                    "country": None,
-                    "postalCode": None,
+                    "city": "WROCŁAW",
+                    "region": "",
+                    "country": "PL",
+                    "postalCode": "53-601",
                 },
                 "shipTo": {
                     "line1": address.street_address_1,
                     "line2": address.street_address_2,
                     "city": address.city,
                     "region": address.city_area or "",
-                    "country": address.country,
+                    "country": address.country.code,
                     "postalCode": address.postal_code,
                 },
             },
@@ -1359,6 +1393,11 @@ def test_order_created(api_post_request_task_mock, order, plugin_configuration):
         "use_sandbox": conf["Use sandbox"],
         "company_name": conf["Company name"],
         "autocommit": conf["Autocommit"],
+        "from_street_address": conf["from_street_address"],
+        "from_city": conf["from_city"],
+        "from_postal_code": conf["from_postal_code"],
+        "from_country": conf["from_country"],
+        "from_country_area": conf["from_country_area"],
     }
 
     api_post_request_task_mock.assert_called_once_with(
@@ -1450,6 +1489,11 @@ def test_api_get_request_handles_request_errors(product, monkeypatch):
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     url = "https://www.avatax.api.com/some-get-path"
 
@@ -1469,6 +1513,11 @@ def test_api_get_request_handles_json_errors(product, monkeypatch):
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     url = "https://www.avatax.api.com/some-get-path"
 
@@ -1488,6 +1537,11 @@ def test_api_post_request_handles_request_errors(product, monkeypatch):
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     url = "https://www.avatax.api.com/some-get-path"
 
@@ -1505,6 +1559,11 @@ def test_api_post_request_handles_json_errors(product, monkeypatch):
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     url = "https://www.avatax.api.com/some-get-path"
 
@@ -1534,6 +1593,11 @@ def test_get_order_request_data_checks_when_taxes_are_included_to_price(
         username_or_account="",
         password_or_license="",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     request_data = get_order_request_data(order_with_lines, config)
     lines_data = request_data["createTransactionModel"]["lines"]
@@ -1562,6 +1626,11 @@ def test_get_order_request_data_checks_when_taxes_are_not_included_to_price(
         username_or_account="",
         password_or_license="",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_country_area="",
+        from_postal_code="53-601",
+        from_country="PL",
     )
 
     request_data = get_order_request_data(order_with_lines, config)

--- a/saleor/plugins/avatax/tests/test_tasks.py
+++ b/saleor/plugins/avatax/tests/test_tasks.py
@@ -26,6 +26,10 @@ def test_api_post_request_task_sends_request(
         username_or_account="",
         password_or_license="",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     request_data = get_order_request_data(order_with_lines, config)
 
@@ -54,6 +58,10 @@ def test_api_post_request_task_creates_order_event(
         username_or_account="",
         password_or_license="",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     request_data = get_order_request_data(order_with_lines, config)
 
@@ -83,6 +91,10 @@ def test_api_post_request_task_missing_response(
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     request_data = get_order_request_data(order_with_lines, config)
 
@@ -113,6 +125,10 @@ def test_api_post_request_task_order_doesnt_have_any_lines_with_taxes_to_calcula
         username_or_account="test",
         password_or_license="test",
         use_sandbox=False,
+        from_street_address="Tęczowa 7",
+        from_city="WROCŁAW",
+        from_postal_code="53-601",
+        from_country="PL",
     )
     request_data = {}
 

--- a/saleor/plugins/migrations/0008_pluginconfiguration_channel.py
+++ b/saleor/plugins/migrations/0008_pluginconfiguration_channel.py
@@ -9,6 +9,44 @@ PLUGINS_ID_TO_SKIP = [
 ]
 
 
+def move_company_address_to_avatax_configuration(apps, schema):
+    avatax_configuration = (
+        apps.get_model("plugins", "PluginConfiguration")
+        .objects.filter(identifier="mirumee.taxes.avalara")
+        .first()
+    )
+    if avatax_configuration and avatax_configuration.configuration:
+        site_settings = apps.get_model("site", "SiteSettings").objects.first()
+        configuration = avatax_configuration.configuration
+
+        if company_address := site_settings.company_address:
+            configuration.extend(
+                [
+                    {
+                        "name": "from_street_address",
+                        "value": company_address.street_address_1,
+                    },
+                    {
+                        "name": "from_city",
+                        "value": company_address.city,
+                    },
+                    {
+                        "name": "from_country",
+                        "value": company_address.country.code,
+                    },
+                    {
+                        "name": "from_country_area",
+                        "value": company_address.country_area,
+                    },
+                    {
+                        "name": "from_postal_code",
+                        "value": company_address.postal_code,
+                    },
+                ]
+            )
+            avatax_configuration.save()
+
+
 def populate_plugin_configurations_for_channels(apps, schema):
     PluginConfiguration = apps.get_model("plugins", "PluginConfiguration")
     Channel = apps.get_model("channel", "Channel")
@@ -54,5 +92,6 @@ class Migration(migrations.Migration):
             name="pluginconfiguration",
             unique_together={("identifier", "channel")},
         ),
+        migrations.RunPython(move_company_address_to_avatax_configuration),
         migrations.RunPython(populate_plugin_configurations_for_channels),
     ]


### PR DESCRIPTION
I want to merge this change because it adds new fields to Avalara configuration. It stores the ShipFrom details, required to calculated taxes by Avatax

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
