### PR TITLE
Fix flaky tests that defines pk for objects

### DIFF
--- a/saleor/discount/tests/test_discounts.py
+++ b/saleor/discount/tests/test_discounts.py
@@ -245,7 +245,6 @@ def test_sale_applies_to_correct_products(product_type, category, channel_USD):
         name="Test Product",
         slug="test-product",
         description={},
-        pk=111,
         product_type=product_type,
         category=category,
     )
@@ -263,7 +262,7 @@ def test_sale_applies_to_correct_products(product_type, category, channel_USD):
         product_type=product_type,
         category=category,
     )
-    sec_variant = ProductVariant.objects.create(product=product2, sku="secvar", pk=111)
+    sec_variant = ProductVariant.objects.create(product=product2, sku="secvar")
     ProductVariantChannelListing.objects.create(
         variant=sec_variant,
         channel=channel_USD,

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -234,7 +234,7 @@ def test_get_nodes(product_list):
     assert products == product_list
 
     # Raise an error if requested id has no related database object
-    nonexistent_item = Mock(type="Product", pk=123)
+    nonexistent_item = Mock(type="Product", pk=-1)
     nonexistent_item_global_id = to_global_id(
         nonexistent_item.type, nonexistent_item.pk
     )
@@ -249,7 +249,7 @@ def test_get_nodes(product_list):
     global_ids.pop()
 
     # Raise an error if one of the node is of wrong type
-    invalid_item = Mock(type="test", pk=123)
+    invalid_item = Mock(type="test", pk=-1)
     invalid_item_global_id = to_global_id(invalid_item.type, invalid_item.pk)
     global_ids.append(invalid_item_global_id)
     with pytest.raises(GraphQLError) as exc:

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1717,7 +1717,6 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
         Product.objects.bulk_create(
             [
                 Product(
-                    pk=1486,
                     name="Test product 1",
                     slug="test-product-a",
                     description_plaintext="big blue product",
@@ -1725,7 +1724,6 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
                     product_type=product_type,
                 ),
                 Product(
-                    pk=1487,
                     name="Test product 2",
                     slug="test-product-b",
                     description_plaintext="big orange product",
@@ -1733,7 +1731,6 @@ def product_list(product_type, category, warehouse, channel_USD, channel_PLN):
                     product_type=product_type,
                 ),
                 Product(
-                    pk=1489,
                     name="Test product 3",
                     slug="test-product-c",
                     description_plaintext="small red",
@@ -1836,21 +1833,18 @@ def product_list_with_variants_many_channel(
         Product.objects.bulk_create(
             [
                 Product(
-                    pk=1486,
                     name="Test product 1",
                     slug="test-product-a",
                     category=category,
                     product_type=product_type,
                 ),
                 Product(
-                    pk=1487,
                     name="Test product 2",
                     slug="test-product-b",
                     category=category,
                     product_type=product_type,
                 ),
                 Product(
-                    pk=1489,
                     name="Test product 3",
                     slug="test-product-c",
                     category=category,


### PR DESCRIPTION
Fix flaky tests.
- drop defining `pk` in tests

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
