### PR TITLE
Rebuild webhooks logic to handle plugins with channel configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,10 @@ All notable, unreleased changes to this project will be documented in this file.
       - add `statusInChannels` field
       - add `type` field
       - removed `active` field. Use `statusInChannels` instead
+  - Change plugin webhook endpoint - #7332 by @korycins.
+    - Use /plugins/channel/<channel_slug>/<plugin_id> for plugins with channel configuration
+    - Use /plugins/global/<plugin_id> for plugins with global configuration
+    - Remove /plugin/<plugin_id> endpoint
 
 - Add description to shipping method - #7116 by @IKarbowiak
   - `ShippingMethod` was extended with `description` field.

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1302,6 +1302,7 @@ enum ConfigurationTypeFieldEnum {
   SECRET
   PASSWORD
   SECRETMULTILINE
+  OUTPUT
 }
 
 type ConfirmAccount {

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -194,7 +194,7 @@ class AdyenGatewayPlugin(BasePlugin):
     def __init__(self, *args, **kwargs):
         channel = kwargs["channel"]
         raw_configuration = kwargs["configuration"].copy()
-        self._insert_webhook_enpoint_to_configuration(raw_configuration, channel)
+        self._insert_webhook_endpoint_to_configuration(raw_configuration, channel)
         kwargs["configuration"] = raw_configuration
 
         super().__init__(*args, **kwargs)
@@ -224,7 +224,7 @@ class AdyenGatewayPlugin(BasePlugin):
             xapikey=api_key, live_endpoint_prefix=live_endpoint, platform=platform
         )
 
-    def _insert_webhook_enpoint_to_configuration(self, raw_configuration, channel):
+    def _insert_webhook_endpoint_to_configuration(self, raw_configuration, channel):
         updated = False
         for config in raw_configuration:
             if config["name"] == "webhook-endpoint":

--- a/saleor/payment/gateways/adyen/plugin.py
+++ b/saleor/payment/gateways/adyen/plugin.py
@@ -67,6 +67,7 @@ class AdyenGatewayPlugin(BasePlugin):
         {"name": "notification-password", "value": ""},
         {"name": "enable-native-3d-secure", "value": False},
         {"name": "apple-pay-cert", "value": None},
+        {"name": "webhook-endpoint", "value": "Test read only value "},
     ]
 
     CONFIG_STRUCTURE = {
@@ -183,6 +184,15 @@ class AdyenGatewayPlugin(BasePlugin):
                 "offer Apple Pay or offer it only as a payment method in your iOS app."
             ),
             "label": "Apple Pay certificate",
+        },
+        "webhook-endpoint": {
+            "type": ConfigurationTypeField.OUTPUT,
+            "help_text": (
+                "Endpoint which should be used to activate Adyen's webhooks. "
+                "More details can be find here: "
+                "https://docs.adyen.com/development-resources/webhooks"
+            ),
+            "label": "Webhook endpoint",
         },
     }
 

--- a/saleor/plugins/base_plugin.py
+++ b/saleor/plugins/base_plugin.py
@@ -41,6 +41,7 @@ class ConfigurationTypeField:
     SECRET = "Secret"
     SECRET_MULTILINE = "SecretMultiline"
     PASSWORD = "Password"
+    OUTPUT = "OUTPUT"
     CHOICES = [
         (STRING, "Field is a String"),
         (MULTILINE, "Field is a Multiline"),
@@ -48,6 +49,7 @@ class ConfigurationTypeField:
         (SECRET, "Field is a Secret"),
         (PASSWORD, "Field is a Password"),
         (SECRET_MULTILINE, "Field is a Secret multiline"),
+        (OUTPUT, "Field is a read only"),
     ]
 
 
@@ -667,6 +669,9 @@ class BasePlugin:
                         and not isinstance(new_value, bool)
                     ):
                         new_value = new_value.lower() == "true"
+                    if item_type == ConfigurationTypeField.OUTPUT:
+                        # OUTPUT field is read only. No need to update it
+                        continue
                     config_item.update([("value", new_value)])
 
         # Get new keys that don't exist in current_config and extend it.

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -238,6 +238,22 @@ class ChannelPluginSample(PluginSample):
     }
 
 
+class InactiveChannelPluginSample(PluginSample):
+    PLUGIN_ID = "channel.plugin.inactive.sample"
+    PLUGIN_NAME = "Inactive Channel Plugin"
+    PLUGIN_DESCRIPTION = "Test channel plugin"
+    DEFAULT_ACTIVE = False
+    CONFIGURATION_PER_CHANNEL = True
+    DEFAULT_CONFIGURATION = [{"name": "input-per-channel", "value": None}]
+    CONFIG_STRUCTURE = {
+        "input-per-channel": {
+            "type": ConfigurationTypeField.STRING,
+            "help_text": "Test input",
+            "label": "Input per channel",
+        }
+    }
+
+
 class PluginInactive(BasePlugin):
     PLUGIN_ID = "mirumee.taxes.plugin.inactive"
     PLUGIN_NAME = "PluginInactive"

--- a/saleor/plugins/tests/test_views.py
+++ b/saleor/plugins/tests/test_views.py
@@ -1,6 +1,11 @@
 import pytest
 
-from .sample_plugins import PluginInactive, PluginSample
+from .sample_plugins import (
+    ChannelPluginSample,
+    InactiveChannelPluginSample,
+    PluginInactive,
+    PluginSample,
+)
 
 
 @pytest.mark.parametrize(
@@ -20,4 +25,48 @@ def test_plugin_webhook_view(
     ]
 
     response = client.post(f"/plugins/{plugin_id}{plugin_path}")
+    assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "plugin_id, plugin_path, status_code",
+    [
+        (PluginSample.PLUGIN_ID, "/webhook/paid", 200),
+        (ChannelPluginSample.PLUGIN_ID, "/webhook/paid", 200),
+        (InactiveChannelPluginSample.PLUGIN_ID, "/webhook/paid", 404),
+        ("wrong.id", "/webhook/", 404),
+    ],
+)
+def test_plugin_per_channel_webhook_view(
+    plugin_id, plugin_path, status_code, client, settings, monkeypatch, channel_PLN
+):
+    settings.PLUGINS = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.ChannelPluginSample",
+        "saleor.plugins.tests.sample_plugins.InactiveChannelPluginSample",
+    ]
+
+    response = client.post(
+        f"/plugins/channel/{channel_PLN.slug}/{plugin_id}{plugin_path}"
+    )
+    assert response.status_code == status_code
+
+
+@pytest.mark.parametrize(
+    "plugin_id, plugin_path, status_code",
+    [
+        (PluginSample.PLUGIN_ID, "/webhook/paid", 200),
+        (PluginInactive.PLUGIN_ID, "/webhook/paid", 404),
+        ("wrong.id", "/webhook/", 404),
+    ],
+)
+def test_plugin_global_webhook_view(
+    plugin_id, plugin_path, status_code, client, settings, monkeypatch, channel_PLN
+):
+    settings.PLUGINS = [
+        "saleor.plugins.tests.sample_plugins.PluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+    ]
+
+    response = client.post(f"/plugins/global/{plugin_id}{plugin_path}")
     assert response.status_code == status_code

--- a/saleor/plugins/views.py
+++ b/saleor/plugins/views.py
@@ -6,4 +6,16 @@ from .manager import get_plugins_manager
 
 def handle_plugin_webhook(request: WSGIRequest, plugin_id: str) -> HttpResponse:
     manager = get_plugins_manager()
-    return manager.webhook(request, plugin_id)
+    return manager.webhook_endpoint_without_channel(request, plugin_id)
+
+
+def handle_global_plugin_webhook(request: WSGIRequest, plugin_id: str) -> HttpResponse:
+    manager = get_plugins_manager()
+    return manager.webhook(request, plugin_id, channel_slug=None)
+
+
+def handle_plugin_per_channel_webhook(
+    request: WSGIRequest, plugin_id: str, channel_slug: str
+) -> HttpResponse:
+    manager = get_plugins_manager()
+    return manager.webhook(request, plugin_id, channel_slug=channel_slug)

--- a/saleor/urls.py
+++ b/saleor/urls.py
@@ -6,7 +6,11 @@ from django.views.decorators.csrf import csrf_exempt
 
 from .graphql.api import schema
 from .graphql.views import GraphQLView
-from .plugins.views import handle_plugin_webhook
+from .plugins.views import (
+    handle_global_plugin_webhook,
+    handle_plugin_per_channel_webhook,
+    handle_plugin_webhook,
+)
 from .product.views import digital_product
 
 urlpatterns = [
@@ -15,6 +19,17 @@ urlpatterns = [
         r"^digital-download/(?P<token>[0-9A-Za-z_\-]+)/$",
         digital_product,
         name="digital-product",
+    ),
+    url(
+        r"plugins/channel/(?P<channel_slug>[.0-9A-Za-z_\-]+)/"
+        r"(?P<plugin_id>[.0-9A-Za-z_\-]+)/",
+        handle_plugin_per_channel_webhook,
+        name="plugins-per-channel",
+    ),
+    url(
+        r"plugins/global/(?P<plugin_id>[.0-9A-Za-z_\-]+)/",
+        handle_global_plugin_webhook,
+        name="plugins-global",
     ),
     url(
         r"plugins/(?P<plugin_id>[.0-9A-Za-z_\-]+)/",


### PR DESCRIPTION
I want to merge this change because we need to have a possibility to process webhook with proper configuration. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
