### PR TITLE
Stripe handle refund webhook event

### DIFF
--- a/saleor/payment/gateways/stripe/consts.py
+++ b/saleor/payment/gateways/stripe/consts.py
@@ -7,12 +7,17 @@ WEBHOOK_PROCESSING_EVENT = "payment_intent.processing"
 WEBHOOK_FAILED_EVENT = "payment_intent.payment_failed"
 WEBHOOK_AUTHORIZED_EVENT = "payment_intent.amount_capturable_updated"
 WEBHOOK_CANCELED_EVENT = "payment_intent.canceled"
+
+WEBHOOK_REFUND_EVENT = "charge.refunded"
+
+
 WEBHOOK_EVENTS = [
     WEBHOOK_SUCCESS_EVENT,
     WEBHOOK_PROCESSING_EVENT,
     WEBHOOK_FAILED_EVENT,
     WEBHOOK_AUTHORIZED_EVENT,
     WEBHOOK_CANCELED_EVENT,
+    WEBHOOK_REFUND_EVENT,
 ]
 METADATA_IDENTIFIER = "saleor-domain"
 

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -375,8 +375,7 @@ class StripeGatewayPlugin(BasePlugin):
             return
 
         webhook = subscribe_webhook(
-            api_key,
-            plugin_configuration.channel.slug  # type: ignore
+            api_key, plugin_configuration.channel.slug  # type: ignore
         )
         cls._update_or_create_config_field(
             plugin_configuration.configuration, "webhook_endpoint_id", webhook.id

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -281,23 +281,23 @@ class StripeGatewayPlugin(BasePlugin):
         refund_amount = price_to_minor_unit(
             payment_information.amount, payment_information.currency
         )
-        payment_intent, error = refund_payment_intent(
+        refund, error = refund_payment_intent(
             api_key=self.config.connection_params["secret_api_key"],
             payment_intent_id=payment_intent_id,  # type: ignore
             amount_to_refund=refund_amount,
         )
 
         raw_response = None
-        if payment_intent and payment_intent.last_response:
-            raw_response = payment_intent.last_response.data
+        if refund and refund.last_response:
+            raw_response = refund.last_response.data
 
         return GatewayResponse(
-            is_success=True if payment_intent else False,
+            is_success=True if refund else False,
             action_required=False,
             kind=TransactionKind.REFUND,
             amount=payment_information.amount,
             currency=payment_information.currency,
-            transaction_id=payment_intent.id if payment_intent else "",
+            transaction_id=refund.id if refund else "",
             error=error.user_message if error else None,
             raw_response=raw_response,
         )
@@ -374,7 +374,10 @@ class StripeGatewayPlugin(BasePlugin):
             )
             return
 
-        webhook = subscribe_webhook(api_key)
+        webhook = subscribe_webhook(
+            api_key,
+            plugin_configuration.channel.slug  # type: ignore
+        )
         cls._update_or_create_config_field(
             plugin_configuration.configuration, "webhook_endpoint_id", webhook.id
         )

--- a/saleor/payment/gateways/stripe/tests/test_stripe_api.py
+++ b/saleor/payment/gateways/stripe/tests/test_stripe_api.py
@@ -46,11 +46,13 @@ def test_is_secret_api_key_valid_correct_key(mocked_webhook):
 @patch(
     "saleor.payment.gateways.stripe.stripe_api.stripe.WebhookEndpoint",
 )
-def test_subscribe_webhook_returns_webhook_object(mocked_webhook):
+def test_subscribe_webhook_returns_webhook_object(mocked_webhook, channel_USD):
     api_key = "api_key"
-    expected_url = "http://mirumee.com/plugins/saleor.payments.stripe/webhooks/"
+    expected_url = (
+        "http://mirumee.com/plugins/channel/main/saleor.payments.stripe/webhooks/"
+    )
 
-    subscribe_webhook(api_key)
+    subscribe_webhook(api_key, channel_slug=channel_USD.slug)
 
     mocked_webhook.create.assert_called_with(
         api_key=api_key,


### PR DESCRIPTION
I want to merge this change because it:
- adds webhook refund handlers
- adds proper generation of webhook URL

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
