### PR TITLE
Remove unused field(costPrice) from ProductVariant

### DIFF
--- a/saleor/graphql/product/tests/benchmark/test_variant.py
+++ b/saleor/graphql/product/tests/benchmark/test_variant.py
@@ -222,10 +222,6 @@ def test_product_variant_create(
                             }
                         }
                     }
-                    costPrice {
-                        currency
-                        amount
-                    }
                     weight {
                         value
                         unit

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -63,10 +63,6 @@ def test_fetch_variant(
                     slug
                 }
             }
-            costPrice {
-                currency
-                amount
-            }
             media {
                 id
             }
@@ -366,10 +362,6 @@ CREATE_VARIANT_MUTATION = """
                                     contentType
                                 }
                             }
-                        }
-                        costPrice {
-                            currency
-                            amount
                         }
                         weight {
                             value
@@ -1399,10 +1391,6 @@ def test_update_product_variant(
                             channel {
                                 slug
                             }
-                        }
-                        costPrice {
-                            currency
-                            amount
                         }
                     }
                 }

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -39,7 +39,7 @@ from ...core.fields import (
     FilterInputConnectionField,
     PrefetchingConnectionField,
 )
-from ...core.types import Image, Money, TaxedMoney, TaxedMoneyRange, TaxType
+from ...core.types import Image, TaxedMoney, TaxedMoneyRange, TaxType
 from ...core.utils import from_global_id_or_error
 from ...decorators import (
     one_of_permissions_required,
@@ -192,7 +192,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             description="Define scope of returned attributes.",
         ),
     )
-    cost_price = graphene.Field(Money, description="Cost price of the variant.")
     margin = graphene.Int(description="Gross margin percentage value.")
     quantity_ordered = graphene.Int(description="Total quantity ordered.")
     revenue = graphene.Field(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4548,7 +4548,6 @@ type ProductVariant implements Node & ObjectWithMetadata {
   channelListings: [ProductVariantChannelListing!]
   pricing(address: AddressInput): VariantPricingInfo
   attributes(variantSelection: VariantAttributeScope): [SelectedAttribute!]!
-  costPrice: Money
   margin: Int
   quantityOrdered: Int
   revenue(period: ReportingPeriod): TaxedMoney


### PR DESCRIPTION
I want to merge this change because of removing unused field(costPrice) from ProductVariant. Currently, this field always returns `null`. Cost prices are available through `ProductVariant.channelListings.costPrice`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
