### PR TITLE
Return empty values list for attribute without choices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,10 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add channel data to Order webhook - #7299 by @krzysztofwolski
 - Always create new checkout in `checkoutCreate` mutation - #7318 by @IKarbowiak
   - deprecate `created` return field on `checkoutCreate` mutation
+- Return empty values list for attribute without choices - #7394 by @fowczarek
+  - `values` for attributes without choices from now are empty list.
+  - attributes with choices - `DROPDOWN` and `MULTISELECT`
+  - attributes without choices - `FILE`, `REFERENCE`, `NUMERIC` and `RICH_TEXT`
 
 ### Other
 

--- a/saleor/attribute/__init__.py
+++ b/saleor/attribute/__init__.py
@@ -22,6 +22,11 @@ class AttributeInputType:
     # list of the input types that can be used in variant selection
     ALLOWED_IN_VARIANT_SELECTION = [DROPDOWN]
 
+    TYPES_WITH_CHOICES = [
+        DROPDOWN,
+        MULTISELECT,
+    ]
+
 
 # list of input types that are allowed for given attribute property
 ATTRIBUTE_PROPERTIES_CONFIGURATION = {

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_create.py
@@ -144,7 +144,6 @@ def test_create_numeric_attribute_and_attribute_values(
     ), "The attribute should not have been assigned to a product type"
 
     # Check if the attribute values were correctly created
-    assert len(data["attribute"]["values"]) == 1
     assert data["attribute"]["type"] == AttributeTypeEnum.PRODUCT_TYPE.name
     assert data["attribute"]["unit"] == MeasurementUnitsEnum.M.name
     assert data["attribute"]["inputType"] == AttributeInputTypeEnum.NUMERIC.name
@@ -152,8 +151,7 @@ def test_create_numeric_attribute_and_attribute_values(
     assert data["attribute"]["filterableInDashboard"] is True
     assert data["attribute"]["availableInGrid"] is True
     assert data["attribute"]["storefrontSearchPosition"] == 0
-    assert data["attribute"]["values"][0]["name"] == name
-    assert data["attribute"]["values"][0]["slug"] == slugify(name.replace(".", "_"))
+    assert data["attribute"]["values"] == []
 
 
 def test_create_numeric_attribute_and_attribute_values_not_numeric_value_provided(

--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -236,18 +236,7 @@ def test_get_single_product_attribute_with_file_value(
         attribute_data["storefrontSearchPosition"]
         == file_attribute.storefront_search_position
     )
-    assert len(attribute_data["values"]) == file_attribute.values.count()
-    attribute_value_data = []
-    for value in file_attribute.values.all():
-        data = {
-            "slug": value.slug,
-            "inputType": value.input_type.upper(),
-            "file": {"url": value.file_url, "contentType": value.content_type},
-        }
-        attribute_value_data.append(data)
-
-    for data in attribute_value_data:
-        assert data in attribute_data["values"]
+    assert attribute_data["values"] == []
 
 
 def test_get_single_reference_attribute_by_staff(

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -124,7 +124,9 @@ class Attribute(CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_values(root: models.Attribute, info):
-        return AttributeValuesByAttributeIdLoader(info.context).load(root.id)
+        if root.input_type in AttributeInputType.TYPES_WITH_CHOICES:
+            return AttributeValuesByAttributeIdLoader(info.context).load(root.id)
+        return []
 
     @staticmethod
     @check_attribute_required_permissions()

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -6626,14 +6626,7 @@ def test_create_product_type_with_rich_text_attribute(
         },
         {
             "name": "Text",
-            "values": [
-                {
-                    "name": "Rich text attribute content.",
-                    "richText": json.dumps(
-                        rich_text_attribute.values.first().rich_text
-                    ),
-                }
-            ],
+            "values": [],
         },
     ]
     for attribute in data["productAttributes"]:


### PR DESCRIPTION
I want to merge this change because returning empty values list for an attribute without choises.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
