### PR TITLE
Add timeout to appFetchManifest mutation

### DIFF
--- a/saleor/app/installation_utils.py
+++ b/saleor/app/installation_utils.py
@@ -6,7 +6,7 @@ from ..app.validators import AppURLValidator
 from .models import App, AppInstallation
 from .types import AppType
 
-REQUEST_TIMEOUT = 30
+REQUEST_TIMEOUT = 25
 
 
 def send_app_token(target_url: str, token: str):


### PR DESCRIPTION
I want to merge this change because we didn't have a timeout for mutation responsible for fetching app manifest.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
