### PR TITLE
Deprecate values field on AttributeType

### DIFF
--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -207,6 +207,16 @@ def test_real_query(user_api_client, product):
             slug
             __typename
         }
+        choices(first: 10) {
+            edges {
+                node {
+                    id
+                    name
+                    slug
+                    __typename
+                }
+            }
+        }
         __typename
     }
     """

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -10,6 +10,7 @@ from graphene_django.filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 from ...product.filters import filter_products_by_attributes_values
 from ...product.models import (
     Attribute,
+    AttributeValue,
     Category,
     Collection,
     Product,
@@ -439,6 +440,16 @@ class AttributeFilter(django_filters.FilterSet):
         return filter_attributes_by_product_types(queryset, name, value, requestor)
 
 
+class AttributeChoiceFilter(django_filters.FilterSet):
+    search = django_filters.CharFilter(
+        method=filter_fields_containing_value("slug", "name")
+    )
+
+    class Meta:
+        model = AttributeValue
+        fields = ["search"]
+
+
 class ProductFilterInput(FilterInputObjectType):
     class Meta:
         filterset_class = ProductFilter
@@ -467,3 +478,8 @@ class ProductTypeFilterInput(FilterInputObjectType):
 class AttributeFilterInput(FilterInputObjectType):
     class Meta:
         filterset_class = AttributeFilter
+
+
+class AttributeChoiceFilterInput(FilterInputObjectType):
+    class Meta:
+        filterset_class = AttributeChoiceFilter

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -58,6 +58,27 @@ class AttributeSortingInput(SortInputObjectType):
         type_name = "attributes"
 
 
+class AttributeChoicesSortField(graphene.Enum):
+    NAME = ["name", "slug"]
+    SLUG = ["slug"]
+
+    @property
+    def description(self):
+        descriptions = {
+            AttributeSortField.NAME.name: "Sort attribute choice by name.",
+            AttributeSortField.SLUG.name: "Sort attribute choice by slug.",
+        }
+        if self.name in descriptions:
+            return descriptions[self.name]
+        raise ValueError("Unsupported enum value: %s" % self.value)
+
+
+class AttributeChoicesSortingInput(SortInputObjectType):
+    class Meta:
+        sort_enum = AttributeChoicesSortField
+        type_name = "attribute choices"
+
+
 class CategorySortField(graphene.Enum):
     NAME = ["name", "slug"]
     PRODUCT_COUNT = ["product_count", "name", "slug"]

--- a/saleor/graphql/product/tests/benchmark/test_category.py
+++ b/saleor/graphql/product/tests/benchmark/test_category.py
@@ -101,6 +101,15 @@ def test_category_view(api_client, category_with_products, count_queries):
                   name
                   slug
                 }
+                choices(first: 10) {
+                  edges {
+                    node {
+                      id
+                      name
+                      slug
+                    }
+                  }
+                }
               }
             }
           }

--- a/saleor/graphql/product/tests/benchmark/test_collection.py
+++ b/saleor/graphql/product/tests/benchmark/test_collection.py
@@ -94,6 +94,15 @@ def test_collection_view(api_client, homepage_collection, count_queries):
                   name
                   slug
                 }
+                choices(first: 10) {
+                  edges {
+                    node {
+                      id
+                      name
+                      slug
+                    }
+                  }
+                }
               }
             }
           }

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -80,6 +80,11 @@ QUERY_ATTRIBUTES = """
                         name
                         slug
                     }
+                    choices {
+                        id
+                        name
+                        slug
+                    }
                 }
             }
         }
@@ -456,6 +461,10 @@ CREATE_ATTRIBUTES_QUERY = """
                     name
                     slug
                 }
+                choices {
+                    name
+                    slug
+                }
                 productTypes(first: 10) {
                     edges {
                         node {
@@ -497,6 +506,11 @@ def test_create_attribute_and_attribute_values(
     assert len(data["attribute"]["values"]) == 1
     assert data["attribute"]["values"][0]["name"] == name
     assert data["attribute"]["values"][0]["slug"] == slugify(name)
+
+    # Check if the attribute choices were correctly created
+    assert len(data["attribute"]["choices"]) == 1
+    assert data["attribute"]["choices"][0]["name"] == name
+    assert data["attribute"]["choices"][0]["slug"] == slugify(name)
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/product/tests/test_attributes.py
+++ b/saleor/graphql/product/tests/test_attributes.py
@@ -80,10 +80,14 @@ QUERY_ATTRIBUTES = """
                         name
                         slug
                     }
-                    choices {
-                        id
-                        name
-                        slug
+                    choices(first: 10) {
+                        edges {
+                            node {
+                                id
+                                name
+                                slug
+                            }
+                        }
                     }
                 }
             }
@@ -461,9 +465,13 @@ CREATE_ATTRIBUTES_QUERY = """
                     name
                     slug
                 }
-                choices {
-                    name
-                    slug
+                choices(first: 10) {
+                    edges {
+                        node {
+                            name
+                            slug
+                        }
+                    }
                 }
                 productTypes(first: 10) {
                     edges {
@@ -507,10 +515,11 @@ def test_create_attribute_and_attribute_values(
     assert data["attribute"]["values"][0]["name"] == name
     assert data["attribute"]["values"][0]["slug"] == slugify(name)
 
-    # Check if the attribute choices were correctly created
-    assert len(data["attribute"]["choices"]) == 1
-    assert data["attribute"]["choices"][0]["name"] == name
-    assert data["attribute"]["choices"][0]["slug"] == slugify(name)
+    # Check if the attribute choices were correctly returned
+    choices = data["attribute"]["choices"]["edges"]
+    assert len(choices) == 1
+    assert choices[0]["node"]["name"] == name
+    assert choices[0]["node"]["slug"] == slugify(name)
 
 
 @pytest.mark.parametrize(
@@ -637,6 +646,14 @@ UPDATE_ATTRIBUTE_MUTATION = """
             values {
                 name
                 slug
+            }
+            choices(first: 10) {
+                edges {
+                    node {
+                        name
+                        slug
+                    }
+                }
             }
             productTypes(first: 10) {
                 edges {
@@ -1019,6 +1036,13 @@ CREATE_ATTRIBUTE_VALUE_QUERY = """
             values {
                 name
             }
+            choices(first: 10) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
         }
         attributeValue {
             name
@@ -1050,6 +1074,9 @@ def test_create_attribute_value(
     assert attr_data["slug"] == slugify(name)
     assert attr_data["type"] == "STRING"
     assert name in [value["name"] for value in data["attribute"]["values"]]
+    assert name in [
+        choice["node"]["name"] for choice in data["attribute"]["choices"]["edges"]
+    ]
 
 
 def test_create_attribute_value_not_unique_name(
@@ -1105,6 +1132,13 @@ mutation updateChoice(
             values {
                 name
             }
+            choices(first: 10) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
         }
     }
 }
@@ -1130,6 +1164,9 @@ def test_update_attribute_value(
     assert data["attributeValue"]["name"] == name == value.name
     assert data["attributeValue"]["slug"] == slugify(name)
     assert name in [value["name"] for value in data["attribute"]["values"]]
+    assert name in [
+        choice["node"]["name"] for choice in data["attribute"]["choices"]["edges"]
+    ]
 
 
 def test_update_attribute_value_name_not_unique(
@@ -1832,21 +1869,27 @@ def test_sort_attributes_within_product_type(
 
 
 ATTRIBUTE_VALUES_RESORT_QUERY = """
-    mutation attributeReorderValues($attributeId: ID!, $moves: [ReorderInput]!) {
-      attributeReorderValues(attributeId: $attributeId, moves: $moves) {
+mutation attributeReorderValues($attributeId: ID!, $moves: [ReorderInput]!) {
+    attributeReorderValues(attributeId: $attributeId, moves: $moves) {
         attribute {
-          id
-          values {
             id
-          }
+            values {
+                id
+            }
+            choices(first: 10) {
+                edges {
+                    node {
+                        id
+                    }
+                }
+            }
         }
-
         errors {
-          field
-          message
+            field
+            message
         }
-      }
     }
+}
 """
 
 
@@ -2843,3 +2886,88 @@ def test_attributes_of_products_are_sorted(
 
     # Compare the received data against our expectations
     assert actual_order == expected_order
+
+
+ATTRIBUTE_CHOICES_SORT_QUERY = """
+query($sortBy: AttributeChoicesSortingInput) {
+    attributes(first: 10) {
+        edges {
+            node {
+                slug
+                choices(first: 10, sortBy: $sortBy) {
+                    edges {
+                        node {
+                            name
+                            slug
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def test_sort_attribute_choices_by_slug(api_client, attribute_choices_for_sorting):
+    variables = {"sortBy": {"field": "SLUG", "direction": "ASC"}}
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTE_CHOICES_SORT_QUERY, variables)
+    )["data"]["attributes"]
+    choices = attributes["edges"][0]["node"]["choices"]["edges"]
+
+    assert len(choices) == 3
+    assert choices[0]["node"]["slug"] == "absorb"
+    assert choices[1]["node"]["slug"] == "summer"
+    assert choices[2]["node"]["slug"] == "zet"
+
+
+def test_sort_attribute_choices_by_name(api_client, attribute_choices_for_sorting):
+    variables = {"sortBy": {"field": "NAME", "direction": "ASC"}}
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTE_CHOICES_SORT_QUERY, variables)
+    )["data"]["attributes"]
+    choices = attributes["edges"][0]["node"]["choices"]["edges"]
+
+    assert len(choices) == 3
+    assert choices[0]["node"]["name"] == "Apex"
+    assert choices[1]["node"]["name"] == "Global"
+    assert choices[2]["node"]["name"] == "Police"
+
+
+ATTRIBUTES_CHOICE_FILTER_QUERY = """
+query($filters: AttributeChoiceFilterInput!) {
+    attributes(first: 10) {
+        edges {
+            node {
+                name
+                slug
+                choices(first: 10, filter: $filters) {
+                    edges {
+                        node {
+                            name
+                            slug
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "filter_value", ["red", "blue"],
+)
+def test_search_attributes_choice(
+    filter_value, api_client, color_attribute, size_attribute
+):
+    variables = {"filters": {"search": filter_value}}
+
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTES_CHOICE_FILTER_QUERY, variables)
+    )
+    values = attributes["data"]["attributes"]["edges"][0]["node"]["choices"]["edges"]
+    assert len(values) == 1
+    assert values[0]["node"]["slug"] == filter_value

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -186,24 +186,31 @@ def test_collections_query(
 
 
 GET_FILTERED_PRODUCTS_COLLECTION_QUERY = """
-query CollectionProducts($id: ID!, $filters: ProductFilterInput) {
-  collection(id: $id) {
-    products(first: 10, filter: $filters) {
-      edges {
-        node {
-          id
-          attributes {
-            attribute {
-              values {
-                slug
-              }
+    query CollectionProducts($id: ID!, $filters: ProductFilterInput) {
+        collection(id: $id) {
+            products(first: 10, filter: $filters) {
+                edges {
+                    node {
+                        id
+                        attributes {
+                            attribute {
+                                values {
+                                    slug
+                                }
+                                choices(first: 10) {
+                                    edges {
+                                        node {
+                                            slug
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
-          }
         }
-      }
     }
-  }
-}
 """
 
 
@@ -273,7 +280,14 @@ def test_filter_collection_products_by_multiple_attributes(
         "Product", product_with_multiple_values_attributes.pk
     )
     assert product["attributes"] == [
-        {"attribute": {"values": [{"slug": "eco"}, {"slug": "power"}]}}
+        {
+            "attribute": {
+                "values": [{"slug": "eco"}, {"slug": "power"}],
+                "choices": {
+                    "edges": [{"node": {"slug": "eco"}}, {"node": {"slug": "power"}}]
+                },
+            }
+        }
     ]
 
 

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -3607,11 +3607,25 @@ PRODUCT_TYPE_CREATE_MUTATION = """
                     values {
                         name
                     }
+                    choices(first: 10) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
                 }
                 productAttributes {
                     name
                     values {
                         name
+                    }
+                    choices(first: 10) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
                     }
                 }
             }

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -503,6 +503,16 @@ def test_create_product_variant_update_with_new_attributes(
                     slug
                     __typename
                   }
+                  choices(first: 10) {
+                    edges {
+                      node {
+                        id
+                        name
+                        slug
+                        __typename
+                      }
+                    }
+                  }
                   __typename
                 }
                 __typename

--- a/saleor/graphql/product/types/attributes.py
+++ b/saleor/graphql/product/types/attributes.py
@@ -83,14 +83,7 @@ class Attribute(CountableDjangoObjectType):
         description=AttributeDescriptions.VALUES,
     )
     value_required = graphene.Boolean(
-        description=AttributeDescriptions.VALUE_REQUIRED,
-        deprecation_reason=(
-            "Use the `choiceRequired` field instead. It will be removed in Saleor 3.0."
-        ),
-        required=True,
-    )
-    choice_required = graphene.Boolean(
-        description=AttributeDescriptions.VALUE_REQUIRED, required=True
+        description=AttributeDescriptions.VALUE_REQUIRED, required=True,
     )
     visible_in_storefront = graphene.Boolean(
         description=AttributeDescriptions.VISIBLE_IN_STOREFRONT, required=True
@@ -125,7 +118,7 @@ class Attribute(CountableDjangoObjectType):
         return AttributeValuesByAttributeIdLoader(info.context).load(root.id)
 
     @staticmethod
-    def resolve_choices(root: models.Attribute, info):
+    def resolve_choices(root: models.Attribute, _info, **_kwargs):
         return root.values.all()
 
     @staticmethod
@@ -140,11 +133,6 @@ class Attribute(CountableDjangoObjectType):
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_value_required(root: models.Attribute, *_args):
-        return root.value_required
-
-    @staticmethod
-    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    def resolve_choice_required(root: models.Attribute, *_args):
         return root.value_required
 
     @staticmethod

--- a/saleor/graphql/product/types/attributes.py
+++ b/saleor/graphql/product/types/attributes.py
@@ -6,6 +6,7 @@ from graphene import relay
 from ....core.permissions import ProductPermissions
 from ....product import models
 from ...core.connection import CountableDjangoObjectType
+from ...core.fields import FilterInputConnectionField
 from ...decorators import permission_required
 from ...meta.deprecated.resolvers import resolve_meta, resolve_private_meta
 from ...meta.types import ObjectWithMetadata
@@ -14,6 +15,8 @@ from ...translations.types import AttributeTranslation, AttributeValueTranslatio
 from ..dataloaders import AttributeValuesByAttributeIdLoader
 from ..descriptions import AttributeDescriptions, AttributeValueDescriptions
 from ..enums import AttributeInputTypeEnum, AttributeValueType
+from ..filters import AttributeChoiceFilterInput
+from ..sorters import AttributeChoicesSortingInput
 
 COLOR_PATTERN = r"^(#[0-9a-fA-F]{3}|#(?:[0-9a-fA-F]{2}){2,4}|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))$"  # noqa
 color_pattern = re.compile(COLOR_PATTERN)
@@ -66,9 +69,27 @@ class Attribute(CountableDjangoObjectType):
     name = graphene.String(description=AttributeDescriptions.NAME)
     slug = graphene.String(description=AttributeDescriptions.SLUG)
 
-    values = graphene.List(AttributeValue, description=AttributeDescriptions.VALUES)
-
+    values = graphene.List(
+        AttributeValue,
+        description=AttributeDescriptions.VALUES,
+        deprecation_reason=(
+            "Use the `choices` field instead. It will be removed in Saleor 3.0."
+        ),
+    )
+    choices = FilterInputConnectionField(
+        AttributeValue,
+        sort_by=AttributeChoicesSortingInput(),
+        filter=AttributeChoiceFilterInput(),
+        description=AttributeDescriptions.VALUES,
+    )
     value_required = graphene.Boolean(
+        description=AttributeDescriptions.VALUE_REQUIRED,
+        deprecation_reason=(
+            "Use the `choiceRequired` field instead. It will be removed in Saleor 3.0."
+        ),
+        required=True,
+    )
+    choice_required = graphene.Boolean(
         description=AttributeDescriptions.VALUE_REQUIRED, required=True
     )
     visible_in_storefront = graphene.Boolean(
@@ -104,6 +125,10 @@ class Attribute(CountableDjangoObjectType):
         return AttributeValuesByAttributeIdLoader(info.context).load(root.id)
 
     @staticmethod
+    def resolve_choices(root: models.Attribute, info):
+        return root.values.all()
+
+    @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_private_meta(root: models.Attribute, _info):
         return resolve_private_meta(root, _info)
@@ -115,6 +140,11 @@ class Attribute(CountableDjangoObjectType):
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_value_required(root: models.Attribute, *_args):
+        return root.value_required
+
+    @staticmethod
+    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
+    def resolve_choice_required(root: models.Attribute, *_args):
         return root.value_required
 
     @staticmethod

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -405,8 +405,10 @@ type Attribute implements Node & ObjectWithMetadata {
   inputType: AttributeInputTypeEnum
   name: String
   slug: String
-  values: [AttributeValue]
-  valueRequired: Boolean!
+  values: [AttributeValue] @deprecated(reason: "Use the `choices` field instead. It will be removed in Saleor 3.0.")
+  choices(sortBy: AttributeChoicesSortingInput, filter: AttributeChoiceFilterInput, before: String, after: String, first: Int, last: Int): AttributeValueCountableConnection
+  valueRequired: Boolean! @deprecated(reason: "Use the `choiceRequired` field instead. It will be removed in Saleor 3.0.")
+  choiceRequired: Boolean!
   visibleInStorefront: Boolean!
   filterableInStorefront: Boolean!
   filterableInDashboard: Boolean!
@@ -430,6 +432,20 @@ type AttributeBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
   productErrors: [ProductError!]!
+}
+
+input AttributeChoiceFilterInput {
+  search: String
+}
+
+enum AttributeChoicesSortField {
+  NAME
+  SLUG
+}
+
+input AttributeChoicesSortingInput {
+  direction: OrderDirection!
+  field: AttributeChoicesSortField!
 }
 
 type AttributeClearMeta {
@@ -603,6 +619,17 @@ type AttributeValueBulkDelete {
   errors: [Error!]! @deprecated(reason: "Use typed errors with error codes. This field will be removed after 2020-07-31.")
   count: Int!
   productErrors: [ProductError!]!
+}
+
+type AttributeValueCountableConnection {
+  pageInfo: PageInfo!
+  edges: [AttributeValueCountableEdge!]!
+  totalCount: Int
+}
+
+type AttributeValueCountableEdge {
+  node: AttributeValue!
+  cursor: String!
 }
 
 type AttributeValueCreate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -407,8 +407,7 @@ type Attribute implements Node & ObjectWithMetadata {
   slug: String
   values: [AttributeValue] @deprecated(reason: "Use the `choices` field instead. It will be removed in Saleor 3.0.")
   choices(sortBy: AttributeChoicesSortingInput, filter: AttributeChoiceFilterInput, before: String, after: String, first: Int, last: Int): AttributeValueCountableConnection
-  valueRequired: Boolean! @deprecated(reason: "Use the `choiceRequired` field instead. It will be removed in Saleor 3.0.")
-  choiceRequired: Boolean!
+  valueRequired: Boolean!
   visibleInStorefront: Boolean!
   filterableInStorefront: Boolean!
   filterableInDashboard: Boolean!

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -225,6 +225,18 @@ def test_attribute_value_translation(user_api_client, pink_attribute_value):
                             }
                         }
                     }
+                    choices(first: 10) {
+                        edges {
+                            node {
+                                translation(languageCode: PL) {
+                                    name
+                                    language {
+                                        code
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -242,6 +254,10 @@ def test_attribute_value_translation(user_api_client, pink_attribute_value):
     attribute_value = data["attributes"]["edges"][0]["node"]["values"][-1]
     assert attribute_value["translation"]["name"] == "Różowy"
     assert attribute_value["translation"]["language"]["code"] == "PL"
+
+    attribute_choice = data["attributes"]["edges"][0]["node"]["choices"]["edges"][-1]
+    assert attribute_choice["node"]["translation"]["name"] == "Różowy"
+    assert attribute_choice["node"]["translation"]["language"]["code"] == "PL"
 
 
 def test_shipping_method_translation(
@@ -495,6 +511,18 @@ def test_attribute_value_no_translation(user_api_client, pink_attribute_value):
                             }
                         }
                     }
+                    choices(first: 10) {
+                        edges {
+                            node {
+                                translation(languageCode: PL) {
+                                    name
+                                    language {
+                                        code
+                                    }
+                                }
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -511,6 +539,9 @@ def test_attribute_value_no_translation(user_api_client, pink_attribute_value):
 
     attribute_value = data["attributes"]["edges"][0]["node"]["values"][-1]
     assert attribute_value["translation"] is None
+
+    attribute_choices = data["attributes"]["edges"][0]["node"]["choices"]["edges"][-1]
+    assert attribute_choices["node"]["translation"] is None
 
 
 def test_shipping_method_no_translation(

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -656,6 +656,16 @@ def attribute_list() -> List[Attribute]:
 
 
 @pytest.fixture
+def attribute_choices_for_sorting(db):
+    attribute = Attribute.objects.create(slug="sorting", name="Sorting",)
+    AttributeValue.objects.create(attribute=attribute, name="Global", slug="summer")
+    AttributeValue.objects.create(attribute=attribute, name="Apex", slug="zet")
+    AttributeValue.objects.create(attribute=attribute, name="Police", slug="absorb")
+
+    return attribute
+
+
+@pytest.fixture
 def image():
     img_data = BytesIO()
     image = Image.new("RGB", size=(1, 1))


### PR DESCRIPTION
I want to merge this change because...I want to deprecate and add new fields on AttributeType
deprecated:
- values

new fields:
- choices

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
