### PR TITLE
Fix core sorting on related fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - Allow users to enter a list of countries for which no VAT will be added.
 - Fix incorrect payment data for klarna - #7150 by @IKarbowiak
 - Drop deleted images from storage - #7129 by @IKarbowiak
+- Fix core sorting on related fields - #7195 by @tomaszszymanski129
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -32,7 +32,7 @@ def get_field_value(instance: DjangoModel, field_name: str):
     field_path = field_name.split("__")
     attr = instance
     for elem in field_path:
-        attr = getattr(attr, elem)
+        attr = getattr(attr, elem, None)
 
     if callable(attr):
         return "%s" % attr()

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -5097,14 +5097,14 @@ QUERY_ORDER_WITH_SORT = """
 @pytest.mark.parametrize(
     "order_sort, result_order",
     [
-        ({"field": "NUMBER", "direction": "ASC"}, [0, 1, 2]),
-        ({"field": "NUMBER", "direction": "DESC"}, [2, 1, 0]),
-        ({"field": "CREATION_DATE", "direction": "ASC"}, [1, 0, 2]),
-        ({"field": "CREATION_DATE", "direction": "DESC"}, [2, 0, 1]),
-        ({"field": "CUSTOMER", "direction": "ASC"}, [2, 0, 1]),
-        ({"field": "CUSTOMER", "direction": "DESC"}, [1, 0, 2]),
-        ({"field": "FULFILLMENT_STATUS", "direction": "ASC"}, [2, 1, 0]),
-        ({"field": "FULFILLMENT_STATUS", "direction": "DESC"}, [0, 1, 2]),
+        ({"field": "NUMBER", "direction": "ASC"}, [0, 1, 2, 3]),
+        ({"field": "NUMBER", "direction": "DESC"}, [3, 2, 1, 0]),
+        ({"field": "CREATION_DATE", "direction": "ASC"}, [1, 0, 2, 3]),
+        ({"field": "CREATION_DATE", "direction": "DESC"}, [3, 2, 0, 1]),
+        ({"field": "CUSTOMER", "direction": "ASC"}, [2, 0, 1, 3]),
+        ({"field": "CUSTOMER", "direction": "DESC"}, [3, 1, 0, 2]),
+        ({"field": "FULFILLMENT_STATUS", "direction": "ASC"}, [2, 1, 0, 3]),
+        ({"field": "FULFILLMENT_STATUS", "direction": "DESC"}, [3, 0, 1, 2]),
     ],
 )
 def test_query_orders_with_sort(
@@ -5148,6 +5148,15 @@ def test_query_orders_with_sort(
             billing_address=address3,
             status=OrderStatus.CANCELED,
             total=TaxedMoney(net=Money(20, "USD"), gross=Money(26, "USD")),
+            channel=channel_USD,
+        )
+    )
+    created_orders.append(
+        Order.objects.create(
+            token=str(uuid.uuid4()),
+            billing_address=None,
+            status=OrderStatus.UNCONFIRMED,
+            total=TaxedMoney(net=Money(60, "USD"), gross=Money(80, "USD")),
             channel=channel_USD,
         )
     )


### PR DESCRIPTION
I want to merge this change because it fixes core sorting issue when realted object doesn't exist BUT is included in sort.

For ex. in `OrderSortField` we have:
```
CUSTOMER = ["billing_address__last_name", "billing_address__first_name", "pk"]
```
billing_address is optional in case of draft order
then core attempt to sort in `_get_edges_for_connection` using `get_field_value`
that tries to `getattr(billing_address, "last_name")` and fails because orders `billing_address` was `None`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
