### PR TITLE
Extend order benchmark tests

### DIFF
--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -6,7 +6,7 @@ import pytest
 from prices import Money, TaxedMoney
 
 from .....account.models import User
-from .....order import OrderEvents
+from .....order import OrderEvents, OrderStatus
 from .....order.models import Fulfillment, Order, OrderEvent, OrderLine
 from .....payment import ChargeStatus
 from .....payment.models import Payment
@@ -124,3 +124,11 @@ def orders_for_benchmarks(
     OrderLine.objects.bulk_create(lines)
 
     return created_orders
+
+
+@pytest.fixture
+def draft_orders_for_benchmarks(orders_for_benchmarks):
+    for order in orders_for_benchmarks:
+        order.status = OrderStatus.DRAFT
+
+    Order.objects.bulk_update(orders_for_benchmarks, ["status"])

--- a/saleor/graphql/order/tests/benchmark/test_order.py
+++ b/saleor/graphql/order/tests/benchmark/test_order.py
@@ -44,6 +44,8 @@ FRAGMENT_ORDER_DETAILS = (
         paymentStatusDisplay
         status
         statusDisplay
+        canFinalize
+        isShippingRequired
         id
         number
         shippingAddress {
@@ -189,6 +191,8 @@ MULTIPLE_ORDER_DETAILS_QUERY = """
           userEmail
           paymentStatus
           paymentStatusDisplay
+          canFinalize
+          isShippingRequired
           events {
             id
           }
@@ -227,6 +231,24 @@ def test_staff_multiple_orders(
     permission_manage_orders,
     permission_manage_users,
     orders_for_benchmarks,
+    count_queries,
+):
+    staff_api_client.user.user_permissions.set(
+        [permission_manage_orders, permission_manage_users]
+    )
+    content = get_graphql_content(
+        staff_api_client.post_graphql(MULTIPLE_ORDER_DETAILS_QUERY)
+    )
+    assert content["data"]["orders"] is not None
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_staff_multiple_draft_orders(
+    staff_api_client,
+    permission_manage_orders,
+    permission_manage_users,
+    draft_orders_for_benchmarks,
     count_queries,
 ):
     staff_api_client.user.user_permissions.set(


### PR DESCRIPTION
- Add benchmark for fetching draft orders
- Extend order details query in benchmark with `canFinalize` and `isShippingRequired` fields

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
