### PR TITLE
customerName field in order type

### DIFF
--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -183,6 +183,7 @@ MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY = """
           billingAddress {
             id
           }
+          customerName
           user {
             id
           }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2926,6 +2926,7 @@ type Order implements Node & ObjectWithMetadata {
   actions: [OrderAction]!
   availableShippingMethods: [ShippingMethod]
   invoices: [Invoice]
+  customerName: String
   number: String
   isPaid: Boolean!
   paymentStatus: PaymentChargeStatusEnum!


### PR DESCRIPTION
I want to merge this change because it adds customerName field in order type
In dashboard, on order list we're overfetching the billing address, just to show the customer name in the list.

⚠️ Dashboard PR should be created to remove the unnecessary ask for billing address and use customerName field instead.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
