### PR TITLE
Benchmarks for totalCaptured, totalAuthorized, events and subtotal on Order Type

### DIFF
--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -1,5 +1,6 @@
 import random
 import uuid
+from decimal import Decimal
 
 import pytest
 from prices import Money, TaxedMoney
@@ -12,7 +13,6 @@ from .....payment.models import Payment
 
 ORDER_COUNT_IN_BENCHMARKS = 10
 EVENTS_PER_ORDER = 5
-PAYMENTS_PER_ORDER = 3
 
 
 def _prepare_payments_for_order(order):
@@ -21,9 +21,22 @@ def _prepare_payments_for_order(order):
             gateway="mirumee.payments.dummy",
             order=order,
             is_active=True,
-            charge_status=random.choice(ChargeStatus.CHOICES)[0],
-        )
-        for _ in range(PAYMENTS_PER_ORDER)
+            charge_status=ChargeStatus.NOT_CHARGED,
+        ),
+        Payment(
+            gateway="mirumee.payments.dummy",
+            order=order,
+            is_active=True,
+            charge_status=ChargeStatus.PARTIALLY_CHARGED,
+            captured_amount=Decimal("6.0"),
+        ),
+        Payment(
+            gateway="mirumee.payments.dummy",
+            order=order,
+            is_active=True,
+            charge_status=ChargeStatus.FULLY_CHARGED,
+            captured_amount=Decimal("10.0"),
+        ),
     ]
 
 

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -174,6 +174,21 @@ MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY = """
           events {
             id
           }
+          totalCaptured {
+            amount
+          }
+          totalAuthorized {
+            amount
+          }
+          actions
+          subtotal {
+            net {
+              amount
+            }
+          }
+          fulfillments {
+            id
+          }
         }
       }
     }


### PR DESCRIPTION
I want to merge this change because it adds benchmarks for unoptimized resolvers on Order type:
- totalCaptured
- totalAuthorized
- events
- subtotal
- fulfillments

Each of these produces unoptimized number of queries which will be fixed in subsequent PRs.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
