### PR TITLE
Allow passing metadata to `accountRegister` mutation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend Vatlayer functionalities - #7101 by @korycins:
     - Allow users to enter a list of exceptions (country ISO codes) that will use the source country rather than the destination country for tax purposes.
     - Allow users to enter a list of countries for which no VAT will be added.
+- Allow passing metadata to `accountUpdate` and `accountRegister` mutations - #7152 by @piotrgrundas
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Extend Vatlayer functionalities - #7101 by @korycins:
     - Allow users to enter a list of exceptions (country ISO codes) that will use the source country rather than the destination country for tax purposes.
     - Allow users to enter a list of countries for which no VAT will be added.
-- Allow passing metadata to `accountUpdate` and `accountRegister` mutations - #7152 by @piotrgrundas
+- Allow passing metadata to `accountRegister` mutation - #7152 by @piotrgrundas
 - Fix incorrect payment data for klarna - #7150 by @IKarbowiak
 
 ### Breaking

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -40,7 +40,9 @@ class AccountRegisterInput(graphene.InputObjectType):
         LanguageCodeEnum, required=False, description="User language code."
     )
     metadata = graphene.List(
-        MetadataInput, description="User public metadata.", required=False
+        graphene.NonNull(MetadataInput),
+        description="User public metadata.",
+        required=False,
     )
 
 
@@ -70,7 +72,7 @@ class AccountRegister(ModelMutation):
     @classmethod
     def clean_input(cls, info, instance, data, input_cls=None):
         data["metadata"] = {
-            item["key"]: item["value"] for item in data.get("metadata", [])
+            item["key"]: item["value"] for item in data.get("metadata") or []
         }
         if not settings.ENABLE_ACCOUNT_CONFIRMATION_BY_EMAIL:
             return super().clean_input(info, instance, data, input_cls=None)
@@ -131,7 +133,9 @@ class AccountInput(graphene.InputObjectType):
         LanguageCodeEnum, required=False, description="User language code."
     )
     metadata = graphene.List(
-        MetadataInput, description="User public metadata.", required=False
+        graphene.NonNull(MetadataInput),
+        description="User public metadata.",
+        required=False,
     )
 
 
@@ -155,9 +159,9 @@ class AccountUpdate(BaseCustomerCreate):
 
     @classmethod
     def clean_input(cls, info, instance, data):
-        data["metadata"] = {
-            item["key"]: item["value"] for item in data.get("metadata", [])
-        }
+        metadata = data.pop("metadata", [])
+        if metadata is not None:
+            data["metadata"] = {item["key"]: item["value"] for item in metadata}
         return super().clean_input(info, instance, data)
 
     @classmethod

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -132,11 +132,6 @@ class AccountInput(graphene.InputObjectType):
     language_code = graphene.Argument(
         LanguageCodeEnum, required=False, description="User language code."
     )
-    metadata = graphene.List(
-        graphene.NonNull(MetadataInput),
-        description="User public metadata.",
-        required=False,
-    )
 
 
 class AccountUpdate(BaseCustomerCreate):
@@ -156,13 +151,6 @@ class AccountUpdate(BaseCustomerCreate):
     @classmethod
     def check_permissions(cls, context):
         return context.user.is_authenticated
-
-    @classmethod
-    def clean_input(cls, info, instance, data):
-        metadata = data.pop("metadata", [])
-        if metadata is not None:
-            data["metadata"] = {item["key"]: item["value"] for item in metadata}
-        return super().clean_input(info, instance, data)
 
     @classmethod
     def perform_mutation(cls, root, info, **data):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -1444,7 +1444,6 @@ ACCOUNT_UPDATE_QUERY = """
         $firstName: String,
         $lastName: String
         $languageCode: LanguageCodeEnum
-        $metadata: [MetadataInput!]
     ) {
         accountUpdate(
           input: {
@@ -1453,7 +1452,6 @@ ACCOUNT_UPDATE_QUERY = """
             firstName: $firstName,
             lastName: $lastName,
             languageCode: $languageCode
-            metadata: $metadata
         }) {
             errors {
                 field
@@ -1470,10 +1468,6 @@ ACCOUNT_UPDATE_QUERY = """
                     id
                 }
                 languageCode
-                metadata {
-                    key
-                    value
-                }
             }
         }
     }
@@ -1547,21 +1541,6 @@ def test_logged_customer_update_anonymous_user(api_client):
     query = ACCOUNT_UPDATE_QUERY
     response = api_client.post_graphql(query, {})
     assert_no_permission(response)
-
-
-def test_logged_customer_updates_metadata(user_api_client):
-    user = user_api_client.user
-    assert user.metadata == {}
-    variables = {"metadata": [{"key": "meta", "value": "data"}]}
-
-    response = user_api_client.post_graphql(ACCOUNT_UPDATE_QUERY, variables)
-    content = get_graphql_content(response)
-    data = content["data"]["accountUpdate"]
-
-    assert not data["errors"]
-    assert data["user"]["metadata"] == variables["metadata"]
-    user.refresh_from_db()
-    assert user.metadata == {"meta": "data"}
 
 
 ACCOUNT_REQUEST_DELETION_MUTATION = """

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -958,7 +958,7 @@ ACCOUNT_REGISTER_MUTATION = """
         $email: String!,
         $redirectUrl: String,
         $languageCode: LanguageCodeEnum
-        $metadata: [MetadataInput]
+        $metadata: [MetadataInput!]
     ) {
         accountRegister(
             input: {
@@ -1444,7 +1444,7 @@ ACCOUNT_UPDATE_QUERY = """
         $firstName: String,
         $lastName: String
         $languageCode: LanguageCodeEnum
-        $metadata: [MetadataInput]
+        $metadata: [MetadataInput!]
     ) {
         accountUpdate(
           input: {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -75,7 +75,6 @@ input AccountInput {
   defaultBillingAddress: AddressInput
   defaultShippingAddress: AddressInput
   languageCode: LanguageCodeEnum
-  metadata: [MetadataInput!]
 }
 
 type AccountRegister {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -75,6 +75,7 @@ input AccountInput {
   defaultBillingAddress: AddressInput
   defaultShippingAddress: AddressInput
   languageCode: LanguageCodeEnum
+  metadata: [MetadataInput]
 }
 
 type AccountRegister {
@@ -89,6 +90,7 @@ input AccountRegisterInput {
   password: String!
   redirectUrl: String
   languageCode: LanguageCodeEnum
+  metadata: [MetadataInput]
 }
 
 type AccountRequestDeletion {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -75,7 +75,7 @@ input AccountInput {
   defaultBillingAddress: AddressInput
   defaultShippingAddress: AddressInput
   languageCode: LanguageCodeEnum
-  metadata: [MetadataInput]
+  metadata: [MetadataInput!]
 }
 
 type AccountRegister {
@@ -90,7 +90,7 @@ input AccountRegisterInput {
   password: String!
   redirectUrl: String
   languageCode: LanguageCodeEnum
-  metadata: [MetadataInput]
+  metadata: [MetadataInput!]
 }
 
 type AccountRequestDeletion {


### PR DESCRIPTION
I want to merge this change because I want to support passing public metadata to:
- accountUpdate
- accountRegister

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
