### PR TITLE
add standard environments exclusion to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,14 @@ dist/
 /node_modules/
 /static/
 
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
 # Exported results file
 django-queries-results.html


### PR DESCRIPTION
Its better to make gitignore file more standard, I check it out and add standard environments folder exclusion to the gitignore file
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
