### PR TITLE
Fix AttributeError when deleting user address as app

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -15,6 +15,7 @@ from ....core.exceptions import PermissionDenied
 from ....core.permissions import AccountPermissions
 from ....core.tracing import traced_atomic_transaction
 from ....core.utils.url import validate_storefront_url
+from ....graphql.utils import get_user_or_app_from_context
 from ....order.utils import match_orders_with_new_user
 from ...account.i18n import I18nMixin
 from ...account.types import Address, AddressInput, User
@@ -34,17 +35,19 @@ SHIPPING_ADDRESS_FIELD = "default_shipping_address"
 INVALID_TOKEN = "Invalid or expired token."
 
 
-def can_edit_address(user, address):
-    """Determine whether the user can edit the given address.
+def can_edit_address(context, address):
+    """Determine whether the user or app can edit the given address.
 
     This method assumes that an address can be edited by:
-    - users with proper permissions (staff)
+    - apps with manage users permission
+    - staff with manage users permission
     - customers associated to the given address.
     """
-    return (
-        user.has_perm(AccountPermissions.MANAGE_USERS)
-        or user.addresses.filter(pk=address.pk).exists()
-    )
+    requester = get_user_or_app_from_context(context)
+    if requester.has_perm(AccountPermissions.MANAGE_USERS):
+        return True
+    if not context.app:
+        return requester.addresses.filter(pk=address.pk).exists()
 
 
 class SetPassword(CreateToken):
@@ -293,7 +296,7 @@ class BaseAddressUpdate(ModelMutation, I18nMixin):
     def clean_input(cls, info, instance, data):
         # Method check_permissions cannot be used for permission check, because
         # it doesn't have the address instance.
-        if not can_edit_address(info.context.user, instance):
+        if not can_edit_address(info.context, instance):
             raise PermissionDenied()
         return super().clean_input(info, instance, data)
 
@@ -333,7 +336,7 @@ class BaseAddressDelete(ModelDeleteMutation):
     def clean_instance(cls, info, instance):
         # Method check_permissions cannot be used for permission check, because
         # it doesn't have the address instance.
-        if not can_edit_address(info.context.user, instance):
+        if not can_edit_address(info.context, instance):
             raise PermissionDenied()
         return super().clean_instance(info, instance)
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -3266,6 +3266,23 @@ def test_address_delete_mutation(
         address_obj.refresh_from_db()
 
 
+def test_address_delete_mutation_as_app(
+    app_api_client, customer_user, permission_manage_users
+):
+    query = ADDRESS_DELETE_MUTATION
+    address_obj = customer_user.addresses.first()
+    variables = {"id": graphene.Node.to_global_id("Address", address_obj.id)}
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_users]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["addressDelete"]
+    assert data["address"]["city"] == address_obj.city
+    assert data["user"]["id"] == graphene.Node.to_global_id("User", customer_user.pk)
+    with pytest.raises(address_obj._meta.model.DoesNotExist):
+        address_obj.refresh_from_db()
+
+
 ACCOUNT_ADDRESS_DELETE_MUTATION = """
     mutation deleteUserAddress($id: ID!) {
         accountAddressDelete(id: $id) {


### PR DESCRIPTION
I want to merge this change because it handles the case when an app tries to delete a user with proper permissions.

In case app performs the query, context.app is app but context.user is anonymous user.
In `can_edit_address` method (used in multiple account mutations),  we try to do `requester.addresses.filter(pk=address.pk).exists()` which fails if the user is anonymous (raises AttributeError).
Now the function checks if requester has the permission and if it does't - if it's not anonymous user AND ONLY THEN checks if the address belongs to him.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
