### PR TITLE
Remove order QS distincts in favor of Exists, OuterRef

### DIFF
--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -45,8 +45,6 @@ def filter_status(qs, _, value):
         query_objects |= qs.ready_to_fulfill()
 
     if OrderStatusFilter.READY_TO_CAPTURE in value:
-        qs = qs.distinct()
-        query_objects = query_objects.distinct()
         query_objects |= qs.ready_to_capture()
 
     return qs & query_objects

--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -9,6 +9,7 @@ from django.core.validators import MinValueValidator
 from django.db import models
 from django.db.models import JSONField  # type: ignore
 from django.db.models import F, Max, Sum
+from django.db.models.expressions import Exists, OuterRef
 from django.utils.timezone import now
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField, TaxedMoneyField
@@ -31,6 +32,7 @@ from ..payment.model_helpers import (
     get_total_authorized,
     get_total_captured,
 )
+from ..payment.models import Payment
 from ..shipping.models import ShippingMethod
 from . import FulfillmentStatus, OrderEvents, OrderStatus
 
@@ -59,9 +61,12 @@ class OrderQueryset(models.QuerySet):
         fulfilled).
         """
         statuses = {OrderStatus.UNFULFILLED, OrderStatus.PARTIALLY_FULFILLED}
-        qs = self.filter(status__in=statuses, payments__is_active=True)
+        payments = Payment.objects.filter(is_active=True).values("id")
+        qs = self.annotate(
+            matching=Exists(payments.filter(order_id=OuterRef("id")))
+        ).filter(matching=True)
         qs = qs.annotate(amount_paid=Sum("payments__captured_amount"))
-        return qs.filter(total_gross_amount__lte=F("amount_paid"))
+        return qs.filter(status__in=statuses, total_gross_amount__lte=F("amount_paid"))
 
     def ready_to_capture(self):
         """Return orders with payments to capture.
@@ -70,11 +75,14 @@ class OrderQueryset(models.QuerySet):
         have a preauthorized payment. The preauthorized payment can not
         already be partially or fully captured.
         """
-        qs = self.filter(
-            payments__is_active=True, payments__charge_status=ChargeStatus.NOT_CHARGED
-        )
-        qs = qs.exclude(status={OrderStatus.DRAFT, OrderStatus.CANCELED})
-        return qs.distinct()
+        payments = Payment.objects.filter(
+            is_active=True, charge_status=ChargeStatus.NOT_CHARGED
+        ).values("id")
+        qs = self.annotate(
+            matching=Exists(payments.filter(order_id=OuterRef("id")))
+        ).filter(matching=True)
+
+        return qs.exclude(status={OrderStatus.DRAFT, OrderStatus.CANCELED})
 
     def ready_to_confirm(self):
         """Return unconfirmed orders."""


### PR DESCRIPTION
I want to merge this change because it increases performance of order status filtering.
It implements subquery instead of doing distincts on large data sets.

Local testing [sample DB, 25k orders], querying orders with status on ["READY_TO_CAPTURE", "READY_TO_FULFILL"]:
Master: planning 4,98ms, execution: 118ms
This branch: planning 0,983ms, execution: 10,4ms

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
