### PR TITLE
Raise ValidationError when refund cannot be performed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Use GraphQL IDs instead of database IDs in export - #7240 by @IKarbowiak
 - Fix draft order tax mismatch - #7226 by @IKarbowiak
   - Introduce `calculate_order_line_total` plugin method
+- Raise ValidationError when refund cannot be performed - #7260 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/order/tests/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_return_products.py
@@ -8,7 +8,7 @@ from ....core.prices import quantize_price
 from ....order import OrderStatus
 from ....order.error_codes import OrderErrorCode
 from ....order.models import FulfillmentStatus, Order
-from ....payment import ChargeStatus
+from ....payment import ChargeStatus, PaymentError
 from ....warehouse.models import Stock
 from ...tests.utils import get_graphql_content
 
@@ -110,6 +110,40 @@ def test_fulfillment_return_products_amount_and_shipping_costs(
     mocked_refund.assert_called_with(
         payment_dummy, ANY, quantize_price(amount_to_refund, fulfilled_order.currency)
     )
+
+
+@patch("saleor.order.actions.gateway.refund")
+def test_fulfillment_return_products_refund_raising_payment_error(
+    mocked_refund,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+    payment_dummy,
+):
+    mocked_refund.side_effect = PaymentError("Error")
+
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    fulfilled_order.payments.add(payment_dummy)
+    order_id = graphene.Node.to_global_id("Order", fulfilled_order.pk)
+    amount_to_refund = Decimal("11.00")
+    variables = {
+        "order": order_id,
+        "input": {
+            "refund": True,
+            "amountToRefund": amount_to_refund,
+            "includeShippingCosts": True,
+        },
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentReturnProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert errors[0]["code"] == OrderErrorCode.CANNOT_REFUND.name
 
 
 @patch("saleor.order.actions.gateway.refund")


### PR DESCRIPTION
Catch `PaymentError` and raise `ValidationError` when refund cannot be performed.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
