### PR TITLE
Extend warehouse queries with manage shipping permission

### DIFF
--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -1,6 +1,10 @@
 import graphene
 
-from ...core.permissions import OrderPermissions, ProductPermissions
+from ...core.permissions import (
+    OrderPermissions,
+    ProductPermissions,
+    ShippingPermissions,
+)
 from ...core.tracing import traced_resolver
 from ...warehouse import models
 from ..core.fields import FilterInputConnectionField
@@ -33,7 +37,11 @@ class WarehouseQueries(graphene.ObjectType):
     )
 
     @one_of_permissions_required(
-        [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
+        [
+            ProductPermissions.MANAGE_PRODUCTS,
+            OrderPermissions.MANAGE_ORDERS,
+            ShippingPermissions.MANAGE_SHIPPING,
+        ]
     )
     @traced_resolver
     def resolve_warehouse(self, info, **data):
@@ -42,7 +50,11 @@ class WarehouseQueries(graphene.ObjectType):
         return warehouse
 
     @one_of_permissions_required(
-        [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
+        [
+            ProductPermissions.MANAGE_PRODUCTS,
+            OrderPermissions.MANAGE_ORDERS,
+            ShippingPermissions.MANAGE_SHIPPING,
+        ]
     )
     @traced_resolver
     def resolve_warehouses(self, info, **_kwargs):

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -123,7 +123,10 @@ class Allocation(CountableDjangoObjectType):
 
     @staticmethod
     @one_of_permissions_required(
-        [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
+        [
+            ProductPermissions.MANAGE_PRODUCTS,
+            OrderPermissions.MANAGE_ORDERS,
+        ]
     )
     @traced_resolver
     def resolve_warehouse(root, *_args):
@@ -131,7 +134,10 @@ class Allocation(CountableDjangoObjectType):
 
     @staticmethod
     @one_of_permissions_required(
-        [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
+        [
+            ProductPermissions.MANAGE_PRODUCTS,
+            OrderPermissions.MANAGE_ORDERS,
+        ]
     )
     def resolve_quantity(root, *_args):
         return root.quantity_allocated


### PR DESCRIPTION
I want to merge this change because...I want to extend warehouse queries with manage shipping permission

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
