### PR TITLE
Update Django Storages variables

### DIFF
--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -419,16 +419,18 @@ AWS_S3_REGION_NAME = os.environ.get("AWS_S3_REGION_NAME", None)
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY")
 AWS_STORAGE_BUCKET_NAME = os.environ.get("AWS_STORAGE_BUCKET_NAME")
 AWS_DEFAULT_ACL = os.environ.get("AWS_DEFAULT_ACL", None)
+AWS_S3_FILE_OVERWRITE = get_bool_from_env("AWS_S3_FILE_OVERWRITE", True)
 
 # Google Cloud Storage configuration
 GS_PROJECT_ID = os.environ.get("GS_PROJECT_ID")
-GS_STORAGE_BUCKET_NAME = os.environ.get("GS_STORAGE_BUCKET_NAME")
+GS_BUCKET_NAME = os.environ.get("GS_BUCKET_NAME")
 GS_MEDIA_BUCKET_NAME = os.environ.get("GS_MEDIA_BUCKET_NAME")
 GS_AUTO_CREATE_BUCKET = get_bool_from_env("GS_AUTO_CREATE_BUCKET", False)
 GS_QUERYSTRING_AUTH = get_bool_from_env("GS_QUERYSTRING_AUTH", False)
 GS_DEFAULT_ACL = os.environ.get("GS_DEFAULT_ACL", None)
 GS_MEDIA_CUSTOM_ENDPOINT = os.environ.get("GS_MEDIA_CUSTOM_ENDPOINT", None)
 GS_EXPIRATION = os.environ.get("GS_EXPIRATION", None)
+GS_FILE_OVERWRITE = get_bool_from_env("GS_FILE_OVERWRITE", True)
 
 # If GOOGLE_APPLICATION_CREDENTIALS is set there is no need to load OAuth token
 # See https://django-storages.readthedocs.io/en/latest/backends/gcloud.html
@@ -437,7 +439,7 @@ if "GOOGLE_APPLICATION_CREDENTIALS" not in os.environ:
 
 if AWS_STORAGE_BUCKET_NAME:
     STATICFILES_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
-elif GS_STORAGE_BUCKET_NAME:
+elif GS_BUCKET_NAME:
     STATICFILES_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"
 
 if AWS_MEDIA_BUCKET_NAME:


### PR DESCRIPTION
During my work with Google storages, I found that when trying to upload a picture in the dashboard (say `some_image_name.png`), everything goes smooth and fine. However, if I try to upload a different image with the same name `some_image_name.png` all previously uploaded images will be replaced with the new one.
I posted this issue on Spectrum chat [here](https://spectrum.chat/saleor/saleor-3-0/image-with-the-same-name-get-replaced-bug~419e8869-a069-4f93-a76d-db583a5f9854) and people suggested bucket versioning. However, this didn't work for me. 
After some digging, I found that [Django Storages](https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html) control this behavior with `*_FILE_OVERWRITE` variable.
- `AWS_S3_FILE_OVERWRITE` for S3Boto3Storage
- `GS_BUCKET_NAME` for GoogleCloudStorage

I added these variables to the settings file and set them to `True`, which is the default behavior in the library (to override files with the same name).

On another note, Saleor uses `GS_STORAGE_BUCKET_NAME` which is going to throw errors when you upload a file using GS. This happens because Django Storages checks for `GS_BUCKET_NAME` not ~`GS_STORAGE_BUCKET_NAME`~. See [here](https://django-storages.readthedocs.io/en/latest/backends/gcloud.html) for documentation

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
