### PR TITLE
Add chennel data to order webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - drop `created` argument from `draftOrders` query
   - drop `productType` from `ProductFilter`
   - deprecate mutations' `<name>Errors`, typed `errors` fields and remove deprecation
+- Add channel data to Order webhook - #7299 by @krzysztofwolski
 
 ### Other
 

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -130,12 +130,16 @@ def generate_order_payload(order: "Order"):
         "translated_name",
         "reason",
     )
+
+    channel_fields = ("slug", "currency_code")
     shipping_method_fields = ("name", "type", "currency", "price_amount")
+
     lines = order.lines.all()
     order_data = serializer.serialize(
         [order],
         fields=ORDER_FIELDS,
         additional_fields={
+            "channel": (lambda o: o.channel, channel_fields),
             "shipping_method": (lambda o: o.shipping_method, shipping_method_fields),
             "payments": (lambda o: o.payments.all(), payment_fields),
             "shipping_address": (lambda o: o.shipping_address, ADDRESS_FIELDS),


### PR DESCRIPTION
I want to merge this change because crucial data was missing

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
