### PR TITLE
Trigger checkout_updated for checkout meta mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Copy metadata fields when creating reissue - #7358 by @IKarbowiak
 - Fix invoice generation - #7376 by @tomaszszymanski129
 - Allow defining only one field in translations - #7363 by @IKarbowiak
+- Trigger `checkout_updated` hook for checkout meta mutations - #7392 by @maarcingebala
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/meta/extra_methods.py
+++ b/saleor/graphql/meta/extra_methods.py
@@ -1,6 +1,10 @@
 from ...product.models import Product, ProductVariant
 
 
+def extra_checkout_actions(instance, info, **data):
+    info.context.plugins.checkout_updated(instance)
+
+
 def extra_product_actions(instance, info, **data):
     info.context.plugins.product_updated(instance)
 
@@ -14,6 +18,7 @@ def extra_user_actions(instance, info, **data):
 
 
 MODEL_EXTRA_METHODS = {
+    "Checkout": extra_checkout_actions,
     "Product": extra_product_actions,
     "ProductVariant": extra_variant_actions,
     "User": extra_user_actions,

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -106,9 +106,12 @@ class BaseMetadataMutation(BaseMutation):
             return cls.handle_errors(e)
         if not cls.check_permissions(info.context, permissions):
             raise PermissionDenied()
-        result = super().mutate(root, info, **data)
-        if not result.errors:
-            cls.perform_model_extra_actions(root, info, **data)
+        try:
+            result = super().mutate(root, info, **data)
+            if not result.errors:
+                cls.perform_model_extra_actions(root, info, **data)
+        except ValidationError as e:
+            return cls.handle_errors(e)
         return result
 
     @classmethod

--- a/saleor/graphql/meta/tests/test_meta_mutations.py
+++ b/saleor/graphql/meta/tests/test_meta_mutations.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import graphene
 import pytest
+from django.core.exceptions import ValidationError
 
 from ....core.error_codes import MetadataErrorCode
 from ....core.models import ModelWithMetadata
@@ -121,6 +122,22 @@ def item_contains_multiple_proper_public_metadata(
             item.get_value_from_metadata(key2) == value2,
         ]
     )
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_base_metadata_mutation_handles_errors_from_extra_action(
+    mock_checkout_updated, api_client, checkout
+):
+    error_field = "field"
+    error_msg = "boom"
+    mock_checkout_updated.side_effect = ValidationError({error_field: error_msg})
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    response = execute_update_public_metadata_for_item(
+        api_client, None, checkout_id, "Checkout"
+    )
+    errors = response["data"]["updateMetadata"]["errors"]
+    assert errors[0]["field"] == error_field
+    assert errors[0]["message"] == error_msg
 
 
 def test_add_public_metadata_for_customer_as_staff(
@@ -321,6 +338,18 @@ def test_add_public_metadata_for_checkout(api_client, checkout):
     assert item_contains_proper_public_metadata(
         response["data"]["updateMetadata"]["item"], checkout, checkout_id
     )
+
+
+@patch("saleor.plugins.manager.PluginsManager.checkout_updated")
+def test_add_metadata_for_checkout_triggers_checkout_updated_hook(
+    mock_checkout_updated, api_client, checkout
+):
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    response = execute_update_public_metadata_for_item(
+        api_client, None, checkout_id, "Checkout"
+    )
+    assert response["data"]["updateMetadata"]["errors"] == []
+    mock_checkout_updated.assert_called_once_with(checkout)
 
 
 def test_add_public_metadata_for_order(api_client, order):


### PR DESCRIPTION
This PR adds/changes:
- calling `checkout_updated` plugin hook when checkout metadata is changed in API
- `BaseMetadataMutation` will not crash when a validation error is returned from extra action; instead the error is handled and returned as part of the success response in the `errors` field.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
