### PR TITLE
Fix performance of order events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - `channel` from `DraftOrderCreateInput` changed to channelId
   - `channel` from `DraftOrderInput` changed to channelId
   - `channel` from `pluginUpdate` changed to channelId
+- Order events performance - #7424 by tomaszszymanski129
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from django.db.models import F
 
-from ...order.models import Fulfillment, Order, OrderEvent, OrderLine
+from ...order.models import Fulfillment, FulfillmentLine, Order, OrderEvent, OrderLine
 from ...warehouse.models import Allocation
 from ..core.dataloaders import DataLoader
 
@@ -84,3 +84,11 @@ class FulfillmentsByOrderIdLoader(DataLoader):
         for fulfillment in fulfillments.iterator():
             fulfillments_map[fulfillment.order_id].append(fulfillment)
         return [fulfillments_map.get(order_id, []) for order_id in keys]
+
+
+class FulfillmentLinesByIdLoader(DataLoader):
+    context_key = "fulfillment_lines_by_id"
+
+    def batch_load(self, keys):
+        fulfillment_lines = FulfillmentLine.objects.in_bulk(keys)
+        return [fulfillment_lines.get(line_id) for line_id in keys]

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1166,6 +1166,40 @@ def test_related_order_events_query(
             assert events_data[0]["relatedOrder"]["id"] == related_order_id
 
 
+def test_order_events_without_permission(
+    staff_api_client,
+    permission_manage_orders,
+    order_with_lines_and_events,
+    customer_user,
+):
+    query = """
+        query OrdersQuery {
+            orders(first: 2) {
+                edges {
+                    node {
+                        id
+                        events {
+                            user {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    last_event = order_with_lines_and_events.events.last()
+    last_event.user = customer_user
+    last_event.save()
+
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(query)
+    content = get_graphql_content(response)
+
+    response_events = content["data"]["orders"]["edges"][0]["node"]["events"]
+    assert response_events[-1]["user"] is None
+
+
 def test_payment_information_order_events_query(
     staff_api_client, permission_manage_orders, order, payment_dummy, staff_user
 ):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -193,7 +193,7 @@ class OrderEvent(CountableDjangoObjectType):
                 or user.has_perm(AccountPermissions.MANAGE_STAFF)
             ):
                 return event_user
-            raise PermissionDenied()
+            return None
 
         if not root.user_id:
             return None
@@ -337,9 +337,6 @@ class FulfillmentLine(CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_order_line(root: models.FulfillmentLine, info):
-        if not root.order_line_id:
-            return None
-
         return OrderLineByIdLoader(info.context).load(root.order_line_id)
 
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -61,6 +61,7 @@ from ..shipping.types import ShippingMethod
 from ..warehouse.types import Allocation, Warehouse
 from .dataloaders import (
     AllocationsByOrderLineIdLoader,
+    FulfillmentLinesByIdLoader,
     FulfillmentsByOrderIdLoader,
     OrderByIdLoader,
     OrderEventsByOrderIdLoader,
@@ -184,14 +185,20 @@ class OrderEvent(CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_user(root: models.OrderEvent, info):
-        user = info.context.user
-        if (
-            user == root.user
-            or user.has_perm(AccountPermissions.MANAGE_USERS)
-            or user.has_perm(AccountPermissions.MANAGE_STAFF)
-        ):
-            return root.user
-        raise PermissionDenied()
+        def _resolve_user(event_user):
+            user = info.context.user
+            if (
+                user == event_user
+                or user.has_perm(AccountPermissions.MANAGE_USERS)
+                or user.has_perm(AccountPermissions.MANAGE_STAFF)
+            ):
+                return event_user
+            raise PermissionDenied()
+
+        if not root.user_id:
+            return None
+
+        return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
 
     @staticmethod
     def resolve_email(root: models.OrderEvent, _info):
@@ -279,9 +286,13 @@ class OrderEvent(CountableDjangoObjectType):
 
     @staticmethod
     @traced_resolver
-    def resolve_fulfilled_items(root: models.OrderEvent, _info):
-        lines = root.parameters.get("fulfilled_items", [])
-        return models.FulfillmentLine.objects.filter(pk__in=lines)
+    def resolve_fulfilled_items(root: models.OrderEvent, info):
+        fulfillment_lines_ids = root.parameters.get("fulfilled_items", [])
+
+        if not fulfillment_lines_ids:
+            return None
+
+        return FulfillmentLinesByIdLoader(info.context).load_many(fulfillment_lines_ids)
 
     @staticmethod
     @traced_resolver
@@ -325,8 +336,11 @@ class FulfillmentLine(CountableDjangoObjectType):
 
     @staticmethod
     @traced_resolver
-    def resolve_order_line(root: models.FulfillmentLine, _info):
-        return root.order_line
+    def resolve_order_line(root: models.FulfillmentLine, info):
+        if not root.order_line_id:
+            return None
+
+        return OrderLineByIdLoader(info.context).load(root.order_line_id)
 
 
 class Fulfillment(CountableDjangoObjectType):

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -186,11 +186,11 @@ class OrderEvent(CountableDjangoObjectType):
     @traced_resolver
     def resolve_user(root: models.OrderEvent, info):
         def _resolve_user(event_user):
-            user = info.context.user
+            requester = get_user_or_app_from_context(info.context)
             if (
-                user == event_user
-                or user.has_perm(AccountPermissions.MANAGE_USERS)
-                or user.has_perm(AccountPermissions.MANAGE_STAFF)
+                requester == event_user
+                or requester.has_perm(AccountPermissions.MANAGE_USERS)
+                or requester.has_perm(AccountPermissions.MANAGE_STAFF)
             ):
                 return event_user
             return None


### PR DESCRIPTION
I want to merge this change because it adds missing dataloaders for order events
- `user` resolver on `OrderEvent` type
- `fulfilled_items` resolver on `OrderEvent` type (new dataloader - FulfillmentLinesByIdLoader)
- `order_line` resolver on `FulfillmentLine` type

test staff order details:

before: 86 queries
after: 46 queries

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
