### PR TITLE
Fix failing checkout when shipping method is invalid

### DIFF
--- a/saleor/graphql/checkout/dataloaders.py
+++ b/saleor/graphql/checkout/dataloaders.py
@@ -192,6 +192,7 @@ class CheckoutInfoByCheckoutTokenLoader(DataLoader):
                     shipping_method_channel_listing_map = {
                         (listing.shipping_method_id, listing.channel_id): listing
                         for listing in channel_listings
+                        if listing
                     }
 
                     checkout_info_map = {}

--- a/saleor/graphql/shipping/dataloaders.py
+++ b/saleor/graphql/shipping/dataloaders.py
@@ -39,7 +39,7 @@ class ShippingMethodsByShippingZoneIdLoader(DataLoader):
                 shipping_method.shipping_zone_id
             ].append(shipping_method)
         return [
-            shipping_methods_by_shipping_zone_map[shipping_zone_id]
+            shipping_methods_by_shipping_zone_map.get(shipping_zone_id, [])
             for shipping_zone_id in keys
         ]
 
@@ -56,7 +56,8 @@ class PostalCodeRulesByShippingMethodIdLoader(DataLoader):
         for postal_code in postal_code_rules:
             postal_code_rules_map[postal_code.shipping_method_id].append(postal_code)
         return [
-            postal_code_rules_map[shipping_method_id] for shipping_method_id in keys
+            postal_code_rules_map.get(shipping_method_id, [])
+            for shipping_method_id in keys
         ]
 
 
@@ -74,7 +75,10 @@ class ShippingMethodsByShippingZoneIdAndChannelSlugLoader(DataLoader):
             shipping_methods_by_shipping_zone_and_channel_map[key].append(
                 shipping_method
             )
-        return [shipping_methods_by_shipping_zone_and_channel_map[key] for key in keys]
+        return [
+            shipping_methods_by_shipping_zone_and_channel_map.get(key, [])
+            for key in keys
+        ]
 
 
 class ShippingMethodChannelListingByShippingMethodIdLoader(DataLoader):
@@ -90,7 +94,9 @@ class ShippingMethodChannelListingByShippingMethodIdLoader(DataLoader):
                 shipping_method_channel_listing.shipping_method_id
             ].append(shipping_method_channel_listing)
         return [
-            shipping_method_channel_listings_by_shipping_method_map[shipping_method_id]
+            shipping_method_channel_listings_by_shipping_method_map.get(
+                shipping_method_id, []
+            )
             for shipping_method_id in keys
         ]
 
@@ -114,7 +120,7 @@ class ShippingMethodChannelListingByShippingMethodIdAndChannelSlugLoader(DataLoa
                 key
             ] = shipping_method_channel_listing
         return [
-            shipping_method_channel_listings_by_shipping_method_and_channel_map[key]
+            shipping_method_channel_listings_by_shipping_method_and_channel_map.get(key)
             for key in keys
         ]
 
@@ -137,7 +143,7 @@ class ChannelsByShippingZoneIdLoader(DataLoader):
             return [
                 [
                     channel_map[channel_id]
-                    for channel_id in shipping_zone_channel_map[zone_id]
+                    for channel_id in shipping_zone_channel_map.get(zone_id, [])
                 ]
                 for zone_id in keys
             ]

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -9,6 +9,9 @@ from ....core.permissions import ShippingPermissions
 from ....product import models as product_models
 from ....shipping import models
 from ....shipping.error_codes import ShippingErrorCode
+from ....shipping.tasks import (
+    drop_invalid_shipping_methods_relations_for_given_channels,
+)
 from ....shipping.utils import (
     default_shipping_zone_exists,
     get_countries_without_shipping_zone,
@@ -176,9 +179,19 @@ class ShippingZoneMixin:
         remove_channels = cleaned_data.get("remove_channels")
         if remove_channels:
             instance.channels.remove(*remove_channels)
-            models.ShippingMethodChannelListing.objects.filter(
-                shipping_method__shipping_zone=instance, channel__in=remove_channels
-            ).delete()
+            shipping_channel_listings = (
+                models.ShippingMethodChannelListing.objects.filter(
+                    shipping_method__shipping_zone=instance, channel__in=remove_channels
+                )
+            )
+            shipping_method_ids = list(
+                shipping_channel_listings.values_list("shipping_method_id", flat=True)
+            )
+            shipping_channel_listings.delete()
+            channel_ids = [channel.id for channel in remove_channels]
+            drop_invalid_shipping_methods_relations_for_given_channels.delay(
+                shipping_method_ids, channel_ids
+            )
 
 
 class ShippingZoneCreate(ShippingZoneMixin, ModelMutation):

--- a/saleor/graphql/shipping/tests/test_shipping_method.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import graphene
 import pytest
 
@@ -454,7 +456,12 @@ def test_update_shipping_zone_add_channels(
     assert {channel["id"] for channel in data["channels"]} == set(channel_ids)
 
 
+@patch(
+    "saleor.graphql.shipping.mutations.shippings."
+    "drop_invalid_shipping_methods_relations_for_given_channels.delay"
+)
 def test_update_shipping_zone_remove_channels(
+    mocked_drop_invalid_shipping_methods_relations,
     staff_api_client,
     shipping_zone,
     channel_USD,
@@ -465,8 +472,12 @@ def test_update_shipping_zone_remove_channels(
     shipping_id = graphene.Node.to_global_id("ShippingZone", shipping_zone.pk)
     channel_id = graphene.Node.to_global_id("Channel", channel_USD.pk)
 
-    assert ShippingMethodChannelListing.objects.filter(
+    shipping_listing = ShippingMethodChannelListing.objects.filter(
         shipping_method__shipping_zone=shipping_zone, channel=channel_USD
+    )
+    assert shipping_listing
+    shipping_method_ids = list(
+        shipping_listing.values_list("shipping_method_id", flat=True)
     )
 
     variables = {
@@ -487,6 +498,9 @@ def test_update_shipping_zone_remove_channels(
     )
     assert not ShippingMethodChannelListing.objects.filter(
         shipping_method__shipping_zone=shipping_zone, channel=channel_USD
+    )
+    mocked_drop_invalid_shipping_methods_relations.assert_called_once_with(
+        shipping_method_ids, [channel_USD.pk]
     )
 
 

--- a/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
+++ b/saleor/graphql/shipping/tests/test_shipping_method_channel_listing_update.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 import graphene
+import pytest
 
 from ....shipping.error_codes import ShippingErrorCode
 from ....shipping.models import ShippingMethodChannelListing
@@ -555,3 +558,55 @@ def test_shipping_method_channel_listing_create_channel_not_valid(
     assert data["shippingErrors"][0]["field"] == "addChannels"
     assert data["shippingErrors"][0]["code"] == ShippingErrorCode.INVALID.name
     assert data["shippingErrors"][0]["channels"] == [channel_id]
+
+
+@patch(
+    "saleor.graphql.shipping.mutations.channels."
+    "drop_invalid_shipping_methods_relations_for_given_channels.delay"
+)
+def test_shipping_method_channel_listing_update_remove_channels(
+    mocked_drop_invalid_shipping_methods_relations,
+    staff_api_client,
+    shipping_method,
+    permission_manage_shipping,
+    channel_USD,
+):
+    # given
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.pk
+    )
+    assert shipping_method.channel_listings.count() == 1
+    channel_listing = shipping_method.channel_listings.first()
+    channel = channel_listing.channel
+    channel_id = graphene.Node.to_global_id("Channel", channel.id)
+
+    variables = {
+        "id": shipping_method_id,
+        "input": {"removeChannels": [channel_id]},
+    }
+
+    assert channel_listing.price.amount == 10
+    assert channel_listing.minimum_order_price.amount == 0
+    assert channel_listing.maximum_order_price is None
+
+    # when
+    response = staff_api_client.post_graphql(
+        SHIPPING_METHOD_CHANNEL_LISTING_UPDATE_MUTATION,
+        variables=variables,
+        permissions=(permission_manage_shipping,),
+    )
+    content = get_graphql_content(response)
+
+    data = content["data"]["shippingMethodChannelListingUpdate"]
+    shipping_method_data = data["shippingMethod"]
+    assert not data["shippingErrors"]
+    assert shipping_method_data["name"] == shipping_method.name
+
+    # then
+    assert not shipping_method_data["channelListings"]
+    with pytest.raises(channel_listing._meta.model.DoesNotExist):
+        channel_listing.refresh_from_db()
+
+    mocked_drop_invalid_shipping_methods_relations.assert_called_once_with(
+        [shipping_method.pk], [str(channel.pk)]
+    )

--- a/saleor/shipping/tasks.py
+++ b/saleor/shipping/tasks.py
@@ -1,0 +1,23 @@
+from typing import Iterable, Union
+
+from ..celeryconf import app
+from ..checkout.models import Checkout
+from ..graphql.order.mutations.orders import ORDER_EDITABLE_STATUS
+from ..order.models import Order
+
+
+@app.task
+def drop_invalid_shipping_methods_relations_for_given_channels(
+    shipping_method_ids: Iterable[Union[str, int]],
+    channel_ids: Iterable[Union[str, int]],
+):
+    # unlink shipping methods from order and checkout instances
+    # when method is no longer available in given channels
+    Checkout.objects.filter(
+        shipping_method_id__in=shipping_method_ids, channel_id__in=channel_ids
+    ).update(shipping_method=None)
+    Order.objects.filter(
+        status__in=ORDER_EDITABLE_STATUS,
+        shipping_method_id__in=shipping_method_ids,
+        channel_id__in=channel_ids,
+    ).update(shipping_method=None)

--- a/saleor/shipping/tests/test_tasks.py
+++ b/saleor/shipping/tests/test_tasks.py
@@ -1,0 +1,87 @@
+from ...checkout.models import Checkout
+from ...order import OrderStatus
+from ...order.models import Order
+from ..tasks import drop_invalid_shipping_methods_relations_for_given_channels
+
+
+def test_drop_invalid_shipping_method_relations(
+    checkouts_list,
+    order_list,
+    shipping_method,
+    other_shipping_method,
+    shipping_method_weight_based,
+    channel_USD,
+    channel_PLN,
+):
+    # given
+    # given
+    checkout_PLN = checkouts_list[0]
+    checkout_PLN.shipping_method = shipping_method
+    checkout_PLN.channel = channel_PLN
+
+    checkout_USD = checkouts_list[1]
+    checkout_USD.shipping_method = shipping_method
+    checkout_USD.channel = channel_USD
+
+    checkout_weight_shipping_method = checkouts_list[2]
+    checkout_weight_shipping_method.shipping_method = shipping_method_weight_based
+    checkout_weight_shipping_method.channel = channel_USD
+
+    checkout_another_shipping_method = checkouts_list[3]
+    checkout_another_shipping_method.shipping_method = other_shipping_method
+    checkout_another_shipping_method.channel = channel_USD
+
+    Checkout.objects.bulk_update(
+        [
+            checkout_PLN,
+            checkout_USD,
+            checkout_weight_shipping_method,
+            checkout_another_shipping_method,
+        ],
+        ["shipping_method", "channel"],
+    )
+
+    order_confirmed = order_list[0]
+    order_confirmed.status = OrderStatus.UNFULFILLED
+    order_confirmed.shipping_method = shipping_method
+    order_confirmed.channel = channel_USD
+
+    order_draft = order_list[1]
+    order_draft.status = OrderStatus.DRAFT
+    order_draft.shipping_method = shipping_method
+    order_draft.channel = channel_USD
+
+    order_draft_PLN = order_list[2]
+    order_draft_PLN.status = OrderStatus.DRAFT
+    order_draft_PLN.shipping_method = shipping_method
+    order_draft_PLN.channel = channel_PLN
+
+    Order.objects.bulk_update(
+        [order_confirmed, order_draft, order_draft_PLN],
+        ["status", "shipping_method", "channel"],
+    )
+
+    # when
+    drop_invalid_shipping_methods_relations_for_given_channels(
+        [shipping_method.id, other_shipping_method.id], [channel_USD.id]
+    )
+
+    # then
+    checkout_PLN.refresh_from_db()
+    checkout_USD.refresh_from_db()
+    checkout_another_shipping_method.refresh_from_db()
+
+    assert checkout_PLN.shipping_method == shipping_method
+    assert checkout_USD.shipping_method is None
+    assert (
+        checkout_weight_shipping_method.shipping_method == shipping_method_weight_based
+    )
+    assert checkout_another_shipping_method.shipping_method is None
+
+    order_confirmed.refresh_from_db()
+    order_draft.refresh_from_db()
+    order_draft_PLN.refresh_from_db()
+
+    assert order_confirmed.shipping_method == shipping_method
+    assert order_draft.shipping_method is None
+    assert order_draft_PLN.shipping_method == shipping_method


### PR DESCRIPTION
Apply changes from #7164 to master.

- Set `shippingMethod` field as `None` on checkouts and orders when corresponding `ShippingMethodChannelListing` is removed. Call task in following mutations:
   - ShippingZoneUpdate
   - ChannelUpdate
   - ShippingMethodChannelListingUpdate

- Update `OrderUpdateShipping` - alow updating only editable orders

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
