### PR TITLE
Extend order payload with allocations

### DIFF
--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -1912,7 +1912,7 @@ def test_pages_query_with_filter(
 
 
 def test_pages_query_with_filter_by_page_type(
-    staff_api_client, permission_manage_pages, page_type, page_type_list
+    staff_api_client, permission_manage_pages, page_type_list
 ):
     query = """
         query ($filter: PageFilterInput) {
@@ -1926,32 +1926,11 @@ def test_pages_query_with_filter_by_page_type(
             }
         }
     """
-    page_type = page_type_list[0]
-    second_page_type = page_type_list[1]
-    page_type_ids = (
-        [
-            graphene.Node.to_global_id("PageType", page_type.id)
-            for page_type in page_type_list[:2]
-        ],
-    )
-    Page.objects.create(
-        title="Page1",
-        slug="slug_page_1",
-        content=dummy_editorjs("Content for page 1"),
-        page_type=page_type,
-    )
-    Page.objects.create(
-        title="Page2",
-        slug="slug_page_2",
-        content=dummy_editorjs("Content for page 2"),
-        page_type=second_page_type,
-    )
-    Page.objects.create(
-        title="About",
-        slug="slug_about",
-        content=dummy_editorjs("About test content"),
-        page_type=page_type_list[2],
-    )
+    page_type_ids = [
+        graphene.Node.to_global_id("PageType", page_type.id)
+        for page_type in page_type_list
+    ][:2]
+
     variables = {"filter": {"pageTypes": page_type_ids}}
     staff_api_client.user.user_permissions.add(permission_manage_pages)
     response = staff_api_client.post_graphql(query, variables)

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -2,7 +2,7 @@ import json
 from typing import TYPE_CHECKING, Iterable, Optional
 
 import graphene
-from django.db.models import QuerySet
+from django.db.models import F, QuerySet
 
 from ..account.models import User
 from ..checkout.models import Checkout
@@ -90,6 +90,12 @@ def generate_order_lines_payload(lines: Iterable[OrderLine]):
         extra_dict_data={
             "total_price_net_amount": (lambda l: l.total_price.net.amount),
             "total_price_gross_amount": (lambda l: l.total_price.gross.amount),
+            "allocations": list(
+                lines.values(  # type: ignore
+                    warehouse_id=F("allocations__stock__warehouse_id"),
+                    quantity_allocated=F("allocations__quantity_allocated"),
+                )
+            ),
         },
     )
 

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -70,6 +70,9 @@ def test_order_lines_have_all_required_fields(order, order_line_with_one_allocat
     allocation = line.allocations.first()
 
     total_line = line.total_price
+    global_warehouse_id = graphene.Node.to_global_id(
+        "Warehouse", allocation.stock.warehouse_id
+    )
     assert line_payload == {
         "id": line_id,
         "type": "OrderLine",
@@ -92,7 +95,7 @@ def test_order_lines_have_all_required_fields(order, order_line_with_one_allocat
         "tax_rate": str(line.tax_rate.quantize(Decimal("0.0001"))),
         "allocations": [
             {
-                "warehouse_id": str(allocation.stock.warehouse_id),
+                "warehouse_id": global_warehouse_id,
                 "quantity_allocated": allocation.quantity_allocated,
             }
         ],

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -67,6 +67,7 @@ def test_order_lines_have_all_required_fields(order, order_line_with_one_allocat
     unit_net_amount = line.unit_price_net_amount.quantize(Decimal("0.001"))
     unit_gross_amount = line.unit_price_gross_amount.quantize(Decimal("0.001"))
     unit_discount_amount = line.unit_discount_amount.quantize(Decimal("0.001"))
+    allocation = line.allocations.first()
 
     total_line = line.total_price
     assert line_payload == {
@@ -89,6 +90,12 @@ def test_order_lines_have_all_required_fields(order, order_line_with_one_allocat
             total_line.gross.amount.quantize(Decimal("0.001"))
         ),
         "tax_rate": str(line.tax_rate.quantize(Decimal("0.0001"))),
+        "allocations": [
+            {
+                "warehouse_id": str(allocation.stock.warehouse_id),
+                "quantity_allocated": allocation.quantity_allocated,
+            }
+        ],
     }
 
 


### PR DESCRIPTION
I want to merge this change because...I want to extend order payload with warehouse ids and quantity allocated

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
