### PR TITLE
Fix for incorrect call of refund after introduce plugins per channel

### DIFF
--- a/saleor/graphql/order/tests/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_refund_products.py
@@ -81,7 +81,10 @@ def test_fulfillment_refund_products_amount_and_shipping_costs(
     staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
 
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, quantize_price(amount_to_refund, fulfilled_order.currency)
+        payment_dummy,
+        ANY,
+        amount=quantize_price(amount_to_refund, fulfilled_order.currency),
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -151,7 +154,10 @@ def test_fulfillment_refund_products_order_lines(
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, line_to_refund.unit_price_gross_amount * 2
+        payment_dummy,
+        ANY,
+        amount=line_to_refund.unit_price_gross_amount * 2,
+        channel_slug=order_with_lines.channel.slug,
     )
 
 
@@ -258,7 +264,8 @@ def test_fulfillment_refund_products_fulfillment_lines(
     mocked_refund.assert_called_with(
         payment_dummy,
         ANY,
-        fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2,
+        amount=fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2,
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -375,7 +382,9 @@ def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -414,7 +423,9 @@ def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     amount = line_to_refund.unit_price_gross_amount * 2
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -460,7 +471,12 @@ def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     assert len(refund_fulfillment["lines"]) == 1
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == order_line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=fulfilled_order.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -498,7 +514,12 @@ def test_fulfillment_refund_products_order_lines_custom_amount(
     assert len(refund_fulfillment["lines"]) == 1
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=order_with_lines.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -585,4 +606,6 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2
     amount += order_line.unit_price_gross_amount * 2
     amount = quantize_price(amount, fulfilled_order.currency)
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )

--- a/saleor/graphql/order/tests/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_return_products.py
@@ -110,7 +110,10 @@ def test_fulfillment_return_products_amount_and_shipping_costs(
     staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
 
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, quantize_price(amount_to_refund, fulfilled_order.currency)
+        payment_dummy,
+        ANY,
+        amount=quantize_price(amount_to_refund, fulfilled_order.currency),
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -253,7 +256,9 @@ def test_fulfillment_return_products_order_lines(
 
     amount = line_to_return.unit_price_gross_amount * line_quantity_to_return
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 def test_fulfillment_return_products_order_lines_quantity_bigger_than_total(
@@ -355,7 +360,12 @@ def test_fulfillment_return_products_order_lines_custom_amount(
     assert len(return_fulfillment["lines"]) == 1
     assert return_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert return_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=order_with_lines.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -475,7 +485,9 @@ def test_fulfillment_return_products_fulfillment_lines(
         * quantity_to_return
     )
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 def test_fulfillment_return_products_fulfillment_lines_quantity_bigger_than_total(
@@ -635,7 +647,9 @@ def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     assert return_fulfillment["lines"][0]["quantity"] == 2
     amount = fulfillment_line_to_return.order_line.unit_price_gross_amount * 2
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -739,4 +753,6 @@ def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
 
     amount = order_line.unit_price_gross_amount * 2
     amount = quantize_price(amount, fulfilled_order.currency)
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1121,7 +1121,9 @@ def _process_refund(
     if amount:
         amount = min(payment.captured_amount, amount)
         try:
-            gateway.refund(payment, manager, amount)
+            gateway.refund(
+                payment, manager, amount=amount, channel_slug=order.channel.slug
+            )
         except PaymentError:
             raise ValidationError(
                 "The refund operation is not available yet.",

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -147,7 +147,12 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
         )
 
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_return])
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=order_with_lines.channel.slug,
+    )
     assert not replace_order
 
     mocked_order_updated.assert_called_once_with(order_with_lines)
@@ -212,7 +217,12 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
 
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_return])
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=order_with_lines.channel.slug,
+    )
     assert not replace_order
 
     mocked_order_updated.assert_called_once_with(order_with_lines)
@@ -580,6 +590,11 @@ def test_create_return_fulfillment_with_lines_already_refunded(
             for line in fulfillment_lines_to_return
         ]
     )
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=fulfilled_order.channel.slug,
+    )
 
     mocked_order_updated.assert_called_once_with(fulfilled_order)

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -62,7 +62,9 @@ def test_create_refund_fulfillment_only_order_lines(
             == current_allocation.quantity_allocated
         )
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
     mocked_order_updated.assert_called_once_with(order_with_lines)
 
 
@@ -106,7 +108,9 @@ def test_create_refund_fulfillment_included_shipping_costs(
         assert line.quantity_unfulfilled == original_quantity.get(line.pk) - 2
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
     mocked_order_updated.assert_called_once_with(order_with_lines)
 
 
@@ -150,7 +154,9 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
     amount = sum(
         [line.order_line.unit_price_gross_amount * 2 for line in fulfillment_lines]
     )
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
     mocked_order_updated.assert_called_once_with(fulfilled_order)
 
 
@@ -193,5 +199,7 @@ def test_create_refund_fulfillment_custom_amount(
 
     for line in fulfillment_lines:
         assert line.quantity == original_quantity.get(line.pk) - 2
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
     mocked_order_updated.assert_called_once_with(fulfilled_order)


### PR DESCRIPTION
I want to merge this change because it adds a missing parameter to the call of gateway.refund action.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
