### PR TITLE
Fix issue with missing fulfillment in webhook order updated

### DIFF
--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -11,9 +11,14 @@ from ..actions import create_fulfillments_for_returned_products
 from ..models import Fulfillment, FulfillmentLine
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines(
-    mocked_refund, order_with_lines, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
     payment = order_with_lines.get_last_payment()
@@ -76,10 +81,17 @@ def test_create_return_fulfillment_only_order_lines(
     assert order_lines_to_return.filter(id=event_lines[1]["line_pk"]).exists()
     assert event_lines[1]["quantity"] == 2
 
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_refund(
-    mocked_refund, order_with_lines, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
     payment = order_with_lines.get_last_payment()
@@ -108,6 +120,7 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillment.lines.all()
     assert returned_fulfillment.status == FulfillmentStatus.REFUNDED_AND_RETURNED
     assert len(returned_fulfillment_lines) == lines_count
@@ -131,10 +144,17 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
     mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
     assert not replace_order
 
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
-    mocked_refund, order_with_lines, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
     payment = order_with_lines.get_last_payment()
@@ -164,6 +184,7 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillment.lines.all()
     assert returned_fulfillment.status == FulfillmentStatus.REFUNDED_AND_RETURNED
     assert len(returned_fulfillment_lines) == lines_count
@@ -188,10 +209,17 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
     assert not replace_order
 
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_order_lines_with_replace_request(
-    mocked_refund, order_with_lines, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    order_with_lines,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
     payment = order_with_lines.get_last_payment()
@@ -225,6 +253,7 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
     )
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillment.lines.all()
     assert returned_fulfillment.status == FulfillmentStatus.RETURNED
     # we replaced one line
@@ -300,10 +329,17 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
     )
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines(
-    mocked_refund, fulfilled_order, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    fulfilled_order,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     fulfilled_order.payments.add(payment_dummy_fully_charged)
     payment = fulfilled_order.get_last_payment()
@@ -325,6 +361,7 @@ def test_create_return_fulfillment_only_fulfillment_lines(
 
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillment.lines.all()
     assert returned_fulfillment.status == FulfillmentStatus.RETURNED
     assert returned_fulfillment_lines.count() == len(order_line_ids)
@@ -339,10 +376,17 @@ def test_create_return_fulfillment_only_fulfillment_lines(
     assert not mocked_refund.called
     assert not replace_order
 
+    mocked_order_updated.assert_called_once_with(fulfilled_order)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
-    mocked_refund, fulfilled_order, payment_dummy_fully_charged, staff_user
+    mocked_refund,
+    mocked_order_updated,
+    fulfilled_order,
+    payment_dummy_fully_charged,
+    staff_user,
 ):
     fulfilled_order.payments.add(payment_dummy_fully_charged)
     payment = fulfilled_order.get_last_payment()
@@ -371,6 +415,7 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
 
     returned_fulfillment, replaced_fulfillment, replace_order = response
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillment.lines.all()
     assert returned_fulfillment.status == FulfillmentStatus.RETURNED
     # make sure that all order lines from refund are in expected fulfillment
@@ -436,10 +481,14 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     )
     assert replaced_line.tax_rate == expected_replaced_line.tax_rate
 
+    mocked_order_updated.assert_called_once_with(fulfilled_order)
 
+
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_return_fulfillment_with_lines_already_refunded(
     mocked_refund,
+    mocked_order_updated,
     fulfilled_order,
     payment_dummy_fully_charged,
     staff_user,
@@ -502,6 +551,7 @@ def test_create_return_fulfillment_with_lines_already_refunded(
         refund=True,
     )
 
+    flush_post_commit_hooks()
     returned_and_refunded_fulfillment = Fulfillment.objects.get(
         order=fulfilled_order, status=FulfillmentStatus.REFUNDED_AND_RETURNED
     )
@@ -523,3 +573,5 @@ def test_create_return_fulfillment_with_lines_already_refunded(
         ]
     )
     mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+
+    mocked_order_updated.assert_called_once_with(fulfilled_order)

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -3,15 +3,17 @@ from unittest.mock import ANY, patch
 
 from ...payment import ChargeStatus
 from ...plugins.manager import get_plugins_manager
+from ...tests.utils import flush_post_commit_hooks
 from ...warehouse.models import Allocation
 from .. import FulfillmentLineData, FulfillmentStatus, OrderLineData
 from ..actions import create_refund_fulfillment
 from ..models import FulfillmentLine
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_order_lines(
-    mocked_refund, order_with_lines, payment_dummy
+    mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -40,6 +42,7 @@ def test_create_refund_fulfillment_only_order_lines(
         manager=get_plugins_manager(),
     )
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == lines_count
@@ -60,11 +63,13 @@ def test_create_refund_fulfillment_only_order_lines(
         )
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
     mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_included_shipping_costs(
-    mocked_refund, order_with_lines, payment_dummy
+    mocked_refund, mocked_order_updated, order_with_lines, payment_dummy
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -89,6 +94,8 @@ def test_create_refund_fulfillment_included_shipping_costs(
         manager=get_plugins_manager(),
         refund_shipping_costs=True,
     )
+
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == lines_count
@@ -100,11 +107,13 @@ def test_create_refund_fulfillment_included_shipping_costs(
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
     amount += order_with_lines.shipping_price_gross_amount
     mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_order_updated.assert_called_once_with(order_with_lines)
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_only_fulfillment_lines(
-    mocked_refund, fulfilled_order, payment_dummy
+    mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -127,6 +136,8 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
         ],
         manager=get_plugins_manager(),
     )
+
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == len(order_line_ids)
@@ -140,11 +151,13 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
         [line.order_line.unit_price_gross_amount * 2 for line in fulfillment_lines]
     )
     mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_order_updated.assert_called_once_with(fulfilled_order)
 
 
+@patch("saleor.plugins.manager.PluginsManager.order_updated")
 @patch("saleor.order.actions.gateway.refund")
 def test_create_refund_fulfillment_custom_amount(
-    mocked_refund, fulfilled_order, payment_dummy
+    mocked_refund, mocked_order_updated, fulfilled_order, payment_dummy
 ):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
@@ -170,6 +183,7 @@ def test_create_refund_fulfillment_custom_amount(
         amount=amount,
     )
 
+    flush_post_commit_hooks()
     returned_fulfillment_lines = returned_fulfillemnt.lines.all()
     assert returned_fulfillemnt.status == FulfillmentStatus.REFUNDED
     assert len(returned_fulfillment_lines) == len(order_line_ids)
@@ -180,3 +194,4 @@ def test_create_refund_fulfillment_custom_amount(
     for line in fulfillment_lines:
         assert line.quantity == original_quantity.get(line.pk) - 2
     mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_order_updated.assert_called_once_with(fulfilled_order)


### PR DESCRIPTION
I want to merge this change because it fixes the hook call when staff user triggers actions like refund or return. 
Previously: 
- in some places, we call twice order_updated for single action
- we call order_updated before we fully moved the lines to proper fulfillment, which causes a mismatch between data in DB and in the webhook payload.

Now:
- each action - single call of order_updated
- order_updated is called at the end of the transaction so we are sure that we have proper data in the webhook payload

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
