### PR TITLE
Allow filtering pages by ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix invoice generation - #7376 by @tomaszszymanski129
 - Allow defining only one field in translations - #7363 by @IKarbowiak
 - Trigger `checkout_updated` hook for checkout meta mutations - #7392 by @maarcingebala
+- Allow filtering pages by ids - #7393 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/page/filters.py
+++ b/saleor/graphql/page/filters.py
@@ -1,16 +1,25 @@
 import django_filters
 from graphene_django.filter import GlobalIDMultipleChoiceFilter
 
-from ...page.models import Page
+from ...page import models
 from ..core.filters import MetadataFilterBase
 from ..core.types import FilterInputObjectType
+from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_by_query_param
+from .types import Page
 
 
 def filter_page_search(qs, _, value):
     page_fields = ["content", "slug", "title"]
     qs = filter_by_query_param(qs, value, page_fields)
     return qs
+
+
+def filter_page_ids(qs, _, value):
+    if not value:
+        return qs
+    _, page_pks = resolve_global_ids_to_primary_keys(value, Page)
+    return qs.filter(id__in=page_pks)
 
 
 def filter_page_type_search(qs, _, value):
@@ -23,9 +32,10 @@ def filter_page_type_search(qs, _, value):
 class PageFilter(MetadataFilterBase):
     search = django_filters.CharFilter(method=filter_page_search)
     page_types = GlobalIDMultipleChoiceFilter(field_name="page_type")
+    ids = GlobalIDMultipleChoiceFilter(method=filter_page_ids)
 
     class Meta:
-        model = Page
+        model = models.Page
         fields = ["search"]
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3593,6 +3593,7 @@ input PageFilterInput {
   search: String
   metadata: [MetadataInput]
   pageTypes: [ID]
+  ids: [ID]
 }
 
 type PageInfo {


### PR DESCRIPTION
Extend `PageFilter` with `ids`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
