### PR TITLE
Make Saleor webhooks handle SQS FIFO queues

### DIFF
--- a/saleor/plugins/webhook/tests/test_webhook_protocols.py
+++ b/saleor/plugins/webhook/tests/test_webhook_protocols.py
@@ -12,7 +12,13 @@ from ...webhook import signature_for_payload
 from ...webhook.tasks import trigger_webhooks_for_event
 
 
+@pytest.mark.parametrize(
+    "queue_name, additional_call_args",
+    (("queue_name", {}), ("queue_name.fifo", {"MessageGroupId": "mirumee.com"})),
+)
 def test_trigger_webhooks_with_aws_sqs(
+    queue_name,
+    additional_call_args,
     webhook,
     order_with_lines,
     permission_manage_orders,
@@ -35,7 +41,7 @@ def test_trigger_webhooks_with_aws_sqs(
 
     webhook.target_url = (
         f"awssqs://{access_key}:{secret_key}@sqs.{region}.amazonaws.com/account_id/"
-        f"queue_name"
+        f"{queue_name}"
     )
     webhook.save()
 
@@ -49,14 +55,16 @@ def test_trigger_webhooks_with_aws_sqs(
         aws_access_key_id=access_key,
         aws_secret_access_key=secret_key,
     )
-    mocked_client.send_message.assert_called_once_with(
-        QueueUrl="https://sqs.us-east-1.amazonaws.com/account_id/queue_name",
-        MessageAttributes={
+    expected_call_args = {
+        "QueueUrl": f"https://sqs.us-east-1.amazonaws.com/account_id/{queue_name}",
+        "MessageAttributes": {
             "SaleorDomain": {"DataType": "String", "StringValue": "mirumee.com"},
             "EventType": {"DataType": "String", "StringValue": "order_created"},
         },
-        MessageBody=expected_data,
-    )
+        "MessageBody": expected_data,
+    }
+    expected_call_args.update(additional_call_args)
+    mocked_client.send_message.assert_called_once_with(**expected_call_args)
 
 
 def test_trigger_webhooks_with_aws_sqs_and_secret_key(


### PR DESCRIPTION
Currently, Saleor webhooks do not support SQS FIFO queues. It was agreed that the value of `MessageGroupId`, which is required by AWS API, will be equal to a domain of Saleor instance (@patrys). It is assumed that FIFO queue is configured to have ContentBasedDeduplication turned on.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
