### PR TITLE
Fix for incorrect call of refund after introduced plugins per channel

### DIFF
--- a/saleor/graphql/order/tests/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_refund_products.py
@@ -81,7 +81,10 @@ def test_fulfillment_refund_products_amount_and_shipping_costs(
     staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
 
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, quantize_price(amount_to_refund, fulfilled_order.currency)
+        payment_dummy,
+        ANY,
+        amount=quantize_price(amount_to_refund, fulfilled_order.currency),
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -151,7 +154,10 @@ def test_fulfillment_refund_products_order_lines(
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, line_to_refund.unit_price_gross_amount * 2
+        payment_dummy,
+        ANY,
+        amount=line_to_refund.unit_price_gross_amount * 2,
+        channel_slug=order_with_lines.channel.slug,
     )
 
 
@@ -258,7 +264,8 @@ def test_fulfillment_refund_products_fulfillment_lines(
     mocked_refund.assert_called_with(
         payment_dummy,
         ANY,
-        fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2,
+        amount=fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2,
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -375,7 +382,9 @@ def test_fulfillment_refund_products_fulfillment_lines_include_shipping_costs(
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -414,7 +423,9 @@ def test_fulfillment_refund_products_order_lines_include_shipping_costs(
     assert refund_fulfillment["lines"][0]["quantity"] == 2
     amount = line_to_refund.unit_price_gross_amount * 2
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -460,7 +471,12 @@ def test_fulfillment_refund_products_fulfillment_lines_custom_amount(
     assert len(refund_fulfillment["lines"]) == 1
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == order_line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=fulfilled_order.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -498,7 +514,12 @@ def test_fulfillment_refund_products_order_lines_custom_amount(
     assert len(refund_fulfillment["lines"]) == 1
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=order_with_lines.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -585,4 +606,6 @@ def test_fulfillment_refund_products_fulfillment_lines_and_order_lines(
     amount = fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2
     amount += order_line.unit_price_gross_amount * 2
     amount = quantize_price(amount, fulfilled_order.currency)
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )

--- a/saleor/graphql/order/tests/test_fulfillment_return_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_return_products.py
@@ -108,7 +108,10 @@ def test_fulfillment_return_products_amount_and_shipping_costs(
     staff_api_client.post_graphql(ORDER_FULFILL_RETURN_MUTATION, variables)
 
     mocked_refund.assert_called_with(
-        payment_dummy, ANY, quantize_price(amount_to_refund, fulfilled_order.currency)
+        payment_dummy,
+        ANY,
+        amount=quantize_price(amount_to_refund, fulfilled_order.currency),
+        channel_slug=fulfilled_order.channel.slug,
     )
 
 
@@ -249,7 +252,9 @@ def test_fulfillment_return_products_order_lines(
 
     amount = line_to_return.unit_price_gross_amount * line_quantity_to_return
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 def test_fulfillment_return_products_order_lines_quantity_bigger_than_total(
@@ -351,7 +356,12 @@ def test_fulfillment_return_products_order_lines_custom_amount(
     assert len(return_fulfillment["lines"]) == 1
     assert return_fulfillment["lines"][0]["orderLine"]["id"] == line_id
     assert return_fulfillment["lines"][0]["quantity"] == 2
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount_to_refund)
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=amount_to_refund,
+        channel_slug=order_with_lines.channel.slug,
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -468,7 +478,9 @@ def test_fulfillment_return_products_fulfillment_lines(
         * quantity_to_return
     )
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 def test_fulfillment_return_products_fulfillment_lines_quantity_bigger_than_total(
@@ -628,7 +640,9 @@ def test_fulfillment_return_products_fulfillment_lines_include_shipping_costs(
     assert return_fulfillment["lines"][0]["quantity"] == 2
     amount = fulfillment_line_to_return.order_line.unit_price_gross_amount * 2
     amount += fulfilled_order.shipping_price_gross_amount
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -729,4 +743,6 @@ def test_fulfillment_return_products_fulfillment_lines_and_order_lines(
 
     amount = order_line.unit_price_gross_amount * 2
     amount = quantize_price(amount, fulfilled_order.currency)
-    mocked_refund.assert_called_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -1117,7 +1117,9 @@ def _process_refund(
     if amount:
         amount = min(payment.captured_amount, amount)
         try:
-            gateway.refund(payment, manager, amount)
+            gateway.refund(
+                payment, manager, amount=amount, channel_slug=order.channel.slug
+            )
         except PaymentError:
             raise ValidationError(
                 "The refund operation is not available yet.",

--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -128,7 +128,12 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
         )
 
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_return])
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=order_with_lines.channel.slug,
+    )
     assert not replace_order
 
 
@@ -185,7 +190,12 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
 
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_return])
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=order_with_lines.channel.slug,
+    )
     assert not replace_order
 
 
@@ -522,4 +532,9 @@ def test_create_return_fulfillment_with_lines_already_refunded(
             for line in fulfillment_lines_to_return
         ]
     )
-    mocked_refund.assert_called_once_with(payment_dummy_fully_charged, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy_fully_charged,
+        ANY,
+        amount=amount,
+        channel_slug=fulfilled_order.channel.slug,
+    )

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -59,7 +59,9 @@ def test_create_refund_fulfillment_only_order_lines(
             == current_allocation.quantity_allocated
         )
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -99,7 +101,9 @@ def test_create_refund_fulfillment_included_shipping_costs(
         assert line.quantity_unfulfilled == original_quantity.get(line.pk) - 2
     amount = sum([line.unit_price_gross_amount * 2 for line in order_lines_to_refund])
     amount += order_with_lines.shipping_price_gross_amount
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=order_with_lines.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -139,7 +143,9 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
     amount = sum(
         [line.order_line.unit_price_gross_amount * 2 for line in fulfillment_lines]
     )
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )
 
 
 @patch("saleor.order.actions.gateway.refund")
@@ -179,4 +185,6 @@ def test_create_refund_fulfillment_custom_amount(
 
     for line in fulfillment_lines:
         assert line.quantity == original_quantity.get(line.pk) - 2
-    mocked_refund.assert_called_once_with(payment_dummy, ANY, amount)
+    mocked_refund.assert_called_once_with(
+        payment_dummy, ANY, amount=amount, channel_slug=fulfilled_order.channel.slug
+    )


### PR DESCRIPTION
It is port of changes from #7337 to branch 3.0

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
