### PR TITLE
Extend notify method to handle channel slug as an input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ All notable, unreleased changes to this project will be documented in this file.
     - `pluginUpdate` - add `channel` parameter.
     - `availablePaymentGateways` - add `channel` parameter.
     - `storedPaymentSources` - add `channel` parameter.
+    - `requestPasswordReset` - add `channel` parameter.
+    - `requestEmailChange` - add `channel` parameter.
+    - `confirmEmailChange` - add `channel` parameter.
+    - `accountRequestDeletion` - add `channel` parameter.
     - change structure of type `Plugin`:
       - add `globalConfiguration` field for storing configuration when a plugin is globally configured
       - add `channelConfigurations` field for storing plugin configuration for each channel

--- a/saleor/account/error_codes.py
+++ b/saleor/account/error_codes.py
@@ -32,6 +32,8 @@ class AccountErrorCode(Enum):
     JWT_DECODE_ERROR = "decode_error"
     JWT_MISSING_TOKEN = "missing_token"
     JWT_INVALID_CSRF_TOKEN = "invalid_csrf_token"
+    CHANNEL_INACTIVE = "channel_inactive"
+    MISSING_CHANNEL_SLUG = "missing_channel_slug"
 
 
 class PermissionGroupErrorCode(Enum):

--- a/saleor/account/notifications.py
+++ b/saleor/account/notifications.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from urllib.parse import urlencode
 
 from django.contrib.auth.tokens import default_token_generator
@@ -22,7 +23,9 @@ def get_default_user_payload(user: User):
     }
 
 
-def send_password_reset_notification(redirect_url, user, manager, staff=False):
+def send_password_reset_notification(
+    redirect_url, user, manager, channel_slug: Optional[str], staff=False
+):
     """Trigger sending a password reset notification for the given customer/staff."""
     token = default_token_generator.make_token(user)
     params = urlencode({"email": user.email, "token": token})
@@ -33,6 +36,7 @@ def send_password_reset_notification(redirect_url, user, manager, staff=False):
         "recipient_email": user.email,
         "token": token,
         "reset_url": reset_url,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
 
@@ -41,10 +45,10 @@ def send_password_reset_notification(redirect_url, user, manager, staff=False):
         if staff
         else NotifyEventType.ACCOUNT_PASSWORD_RESET
     )
-    manager.notify(event, payload=payload)
+    manager.notify(event, payload=payload, channel_slug=channel_slug)
 
 
-def send_account_confirmation(user, redirect_url, manager):
+def send_account_confirmation(user, redirect_url, manager, channel_slug):
     """Trigger sending an account confirmation notification for the given user."""
     token = default_token_generator.make_token(user)
     params = urlencode({"email": user.email, "token": token})
@@ -54,13 +58,16 @@ def send_account_confirmation(user, redirect_url, manager):
         "recipient_email": user.email,
         "token": token,
         "confirm_url": confirm_url,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ACCOUNT_CONFIRMATION, payload=payload)
+    manager.notify(
+        NotifyEventType.ACCOUNT_CONFIRMATION, payload=payload, channel_slug=channel_slug
+    )
 
 
 def send_request_user_change_email_notification(
-    redirect_url, user, new_email, token, manager
+    redirect_url, user, new_email, token, manager, channel_slug
 ):
     """Trigger sending a notification change email for the given user."""
     params = urlencode({"token": token})
@@ -72,22 +79,34 @@ def send_request_user_change_email_notification(
         "new_email": new_email,
         "token": token,
         "redirect_url": redirect_url,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ACCOUNT_CHANGE_EMAIL_REQUEST, payload=payload)
+    manager.notify(
+        NotifyEventType.ACCOUNT_CHANGE_EMAIL_REQUEST,
+        payload=payload,
+        channel_slug=channel_slug,
+    )
 
 
-def send_user_change_email_notification(recipient_email, user, manager):
+def send_user_change_email_notification(recipient_email, user, manager, channel_slug):
     """Trigger sending a email change notification for the given user."""
     payload = {
         "user": get_default_user_payload(user),
         "recipient_email": recipient_email,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ACCOUNT_CHANGE_EMAIL_CONFIRM, payload=payload)
+    manager.notify(
+        NotifyEventType.ACCOUNT_CHANGE_EMAIL_CONFIRM,
+        payload=payload,
+        channel_slug=channel_slug,
+    )
 
 
-def send_account_delete_confirmation_notification(redirect_url, user, manager):
+def send_account_delete_confirmation_notification(
+    redirect_url, user, manager, channel_slug
+):
     """Trigger sending a account delete notification for the given user."""
     token = default_token_generator.make_token(user)
     params = urlencode({"token": token})
@@ -97,12 +116,17 @@ def send_account_delete_confirmation_notification(redirect_url, user, manager):
         "recipient_email": user.email,
         "token": token,
         "delete_url": delete_url,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ACCOUNT_DELETE, payload=payload)
+    manager.notify(
+        NotifyEventType.ACCOUNT_DELETE, payload=payload, channel_slug=channel_slug
+    )
 
 
-def send_set_password_notification(redirect_url, user, manager, staff=False):
+def send_set_password_notification(
+    redirect_url, user, manager, channel_slug, staff=False
+):
     """Trigger sending a set password notification for the given customer/staff."""
     token = default_token_generator.make_token(user)
     params = urlencode({"email": user.email, "token": token})
@@ -112,10 +136,11 @@ def send_set_password_notification(redirect_url, user, manager, staff=False):
         "token": default_token_generator.make_token(user),
         "recipient_email": user.email,
         "password_set_url": password_set_url,
+        "channel_slug": channel_slug,
         **get_site_context(),
     }
     if staff:
         event = NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD
     else:
         event = NotifyEventType.ACCOUNT_SET_CUSTOMER_PASSWORD
-    manager.notify(event, payload=payload)
+    manager.notify(event, payload=payload, channel_slug=channel_slug)

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -28,6 +28,7 @@ def test_create_order_captured_payment_creates_expected_events(
     customer_user,
     shipping_method,
     payment_txn_captured,
+    channel_USD,
 ):
     checkout = checkout_with_item
     checkout_user = customer_user
@@ -143,9 +144,15 @@ def test_create_order_captured_payment_creates_expected_events(
 
     mock_notify.assert_has_calls(
         [
-            mock.call(NotifyEventType.ORDER_CONFIRMATION, expected_order_payload),
             mock.call(
-                NotifyEventType.ORDER_PAYMENT_CONFIRMATION, expected_payment_payload
+                NotifyEventType.ORDER_CONFIRMATION,
+                expected_order_payload,
+                channel_slug=channel_USD.slug,
+            ),
+            mock.call(
+                NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+                expected_payment_payload,
+                channel_slug=channel_USD.slug,
             ),
         ],
         any_order=True,
@@ -167,6 +174,7 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
     customer_user,
     shipping_method,
     payment_txn_captured,
+    channel_USD,
 ):
     checkout = checkout_with_item
     checkout_user = None
@@ -284,9 +292,15 @@ def test_create_order_captured_payment_creates_expected_events_anonymous_user(
 
     mock_notify.assert_has_calls(
         [
-            mock.call(NotifyEventType.ORDER_CONFIRMATION, expected_order_payload),
             mock.call(
-                NotifyEventType.ORDER_PAYMENT_CONFIRMATION, expected_payment_payload
+                NotifyEventType.ORDER_CONFIRMATION,
+                expected_order_payload,
+                channel_slug=channel_USD.slug,
+            ),
+            mock.call(
+                NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+                expected_payment_payload,
+                channel_slug=channel_USD.slug,
             ),
         ],
         any_order=True,
@@ -303,6 +317,7 @@ def test_create_order_preauth_payment_creates_expected_events(
     customer_user,
     shipping_method,
     payment_txn_preauth,
+    channel_USD,
 ):
     checkout = checkout_with_item
     checkout_user = customer_user
@@ -390,7 +405,9 @@ def test_create_order_preauth_payment_creates_expected_events(
     assert order_confirmed_event.parameters == {}
 
     mock_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_CONFIRMATION,
+        expected_payload,
+        channel_slug=channel_USD.slug,
     )
 
     # Ensure the correct customer event was created if the user was not anonymous
@@ -409,6 +426,7 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     customer_user,
     shipping_method,
     payment_txn_preauth,
+    channel_USD,
 ):
     checkout = checkout_with_item
     checkout_user = None
@@ -496,7 +514,9 @@ def test_create_order_preauth_payment_creates_expected_events_anonymous_user(
     assert order_confirmed_event.parameters == {}
 
     mock_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_CONFIRMATION,
+        expected_payload,
+        channel_slug=channel_USD.slug,
     )
 
     # Check no event was created if the user was anonymous

--- a/saleor/graphql/account/mutations/account.py
+++ b/saleor/graphql/account/mutations/account.py
@@ -24,6 +24,7 @@ from .base import (
     BaseAddressDelete,
     BaseAddressUpdate,
     BaseCustomerCreate,
+    clean_channel,
 )
 
 
@@ -43,6 +44,12 @@ class AccountRegisterInput(graphene.InputObjectType):
         graphene.NonNull(MetadataInput),
         description="User public metadata.",
         required=False,
+    )
+    channel = graphene.String(
+        description=(
+            "Slug of a channel which will be used for notify user. Optional when "
+            "only one channel exists."
+        )
     )
 
 
@@ -96,11 +103,14 @@ class AccountRegister(ModelMutation):
                 }
             )
 
+        data["channel"] = clean_channel(data.get("channel")).slug
+
         password = data["password"]
         try:
             password_validation.validate_password(password, instance)
         except ValidationError as error:
             raise ValidationError({"password": error})
+
         data["language_code"] = data.get("language_code", settings.LANGUAGE_CODE)
         return super().clean_input(info, instance, data, input_cls=None)
 
@@ -112,7 +122,10 @@ class AccountRegister(ModelMutation):
             user.is_active = False
             user.save()
             notifications.send_account_confirmation(
-                user, cleaned_input["redirect_url"], info.context.plugins
+                user,
+                cleaned_input["redirect_url"],
+                info.context.plugins,
+                channel_slug=cleaned_input["channel"],
             )
         else:
             user.save()
@@ -168,6 +181,12 @@ class AccountRequestDeletion(BaseMutation):
                 "delete their account. URL in RFC 1808 format."
             ),
         )
+        channel = graphene.String(
+            description=(
+                "Slug of a channel which will be used for notify user. Optional when "
+                "only one channel exists."
+            )
+        )
 
     class Meta:
         description = (
@@ -190,8 +209,9 @@ class AccountRequestDeletion(BaseMutation):
             raise ValidationError(
                 {"redirect_url": error}, code=AccountErrorCode.INVALID
             )
+        channel_slug = clean_channel(data.get("channel")).slug
         notifications.send_account_delete_confirmation_notification(
-            redirect_url, user, info.context.plugins
+            redirect_url, user, info.context.plugins, channel_slug=channel_slug
         )
         return AccountRequestDeletion()
 
@@ -372,6 +392,12 @@ class RequestEmailChange(BaseMutation):
                 "update the email address. URL in RFC 1808 format."
             ),
         )
+        channel = graphene.String(
+            description=(
+                "Slug of a channel which will be used for notify user. Optional when "
+                "only one channel exists."
+            )
+        )
 
     class Meta:
         description = "Request email change of the logged in user."
@@ -412,6 +438,8 @@ class RequestEmailChange(BaseMutation):
             raise ValidationError(
                 {"redirect_url": error}, code=AccountErrorCode.INVALID
             )
+
+        channel_slug = clean_channel(data.get("channel")).slug
         token_payload = {
             "old_email": user.email,
             "new_email": new_email,
@@ -419,7 +447,12 @@ class RequestEmailChange(BaseMutation):
         }
         token = create_token(token_payload, JWT_TTL_REQUEST_EMAIL_CHANGE)
         notifications.send_request_user_change_email_notification(
-            redirect_url, user, new_email, token, info.context.plugins
+            redirect_url,
+            user,
+            new_email,
+            token,
+            info.context.plugins,
+            channel_slug=channel_slug,
         )
         return RequestEmailChange(user=user)
 
@@ -430,6 +463,12 @@ class ConfirmEmailChange(BaseMutation):
     class Arguments:
         token = graphene.String(
             description="A one-time token required to change the email.", required=True
+        )
+        channel = graphene.String(
+            description=(
+                "Slug of a channel which will be used for notify user. Optional when "
+                "only one channel exists."
+            )
         )
 
     class Meta:
@@ -476,8 +515,10 @@ class ConfirmEmailChange(BaseMutation):
 
         user.email = new_email
         user.save(update_fields=["email"])
+
+        channel_slug = clean_channel(data.get("channel")).slug
         notifications.send_user_change_email_notification(
-            old_email, user, info.context.plugins
+            old_email, user, info.context.plugins, channel_slug=channel_slug
         )
         info.context.plugins.customer_updated(user)
         return ConfirmEmailChange(user=user)

--- a/saleor/graphql/account/mutations/staff.py
+++ b/saleor/graphql/account/mutations/staff.py
@@ -246,6 +246,7 @@ class StaffCreate(ModelMutation):
                 redirect_url=cleaned_input.get("redirect_url"),
                 user=user,
                 manager=info.context.plugins,
+                channel_slug=None,
                 staff=True,
             )
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -958,7 +958,8 @@ ACCOUNT_REGISTER_MUTATION = """
         $email: String!,
         $redirectUrl: String,
         $languageCode: LanguageCodeEnum
-        $metadata: [MetadataInput!]
+        $metadata: [MetadataInput!],
+        $channel: String
     ) {
         accountRegister(
             input: {
@@ -966,7 +967,8 @@ ACCOUNT_REGISTER_MUTATION = """
                 email: $email,
                 redirectUrl: $redirectUrl,
                 languageCode: $languageCode,
-                metadata: $metadata
+                metadata: $metadata,
+                channel: $channel
             }
         ) {
             accountErrors {
@@ -987,7 +989,7 @@ ACCOUNT_REGISTER_MUTATION = """
 )
 @patch("saleor.account.notifications.default_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
-def test_customer_register(mocked_notify, mocked_generator, api_client):
+def test_customer_register(mocked_notify, mocked_generator, api_client, channel_PLN):
     mocked_generator.return_value = "token"
     email = "customer@example.com"
     redirect_url = "http://localhost:3000"
@@ -997,6 +999,7 @@ def test_customer_register(mocked_notify, mocked_generator, api_client):
         "redirectUrl": redirect_url,
         "languageCode": "PL",
         "metadata": [{"key": "meta", "value": "data"}],
+        "channel": channel_PLN.slug,
     }
     query = ACCOUNT_REGISTER_MUTATION
     mutation_name = "accountRegister"
@@ -1015,12 +1018,15 @@ def test_customer_register(mocked_notify, mocked_generator, api_client):
         "recipient_email": new_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
     assert new_user.metadata == {"meta": "data"}
     assert new_user.language_code == "pl"
     assert not data["accountErrors"]
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_CONFIRMATION, payload=expected_payload
+        NotifyEventType.ACCOUNT_CONFIRMATION,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
     response = api_client.post_graphql(query, variables)
@@ -1108,7 +1114,12 @@ CUSTOMER_CREATE_MUTATION = """
 @patch("saleor.account.notifications.default_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_customer_create(
-    mocked_notify, mocked_generator, staff_api_client, address, permission_manage_users
+    mocked_notify,
+    mocked_generator,
+    staff_api_client,
+    address,
+    permission_manage_users,
+    channel_PLN,
 ):
     mocked_generator.return_value = "token"
     email = "api_user@example.com"
@@ -1126,6 +1137,7 @@ def test_customer_create(
         "billing": address_data,
         "redirect_url": redirect_url,
         "languageCode": "PL",
+        "channel": channel_PLN.slug,
     }
 
     response = staff_api_client.post_graphql(
@@ -1163,9 +1175,12 @@ def test_customer_create(
         "recipient_email": new_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_CUSTOMER_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_SET_CUSTOMER_PASSWORD,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
     customer_creation_event = account_events.CustomerEvent.objects.get()
@@ -1180,10 +1195,15 @@ def test_customer_create_send_password_with_url(
     mocked_generator,
     staff_api_client,
     permission_manage_users,
+    channel_PLN,
 ):
     mocked_generator.return_value = "token"
     email = "api_user@example.com"
-    variables = {"email": email, "redirect_url": "https://www.example.com"}
+    variables = {
+        "email": email,
+        "redirect_url": "https://www.example.com",
+        "channel": channel_PLN.slug,
+    }
 
     response = staff_api_client.post_graphql(
         CUSTOMER_CREATE_MUTATION, variables, permissions=[permission_manage_users]
@@ -1204,9 +1224,12 @@ def test_customer_create_send_password_with_url(
         "recipient_email": new_customer.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_CUSTOMER_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_SET_CUSTOMER_PASSWORD,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
@@ -1544,8 +1567,8 @@ def test_logged_customer_update_anonymous_user(api_client):
 
 
 ACCOUNT_REQUEST_DELETION_MUTATION = """
-    mutation accountRequestDeletion($redirectUrl: String!) {
-        accountRequestDeletion(redirectUrl: $redirectUrl) {
+    mutation accountRequestDeletion($redirectUrl: String!, $channel: String) {
+        accountRequestDeletion(redirectUrl: $redirectUrl, channel: $channel) {
             errors {
                 field
                 message
@@ -1561,11 +1584,13 @@ ACCOUNT_REQUEST_DELETION_MUTATION = """
 
 @patch("saleor.account.notifications.default_token_generator.make_token")
 @patch("saleor.plugins.manager.PluginsManager.notify")
-def test_account_request_deletion(mocked_notify, mocked_token, user_api_client):
+def test_account_request_deletion(
+    mocked_notify, mocked_token, user_api_client, channel_PLN
+):
     mocked_token.return_value = "token"
     user = user_api_client.user
     redirect_url = "https://www.example.com"
-    variables = {"redirectUrl": redirect_url}
+    variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
     response = user_api_client.post_graphql(
         ACCOUNT_REQUEST_DELETION_MUTATION, variables
     )
@@ -1581,20 +1606,25 @@ def test_account_request_deletion(mocked_notify, mocked_token, user_api_client):
         "recipient_email": user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_DELETE, payload=expected_payload
+        NotifyEventType.ACCOUNT_DELETE,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
-def test_account_request_deletion_token_validation(mocked_notify, user_api_client):
+def test_account_request_deletion_token_validation(
+    mocked_notify, user_api_client, channel_PLN
+):
     user = user_api_client.user
     token = default_token_generator.make_token(user)
     redirect_url = "https://www.example.com"
-    variables = {"redirectUrl": redirect_url}
+    variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
     response = user_api_client.post_graphql(
         ACCOUNT_REQUEST_DELETION_MUTATION, variables
     )
@@ -1610,10 +1640,13 @@ def test_account_request_deletion_token_validation(mocked_notify, user_api_clien
         "recipient_email": user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_DELETE, payload=expected_payload
+        NotifyEventType.ACCOUNT_DELETE,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
@@ -1646,13 +1679,13 @@ def test_account_request_deletion_storefront_hosts_not_allowed(
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_account_request_deletion_all_storefront_hosts_allowed(
-    mocked_notify, user_api_client, settings
+    mocked_notify, user_api_client, settings, channel_PLN
 ):
     user = user_api_client.user
     token = default_token_generator.make_token(user)
     settings.ALLOWED_CLIENT_HOSTS = ["*"]
     redirect_url = "https://www.test.com"
-    variables = {"redirectUrl": redirect_url}
+    variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
     response = user_api_client.post_graphql(
         ACCOUNT_REQUEST_DELETION_MUTATION, variables
     )
@@ -1669,21 +1702,26 @@ def test_account_request_deletion_all_storefront_hosts_allowed(
         "recipient_email": user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_DELETE, payload=expected_payload
+        NotifyEventType.ACCOUNT_DELETE,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
-def test_account_request_deletion_subdomain(mocked_notify, user_api_client, settings):
+def test_account_request_deletion_subdomain(
+    mocked_notify, user_api_client, settings, channel_PLN
+):
     user = user_api_client.user
     token = default_token_generator.make_token(user)
     settings.ALLOWED_CLIENT_HOSTS = [".example.com"]
     redirect_url = "https://sub.example.com"
-    variables = {"redirectUrl": redirect_url}
+    variables = {"redirectUrl": redirect_url, "channel": channel_PLN.slug}
     response = user_api_client.post_graphql(
         ACCOUNT_REQUEST_DELETION_MUTATION, variables
     )
@@ -1699,10 +1737,13 @@ def test_account_request_deletion_subdomain(mocked_notify, user_api_client, sett
         "recipient_email": user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_DELETE, payload=expected_payload
+        NotifyEventType.ACCOUNT_DELETE,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
@@ -1893,6 +1934,7 @@ def test_staff_create(
     permission_manage_products,
     permission_manage_staff,
     permission_manage_users,
+    channel_PLN,
 ):
     group = permission_group_manage_users
     group.permissions.add(permission_manage_products)
@@ -1944,10 +1986,13 @@ def test_staff_create(
         "recipient_email": staff_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": None,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
+        payload=expected_payload,
+        channel_slug=None,
     )
 
 
@@ -1987,6 +2032,7 @@ def test_staff_create_out_of_scope_group(
     permission_manage_staff,
     permission_manage_users,
     permission_group_manage_users,
+    channel_PLN,
 ):
     """Ensure user can't create staff with groups which are out of user scope.
     Ensure superuser pass restrictions.
@@ -2073,10 +2119,13 @@ def test_staff_create_out_of_scope_group(
         "recipient_email": staff_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": None,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
+        payload=expected_payload,
+        channel_slug=None,
     )
 
 
@@ -2112,10 +2161,13 @@ def test_staff_create_send_password_with_url(
         "recipient_email": staff_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": None,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_SET_STAFF_PASSWORD,
+        payload=expected_payload,
+        channel_slug=None,
     )
 
 
@@ -3422,7 +3474,9 @@ CONFIRM_ACCOUNT_MUTATION = """
 
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
-def test_account_reset_password(mocked_notify, user_api_client, customer_user):
+def test_account_reset_password(
+    mocked_notify, user_api_client, customer_user, channel_PLN
+):
     redirect_url = "https://www.example.com"
     variables = {"email": customer_user.email, "redirectUrl": redirect_url}
     response = user_api_client.post_graphql(REQUEST_PASSWORD_RESET_MUTATION, variables)
@@ -3439,10 +3493,13 @@ def test_account_reset_password(mocked_notify, user_api_client, customer_user):
         "recipient_email": customer_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=expected_payload
+        NotifyEventType.ACCOUNT_PASSWORD_RESET,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
@@ -3520,10 +3577,13 @@ def test_request_password_reset_email_for_staff(mocked_notify, staff_api_client)
         "recipient_email": staff_api_client.user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": None,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD, payload=expected_payload
+        NotifyEventType.ACCOUNT_STAFF_RESET_PASSWORD,
+        payload=expected_payload,
+        channel_slug=None,
     )
 
 
@@ -3577,7 +3637,7 @@ def test_account_reset_password_storefront_hosts_not_allowed(
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_account_reset_password_all_storefront_hosts_allowed(
-    mocked_notify, user_api_client, customer_user, settings
+    mocked_notify, user_api_client, customer_user, settings, channel_PLN
 ):
     settings.ALLOWED_CLIENT_HOSTS = ["*"]
     redirect_url = "https://www.test.com"
@@ -3597,17 +3657,20 @@ def test_account_reset_password_all_storefront_hosts_allowed(
         "recipient_email": customer_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=expected_payload
+        NotifyEventType.ACCOUNT_PASSWORD_RESET,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
 @freeze_time("2018-05-31 12:00:01")
 @patch("saleor.plugins.manager.PluginsManager.notify")
 def test_account_reset_password_subdomain(
-    mocked_notify, user_api_client, customer_user, settings
+    mocked_notify, user_api_client, customer_user, settings, channel_PLN
 ):
     settings.ALLOWED_CLIENT_HOSTS = [".example.com"]
     redirect_url = "https://sub.example.com"
@@ -3627,10 +3690,13 @@ def test_account_reset_password_subdomain(
         "recipient_email": customer_user.email,
         "site_name": "mirumee.com",
         "domain": "mirumee.com",
+        "channel_slug": channel_PLN.slug,
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ACCOUNT_PASSWORD_RESET, payload=expected_payload
+        NotifyEventType.ACCOUNT_PASSWORD_RESET,
+        payload=expected_payload,
+        channel_slug=channel_PLN.slug,
     )
 
 
@@ -4507,10 +4573,13 @@ def test_address_query_as_anonymous_user(api_client, address_other_country):
 
 REQUEST_EMAIL_CHANGE_QUERY = """
 mutation requestEmailChange(
-    $password: String!, $new_email: String!, $redirect_url: String!
+    $password: String!, $new_email: String!, $redirect_url: String!, $channel:String
 ) {
     requestEmailChange(
-        password: $password, newEmail: $new_email, redirectUrl: $redirect_url
+        password: $password,
+        newEmail: $new_email,
+        redirectUrl: $redirect_url,
+        channel: $channel
     ) {
         user {
             email
@@ -4525,11 +4594,12 @@ mutation requestEmailChange(
 """
 
 
-def test_request_email_change(user_api_client, customer_user):
+def test_request_email_change(user_api_client, customer_user, channel_PLN):
     variables = {
         "password": "password",
         "new_email": "new_email@example.com",
         "redirect_url": "http://www.example.com",
+        "channel": channel_PLN.slug,
     }
 
     response = user_api_client.post_graphql(REQUEST_EMAIL_CHANGE_QUERY, variables)
@@ -4612,7 +4682,7 @@ mutation emailUpdate($token: String!) {
 """
 
 
-def test_email_update(user_api_client, customer_user):
+def test_email_update(user_api_client, customer_user, channel_PLN):
     new_email = "new_email@example.com"
     payload = {
         "old_email": customer_user.email,

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -871,6 +871,7 @@ def test_order_confirm(
     mocked_notify.assert_called_once_with(
         NotifyEventType.ORDER_CONFIRMED,
         expected_payload,
+        channel_slug=order_unconfirmed.channel.slug,
     )
 
 
@@ -3584,7 +3585,9 @@ def test_order_capture(
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_PAYMENT_CONFIRMATION, expected_payment_payload
+        NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+        expected_payment_payload,
+        channel_slug=order.channel.slug,
     )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -67,6 +67,8 @@ enum AccountErrorCode {
   JWT_DECODE_ERROR
   JWT_MISSING_TOKEN
   JWT_INVALID_CSRF_TOKEN
+  CHANNEL_INACTIVE
+  MISSING_CHANNEL_SLUG
 }
 
 input AccountInput {
@@ -90,6 +92,7 @@ input AccountRegisterInput {
   redirectUrl: String
   languageCode: LanguageCodeEnum
   metadata: [MetadataInput!]
+  channel: String
 }
 
 type AccountRequestDeletion {
@@ -2842,19 +2845,19 @@ type Mutation {
   externalRefresh(input: JSONString!, pluginId: String!): ExternalRefresh
   externalLogout(input: JSONString!, pluginId: String!): ExternalLogout
   externalVerify(input: JSONString!, pluginId: String!): ExternalVerify
-  requestPasswordReset(email: String!, redirectUrl: String!): RequestPasswordReset
+  requestPasswordReset(channel: String, email: String!, redirectUrl: String!): RequestPasswordReset
   confirmAccount(email: String!, token: String!): ConfirmAccount
   setPassword(email: String!, password: String!, token: String!): SetPassword
   passwordChange(newPassword: String!, oldPassword: String!): PasswordChange
-  requestEmailChange(newEmail: String!, password: String!, redirectUrl: String!): RequestEmailChange
-  confirmEmailChange(token: String!): ConfirmEmailChange
+  requestEmailChange(channel: String, newEmail: String!, password: String!, redirectUrl: String!): RequestEmailChange
+  confirmEmailChange(channel: String, token: String!): ConfirmEmailChange
   accountAddressCreate(input: AddressInput!, type: AddressTypeEnum): AccountAddressCreate
   accountAddressUpdate(id: ID!, input: AddressInput!): AccountAddressUpdate
   accountAddressDelete(id: ID!): AccountAddressDelete
   accountSetDefaultAddress(id: ID!, type: AddressTypeEnum!): AccountSetDefaultAddress
   accountRegister(input: AccountRegisterInput!): AccountRegister
   accountUpdate(input: AccountInput!): AccountUpdate
-  accountRequestDeletion(redirectUrl: String!): AccountRequestDeletion
+  accountRequestDeletion(channel: String, redirectUrl: String!): AccountRequestDeletion
   accountDelete(token: String!): AccountDelete
   addressCreate(input: AddressInput!, userId: ID!): AddressCreate
   addressUpdate(id: ID!, input: AddressInput!): AddressUpdate
@@ -5599,6 +5602,7 @@ input UserCreateInput {
   note: String
   languageCode: LanguageCodeEnum
   redirectUrl: String
+  channel: String
 }
 
 type UserPermission {

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -273,7 +273,9 @@ def send_order_confirmation(order, redirect_url, manager):
         "recipient_email": order.get_customer_email(),
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ORDER_CONFIRMATION, payload)
+    manager.notify(
+        NotifyEventType.ORDER_CONFIRMATION, payload, channel_slug=order.channel.slug
+    )
 
     # Prepare staff notification for this order
     staff_notifications = StaffNotificationRecipient.objects.filter(
@@ -299,18 +301,28 @@ def send_order_confirmed(order, user, manager):
         "requester_user_id": user.id,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ORDER_CONFIRMED, payload)
+    manager.notify(
+        NotifyEventType.ORDER_CONFIRMED, payload, channel_slug=order.channel.slug
+    )
 
 
 def send_fulfillment_confirmation_to_customer(order, fulfillment, user, manager):
     payload = get_default_fulfillment_payload(order, fulfillment)
     payload["requester_user_id"] = user.id if user else None
-    manager.notify(NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION, payload=payload)
+    manager.notify(
+        NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
+        payload=payload,
+        channel_slug=order.channel.slug,
+    )
 
 
 def send_fulfillment_update(order, fulfillment, manager):
     payload = get_default_fulfillment_payload(order, fulfillment)
-    manager.notify(NotifyEventType.ORDER_FULFILLMENT_UPDATE, payload)
+    manager.notify(
+        NotifyEventType.ORDER_FULFILLMENT_UPDATE,
+        payload,
+        channel_slug=order.channel.slug,
+    )
 
 
 def send_payment_confirmation(order, manager):
@@ -329,7 +341,11 @@ def send_payment_confirmation(order, manager):
         },
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ORDER_PAYMENT_CONFIRMATION, payload)
+    manager.notify(
+        NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+        payload,
+        channel_slug=order.channel.slug,
+    )
 
 
 def send_order_canceled_confirmation(order: "Order", user: Optional["User"], manager):
@@ -339,7 +355,9 @@ def send_order_canceled_confirmation(order: "Order", user: Optional["User"], man
         "recipient_email": order.get_customer_email(),
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ORDER_CANCELED, payload)
+    manager.notify(
+        NotifyEventType.ORDER_CANCELED, payload, channel_slug=order.channel.slug
+    )
 
 
 def send_order_refunded_confirmation(
@@ -353,4 +371,8 @@ def send_order_refunded_confirmation(
         "currency": currency,
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.ORDER_REFUND_CONFIRMATION, payload)
+    manager.notify(
+        NotifyEventType.ORDER_REFUND_CONFIRMATION,
+        payload,
+        channel_slug=order.channel.slug,
+    )

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -235,7 +235,9 @@ def test_send_email_payment_confirmation(mocked_notify, site_settings, payment_d
     }
     notifications.send_payment_confirmation(order, manager)
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_PAYMENT_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )
 
 
@@ -253,7 +255,9 @@ def test_send_email_order_confirmation(mocked_notify, order, site_settings):
         "domain": "mirumee.com",
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_CONFIRMATION,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )
 
 
@@ -298,7 +302,9 @@ def test_send_confirmation_emails_without_addresses_for_payment(
         "domain": "mirumee.com",
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_PAYMENT_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_PAYMENT_CONFIRMATION,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )
 
 
@@ -335,7 +341,9 @@ def test_send_confirmation_emails_without_addresses_for_order(
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_CONFIRMATION,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )
 
 
@@ -358,7 +366,9 @@ def test_send_fulfillment_confirmation(
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
     expected_payload["requester_user_id"] = staff_user.id
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION, payload=expected_payload
+        NotifyEventType.ORDER_FULFILLMENT_CONFIRMATION,
+        payload=expected_payload,
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -376,7 +386,9 @@ def test_send_fulfillment_update(mocked_notify, fulfilled_order, site_settings):
     expected_payload = get_default_fulfillment_payload(fulfilled_order, fulfillment)
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_FULFILLMENT_UPDATE, expected_payload
+        NotifyEventType.ORDER_FULFILLMENT_UPDATE,
+        expected_payload,
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -397,7 +409,9 @@ def test_send_email_order_canceled(mocked_notify, order, site_settings, staff_us
         "requester_user_id": staff_user.id,
     }
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_CANCELED, expected_payload
+        NotifyEventType.ORDER_CANCELED,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )
 
 
@@ -424,5 +438,7 @@ def test_send_email_order_refunded(mocked_notify, order, site_settings, staff_us
     }
 
     mocked_notify.assert_called_once_with(
-        NotifyEventType.ORDER_REFUND_CONFIRMATION, expected_payload
+        NotifyEventType.ORDER_REFUND_CONFIRMATION,
+        expected_payload,
+        channel_slug=order.channel.slug,
     )

--- a/saleor/order/tests/test_order.py
+++ b/saleor/order/tests/test_order.py
@@ -983,7 +983,9 @@ def test_send_fulfillment_order_lines_mails(
     expected_payload = get_default_fulfillment_payload(order, fulfillment)
     expected_payload["requester_user_id"] = staff_user.id
     mocked_notify.assert_called_once_with(
-        "order_fulfillment_confirmation", payload=expected_payload
+        "order_fulfillment_confirmation",
+        payload=expected_payload,
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 

--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -441,7 +441,11 @@ class PluginsManager(PaymentInterface):
         )
         return quantize_price(
             self.__run_method_on_plugins(
-                "apply_taxes_to_shipping", default_value, price, shipping_address
+                "apply_taxes_to_shipping",
+                default_value,
+                price,
+                shipping_address,
+                channel_slug=channel_slug,
             ),
             price.currency,
         )
@@ -898,9 +902,16 @@ class PluginsManager(PaymentInterface):
             plugin, "webhook", default_value, request, path
         )
 
-    def notify(self, event: "NotifyEventTypeChoice", payload: dict):
+    def notify(
+        self,
+        event: "NotifyEventTypeChoice",
+        payload: dict,
+        channel_slug: Optional[str] = None,
+    ):
         default_value = None
-        return self.__run_method_on_plugins("notify", default_value, event, payload)
+        return self.__run_method_on_plugins(
+            "notify", default_value, event, payload, channel_slug=channel_slug
+        )
 
     def external_obtain_access_tokens(
         self, plugin_id: str, data: dict, request: WSGIRequest

--- a/saleor/plugins/webhook/tests/test_webhook.py
+++ b/saleor/plugins/webhook/tests/test_webhook.py
@@ -364,12 +364,12 @@ def test_invoice_sent(mocked_webhook_trigger, settings, fulfilled_order):
 
 @freeze_time("2020-03-18 12:00:00")
 @mock.patch("saleor.plugins.webhook.plugin.trigger_webhooks_for_event.delay")
-def test_notify_user(mocked_webhook_trigger, settings, customer_user):
+def test_notify_user(mocked_webhook_trigger, settings, customer_user, channel_USD):
     settings.PLUGINS = ["saleor.plugins.webhook.plugin.WebhookPlugin"]
     manager = get_plugins_manager()
 
     redirect_url = "http://redirect.com/"
-    send_account_confirmation(customer_user, redirect_url, manager)
+    send_account_confirmation(customer_user, redirect_url, manager, channel_USD.slug)
 
     token = default_token_generator.make_token(customer_user)
     params = urlencode({"email": customer_user.email, "token": token})
@@ -380,6 +380,7 @@ def test_notify_user(mocked_webhook_trigger, settings, customer_user):
         "recipient_email": customer_user.email,
         "token": token,
         "confirm_url": confirm_url,
+        "channel_slug": channel_USD.slug,
         **get_site_context(),
     }
 


### PR DESCRIPTION
I want to merge this change because it:
- adds channel_slug parameter to manager.notify method.
- add input field - `channel` to account mutation, where channel slug is required to trigger proper Email plugins.
- add channel_slug to all manager.notify calls

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
