### PR TITLE
Add possibility to store, use  and retrieve stored payment method

### DIFF
--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -366,7 +366,7 @@ class StripeGatewayPlugin(BasePlugin):
             customer_sources = [
                 CustomerSource(
                     id=c.id,
-                    gateway="stripe",
+                    gateway=PLUGIN_ID,
                     credit_card_info=PaymentMethodInfo(
                         exp_year=c.card.exp_year,
                         exp_month=c.card.exp_month,

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -1,5 +1,5 @@
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -10,7 +10,13 @@ from django.http.request import split_domain_port
 from ....graphql.core.enums import PluginErrorCode
 from ....plugins.base_plugin import BasePlugin, ConfigurationTypeField
 from ... import TransactionKind
-from ...interface import GatewayConfig, GatewayResponse, PaymentData
+from ...interface import (
+    CustomerSource,
+    GatewayConfig,
+    GatewayResponse,
+    PaymentData,
+    PaymentMethodInfo,
+)
 from ...models import Transaction
 from ...utils import price_from_minor_unit, price_to_minor_unit
 from ..utils import get_supported_currencies, require_active_plugin
@@ -19,7 +25,9 @@ from .stripe_api import (
     capture_payment_intent,
     create_payment_intent,
     delete_webhook,
+    get_or_create_customer,
     is_secret_api_key_valid,
+    list_customer_payment_methods,
     refund_payment_intent,
     retrieve_payment_intent,
     subscribe_webhook,
@@ -109,7 +117,6 @@ class StripeGatewayPlugin(BasePlugin):
                 "webhook_id": webhook_endpoint_id,
                 "webhook_secret": webhook_secret,
             },
-            # FIXME define if we are able to implement support for this
             store_customer=configuration["store_customers_cards"],
         )
 
@@ -137,20 +144,37 @@ class StripeGatewayPlugin(BasePlugin):
         self, payment_information: "PaymentData", previous_value
     ) -> "GatewayResponse":
 
+        api_key = self.config.connection_params["secret_api_key"]
+
         auto_capture = self.config.auto_capture
         if self.order_auto_confirmation is False:
             auto_capture = False
+
+        payment_method_id = payment_information.data.get("payment_method_id")
+        customer = None
+        if payment_information.reuse_source and self.config.store_customer:
+            customer = get_or_create_customer(
+                api_key=api_key,
+                customer_email=payment_information.customer_email,
+                customer_id=payment_information.customer_id,
+                metadata={"channel": self.channel.slug},
+            )
         intent, error = create_payment_intent(
-            api_key=self.config.connection_params["secret_api_key"],
+            api_key=api_key,
             amount=payment_information.amount,
             currency=payment_information.currency,
             auto_capture=auto_capture,
+            customer=customer,
+            payment_method_id=payment_method_id,
         )
         raw_response = None
         client_secret = None
+        intent_id = None
         if intent:
             client_secret = intent.client_secret
             raw_response = intent.last_response.data
+            intent_id = intent.id
+
         return GatewayResponse(
             is_success=True if not error else False,
             action_required=True,
@@ -160,7 +184,8 @@ class StripeGatewayPlugin(BasePlugin):
             transaction_id=intent.id if intent else "",
             error=error.user_message if error else None,
             raw_response=raw_response,
-            action_required_data={"client_secret": client_secret},
+            action_required_data={"client_secret": client_secret, "id": intent_id},
+            customer_id=customer.id if customer else None,
         )
 
     @require_active_plugin
@@ -328,6 +353,30 @@ class StripeGatewayPlugin(BasePlugin):
             raw_response=raw_response,
         )
 
+    @require_active_plugin
+    def list_payment_sources(
+        self, customer_id: str, previous_value
+    ) -> List[CustomerSource]:
+        payment_methods = list_customer_payment_methods(
+            api_key=self.config.connection_params["secret_api_key"],
+            customer_id=customer_id,
+        )
+        customer_sources = [
+            CustomerSource(
+                id=c.id,
+                gateway="stripe",
+                credit_card_info=PaymentMethodInfo(
+                    exp_year=c.card.exp_year,
+                    exp_month=c.card.exp_month,
+                    last_4=c.card.last4,
+                    name=None,
+                ),
+            )
+            for c in payment_methods
+        ]
+        previous_value.extend(customer_sources)
+        return previous_value
+
     @classmethod
     def pre_save_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
         configuration = plugin_configuration.configuration
@@ -420,3 +469,13 @@ class StripeGatewayPlugin(BasePlugin):
                         )
                     }
                 )
+
+    @require_active_plugin
+    def get_payment_config(self, previous_value):
+        return [
+            {
+                "field": "api_key",
+                "value": self.config.connection_params["public_api_key"],
+            },
+            {"field": "store_customer_card", "value": self.config.store_customer},
+        ]

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -82,7 +82,7 @@ def create_payment_intent(
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
 
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
-    additional_params = {}
+    additional_params = {}  # type: ignore
     if customer:
         additional_params = {
             "customer": customer,

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -56,18 +56,65 @@ def delete_webhook(api_key: str, webhook_id: str):
         pass
 
 
+def get_or_create_customer(
+    api_key: str,
+    customer_id: Optional[str] = None,
+    customer_email: Optional[str] = None,
+    metadata: Optional[dict] = None,
+) -> Optional[StripeObject]:
+    try:
+        if customer_id:
+            return stripe.Customer.retrieve(customer_id, api_key=api_key)
+        return stripe.Customer.create(
+            api_key=api_key, email=customer_email, metadata=metadata
+        )
+    except StripeError:
+        return None
+
+
 def create_payment_intent(
-    api_key: str, amount: Decimal, currency: str, auto_capture: bool = True
+    api_key: str,
+    amount: Decimal,
+    currency: str,
+    auto_capture: bool = True,
+    customer: Optional[StripeObject] = None,
+    payment_method_id: Optional[str] = None,
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
+
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
+    additional_params = {}
+    if customer:
+        additional_params = {
+            "customer": customer,
+            "setup_future_usage": "on_session",
+        }
+
+    if payment_method_id and customer:
+        additional_params["payment_method"] = payment_method_id
+
     try:
         intent = stripe.PaymentIntent.create(
             api_key=api_key,
             amount=price_to_minor_unit(amount, currency),
             currency=currency,
             capture_method=capture_method,
+            **additional_params,
         )
         return intent, None
+    except StripeError as error:
+        return None, error
+
+
+def list_customer_payment_methods(
+    api_key: str, customer_id: str
+) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
+    try:
+        payment_methods = stripe.PaymentMethod.list(
+            api_key=api_key,
+            customer=customer_id,
+            type="card",  # we support only cards for now
+        )
+        return payment_methods, None
     except StripeError as error:
         return None, error
 

--- a/saleor/payment/gateways/stripe/tests/conftest.py
+++ b/saleor/payment/gateways/stripe/tests/conftest.py
@@ -65,6 +65,7 @@ def stripe_plugin(settings, monkeypatch, channel_USD):
         webhook_secret_key="ABCD",
         active=True,
         auto_capture=True,
+        store_customers_cards=False,
     ):
         public_api_key = public_api_key or "test_key"
         secret_api_key = secret_api_key or "secret_key"
@@ -74,7 +75,7 @@ def stripe_plugin(settings, monkeypatch, channel_USD):
         configuration = [
             {"name": "public_api_key", "value": public_api_key},
             {"name": "secret_api_key", "value": secret_api_key},
-            {"name": "store_customers_cards", "value": False},
+            {"name": "store_customers_cards", "value": store_customers_cards},
             {"name": "automatic_payment_capture", "value": auto_capture},
             {"name": "supported_currencies", "value": "USD"},
         ]

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -187,7 +187,10 @@ def test_process_payment(
     assert response.transaction_id == payment_intent_id
     assert response.error is None
     assert response.raw_response == dummy_response
-    assert response.action_required_data == {"client_secret": client_secret}
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
 
     api_key = plugin.config.connection_params["secret_api_key"]
     mocked_payment_intent.assert_called_once_with(
@@ -195,6 +198,136 @@ def test_process_payment(
         amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
         currency=payment_info.currency,
         capture_method=AUTOMATIC_CAPTURE_METHOD,
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_customer(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+
+    plugin = stripe_plugin(auto_capture=True, store_customers_cards=True)
+
+    payment_stripe_for_checkout.billing_email = "admin@example.com"
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout, customer_id=None, store_source=True
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is True
+    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        setup_future_usage="on_session",
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email="admin@example.com",
+        metadata={"channel": channel_USD.slug},
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_customer_and_payment_method(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+
+    plugin = stripe_plugin(auto_capture=True, store_customers_cards=True)
+
+    payment_stripe_for_checkout.billing_email = "admin@example.com"
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        customer_id=None,
+        store_source=True,
+        additional_data={"payment_method_id": "pm_ID"},
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is True
+    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        setup_future_usage="on_session",
+        payment_method="pm_ID",
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email="admin@example.com",
+        metadata={"channel": channel_USD.slug},
     )
 
 
@@ -230,7 +363,10 @@ def test_process_payment_with_disabled_order_auto_confirmation(
     assert response.transaction_id == payment_intent_id
     assert response.error is None
     assert response.raw_response == dummy_response
-    assert response.action_required_data == {"client_secret": client_secret}
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
 
     api_key = plugin.config.connection_params["secret_api_key"]
     mocked_payment_intent.assert_called_once_with(
@@ -295,7 +431,7 @@ def test_process_payment_with_error(
     assert response.transaction_id == ""
     assert response.error == "stripe-error"
     assert response.raw_response is None
-    assert response.action_required_data == {"client_secret": None}
+    assert response.action_required_data == {"client_secret": None, "id": None}
 
     api_key = plugin.config.connection_params["secret_api_key"]
     mocked_payment_intent.assert_called_once_with(

--- a/saleor/payment/gateways/stripe/tests/test_stripe_api.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe_api.py
@@ -17,7 +17,9 @@ from ..stripe_api import (
     capture_payment_intent,
     create_payment_intent,
     delete_webhook,
+    get_or_create_customer,
     is_secret_api_key_valid,
+    list_customer_payment_methods,
     refund_payment_intent,
     retrieve_payment_intent,
     subscribe_webhook,
@@ -90,6 +92,31 @@ def test_create_payment_intent_returns_intent_object(mocked_payment_intent):
         amount="1000",
         currency="USD",
         capture_method=AUTOMATIC_CAPTURE_METHOD,
+    )
+
+    assert isinstance(intent, StripeObject)
+    assert error is None
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent",
+)
+def test_create_payment_intent_with_customer(mocked_payment_intent):
+    customer = StripeObject(id="c_ABC")
+    api_key = "api_key"
+    mocked_payment_intent.create.return_value = StripeObject()
+
+    intent, error = create_payment_intent(
+        api_key, Decimal(10), "USD", auto_capture=True, customer=customer
+    )
+
+    mocked_payment_intent.create.assert_called_with(
+        api_key=api_key,
+        amount="1000",
+        currency="USD",
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        setup_future_usage="on_session",
     )
 
     assert isinstance(intent, StripeObject)
@@ -289,3 +316,129 @@ def test_cancel_payment_intent_stripe_returns_error(mocked_payment_intent):
     mocked_payment_intent.cancel.assert_called_with(payment_intent_id, api_key=api_key)
 
     assert error == expected_error
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.Customer",
+)
+def test_get_or_create_customer_retrieve(mocked_customer):
+    mocked_customer.retrieve.return_value = StripeObject()
+    api_key = "123"
+    customer_email = "admin@example.com"
+    customer_id = "c_12345"
+
+    customer = get_or_create_customer(
+        api_key=api_key,
+        customer_email=customer_email,
+        customer_id=customer_id,
+        metadata={},
+    )
+
+    assert isinstance(customer, StripeObject)
+    mocked_customer.retrieve.assert_called_with(customer_id, api_key=api_key)
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.Customer",
+)
+def test_get_or_create_customer_failed_retrieve(mocked_customer):
+
+    expected_error = StripeError(message="stripe-error")
+    mocked_customer.retrieve.side_effect = expected_error
+
+    api_key = "123"
+    customer_email = "admin@example.com"
+    customer_id = "c_12345"
+
+    customer = get_or_create_customer(
+        api_key=api_key,
+        customer_email=customer_email,
+        customer_id=customer_id,
+        metadata={},
+    )
+
+    assert customer is None
+    mocked_customer.retrieve.assert_called_with(customer_id, api_key=api_key)
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.Customer",
+)
+def test_get_or_create_customer_create(mocked_customer):
+    mocked_customer.create.return_value = StripeObject()
+    api_key = "123"
+    customer_email = "admin@example.com"
+    customer = get_or_create_customer(
+        api_key=api_key,
+        customer_email=customer_email,
+        customer_id=None,
+        metadata={"channel": "usd"},
+    )
+
+    assert isinstance(customer, StripeObject)
+    mocked_customer.create.assert_called_with(
+        email=customer_email, api_key=api_key, metadata={"channel": "usd"}
+    )
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.Customer",
+)
+def test_get_or_create_customer_failed_create(mocked_customer):
+    expected_error = StripeError(message="stripe-error")
+    mocked_customer.create.side_effect = expected_error
+
+    api_key = "123"
+    customer_email = "admin@example.com"
+    customer = get_or_create_customer(
+        api_key=api_key,
+        customer_email=customer_email,
+        customer_id=None,
+        metadata={"channel": "usd"},
+    )
+
+    assert customer is None
+    mocked_customer.create.assert_called_with(
+        email=customer_email, api_key=api_key, metadata={"channel": "usd"}
+    )
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.PaymentMethod",
+)
+def test_list_customer_payment_methods(mocked_payment_method):
+    api_key = "123"
+    customer_id = "c_customer_id"
+    mocked_payment_method.list.return_value = StripeObject()
+
+    payment_method, error = list_customer_payment_methods(
+        api_key=api_key, customer_id=customer_id
+    )
+
+    assert error is None
+    assert isinstance(payment_method, StripeObject)
+    mocked_payment_method.list.assert_called_with(
+        api_key=api_key, customer=customer_id, type="card"
+    )
+
+
+@patch(
+    "saleor.payment.gateways.stripe.stripe_api.stripe.PaymentMethod",
+)
+def test_list_customer_payment_methods_failed_to_fetch(mocked_payment_method):
+    api_key = "123"
+    customer_id = "c_customer_id"
+
+    expected_error = StripeError(message="stripe-error")
+    mocked_payment_method.list.side_effect = expected_error
+
+    payment_method, error = list_customer_payment_methods(
+        api_key=api_key, customer_id=customer_id
+    )
+
+    assert payment_method is None
+    assert isinstance(error, StripeError)
+
+    mocked_payment_method.list.assert_called_with(
+        api_key=api_key, customer=customer_id, type="card"
+    )


### PR DESCRIPTION
I want to merge this change because it adds logic for storing/using and retrieving payment methods

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
