### PR TITLE
Performance fix for input_type resolver on AttributeValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix invoice generation - #7376 by @tomaszszymanski129
 - Allow defining only one field in translations - #7363 by @IKarbowiak
 - Trigger `checkout_updated` hook for checkout meta mutations - #7392 by @maarcingebala
+- Optimize `inputType` resolver on `AttributeValue` type - 7396 by @tomaszszymanski129
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -2,16 +2,16 @@ import re
 
 import graphene
 
-from ...attribute import AttributeInputType, models
+from ...attribute import AttributeInputType, AttributeType, models
+from ...core.exceptions import PermissionDenied
+from ...core.permissions import PagePermissions, ProductPermissions
 from ...core.tracing import traced_resolver
+from ...graphql.utils import get_user_or_app_from_context
 from ..core.connection import CountableDjangoObjectType
 from ..core.enums import MeasurementUnitsEnum
 from ..core.types import File
 from ..core.types.common import IntRangeInput
-from ..decorators import (
-    check_attribute_required_permissions,
-    check_attribute_value_required_permissions,
-)
+from ..decorators import check_attribute_required_permissions
 from ..meta.types import ObjectWithMetadata
 from ..translations.fields import TranslationField
 from ..translations.types import AttributeTranslation, AttributeValueTranslation
@@ -47,9 +47,23 @@ class AttributeValue(CountableDjangoObjectType):
 
     @staticmethod
     @traced_resolver
-    @check_attribute_value_required_permissions()
-    def resolve_input_type(root: models.AttributeValue, *_args):
-        return root.input_type
+    def resolve_input_type(root: models.AttributeValue, info, *_args):
+        def _resolve_input_type(attribute):
+            requester = get_user_or_app_from_context(info.context)
+            if attribute.type == AttributeType.PAGE_TYPE:
+                if requester.has_perm(PagePermissions.MANAGE_PAGES):
+                    return attribute.input_type
+                else:
+                    raise PermissionDenied()
+            elif requester.has_perm(ProductPermissions.MANAGE_PRODUCTS):
+                return attribute.input_type
+            raise PermissionDenied()
+
+        return (
+            AttributesByAttributeId(info.context)
+            .load(root.attribute_id)
+            .then(_resolve_input_type)
+        )
 
     @staticmethod
     @traced_resolver

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -46,7 +46,6 @@ class AttributeValue(CountableDjangoObjectType):
         model = models.AttributeValue
 
     @staticmethod
-    @traced_resolver
     def resolve_input_type(root: models.AttributeValue, info, *_args):
         def _resolve_input_type(attribute):
             requester = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -52,8 +52,7 @@ class AttributeValue(CountableDjangoObjectType):
             if attribute.type == AttributeType.PAGE_TYPE:
                 if requester.has_perm(PagePermissions.MANAGE_PAGES):
                     return attribute.input_type
-                else:
-                    raise PermissionDenied()
+                raise PermissionDenied()
             elif requester.has_perm(ProductPermissions.MANAGE_PRODUCTS):
                 return attribute.input_type
             raise PermissionDenied()

--- a/saleor/graphql/decorators.py
+++ b/saleor/graphql/decorators.py
@@ -110,18 +110,3 @@ def check_attribute_required_permissions():
         return _permission_required((ProductPermissions.MANAGE_PRODUCTS,), context)
 
     return account_passes_test_for_attribute(check_perms)
-
-
-def check_attribute_value_required_permissions():
-    """Check attribute value permissions depending on the corresponding attribute type.
-
-    As an value's attribute can belong to the product or to the page,
-    different permissions need to be checked.
-    """
-
-    def check_perms(context, attribute_value):
-        if attribute_value.attribute.type == AttributeType.PAGE_TYPE:
-            return _permission_required((PagePermissions.MANAGE_PAGES,), context)
-        return _permission_required((ProductPermissions.MANAGE_PRODUCTS,), context)
-
-    return account_passes_test_for_attribute(check_perms)


### PR DESCRIPTION
I want to merge this change because it increases performance of input_type resolver in AttributeValue type.

Local testing (5k values):

Master: 7.93s
PR: **0.69s**

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
