### PR TITLE
Use GraphQL IDs instead of database IDs in export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix export with empty assignment values - #7207 by @IKarbowiak
 - Change exported file name - #7218 by @IKarbowiak
 - Performance upgrade on `OrderLine` type with `thumbnail` field - #7224 by @tomaszszymanski129
+- Use GraphQL IDs instead of database IDs in export - #7240 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/csv/tests/export/products_data/test_get_products_data.py
+++ b/saleor/csv/tests/export/products_data/test_get_products_data.py
@@ -1,5 +1,6 @@
 import json
 
+import graphene
 from measurement.measures import Weight
 
 from .....attribute.models import Attribute, AttributeValue
@@ -66,8 +67,9 @@ def test_get_products_data(product, product_with_image, collection, image, chann
     # then
     expected_data = []
     for product in products.order_by("pk"):
+        id = graphene.Node.to_global_id("Product", product.pk)
         product_data = {
-            "id": product.id,
+            "id": id,
             "name": product.name,
             "description_as_str": json.dumps(product.description),
             "category__slug": product.category.slug,
@@ -141,7 +143,8 @@ def test_get_products_data_for_specified_attributes(
     # then
     expected_data = []
     for product in products.order_by("pk"):
-        product_data = {"id": product.pk}
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data = {"id": id}
 
         product_data = add_product_attribute_data_to_expected_data(
             product_data, product, attribute_ids
@@ -180,7 +183,8 @@ def test_get_products_data_for_specified_warehouses(
     # then
     expected_data = []
     for product in products.order_by("pk"):
-        product_data = {"id": product.pk}
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data = {"id": id}
 
         for variant in product.variants.all():
             data = {"variants__sku": variant.sku}
@@ -214,7 +218,8 @@ def test_get_products_data_for_product_without_channel(
     # then
     expected_data = []
     for product in products.order_by("pk"):
-        product_data = {"id": product.pk}
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data = {"id": id}
 
         for variant in product.variants.all():
             data = {"variants__sku": variant.sku}
@@ -337,7 +342,8 @@ def test_get_products_data_for_specified_warehouses_channels_and_attributes(
     # then
     expected_data = []
     for product in products.order_by("pk"):
-        product_data = {"id": product.id}
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data = {"id": id}
 
         product_data = add_product_attribute_data_to_expected_data(
             product_data, product, attribute_ids

--- a/saleor/csv/tests/export/test_export.py
+++ b/saleor/csv/tests/export/test_export.py
@@ -496,7 +496,8 @@ def test_export_products_in_batches_for_csv(
     expected_data = []
     for product in qs.order_by("pk"):
         product_data = []
-        product_data.append(str(product.pk))
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data.append(id)
         product_data.append(product.name)
 
         for variant in product.variants.all():
@@ -564,7 +565,8 @@ def test_export_products_in_batches_for_xlsx(
     expected_data = []
     for product in qs.order_by("pk"):
         product_data = []
-        product_data.append(product.pk)
+        id = graphene.Node.to_global_id("Product", product.pk)
+        product_data.append(id)
         product_data.append(product.name)
         product_data.append(json.dumps(product.description))
 

--- a/saleor/csv/utils/products_data.py
+++ b/saleor/csv/utils/products_data.py
@@ -2,6 +2,7 @@ from collections import defaultdict, namedtuple
 from typing import TYPE_CHECKING, Dict, List, Optional, Set, Union
 from urllib.parse import urljoin
 
+import graphene
 from django.conf import settings
 from django.db.models import Case, CharField
 from django.db.models import Value as V
@@ -77,6 +78,7 @@ def get_products_data(
             variant_pk, {}
         )
 
+        product_data["id"] = graphene.Node.to_global_id("Product", pk)
         data = {**product_data, **product_relations_data, **variant_relations_data}
 
         products_with_variants_data.append(data)


### PR DESCRIPTION
Replace database IDs with GraphQL IDs in export.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
