### PR TITLE
Fix attribute input validation for numeric attributes

### DIFF
--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -201,7 +201,7 @@ class AttributeInput(graphene.InputObjectType):
 class AttributeValueInput(graphene.InputObjectType):
     id = graphene.ID(description="ID of the selected attribute.")
     values = graphene.List(
-        graphene.String,
+        graphene.NonNull(graphene.String),
         required=False,
         description=(
             "The value or slug of an attribute to resolve. "

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -154,6 +154,8 @@ class AttributeAssignmentMixin:
         attribute: attribute_models.Attribute,
         attr_values: AttrValuesInput,
     ):
+        if not attr_values.values:
+            return tuple()
         defaults = {
             "name": attr_values.values[0],
         }

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -158,7 +158,7 @@ class ProductBulkDelete(ModelBulkDeleteMutation):
 class BulkAttributeValueInput(InputObjectType):
     id = graphene.ID(description="ID of the selected attribute.")
     values = graphene.List(
-        graphene.String,
+        graphene.NonNull(graphene.String),
         required=True,
         description=(
             "The value or slug of an attribute to resolve. "
@@ -169,7 +169,7 @@ class BulkAttributeValueInput(InputObjectType):
 
 class ProductVariantBulkCreateInput(ProductVariantInput):
     attributes = graphene.List(
-        BulkAttributeValueInput,
+        graphene.NonNull(BulkAttributeValueInput),
         required=True,
         description="List of attributes specific to this variant.",
     )

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -733,7 +733,7 @@ class ProductDelete(ModelDeleteMutation):
 
 class ProductVariantInput(graphene.InputObjectType):
     attributes = graphene.List(
-        AttributeValueInput,
+        graphene.NonNull(AttributeValueInput),
         required=False,
         description="List of attributes specific to this variant.",
     )
@@ -749,7 +749,7 @@ class ProductVariantInput(graphene.InputObjectType):
 
 class ProductVariantCreateInput(ProductVariantInput):
     attributes = graphene.List(
-        AttributeValueInput,
+        graphene.NonNull(AttributeValueInput),
         required=True,
         description="List of attributes specific to this variant.",
     )

--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -184,7 +184,7 @@ def test_product_variant_create(
             $productId: ID!,
             $sku: String,
             $stocks: [StockInput!],
-            $attributes: [AttributeValueInput]!,
+            $attributes: [AttributeValueInput!]!,
             $weight: WeightScalar,
             $trackInventory: Boolean
         ) {
@@ -287,7 +287,7 @@ def test_update_product_variant(
     query = """
         mutation VariantUpdate(
             $id: ID!
-            $attributes: [AttributeValueInput]
+            $attributes: [AttributeValueInput!]
             $sku: String
             $trackInventory: Boolean!
         ) {

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -4473,7 +4473,7 @@ def test_create_product_invalid_product_attributes(
             "taxCode": product_tax_rate,
             "attributes": [
                 {"id": color_attr_id, "values": [" "]},
-                {"id": weight_attr_id, "values": [None]},
+                {"id": weight_attr_id, "values": ["  "]},
                 {
                     "id": size_attr_id,
                     "values": [non_existent_attr_value, color_value_slug],

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -326,7 +326,7 @@ CREATE_VARIANT_MUTATION = """
             $productId: ID!,
             $sku: String,
             $stocks: [StockInput!],
-            $attributes: [AttributeValueInput]!,
+            $attributes: [AttributeValueInput!]!,
             $weight: WeightScalar,
             $trackInventory: Boolean) {
                 productVariantCreate(
@@ -1199,7 +1199,7 @@ def test_create_variant_invalid_variant_attributes(
         "weight": weight,
         "attributes": [
             {"id": color_attr_id, "values": [" "]},
-            {"id": weight_attr_id, "values": [None]},
+            {"id": weight_attr_id, "values": [" "]},
             {"id": size_attr_id, "values": [non_existent_attr_value, size_value_slug]},
             {"id": rich_text_attr_id, "richText": json.dumps(dummy_editorjs(" "))},
         ],
@@ -1298,7 +1298,7 @@ def test_product_variant_update_with_new_attributes(
     query = """
         mutation VariantUpdate(
           $id: ID!
-          $attributes: [AttributeValueInput]
+          $attributes: [AttributeValueInput!]
           $sku: String
           $trackInventory: Boolean!
         ) {
@@ -1376,7 +1376,7 @@ def test_update_product_variant(
             $id: ID!,
             $sku: String!,
             $trackInventory: Boolean!,
-            $attributes: [AttributeValueInput]) {
+            $attributes: [AttributeValueInput!]) {
                 productVariantUpdate(
                     id: $id,
                     input: {
@@ -1472,7 +1472,7 @@ QUERY_UPDATE_VARIANT_ATTRIBUTES = """
     mutation updateVariant (
         $id: ID!,
         $sku: String,
-        $attributes: [AttributeValueInput]!) {
+        $attributes: [AttributeValueInput!]!) {
             productVariantUpdate(
                 id: $id,
                 input: {
@@ -1631,6 +1631,50 @@ def test_update_variant_with_rich_text_attribute(
     assert data["attributes"][-1]["attribute"]["slug"] == rich_text_attribute.slug
     assert data["attributes"][-1]["values"][0]["richText"] == rich_text
     assert rich_text_attribute.values.count() == values_count
+    product_variant_updated.assert_called_once_with(product.variants.last())
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
+def test_update_variant_with_numeric_attribute(
+    product_variant_updated,
+    permission_manage_products,
+    product,
+    product_type,
+    staff_api_client,
+    numeric_attribute,
+    warehouse,
+):
+    product_type.variant_attributes.add(numeric_attribute)
+    query = QUERY_UPDATE_VARIANT_ATTRIBUTES
+    variant = product.variants.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    sku = "123"
+    attr_id = graphene.Node.to_global_id("Attribute", numeric_attribute.id)
+    attribute_value = numeric_attribute.values.first()
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "attributes": [
+            {"id": attr_id, "values": []},
+        ],
+    }
+    attribute_value.slug = f"{variant.id}_{numeric_attribute.id}"
+    attribute_value.save()
+    values_count = numeric_attribute.values.count()
+    associate_attribute_values_to_instance(variant, numeric_attribute, attribute_value)
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)["data"]["productVariantUpdate"]
+    variant.refresh_from_db()
+    data = content["productVariant"]
+
+    assert not content["errors"]
+    assert data["sku"] == sku
+    assert data["attributes"][-1]["attribute"]["slug"] == numeric_attribute.slug
+    assert not data["attributes"][-1]["values"]
+    assert numeric_attribute.values.count() == values_count
     product_variant_updated.assert_called_once_with(product.variants.last())
 
 
@@ -2121,7 +2165,6 @@ def test_update_product_variant_change_attribute_values_ordering(
         ([], "Attribute expects a value but none were given.", "REQUIRED"),
         (["one", "two"], "Attribute must take only one value.", "INVALID"),
         (["   "], "Attribute values cannot be blank.", "REQUIRED"),
-        ([None], "Attribute values cannot be blank.", "REQUIRED"),
     ),
 )
 def test_update_product_variant_requires_values(
@@ -2175,7 +2218,7 @@ def test_update_product_variant_with_price_does_not_raise_price_validation_error
     staff_api_client, variant, size_attribute, permission_manage_products
 ):
     mutation = """
-    mutation updateVariant ($id: ID!, $attributes: [AttributeValueInput]) {
+    mutation updateVariant ($id: ID!, $attributes: [AttributeValueInput!]) {
         productVariantUpdate(
             id: $id,
             input: {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -628,7 +628,7 @@ type AttributeValueDelete {
 
 input AttributeValueInput {
   id: ID
-  values: [String]
+  values: [String!]
   file: String
   contentType: String
   references: [ID!]
@@ -669,7 +669,7 @@ type AttributeValueUpdate {
 
 input BulkAttributeValueInput {
   id: ID
-  values: [String]!
+  values: [String!]!
 }
 
 type BulkProductError {
@@ -4542,7 +4542,7 @@ type ProductVariantBulkCreate {
 }
 
 input ProductVariantBulkCreateInput {
-  attributes: [BulkAttributeValueInput]!
+  attributes: [BulkAttributeValueInput!]!
   sku: String!
   trackInventory: Boolean
   weight: WeightScalar
@@ -4594,7 +4594,7 @@ type ProductVariantCreate {
 }
 
 input ProductVariantCreateInput {
-  attributes: [AttributeValueInput]!
+  attributes: [AttributeValueInput!]!
   sku: String
   trackInventory: Boolean
   weight: WeightScalar
@@ -4615,7 +4615,7 @@ input ProductVariantFilterInput {
 }
 
 input ProductVariantInput {
-  attributes: [AttributeValueInput]
+  attributes: [AttributeValueInput!]
   sku: String
   trackInventory: Boolean
   weight: WeightScalar


### PR DESCRIPTION
- Update schema for `AttributeValueInput` - require non null values.
- Fix updating variants with not-required numeric attributes.

Fixes #7389 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
