### PR TITLE
Feature/rebuild sort and filter for plugins per channel

### DIFF
--- a/saleor/graphql/plugins/filters.py
+++ b/saleor/graphql/plugins/filters.py
@@ -1,16 +1,25 @@
-from typing import TYPE_CHECKING, List, Optional
+from typing import List, Optional
 
 import graphene
 
-if TYPE_CHECKING:
-    # flake8: noqa
-    from ...plugins.base_plugin import BasePlugin
+from .types import Plugin
 
 
-def filter_plugin_search(
-    plugins: List["BasePlugin"], value: Optional[str]
-) -> List["BasePlugin"]:
-    plugin_fields = ["PLUGIN_NAME", "PLUGIN_DESCRIPTION"]
+def filter_plugin_is_active(plugins: List[Plugin], is_active) -> List[Plugin]:
+    filtered_plugins = []
+    for plugin in plugins:
+        if plugin.global_configuration:
+            if plugin.global_configuration.active is is_active:
+                filtered_plugins.append(plugin)
+        elif any(
+            [config.active is is_active for config in plugin.channel_configurations]
+        ):
+            filtered_plugins.append(plugin)
+    return filtered_plugins
+
+
+def filter_plugin_search(plugins: List[Plugin], value: Optional[str]) -> List[Plugin]:
+    plugin_fields = ["name", "description"]
     if value is not None:
         return [
             plugin

--- a/saleor/graphql/plugins/tests/queries/test_plugins.py
+++ b/saleor/graphql/plugins/tests/queries/test_plugins.py
@@ -59,7 +59,7 @@ def test_query_plugin_configurations(staff_api_client_can_manage_plugins, settin
     plugin = plugins[0]["node"]
     manager = get_plugins_manager()
     sample_plugin = manager.get_plugin(PluginSample.PLUGIN_ID)
-    confiugration_structure = PluginSample.CONFIG_STRUCTURE
+    configuration_structure = PluginSample.CONFIG_STRUCTURE
 
     assert plugin["id"] == sample_plugin.PLUGIN_ID
     assert plugin["name"] == sample_plugin.PLUGIN_NAME
@@ -71,7 +71,7 @@ def test_query_plugin_configurations(staff_api_client_can_manage_plugins, settin
         assert configuration_item["name"] == sample_plugin.configuration[index]["name"]
 
         if (
-            confiugration_structure[configuration_item["name"]]["type"]
+            configuration_structure[configuration_item["name"]]["type"]
             == ConfigurationTypeField.STRING
         ):
             assert (

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -228,7 +228,7 @@ class ChannelPluginSample(PluginSample):
 
 
 class PluginInactive(BasePlugin):
-    PLUGIN_ID = "plugin.inactive"
+    PLUGIN_ID = "mirumee.taxes.plugin.inactive"
     PLUGIN_NAME = "PluginInactive"
     PLUGIN_DESCRIPTION = "Test plugin description_2"
     CONFIGURATION_PER_CHANNEL = False
@@ -242,7 +242,7 @@ class PluginInactive(BasePlugin):
 
 
 class ActivePlugin(BasePlugin):
-    PLUGIN_ID = "plugin.active"
+    PLUGIN_ID = "mirumee.x.plugin.active"
     PLUGIN_NAME = "Active"
     PLUGIN_DESCRIPTION = "Not working"
     DEFAULT_ACTIVE = True
@@ -250,7 +250,7 @@ class ActivePlugin(BasePlugin):
 
 
 class ActivePaymentGateway(BasePlugin):
-    PLUGIN_ID = "gateway.active"
+    PLUGIN_ID = "mirumee.gateway.active"
     CLIENT_CONFIG = [
         {"field": "foo", "value": "bar"},
     ]


### PR DESCRIPTION
I want to merge this change because it adds proper way for filter and sort plugins after introducing plugins per channel

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
