### PR TITLE
Add opentracing to all stripe requests

### DIFF
--- a/saleor/core/tracing.py
+++ b/saleor/core/tracing.py
@@ -26,3 +26,12 @@ def traced_atomic_transaction():
             span = scope.span
             span.set_tag(opentracing.tags.COMPONENT, "orm")
             yield
+
+
+@contextmanager
+def opentracing_trace(span_name, component_name, service_name):
+    with opentracing.global_tracer().start_active_span(span_name) as scope:
+        span = scope.span
+        span.set_tag(opentracing.tags.COMPONENT, component_name)
+        span.set_tag("service.name", service_name)
+        yield

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -1,8 +1,11 @@
 import logging
+from contextlib import contextmanager
 from decimal import Decimal
 from typing import Optional, Tuple
 from urllib.parse import urljoin
 
+import opentracing
+import opentracing.tags
 import stripe
 from django.contrib.sites.models import Site
 from django.urls import reverse
@@ -24,10 +27,20 @@ from .consts import (
 logger = logging.getLogger(__name__)
 
 
+@contextmanager
+def opentracing_trace(span_name):
+    with opentracing.global_tracer().start_active_span(span_name) as scope:
+        span = scope.span
+        span.set_tag(opentracing.tags.COMPONENT, "payment")
+        span.set_tag("service.name", "stripe")
+        yield
+
+
 def is_secret_api_key_valid(api_key: str):
     """Call api to check if api_key is a correct key."""
     try:
-        stripe.WebhookEndpoint.list(api_key)
+        with opentracing_trace("stripe.WebhookEndpoint.list"):
+            stripe.WebhookEndpoint.list(api_key)
         return True
     except AuthenticationError:
         return False
@@ -43,17 +56,19 @@ def subscribe_webhook(api_key: str, channel_slug: str) -> StripeObject:
     base_url = build_absolute_uri(api_path)
     webhook_url = urljoin(base_url, WEBHOOK_PATH)  # type: ignore
 
-    return stripe.WebhookEndpoint.create(
-        api_key=api_key,
-        url=webhook_url,
-        enabled_events=WEBHOOK_EVENTS,
-        metadata={METADATA_IDENTIFIER: domain},
-    )
+    with opentracing_trace("stripe.WebhookEndpoint.create"):
+        return stripe.WebhookEndpoint.create(
+            api_key=api_key,
+            url=webhook_url,
+            enabled_events=WEBHOOK_EVENTS,
+            metadata={METADATA_IDENTIFIER: domain},
+        )
 
 
 def delete_webhook(api_key: str, webhook_id: str):
     try:
-        stripe.WebhookEndpoint.delete(webhook_id, api_key=api_key)
+        with opentracing_trace("stripe.WebhookEndpoint.delete"):
+            stripe.WebhookEndpoint.delete(webhook_id, api_key=api_key)
     except InvalidRequestError:
         # webhook doesn't exist
         pass
@@ -67,10 +82,12 @@ def get_or_create_customer(
 ) -> Optional[StripeObject]:
     try:
         if customer_id:
-            return stripe.Customer.retrieve(customer_id, api_key=api_key)
-        return stripe.Customer.create(
-            api_key=api_key, email=customer_email, metadata=metadata
-        )
+            with opentracing_trace("stripe.Customer.retrieve"):
+                return stripe.Customer.retrieve(customer_id, api_key=api_key)
+        with opentracing_trace("stripe.Customer.create"):
+            return stripe.Customer.create(
+                api_key=api_key, email=customer_email, metadata=metadata
+            )
     except StripeError:
         return None
 
@@ -96,13 +113,14 @@ def create_payment_intent(
         additional_params["payment_method"] = payment_method_id
 
     try:
-        intent = stripe.PaymentIntent.create(
-            api_key=api_key,
-            amount=price_to_minor_unit(amount, currency),
-            currency=currency,
-            capture_method=capture_method,
-            **additional_params,
-        )
+        with opentracing_trace("stripe.PaymentIntent.create"):
+            intent = stripe.PaymentIntent.create(
+                api_key=api_key,
+                amount=price_to_minor_unit(amount, currency),
+                currency=currency,
+                capture_method=capture_method,
+                **additional_params,
+            )
         return intent, None
     except StripeError as error:
         return None, error
@@ -112,11 +130,12 @@ def list_customer_payment_methods(
     api_key: str, customer_id: str
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
     try:
-        payment_methods = stripe.PaymentMethod.list(
-            api_key=api_key,
-            customer=customer_id,
-            type="card",  # we support only cards for now
-        )
+        with opentracing_trace("stripe.PaymentMethod.list"):
+            payment_methods = stripe.PaymentMethod.list(
+                api_key=api_key,
+                customer=customer_id,
+                type="card",  # we support only cards for now
+            )
         return payment_methods, None
     except StripeError as error:
         return None, error
@@ -126,9 +145,10 @@ def retrieve_payment_intent(
     api_key: str, payment_intent_id: str
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
     try:
-        payment_intent = stripe.PaymentIntent.retrieve(
-            payment_intent_id, api_key=api_key
-        )
+        with opentracing_trace("stripe.PaymentIntent.retrieve"):
+            payment_intent = stripe.PaymentIntent.retrieve(
+                payment_intent_id, api_key=api_key
+            )
         return payment_intent, None
     except StripeError as error:
         logger.warning("Unable to retrieve a payment intent (%s)", payment_intent_id)
@@ -139,9 +159,10 @@ def capture_payment_intent(
     api_key: str, payment_intent_id: str, amount_to_capture: int
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
     try:
-        payment_intent = stripe.PaymentIntent.capture(
-            payment_intent_id, amount_to_capture=amount_to_capture, api_key=api_key
-        )
+        with opentracing_trace("stripe.PaymentIntent.capture"):
+            payment_intent = stripe.PaymentIntent.capture(
+                payment_intent_id, amount_to_capture=amount_to_capture, api_key=api_key
+            )
         return payment_intent, None
     except StripeError as error:
         logger.warning(
@@ -154,9 +175,12 @@ def refund_payment_intent(
     api_key: str, payment_intent_id: str, amount_to_refund: int
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
     try:
-        refund = stripe.Refund.create(
-            payment_intent=payment_intent_id, amount=amount_to_refund, api_key=api_key
-        )
+        with opentracing_trace("stripe.Refund.create"):
+            refund = stripe.Refund.create(
+                payment_intent=payment_intent_id,
+                amount=amount_to_refund,
+                api_key=api_key,
+            )
         return refund, None
     except StripeError as error:
         logger.warning(
@@ -170,7 +194,10 @@ def cancel_payment_intent(
     api_key: str, payment_intent_id: str
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
     try:
-        payment_intent = stripe.PaymentIntent.cancel(payment_intent_id, api_key=api_key)
+        with opentracing_trace("stripe.PaymentIntent.cancel"):
+            payment_intent = stripe.PaymentIntent.cancel(
+                payment_intent_id, api_key=api_key
+            )
         return payment_intent, None
     except StripeError as error:
         logger.warning(
@@ -182,6 +209,7 @@ def cancel_payment_intent(
 def construct_stripe_event(
     api_key: str, payload: bytes, sig_header: str, endpoint_secret: str
 ) -> StripeObject:
-    return stripe.Webhook.construct_event(
-        payload, sig_header, endpoint_secret, api_key=api_key
-    )
+    with opentracing_trace("stripe.Webhook.construct_event"):
+        return stripe.Webhook.construct_event(
+            payload, sig_header, endpoint_secret, api_key=api_key
+        )


### PR DESCRIPTION
I want to merge this change because it adds open tracing spans to new implementation of Stripe plugin

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
