### PR TITLE
Drop ShippingZones field from Channel Type

### DIFF
--- a/saleor/graphql/channel/tests/test_channel_create_mutations.py
+++ b/saleor/graphql/channel/tests/test_channel_create_mutations.py
@@ -13,9 +13,6 @@ CHANNEL_CREATE_MUTATION = """
                 name
                 slug
                 currencyCode
-                shippingZones{
-                    id
-                }
             }
             errors{
                 field
@@ -174,7 +171,7 @@ def test_channel_create_mutation_with_shipping_zones(
     name = "testName"
     slug = "test_slug"
     currency_code = "USD"
-    shipping_zones = [
+    shipping_zones_ids = [
         graphene.Node.to_global_id("ShippingZone", zone.pk) for zone in shipping_zones
     ]
     variables = {
@@ -182,7 +179,7 @@ def test_channel_create_mutation_with_shipping_zones(
             "name": name,
             "slug": slug,
             "currencyCode": currency_code,
-            "addShippingZones": shipping_zones,
+            "addShippingZones": shipping_zones_ids,
         }
     }
 
@@ -204,4 +201,5 @@ def test_channel_create_mutation_with_shipping_zones(
     assert channel_data["name"] == channel.name == name
     assert channel_data["slug"] == channel.slug == slug
     assert channel_data["currencyCode"] == channel.currency_code == currency_code
-    assert {zone["id"] for zone in channel_data["shippingZones"]} == set(shipping_zones)
+    for shipping_zone in shipping_zones:
+        shipping_zone.channels.get(slug=slug)

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -10,7 +10,7 @@ from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
 from ..translations.resolvers import resolve_translation
 from . import ChannelContext
-from .dataloaders import ChannelWithHasOrdersByIdLoader, ShippingZonesByChannelIdLoader
+from .dataloaders import ChannelWithHasOrdersByIdLoader
 
 
 class ChannelContextType(DjangoObjectType):
@@ -65,11 +65,6 @@ class Channel(CountableDjangoObjectType):
     has_orders = graphene.Boolean(
         required=True, description="Whether a channel has associated orders."
     )
-    shipping_zones = graphene.List(
-        graphene.NonNull("saleor.graphql.shipping.types.ShippingZone"),
-        description="List of channel shipping zones.",
-        required=True,
-    )
 
     class Meta:
         description = "Represents channel."
@@ -85,17 +80,4 @@ class Channel(CountableDjangoObjectType):
             ChannelWithHasOrdersByIdLoader(info.context)
             .load(root.id)
             .then(lambda channel: channel.has_orders)
-        )
-
-    @staticmethod
-    @traced_resolver
-    def resolve_shipping_zones(root: models.Channel, info, **_kwargs):
-        return (
-            ShippingZonesByChannelIdLoader(info.context)
-            .load(root.id)
-            .then(
-                lambda zones: [
-                    ChannelContext(node=zone, channel_slug=root.slug) for zone in zones
-                ]
-            )
         )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -809,7 +809,6 @@ type Channel implements Node {
   slug: String!
   currencyCode: String!
   hasOrders: Boolean!
-  shippingZones: [ShippingZone!]!
 }
 
 type ChannelActivate {
@@ -5143,6 +5142,7 @@ type ShippingZoneDelete {
 
 input ShippingZoneFilterInput {
   search: String
+  channels: [ID]
 }
 
 type ShippingZoneUpdate {

--- a/saleor/graphql/shipping/filters.py
+++ b/saleor/graphql/shipping/filters.py
@@ -1,12 +1,23 @@
 import django_filters
+from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
 from ...shipping.models import ShippingZone
+from ..channel.types import Channel
 from ..core.types import FilterInputObjectType
+from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value
+
+
+def filter_channels(qs, _, values):
+    if values:
+        _, channels_ids = resolve_global_ids_to_primary_keys(values, Channel)
+        qs = qs.filter(channels__id__in=channels_ids)
+    return qs
 
 
 class ShippingZoneFilter(django_filters.FilterSet):
     search = django_filters.CharFilter(method=filter_fields_containing_value("name"))
+    channels = GlobalIDMultipleChoiceFilter(method=filter_channels)
 
     class Meta:
         model = ShippingZone

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -262,3 +262,24 @@ def test_query_shipping_zone_search_by_name(
 
     assert len(data) == len(expected_zones)
     assert {zone["node"]["name"] for zone in data} == expected_zones
+
+
+def test_query_shipping_zone_search_by_channels(
+    staff_api_client, shipping_zones, permission_manage_shipping, channel_USD
+):
+    channel_id = graphene.Node.to_global_id("Channel", channel_USD.id)
+    shipping_zone_usd = shipping_zones[0]
+    shipping_zone_usd_id = graphene.Node.to_global_id(
+        "ShippingZone", shipping_zone_usd.id
+    )
+    variables = {"filter": {"channels": [channel_id]}}
+    response = staff_api_client.post_graphql(
+        QUERY_SHIPPING_ZONES_WITH_FILTER,
+        variables=variables,
+        permissions=[permission_manage_shipping],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["shippingZones"]["edges"]
+
+    assert data[0]["node"]["name"] == shipping_zone_usd.name
+    assert data[0]["node"]["id"] == shipping_zone_usd_id


### PR DESCRIPTION
I want to merge this change because...I want to drop `ShippingZones` field from Channel type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
