### PR TITLE
Allow to configure user emails plugins per channel

### DIFF
--- a/saleor/plugins/sendgrid/plugin.py
+++ b/saleor/plugins/sendgrid/plugin.py
@@ -94,7 +94,7 @@ class SendgridEmailPlugin(BasePlugin):
     PLUGIN_ID = "mirumee.notifications.sendgrid_email"
     PLUGIN_NAME = "Sendgrid"
     DEFAULT_ACTIVE = False
-    CONFIGURATION_PER_CHANNEL = False
+    CONFIGURATION_PER_CHANNEL = True
 
     DEFAULT_CONFIGURATION = [
         {"name": "sender_name", "value": ""},

--- a/saleor/plugins/sendgrid/tests/conftest.py
+++ b/saleor/plugins/sendgrid/tests/conftest.py
@@ -5,7 +5,7 @@ from ..plugin import SendgridEmailPlugin
 
 
 @pytest.fixture
-def sendgrid_email_plugin(settings):
+def sendgrid_email_plugin(settings, channel_USD):
     def fun(
         active=True,
         sender_name=None,
@@ -31,7 +31,7 @@ def sendgrid_email_plugin(settings):
         manager = get_plugins_manager()
         manager.save_plugin_configuration(
             SendgridEmailPlugin.PLUGIN_ID,
-            None,
+            channel_USD.slug,
             {
                 "active": active,
                 "configuration": [
@@ -98,6 +98,6 @@ def sendgrid_email_plugin(settings):
             },
         )
         manager = get_plugins_manager()
-        return manager.all_plugins[0]
+        return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -108,7 +108,7 @@ def get_user_event_map():
 class UserEmailPlugin(BasePlugin):
     PLUGIN_ID = constants.PLUGIN_ID
     PLUGIN_NAME = "User emails"
-    CONFIGURATION_PER_CHANNEL = False
+    CONFIGURATION_PER_CHANNEL = True
 
     DEFAULT_CONFIGURATION = [
         {

--- a/saleor/plugins/user_email/tests/conftest.py
+++ b/saleor/plugins/user_email/tests/conftest.py
@@ -64,7 +64,7 @@ def user_email_dict_config():
 
 
 @pytest.fixture
-def user_email_plugin(settings):
+def user_email_plugin(settings, channel_USD):
     def fun(
         host="localhost",
         port="1025",
@@ -112,7 +112,7 @@ def user_email_plugin(settings):
         ):
             manager.save_plugin_configuration(
                 UserEmailPlugin.PLUGIN_ID,
-                None,
+                channel_USD.slug,
                 {
                     "active": active,
                     "configuration": [
@@ -240,6 +240,6 @@ def user_email_plugin(settings):
                 },
             )
         manager = get_plugins_manager()
-        return manager.global_plugins[0]
+        return manager.plugins_per_channel[channel_USD.slug][0]
 
     return fun


### PR DESCRIPTION
I want to merge this change because it adds configruation per channel to UserEmailPlugin and SengridEmailPlugin

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
