### PR TITLE
Fix invoice file generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - `undiscounted_total_price_net_amount`
     - `undiscounted_total_price_gross_amount`
 - Copy metadata fields when creating reissue - #7358 by @IKarbowiak
+- Fix invoice generation - #7376 by tomaszszymanski129
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/plugins/invoicing/plugin.py
+++ b/saleor/plugins/invoicing/plugin.py
@@ -2,6 +2,7 @@ from typing import Any, Optional
 from uuid import uuid4
 
 from django.core.files.base import ContentFile
+from django.utils.text import slugify
 
 from ...core import JobStatus
 from ...invoice.models import Invoice
@@ -17,14 +18,6 @@ class InvoicingPlugin(BasePlugin):
     PLUGIN_DESCRIPTION = "Built-in saleor plugin that handles invoice creation."
     CONFIGURATION_PER_CHANNEL = False
 
-    @staticmethod
-    def sanitize_invoice_number(invoice_number):
-        """Invoice number contains slashes so it's unsafe as saved file would mimic a path.
-
-        Slashes should be replaced with hyphens.
-        """
-        return invoice_number.replace("/", "-")
-
     def invoice_request(
         self,
         order: "Order",
@@ -35,9 +28,9 @@ class InvoicingPlugin(BasePlugin):
         invoice.update_invoice(number=generate_invoice_number())
         file_content, creation_date = generate_invoice_pdf(invoice)
         invoice.created = creation_date
-        sanitized_invoice_number = self.sanitize_invoice_number(invoice.number)
+        slugified_invoice_number = slugify(invoice.number)
         invoice.invoice_file.save(
-            f"invoice-{sanitized_invoice_number}-order-{order.id}-{uuid4()}.pdf",
+            f"invoice-{slugified_invoice_number}-order-{order.id}-{uuid4()}.pdf",
             ContentFile(file_content),
         )
         invoice.status = JobStatus.SUCCESS

--- a/saleor/plugins/invoicing/plugin.py
+++ b/saleor/plugins/invoicing/plugin.py
@@ -25,10 +25,11 @@ class InvoicingPlugin(BasePlugin):
         number: Optional[str],
         previous_value: Any,
     ) -> Any:
-        invoice.update_invoice(number=generate_invoice_number())
+        invoice_number = generate_invoice_number()
+        invoice.update_invoice(number=invoice_number)
         file_content, creation_date = generate_invoice_pdf(invoice)
         invoice.created = creation_date
-        slugified_invoice_number = slugify(invoice.number)
+        slugified_invoice_number = slugify(invoice_number)
         invoice.invoice_file.save(
             f"invoice-{slugified_invoice_number}-order-{order.id}-{uuid4()}.pdf",
             ContentFile(file_content),


### PR DESCRIPTION
I want to merge this change because it fixes invoice generation.

Bug happened probably after django update, fixed invoice file naming to replace invoice number with it's slugified version.

Steps to reproduce:
- Go to dashboard
- Go to Order list
- Go into any order details
- Click "Generate Invoice" button
- Generic error is being displayed 🔥 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
