### PR TITLE
Fix triggering recalculate_orders_task

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -124,7 +124,8 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
 
         # delete order lines for deleted variants
         order_models.OrderLine.objects.filter(pk__in=line_pks).delete()
-        recalculate_orders_task.delay(orders_id)
+        if orders_id:
+            recalculate_orders_task.delay(list(orders_id))
 
         return response
 
@@ -542,7 +543,8 @@ class ProductVariantBulkDelete(ModelBulkDeleteMutation):
 
         # delete order lines for deleted variants
         order_models.OrderLine.objects.filter(pk__in=line_pks).delete()
-        recalculate_orders_task.delay(orders_id)
+        if orders_id:
+            recalculate_orders_task.delay(list(orders_id))
 
         # set new product default variant if any has been removed
         products = models.Product.objects.filter(

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -737,7 +737,8 @@ class ProductDelete(ModelDeleteMutation):
         response = super().perform_mutation(_root, info, **data)
         # delete order lines for deleted variant
         order_models.OrderLine.objects.filter(pk__in=line_pks).delete()
-        recalculate_orders_task.delay(orders_id)
+        if orders_id:
+            recalculate_orders_task.delay(list(orders_id))
         info.context.plugins.product_deleted(instance, variants_id)
 
         return response
@@ -1052,7 +1053,8 @@ class ProductVariantDelete(ModelDeleteMutation):
 
         # delete order lines for deleted variant
         order_models.OrderLine.objects.filter(pk__in=line_pks).delete()
-        recalculate_orders_task.delay(orders_id)
+        if orders_id:
+            recalculate_orders_task.delay(list(orders_id))
 
         transaction.on_commit(
             lambda: info.context.plugins.product_variant_deleted(variant)

--- a/saleor/graphql/product/tests/test_bulk_delete.py
+++ b/saleor/graphql/product/tests/test_bulk_delete.py
@@ -327,7 +327,7 @@ def test_delete_products(
     assert not OrderLine.objects.filter(pk__in=draft_order_lines_pks).exists()
 
     assert OrderLine.objects.filter(pk__in=not_draft_order_lines_pks).exists()
-    mocked_recalculate_orders_task.assert_called_once_with({draft_order.id})
+    mocked_recalculate_orders_task.assert_called_once_with([draft_order.id])
 
 
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
@@ -358,7 +358,7 @@ def test_delete_products_trigger_webhook(
 
     assert content["data"]["productBulkDelete"]["count"] == 3
     assert mocked_webhook_trigger.called
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -387,7 +387,7 @@ def test_delete_products_variants_in_draft_order(
     assert content["data"]["productBulkDelete"]["count"] == 2
     assert not Product.objects.filter(id__in=products_id).exists()
     assert not ProductChannelListing.objects.filter(product_id__in=products_id).exists()
-    mocked_recalculate_orders_task.assert_called_once_with({draft_order.id})
+    mocked_recalculate_orders_task.assert_called_once_with([draft_order.id])
 
 
 def test_delete_product_media(
@@ -492,7 +492,7 @@ def test_delete_product_variants(
         product_variant_deleted_webhook_mock.call_count
         == content["data"]["productVariantBulkDelete"]["count"]
     )
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -588,7 +588,7 @@ def test_delete_product_variants_in_draft_orders(
         second_draft_order.refresh_from_db()
 
     assert OrderLine.objects.filter(pk=order_line_not_in_draft_pk).exists()
-    mocked_recalculate_orders_task.assert_called_once_with({draft_order.id})
+    mocked_recalculate_orders_task.assert_called_once_with([draft_order.id])
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -639,7 +639,7 @@ def test_delete_product_variants_delete_default_variant(
 
     product.refresh_from_db()
     assert product.default_variant.pk == new_default_variant.pk
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -689,7 +689,7 @@ def test_delete_product_variants_delete_all_product_variants(
 
     product.refresh_from_db()
     assert product.default_variant is None
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -741,4 +741,4 @@ def test_delete_product_variants_from_different_products(
 
     assert product_1.default_variant is None
     assert product_2.default_variant.pk == product_2_second_variant.pk
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -5249,7 +5249,7 @@ def test_delete_product(
     with pytest.raises(product._meta.model.DoesNotExist):
         product.refresh_from_db()
     assert node_id == data["product"]["id"]
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
@@ -5283,7 +5283,7 @@ def test_delete_product_trigger_webhook(
     mocked_webhook_trigger.assert_called_once_with(
         WebhookEventType.PRODUCT_DELETED, expected_data
     )
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -5354,7 +5354,7 @@ def test_delete_product_variant_in_draft_order(
     assert not OrderLine.objects.filter(pk__in=draft_order_lines_pks).exists()
 
     assert OrderLine.objects.filter(pk__in=not_draft_order_lines_pks).exists()
-    mocked_recalculate_orders_task.assert_called_once_with({draft_order.id})
+    mocked_recalculate_orders_task.assert_called_once_with([draft_order.id])
 
 
 def test_product_type(user_api_client, product_type, channel_USD):

--- a/saleor/graphql/product/tests/test_product_discounted_price.py
+++ b/saleor/graphql/product/tests/test_product_discounted_price.py
@@ -40,7 +40,7 @@ def test_product_variant_delete_updates_discounted_price(
     assert data["errors"] == []
 
     mock_update_product_discounted_price_task.delay.assert_called_once_with(product.pk)
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.product.utils.update_products_discounted_prices_task")

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -2025,7 +2025,7 @@ def test_delete_variant(
     assert data["productVariant"]["sku"] == variant.sku
     with pytest.raises(variant._meta.model.DoesNotExist):
         variant.refresh_from_db()
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -2092,7 +2092,7 @@ def test_delete_variant_in_draft_order(
 
     assert OrderLine.objects.filter(pk=order_line_not_in_draft_pk).exists()
     mocked_recalculate_orders_task.assert_called_once_with(
-        {draft_order.id, second_draft_order.id}
+        [draft_order.id, second_draft_order.id]
     )
 
 
@@ -2132,7 +2132,7 @@ def test_delete_default_variant(
 
     product.refresh_from_db()
     assert product.default_variant.pk == second_variant.pk
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -2171,7 +2171,7 @@ def test_delete_not_default_variant_left_default_variant_unchanged(
 
     product.refresh_from_db()
     assert product.default_variant.pk == default_variant.pk
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 @patch("saleor.order.tasks.recalculate_orders_task.delay")
@@ -2208,7 +2208,7 @@ def test_delete_default_all_product_variant_left_product_default_variant_unset(
 
     product.refresh_from_db()
     assert not product.default_variant
-    mocked_recalculate_orders_task.assert_called_once_with(set())
+    assert not mocked_recalculate_orders_task.called
 
 
 def _fetch_all_variants(client, variables={}, permissions=None):


### PR DESCRIPTION
I want to merge this change because...I want to fix triggering recalculate_orders_task if there are any orders to recalculate.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
