### PR TITLE
Benchmarks for order line thumbnails

### DIFF
--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -7,12 +7,13 @@ from prices import Money, TaxedMoney
 
 from .....account.models import User
 from .....order import OrderEvents
-from .....order.models import Fulfillment, Order, OrderEvent
+from .....order.models import Fulfillment, Order, OrderEvent, OrderLine
 from .....payment import ChargeStatus
 from .....payment.models import Payment
 
 ORDER_COUNT_IN_BENCHMARKS = 10
 EVENTS_PER_ORDER = 5
+LINES_PER_ORDER = 3
 
 
 def _prepare_payments_for_order(order):
@@ -47,6 +48,23 @@ def _prepare_events_for_order(order):
     ]
 
 
+def _prepare_lines_for_order(order, variant_with_image):
+    price = TaxedMoney(
+        net=Money(amount=5, currency="USD"), gross=Money(amount=5, currency="USD")
+    )
+    return [
+        OrderLine(
+            order=order,
+            variant=variant_with_image,
+            quantity=5,
+            is_shipping_required=False,
+            unit_price=price,
+            total_price=price,
+        )
+        for _ in range(LINES_PER_ORDER)
+    ]
+
+
 @pytest.fixture
 def users_for_benchmarks(address):
     users = [
@@ -64,7 +82,9 @@ def users_for_benchmarks(address):
 
 
 @pytest.fixture
-def orders_for_benchmarks(channel_USD, address, payment_dummy, users_for_benchmarks):
+def orders_for_benchmarks(
+    channel_USD, address, payment_dummy, users_for_benchmarks, variant_with_image
+):
     orders = [
         Order(
             token=str(uuid.uuid4()),
@@ -81,16 +101,20 @@ def orders_for_benchmarks(channel_USD, address, payment_dummy, users_for_benchma
     payments = []
     events = []
     fulfillments = []
+    lines = []
 
     for order in created_orders:
         new_payments = _prepare_payments_for_order(order)
         new_events = _prepare_events_for_order(order)
-        fulfillments.append(Fulfillment(order=order, fulfillment_order=order.id))
+        new_lines = _prepare_lines_for_order(order, variant_with_image)
         payments.extend(new_payments)
         events.extend(new_events)
+        lines.extend(new_lines)
+        fulfillments.append(Fulfillment(order=order, fulfillment_order=order.id))
 
     Payment.objects.bulk_create(payments)
     OrderEvent.objects.bulk_create(events)
     Fulfillment.objects.bulk_create(fulfillments)
+    OrderLine.objects.bulk_create(lines)
 
     return created_orders

--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -57,7 +57,7 @@ def _prepare_lines_for_order(order, variant_with_image):
             order=order,
             variant=variant_with_image,
             quantity=5,
-            is_shipping_required=False,
+            is_shipping_required=True,
             unit_price=price,
             total_price=price,
         )
@@ -83,7 +83,12 @@ def users_for_benchmarks(address):
 
 @pytest.fixture
 def orders_for_benchmarks(
-    channel_USD, address, payment_dummy, users_for_benchmarks, variant_with_image
+    channel_USD,
+    address,
+    payment_dummy,
+    users_for_benchmarks,
+    variant_with_image,
+    shipping_method,
 ):
     orders = [
         Order(
@@ -91,6 +96,7 @@ def orders_for_benchmarks(
             channel=channel_USD,
             billing_address=address.get_copy(),
             shipping_address=address.get_copy(),
+            shipping_method=shipping_method,
             user=users_for_benchmarks[i],
             total=TaxedMoney(net=Money(i, "USD"), gross=Money(i, "USD")),
         )

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -171,7 +171,7 @@ def test_staff_order_details(
     get_graphql_content(staff_api_client.post_graphql(query, variables))
 
 
-MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY = """
+MULTIPLE_ORDER_DETAILS_QUERY = """
   query orders {
     orders(first: 10) {
       edges {
@@ -207,6 +207,12 @@ MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY = """
           fulfillments {
             id
           }
+          lines {
+            id
+            thumbnail {
+              url
+            }
+          }
         }
       }
     }
@@ -227,6 +233,6 @@ def test_staff_multiple_orders(
         [permission_manage_orders, permission_manage_users]
     )
     content = get_graphql_content(
-        staff_api_client.post_graphql(MULTIPLE_ORDER_ADDRESS_DETAILS_QUERY)
+        staff_api_client.post_graphql(MULTIPLE_ORDER_DETAILS_QUERY)
     )
     assert content["data"]["orders"] is not None


### PR DESCRIPTION
I want to merge this change because it implements benchmark tests for order line thumbnails resolving.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
