### PR TITLE
Added sorting choices in AttributeType

### DIFF
--- a/saleor/graphql/attribute/sorters.py
+++ b/saleor/graphql/attribute/sorters.py
@@ -52,3 +52,24 @@ class AttributeSortingInput(SortInputObjectType):
     class Meta:
         sort_enum = AttributeSortField
         type_name = "attributes"
+
+
+class AttributeChoicesSortField(graphene.Enum):
+    NAME = ["name", "slug"]
+    SLUG = ["slug"]
+
+    @property
+    def description(self):
+        descriptions = {
+            AttributeSortField.NAME.name: "Sort attribute choice by name.",
+            AttributeSortField.SLUG.name: "Sort attribute choice by slug.",
+        }
+        if self.name in descriptions:
+            return descriptions[self.name]
+        raise ValueError("Unsupported enum value: %s" % self.value)
+
+
+class AttributeChoicesSortingInput(SortInputObjectType):
+    class Meta:
+        sort_enum = AttributeChoicesSortField
+        type_name = "attribute choices"

--- a/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
+++ b/saleor/graphql/attribute/tests/queries/test_attributes_sort.py
@@ -146,3 +146,50 @@ def test_attributes_of_products_are_sorted(
 
     # Compare the received data against our expectations
     assert actual_order == expected_order
+
+
+ATTRIBUTE_CHOICES_SORT_QUERY = """
+query($sortBy: AttributeChoicesSortingInput) {
+    attributes(first: 10) {
+        edges {
+            node {
+                slug
+                choices(first: 10, sortBy: $sortBy) {
+                    edges {
+                        node {
+                            name
+                            slug
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+def test_sort_attribute_choices_by_slug(api_client, attribute_choices_for_sorting):
+    variables = {"sortBy": {"field": "SLUG", "direction": "ASC"}}
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTE_CHOICES_SORT_QUERY, variables)
+    )["data"]["attributes"]
+    choices = attributes["edges"][0]["node"]["choices"]["edges"]
+
+    assert len(choices) == 3
+    assert choices[0]["node"]["slug"] == "absorb"
+    assert choices[1]["node"]["slug"] == "summer"
+    assert choices[2]["node"]["slug"] == "zet"
+
+
+def test_sort_attribute_choices_by_name(api_client, attribute_choices_for_sorting):
+    variables = {"sortBy": {"field": "NAME", "direction": "ASC"}}
+    attributes = get_graphql_content(
+        api_client.post_graphql(ATTRIBUTE_CHOICES_SORT_QUERY, variables)
+    )["data"]["attributes"]
+    choices = attributes["edges"][0]["node"]["choices"]["edges"]
+
+    assert len(choices) == 3
+    assert choices[0]["node"]["name"] == "Apex"
+    assert choices[1]["node"]["name"] == "Global"
+    assert choices[2]["node"]["name"] == "Police"

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -20,6 +20,7 @@ from .dataloaders import AttributesByAttributeId
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 from .filters import AttributeValueFilterInput
+from .sorters import AttributeChoicesSortingInput
 
 COLOR_PATTERN = r"^(#[0-9a-fA-F]{3}|#(?:[0-9a-fA-F]{2}){2,4}|(rgb|hsl)a?\((-?\d+%?[,\s]+){2,3}\s*[\d\.]+%?\))$"  # noqa
 color_pattern = re.compile(COLOR_PATTERN)
@@ -91,7 +92,10 @@ class Attribute(CountableDjangoObjectType):
     unit = MeasurementUnitsEnum(description=AttributeDescriptions.UNIT)
     choices = FilterInputConnectionField(
         AttributeValue,
-        filter=AttributeValueFilterInput(),
+        sort_by=AttributeChoicesSortingInput(description="Sort attribute choices."),
+        filter=AttributeValueFilterInput(
+            description="Filtering options for attribute choices."
+        ),
         description=AttributeDescriptions.VALUES,
     )
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -413,7 +413,7 @@ type Attribute implements Node & ObjectWithMetadata {
   slug: String
   type: AttributeTypeEnum
   unit: MeasurementUnitsEnum
-  choices(filter: AttributeValueFilterInput, before: String, after: String, first: Int, last: Int): AttributeValueCountableConnection
+  choices(sortBy: AttributeChoicesSortingInput, filter: AttributeValueFilterInput, before: String, after: String, first: Int, last: Int): AttributeValueCountableConnection
   valueRequired: Boolean!
   visibleInStorefront: Boolean!
   filterableInStorefront: Boolean!
@@ -427,6 +427,16 @@ type AttributeBulkDelete {
   count: Int!
   attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
   errors: [AttributeError!]!
+}
+
+enum AttributeChoicesSortField {
+  NAME
+  SLUG
+}
+
+input AttributeChoicesSortingInput {
+  direction: OrderDirection!
+  field: AttributeChoicesSortField!
 }
 
 type AttributeCountableConnection {

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -795,6 +795,22 @@ def color_attribute(db):
 
 
 @pytest.fixture
+def attribute_choices_for_sorting(db):
+    attribute = Attribute.objects.create(
+        slug="sorting",
+        name="Sorting",
+        type=AttributeType.PRODUCT_TYPE,
+        filterable_in_storefront=True,
+        filterable_in_dashboard=True,
+        available_in_grid=True,
+    )
+    AttributeValue.objects.create(attribute=attribute, name="Global", slug="summer")
+    AttributeValue.objects.create(attribute=attribute, name="Apex", slug="zet")
+    AttributeValue.objects.create(attribute=attribute, name="Police", slug="absorb")
+    return attribute
+
+
+@pytest.fixture
 def rich_text_attribute(db):
     attribute = Attribute.objects.create(
         slug="text",


### PR DESCRIPTION
I want to merge this change because...I want to add sorting choices by `name` and `slug` on AttributeType.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
