### PR TITLE
Fix Duplicate Customer Creation in Gateway

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -584,7 +584,9 @@ def complete_checkout(
         gateway.payment_refund_or_void(payment, manager, channel_slug=channel_slug)
         raise exc
 
-    customer_id = fetch_customer_id(user, payment.gateway) if store_source else None
+    customer_id = None
+    if store_source and payment:
+        customer_id = fetch_customer_id(user=user, gateway=payment.gateway)
 
     txn = _process_payment(
         payment=payment,  # type: ignore

--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -512,7 +512,7 @@ def _get_order_data(
 
 def _process_payment(
     payment: Payment,
-    customer_id: str,
+    customer_id: Optional[str],
     store_source: bool,
     payment_data: Optional[dict],
     order_data: dict,

--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -76,12 +76,14 @@ def process_payment(
     token: str,
     manager: "PluginsManager",
     channel_slug: str,
+    customer_id: str = None,
     store_source: bool = False,
     additional_data: Optional[dict] = None,
 ) -> Transaction:
     payment_data = create_payment_information(
         payment=payment,
         payment_token=token,
+        customer_id=customer_id,
         store_source=store_source,
         additional_data=additional_data,
     )
@@ -114,12 +116,14 @@ def authorize(
     token: str,
     manager: "PluginsManager",
     channel_slug: str,
+    customer_id: str = None,
     store_source: bool = False,
 ) -> Transaction:
     clean_authorize(payment)
     payment_data = create_payment_information(
         payment=payment,
         payment_token=token,
+        customer_id=customer_id,
         store_source=store_source,
     )
     response, error = _fetch_gateway_response(
@@ -149,6 +153,7 @@ def capture(
     manager: "PluginsManager",
     channel_slug: str,
     amount: Decimal = None,
+    customer_id: str = None,
     store_source: bool = False,
 ) -> Transaction:
     if amount is None:
@@ -156,7 +161,11 @@ def capture(
     clean_capture(payment, Decimal(amount))
     token = _get_past_transaction_token(payment, TransactionKind.AUTH)
     payment_data = create_payment_information(
-        payment=payment, payment_token=token, amount=amount, store_source=store_source
+        payment=payment,
+        payment_token=token,
+        amount=amount,
+        customer_id=customer_id,
+        store_source=store_source,
     )
     response, error = _fetch_gateway_response(
         manager.capture_payment,


### PR DESCRIPTION
If we set true to "store_source" during complete checkout. It will create customer in gateway and store gateway customer ID in user meta however same user place another order it create duplicate customer in gateway. The below changes fetch gateway customer ID from user meta at complete_checkout() and pass it as argument to process_payment().

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
