### PR TITLE
Validate product has variants

### DIFF
--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -846,28 +846,35 @@ class ProductVariantCreate(ModelMutation):
                 cleaned_input["product"]
             )
 
-        # Run the validation only if product type is configurable
-        if product_type.has_variants:
-            # Attributes are provided as list of `AttributeValueInput` objects.
-            # We need to transform them into the format they're stored in the
-            # `Product` model, which is HStore field that maps attribute's PK to
-            # the value's PK.
-            attributes = cleaned_input.get("attributes")
-            try:
-                if attributes:
-                    cleaned_attributes = cls.clean_attributes(attributes, product_type)
-                    cls.validate_duplicated_attribute_values(
-                        cleaned_attributes, used_attribute_values, instance
+        if not product_type.has_variants:
+            raise ValidationError(
+                {
+                    "product": ValidationError(
+                        "Only one variant can be assigned to this product.",
+                        code=ProductErrorCode.INVALID.value,
                     )
-                    cleaned_input["attributes"] = cleaned_attributes
-                elif not instance.pk and not attributes:
-                    # if attributes were not provided on creation
-                    raise ValidationError(
-                        "All attributes must take a value.",
-                        ProductErrorCode.REQUIRED.value,
-                    )
-            except ValidationError as exc:
-                raise ValidationError({"attributes": exc})
+                }
+            )
+        # Attributes are provided as list of `AttributeValueInput` objects.
+        # We need to transform them into the format they're stored in the
+        # `Product` model, which is HStore field that maps attribute's PK to
+        # the value's PK.
+        attributes = cleaned_input.get("attributes")
+        try:
+            if attributes:
+                cleaned_attributes = cls.clean_attributes(attributes, product_type)
+                cls.validate_duplicated_attribute_values(
+                    cleaned_attributes, used_attribute_values, instance
+                )
+                cleaned_input["attributes"] = cleaned_attributes
+            elif not instance.pk and not attributes:
+                # if attributes were not provided on creation
+                raise ValidationError(
+                    "All attributes must take a value.",
+                    ProductErrorCode.REQUIRED.value,
+                )
+        except ValidationError as exc:
+            raise ValidationError({"attributes": exc})
 
         return cleaned_input
 


### PR DESCRIPTION
I want to merge this change because...I want to validate if product_type has flag `has_variant` set to false.

fixes : https://github.com/mirumee/saleor/issues/7136

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
