### PR TITLE
Unify response for requests with invalid ids

### DIFF
--- a/saleor/csv/error_codes.py
+++ b/saleor/csv/error_codes.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class ExportErrorCode(Enum):
+    GRAPHQL_ERROR = "graphql_error"
     INVALID = "invalid"
     NOT_FOUND = "not_found"
     REQUIRED = "required"

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -12,7 +12,7 @@ from ...payment import gateway
 from ...payment.utils import fetch_customer_id
 from ..core.utils import from_global_id_or_error
 from ..utils import format_permissions_for_display, get_user_or_app_from_context
-from .types import AddressValidationData, ChoiceValue
+from .types import Address, AddressValidationData, ChoiceValue, User
 from .utils import (
     get_allowed_fields_camel_case,
     get_required_fields_camel_case,
@@ -55,7 +55,7 @@ def resolve_user(info, id=None, email=None):
     if requester:
         filter_kwargs = {}
         if id:
-            _model, filter_kwargs["pk"] = from_global_id_or_error(id)
+            _model, filter_kwargs["pk"] = from_global_id_or_error(id, User)
         if email:
             filter_kwargs["email"] = email
         if requester.has_perms(
@@ -156,7 +156,7 @@ def prepare_graphql_payment_sources_type(payment_sources):
 def resolve_address(info, id):
     user = info.context.user
     app = info.context.app
-    _model, address_pk = from_global_id_or_error(id)
+    _model, address_pk = from_global_id_or_error(id, Address)
     if app and app.has_perm(AccountPermissions.MANAGE_USERS):
         return models.Address.objects.filter(pk=address_pk).first()
     if user and not user.is_anonymous:

--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -35,6 +35,10 @@ def resolve_customers(info, **_kwargs):
     return models.User.objects.customers()
 
 
+def resolve_permission_group(id):
+    return auth_models.Group.objects.filter(id=id).first()
+
+
 @traced_resolver
 def resolve_permission_groups(info, **_kwargs):
     return auth_models.Group.objects.all()

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -3,6 +3,7 @@ import graphene
 from ...core.permissions import AccountPermissions
 from ..core.fields import FilterInputConnectionField
 from ..core.types import FilterInputObjectType
+from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
 from ..decorators import one_of_permissions_required, permission_required
 from .bulk_mutations import CustomerBulkDelete, StaffBulkDelete, UserBulkSetActive
@@ -60,6 +61,7 @@ from .resolvers import (
     resolve_address,
     resolve_address_validation_rules,
     resolve_customers,
+    resolve_permission_group,
     resolve_permission_groups,
     resolve_staff_users,
     resolve_user,
@@ -165,7 +167,8 @@ class AccountQueries(graphene.ObjectType):
 
     @permission_required(AccountPermissions.MANAGE_STAFF)
     def resolve_permission_group(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, Group)
+        _, id = from_global_id_or_error(id)
+        return resolve_permission_group(id)
 
     def resolve_me(self, info):
         user = info.context.user

--- a/saleor/graphql/account/schema.py
+++ b/saleor/graphql/account/schema.py
@@ -167,7 +167,7 @@ class AccountQueries(graphene.ObjectType):
 
     @permission_required(AccountPermissions.MANAGE_STAFF)
     def resolve_permission_group(self, info, id):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, Group)
         return resolve_permission_group(id)
 
     def resolve_me(self, info):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -32,6 +32,7 @@ from ...tests.utils import (
     assert_graphql_error_with_message,
     assert_no_permission,
     get_graphql_content,
+    get_graphql_content_from_response,
     get_multipart_request_body,
 )
 from ..mutations.base import INVALID_TOKEN
@@ -609,6 +610,34 @@ def test_user_query_permission_manage_staff_get_staff(
     content = get_graphql_content(response)
     data = content["data"]["user"]
     assert staff_user.email == data["email"]
+
+
+@pytest.mark.parametrize("id", ["'", "abc"])
+def test_user_query_invalid_id(
+    id, staff_api_client, customer_user, permission_manage_users
+):
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        USER_QUERY, variables, permissions=[permission_manage_users]
+    )
+
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["user"] is None
+
+
+def test_user_query_object_with_given_id_does_not_exist(
+    staff_api_client, customer_user, permission_manage_users
+):
+    id = graphene.Node.to_global_id("Order", -1)
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        USER_QUERY, variables, permissions=[permission_manage_users]
+    )
+
+    content = get_graphql_content(response)
+    assert content["data"]["user"] is None
 
 
 def test_query_customers(staff_api_client, user_api_client, permission_manage_users):
@@ -4667,6 +4696,29 @@ def test_address_query_as_anonymous_user(api_client, address_other_country):
     variables = {"id": graphene.Node.to_global_id("Address", address_other_country.pk)}
     response = api_client.post_graphql(ADDRESS_QUERY, variables)
     assert_no_permission(response)
+
+
+def test_address_query_invalid_id(
+    staff_api_client,
+    address_other_country,
+):
+    id = "..afs"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(ADDRESS_QUERY, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["address"] is None
+
+
+def test_address_query_object_with_given_id_does_not_exists(
+    staff_api_client,
+    address_other_country,
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(ADDRESS_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["address"] is None
 
 
 REQUEST_EMAIL_CHANGE_QUERY = """

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -628,9 +628,22 @@ def test_user_query_invalid_id(
 
 
 def test_user_query_object_with_given_id_does_not_exist(
+    staff_api_client, permission_manage_users
+):
+    id = graphene.Node.to_global_id("User", -1)
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        USER_QUERY, variables, permissions=[permission_manage_users]
+    )
+
+    content = get_graphql_content(response)
+    assert content["data"]["user"] is None
+
+
+def test_user_query_object_with_invalid_object_type(
     staff_api_client, customer_user, permission_manage_users
 ):
-    id = graphene.Node.to_global_id("Order", -1)
+    id = graphene.Node.to_global_id("Order", customer_user.pk)
     variables = {"id": id}
     response = staff_api_client.post_graphql(
         USER_QUERY, variables, permissions=[permission_manage_users]

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4711,7 +4711,7 @@ def test_address_query_invalid_id(
     assert content["data"]["address"] is None
 
 
-def test_address_query_object_with_given_id_does_not_exists(
+def test_address_query_with_invalid_object_type(
     staff_api_client,
     address_other_country,
 ):

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -4715,7 +4715,7 @@ def test_address_query_with_invalid_object_type(
     staff_api_client,
     address_other_country,
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", address_other_country.pk)}
     response = staff_api_client.post_graphql(ADDRESS_QUERY, variables)
     content = get_graphql_content(response)
     assert content["data"]["address"] is None

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -2389,7 +2389,7 @@ def test_query_permission_group_by_invalid_id(
     assert content["data"]["permissionGroup"] is None
 
 
-def test_query_permission_group_object_with_given_id_does_not_exists(
+def test_query_permission_group_with_invalid_object_type(
     staff_api_client,
     staff_user,
     permission_group_manage_users,

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -5,7 +5,11 @@ from django.contrib.auth.models import Group
 from ....account.error_codes import PermissionGroupErrorCode
 from ....account.models import User
 from ....core.permissions import AccountPermissions, AppPermission, OrderPermissions
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 PERMISSION_GROUP_CREATE_MUTATION = """
     mutation PermissionGroupCreate(
@@ -2366,3 +2370,34 @@ def test_permission_group_no_permission_to_perform(
     variables = {"id": graphene.Node.to_global_id("Group", group.id)}
     response = staff_api_client.post_graphql(query, variables)
     assert_no_permission(response)
+
+
+def test_query_permission_group_by_invalid_id(
+    staff_api_client,
+    staff_user,
+    permission_group_manage_users,
+    permission_manage_users,
+    permission_manage_staff,
+):
+    staff_user.user_permissions.add(permission_manage_staff, permission_manage_users)
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(QUERY_PERMISSION_GROUP, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["permissionGroup"] is None
+
+
+def test_query_permission_group_object_with_given_id_does_not_exists(
+    staff_api_client,
+    staff_user,
+    permission_group_manage_users,
+    permission_manage_staff,
+    permission_manage_users,
+):
+    staff_user.user_permissions.add(permission_manage_staff, permission_manage_users)
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(QUERY_PERMISSION_GROUP, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["permissionGroup"] is None

--- a/saleor/graphql/account/tests/test_account_permission_group.py
+++ b/saleor/graphql/account/tests/test_account_permission_group.py
@@ -2397,7 +2397,9 @@ def test_query_permission_group_with_invalid_object_type(
     permission_manage_users,
 ):
     staff_user.user_permissions.add(permission_manage_staff, permission_manage_users)
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {
+        "id": graphene.Node.to_global_id("Order", permission_group_manage_users.pk)
+    }
     response = staff_api_client.post_graphql(QUERY_PERMISSION_GROUP, variables)
     content = get_graphql_content(response)
     assert content["data"]["permissionGroup"] is None

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -189,7 +189,7 @@ class UserPermission(Permission):
 
     @traced_resolver
     def resolve_source_permission_groups(root: Permission, _info, user_id, **_kwargs):
-        _type, user_id = from_global_id_or_error(user_id, only_type="User", field="pk")
+        _type, user_id = from_global_id_or_error(user_id, only_type="User")
         groups = auth_models.Group.objects.filter(
             user__pk=user_id, permissions__name=root.name
         )

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -19,7 +19,7 @@ from .mutations import (
     AppTokenVerify,
     AppUpdate,
 )
-from .resolvers import _resolve_app, resolve_apps, resolve_apps_installations
+from .resolvers import resolve_app, resolve_apps, resolve_apps_installations
 from .sorters import AppSortingInput
 from .types import App, AppInstallation
 
@@ -62,7 +62,7 @@ class AppQueries(graphene.ObjectType):
         app = info.context.app
         if not id and app:
             return app
-        return _resolve_app(info, id)
+        return resolve_app(info, id)
 
 
 class AppMutations(graphene.ObjectType):

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -21,9 +21,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     product_qs = Product.objects.visible_to_user(requestor, channel_slug)
 
     if field == "in_category":
-        _type, category_id = from_global_id_or_error(
-            value, only_type="Category", field=field
-        )
+        _type, category_id = from_global_id_or_error(value, field=field)
         category = Category.objects.filter(pk=category_id).first()
 
         if category is None:
@@ -38,9 +36,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
             )
 
     elif field == "in_collection":
-        _type, collection_id = from_global_id_or_error(
-            value, only_type="Collection", field=field
-        )
+        _type, collection_id = from_global_id_or_error(value, field=field)
         product_qs = product_qs.filter(collections__id=collection_id)
 
     else:

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -4,7 +4,7 @@ from graphene_django.filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 
 from ...account.utils import requestor_is_staff_member_or_app
 from ...attribute.models import Attribute, AttributeValue
-from ...product.models import Category, Product
+from ...product import models
 from ..attribute.enums import AttributeTypeEnum
 from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.filters import EnumFilter, MetadataFilterBase
@@ -18,11 +18,11 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
     if not value:
         return qs
 
-    product_qs = Product.objects.visible_to_user(requestor, channel_slug)
+    product_qs = models.Product.objects.visible_to_user(requestor, channel_slug)
 
     if field == "in_category":
-        _type, category_id = from_global_id_or_error(value, field=field)
-        category = Category.objects.filter(pk=category_id).first()
+        _type, category_id = from_global_id_or_error(value, "Category")
+        category = models.Category.objects.filter(pk=category_id).first()
 
         if category is None:
             return qs.none()
@@ -36,7 +36,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
             )
 
     elif field == "in_collection":
-        _type, collection_id = from_global_id_or_error(value, field=field)
+        _type, collection_id = from_global_id_or_error(value, "Collection")
         product_qs = product_qs.filter(collections__id=collection_id)
 
     else:

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -19,7 +19,7 @@ from ..core.enums import MeasurementUnitsEnum
 from ..core.inputs import ReorderInput
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import AttributeError
-from ..core.utils import from_global_id_or_error, validate_slug_and_generate_if_needed
+from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
 from ..utils import resolve_global_ids_to_primary_keys
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
@@ -116,11 +116,11 @@ class BaseReorderAttributeValuesMutation(BaseMutation):
     def get_instance(instance_id: str):
         pass
 
-    @staticmethod
+    @classmethod
     def get_attribute_assignment(
-        instance, instance_type, attribute_id: str, error_code_enum
+        cls, instance, instance_type, attribute_id: str, error_code_enum
     ):
-        _type, attribute_pk = from_global_id_or_error(
+        attribute_pk = cls.get_global_id_or_error(
             attribute_id, only_type=Attribute, field="attribute_id"
         )
 
@@ -671,7 +671,7 @@ class AttributeReorderValues(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, attribute_id, moves):
-        _type, pk = from_global_id_or_error(
+        pk = cls.get_global_id_or_error(
             attribute_id, only_type=Attribute, field="attribute_id"
         )
 
@@ -692,7 +692,7 @@ class AttributeReorderValues(BaseMutation):
 
         # Resolve the values
         for move_info in moves:
-            _type, value_pk = from_global_id_or_error(
+            value_pk = cls.get_global_id_or_error(
                 move_info.id, only_type=AttributeValue, field="moves"
             )
 

--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -21,7 +21,6 @@ from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import AttributeError
 from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
-from ..utils import resolve_global_ids_to_primary_keys
 from .descriptions import AttributeDescriptions, AttributeValueDescriptions
 from .enums import AttributeEntityTypeEnum, AttributeInputTypeEnum, AttributeTypeEnum
 
@@ -49,7 +48,7 @@ class BaseReorderAttributesMutation(BaseMutation):
             attribute_ids.append(move_info.id)
             sort_orders.append(move_info.sort_order)
 
-        _, attr_pks = resolve_global_ids_to_primary_keys(attribute_ids, Attribute)
+        attr_pks = cls.get_global_ids_or_error(attribute_ids, Attribute)
         attr_pks = [int(pk) for pk in attr_pks]
 
         attributes_m2m = attributes.filter(attribute_id__in=attr_pks)
@@ -156,7 +155,7 @@ class BaseReorderAttributeValuesMutation(BaseMutation):
             value_ids.append(move_info.id)
             sort_orders.append(move_info.sort_order)
 
-        _, values_pks = resolve_global_ids_to_primary_keys(value_ids, AttributeValue)
+        values_pks = cls.get_global_ids_or_error(value_ids, AttributeValue)
         values_pks = [int(pk) for pk in values_pks]
 
         values_m2m = values.filter(value_id__in=values_pks)

--- a/saleor/graphql/attribute/resolvers.py
+++ b/saleor/graphql/attribute/resolvers.py
@@ -10,5 +10,9 @@ def resolve_attributes(info, qs=None, **_kwargs):
     return qs.distinct()
 
 
+def resolve_attribute_by_id(id):
+    return models.Attribute.objects.filter(id=id).first()
+
+
 def resolve_attribute_by_slug(slug):
     return models.Attribute.objects.filter(slug=slug).first()

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -2,6 +2,7 @@ import graphene
 
 from ...core.tracing import traced_resolver
 from ..core.fields import FilterInputConnectionField
+from ..core.utils import from_global_id_or_error
 from ..translations.mutations import AttributeTranslate, AttributeValueTranslate
 from .bulk_mutations import AttributeBulkDelete, AttributeValueBulkDelete
 from .filters import AttributeFilterInput
@@ -14,7 +15,11 @@ from .mutations import (
     AttributeValueDelete,
     AttributeValueUpdate,
 )
-from .resolvers import resolve_attribute_by_slug, resolve_attributes
+from .resolvers import (
+    resolve_attribute_by_id,
+    resolve_attribute_by_slug,
+    resolve_attributes,
+)
 from .sorters import AttributeSortingInput
 from .types import Attribute
 
@@ -39,7 +44,8 @@ class AttributeQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_attribute(self, info, id=None, slug=None):
         if id:
-            return graphene.Node.get_node_from_global_id(info, id, Attribute)
+            _, id = from_global_id_or_error(id)
+            return resolve_attribute_by_id(id)
         return resolve_attribute_by_slug(slug=slug)
 
 

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -44,7 +44,7 @@ class AttributeQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_attribute(self, info, id=None, slug=None):
         if id:
-            _, id = from_global_id_or_error(id)
+            _, id = from_global_id_or_error(id, Attribute)
             return resolve_attribute_by_id(id)
         return resolve_attribute_by_slug(slug=slug)
 

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
@@ -6,7 +6,7 @@ import pytest
 from .....attribute.models import Attribute
 from .....attribute.utils import associate_attribute_values_to_instance
 from .....product.models import ProductType
-from ....tests.utils import get_graphql_content
+from ....tests.utils import get_graphql_content, get_graphql_content_from_response
 from ...filters import filter_attributes_by_product_types
 
 ATTRIBUTES_FILTER_QUERY = """
@@ -125,6 +125,83 @@ def test_filter_attributes_by_global_id_list(api_client, product_type_attribute_
     )
 
     assert received_slugs == expected_slugs
+
+
+def test_filter_attributes_in_category_invalid_category_id(
+    user_api_client, product_list, weight_attribute, channel_USD
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.save(update_fields=["product_type"])
+    last_product.channel_listings.all().update(visible_in_listings=False)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    variables = {
+        "filters": {
+            "inCategory": "xyz",
+            "channel": channel_USD.slug,
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+
+    # then
+    content = get_graphql_content_from_response(response)
+    message_error = (
+        '{"in_category": [{"message": "Invalid ID specified.", "code": ""}]}'
+    )
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == message_error
+    assert content["data"]["attributes"] is None
+
+
+def test_filter_attributes_in_category_object_with_given_id_does_not_exist(
+    user_api_client, product_list, weight_attribute, channel_USD
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.save(update_fields=["product_type"])
+    last_product.channel_listings.all().update(visible_in_listings=False)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    variables = {
+        "filters": {
+            "inCategory": graphene.Node.to_global_id("Product", -1),
+            "channel": channel_USD.slug,
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["attributes"]["edges"] == []
 
 
 def test_filter_attributes_in_category_not_visible_in_listings_by_customer(
@@ -567,6 +644,89 @@ def test_filter_attributes_in_category_not_published_by_app_without_manage_produ
 
     # then
     assert len(attributes) == attribute_count
+
+
+def test_filter_attributes_in_collection_invalid_category_id(
+    user_api_client, product_list, weight_attribute, collection, channel_USD
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.save(update_fields=["product_type"])
+    last_product.channel_listings.all().update(visible_in_listings=False)
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    variables = {
+        "filters": {
+            "inCollection": "xnd",
+            "channel": channel_USD.slug,
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+
+    # then
+    content = get_graphql_content_from_response(response)
+    message_error = (
+        '{"in_collection": [{"message": "Invalid ID specified.", "code": ""}]}'
+    )
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == message_error
+    assert content["data"]["attributes"] is None
+
+
+def test_filter_attributes_in_collection_object_with_given_id_does_not_exist(
+    user_api_client, product_list, weight_attribute, collection, channel_USD
+):
+    # given
+    product_type = ProductType.objects.create(
+        name="Default Type 2",
+        slug="default-type-2",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(weight_attribute)
+
+    last_product = product_list[-1]
+    last_product.product_type = product_type
+    last_product.save(update_fields=["product_type"])
+    last_product.channel_listings.all().update(visible_in_listings=False)
+
+    for product in product_list:
+        collection.products.add(product)
+
+    associate_attribute_values_to_instance(
+        product_list[-1], weight_attribute, weight_attribute.values.first()
+    )
+
+    variables = {
+        "filters": {
+            "inCollection": graphene.Node.to_global_id("Product", -1),
+            "channel": channel_USD.slug,
+        }
+    }
+
+    # when
+    response = user_api_client.post_graphql(ATTRIBUTES_FILTER_QUERY, variables)
+
+    # then
+    content = get_graphql_content(response)
+    assert content["data"]["attributes"]["edges"] == []
 
 
 def test_filter_attributes_in_collection_not_visible_in_listings_by_customer(

--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -189,7 +189,7 @@ def test_query_attribute_by_invalid_id(
     assert content["data"]["attribute"] is None
 
 
-def test_query_attribute_object_with_given_id_does_not_exists(
+def test_query_attribute_with_invalid_object_type(
     staff_api_client, color_attribute_without_values
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -192,7 +192,9 @@ def test_query_attribute_by_invalid_id(
 def test_query_attribute_with_invalid_object_type(
     staff_api_client, color_attribute_without_values
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {
+        "id": graphene.Node.to_global_id("Order", color_attribute_without_values.pk)
+    }
     response = staff_api_client.post_graphql(QUERY_ATTRIBUTE, variables)
     content = get_graphql_content(response)
     assert content["data"]["attribute"] is None

--- a/saleor/graphql/attribute/utils.py
+++ b/saleor/graphql/attribute/utils.py
@@ -121,9 +121,12 @@ class AttributeAssignmentMixin:
     @classmethod
     def _resolve_attribute_global_id(cls, error_class, global_id: str) -> int:
         """Resolve an Attribute global ID into an internal ID (int)."""
-        graphene_type, internal_id = from_global_id_or_error(
-            global_id, only_type="Attribute"
-        )
+        try:
+            graphene_type, internal_id = from_global_id_or_error(
+                global_id, only_type="Attribute"
+            )
+        except GraphQLError as e:
+            raise ValidationError(str(e), code=error_class.GRAPHQL_ERROR.value)
         if not internal_id.isnumeric():
             raise ValidationError(
                 f"An invalid ID value was passed: {global_id}",

--- a/saleor/graphql/channel/mutations.py
+++ b/saleor/graphql/channel/mutations.py
@@ -14,7 +14,6 @@ from ...shipping.tasks import drop_invalid_shipping_methods_relations_for_given_
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import ChannelError, ChannelErrorCode
 from ..core.utils import get_duplicated_values, get_duplicates_ids
-from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.validators import check_for_duplicates
 from .types import Channel
 
@@ -305,8 +304,8 @@ class BaseChannelListingMutation(BaseMutation):
             channels_to_add = cls.get_nodes_or_error(  # type: ignore
                 add_channels_ids, "channel_id", Channel
             )
-        _, remove_channels_pks = resolve_global_ids_to_primary_keys(
-            remove_channels_ids, Channel
+        remove_channels_pks = cls.get_global_ids_or_error(
+            remove_channels_ids, Channel, field="remove_channels"
         )
 
         cleaned_input = {input_source: [], "remove_channels": remove_channels_pks}

--- a/saleor/graphql/channel/resolvers.py
+++ b/saleor/graphql/channel/resolvers.py
@@ -1,13 +1,8 @@
-import graphene
-
 from ...channel import models
-from ...core.tracing import traced_resolver
-from .types import Channel
 
 
-@traced_resolver
-def resolve_channel(info, id):
-    return graphene.Node.get_node_from_global_id(info, id, Channel)
+def resolve_channel(id):
+    return models.Channel.objects.filter(id=id).first()
 
 
 def resolve_channels():

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.tracing import traced_resolver
+from ..core.utils import from_global_id_or_error
 from ..decorators import staff_member_or_app_required
 from .mutations import (
     ChannelActivate,
@@ -25,7 +26,8 @@ class ChannelQueries(graphene.ObjectType):
 
     @staff_member_or_app_required
     def resolve_channel(self, info, id=None, **kwargs):
-        return resolve_channel(info, id)
+        _, id = from_global_id_or_error(id)
+        return resolve_channel(id)
 
     @staff_member_or_app_required
     @traced_resolver

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -26,7 +26,7 @@ class ChannelQueries(graphene.ObjectType):
 
     @staff_member_or_app_required
     def resolve_channel(self, info, id=None, **kwargs):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, Channel)
         return resolve_channel(id)
 
     @staff_member_or_app_required

--- a/saleor/graphql/channel/tests/test_channel_queries.py
+++ b/saleor/graphql/channel/tests/test_channel_queries.py
@@ -1,6 +1,10 @@
 import graphene
 
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 QUERY_CHANNELS = """
 query {
@@ -132,14 +136,14 @@ def test_query_channels_with_has_orders_without_permission(
 
 
 QUERY_CHANNEL = """
-query getChannel($id: ID!){
-  channel(id: $id){
-    id
-    name
-    slug
-    currencyCode
-  }
-}
+    query getChannel($id: ID!){
+        channel(id: $id){
+            id
+            name
+            slug
+            currencyCode
+        }
+    }
 """
 
 
@@ -199,3 +203,22 @@ def test_query_channel_as_anonymous(api_client, channel_USD):
 
     # then
     assert_no_permission(response)
+
+
+def test_query_channel_by_invalid_id(staff_api_client, channel_USD):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(QUERY_CHANNEL, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["channel"] is None
+
+
+def test_query_channel_object_with_given_id_does_not_exists(
+    staff_api_client, channel_USD
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(QUERY_CHANNEL, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["channel"] is None

--- a/saleor/graphql/channel/tests/test_channel_queries.py
+++ b/saleor/graphql/channel/tests/test_channel_queries.py
@@ -215,9 +215,7 @@ def test_query_channel_by_invalid_id(staff_api_client, channel_USD):
     assert content["data"]["channel"] is None
 
 
-def test_query_channel_object_with_given_id_does_not_exists(
-    staff_api_client, channel_USD
-):
+def test_query_channel_with_invalid_object_type(staff_api_client, channel_USD):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(QUERY_CHANNEL, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/channel/tests/test_channel_queries.py
+++ b/saleor/graphql/channel/tests/test_channel_queries.py
@@ -216,7 +216,7 @@ def test_query_channel_by_invalid_id(staff_api_client, channel_USD):
 
 
 def test_query_channel_with_invalid_object_type(staff_api_client, channel_USD):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", channel_USD.pk)}
     response = staff_api_client.post_graphql(QUERY_CHANNEL, variables)
     content = get_graphql_content(response)
     assert content["data"]["channel"] is None

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -43,7 +43,6 @@ from ..channel.utils import clean_channel
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import BaseMutation, ModelMutation
 from ..core.types.common import CheckoutError
-from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_variants_available_in_channel
 from ..order.types import Order
 from ..product.types import ProductVariant
@@ -628,7 +627,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
 
     @classmethod
     def perform_mutation(cls, _root, info, checkout_id, shipping_address):
-        _type, pk = from_global_id_or_error(
+        pk = cls.get_global_id_or_error(
             checkout_id, only_type=Checkout, field="checkout_id"
         )
 
@@ -902,7 +901,7 @@ class CheckoutComplete(BaseMutation):
                     field="checkout_id",
                 )
             except ValidationError as e:
-                _type, checkout_token = from_global_id_or_error(
+                checkout_token = cls.get_global_id_or_error(
                     checkout_id, only_type=Checkout, field="checkout_id"
                 )
 

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -4,6 +4,10 @@ from ...core.tracing import traced_resolver
 from ..utils import get_user_or_app_from_context
 
 
+def resolve_checkout_line(id):
+    return models.CheckoutLine.objects.filter(id=id).first()
+
+
 def resolve_checkout_lines():
     queryset = models.CheckoutLine.objects.all()
     return queryset

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -4,6 +4,7 @@ from ...core.permissions import CheckoutPermissions
 from ...core.tracing import traced_resolver
 from ..core.fields import BaseDjangoConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from ..payment.mutations import CheckoutPaymentCreate
 from .mutations import (
@@ -22,7 +23,12 @@ from .mutations import (
     CheckoutShippingAddressUpdate,
     CheckoutShippingMethodUpdate,
 )
-from .resolvers import resolve_checkout, resolve_checkout_lines, resolve_checkouts
+from .resolvers import (
+    resolve_checkout,
+    resolve_checkout_line,
+    resolve_checkout_lines,
+    resolve_checkouts,
+)
 from .types import Checkout, CheckoutLine
 
 
@@ -58,7 +64,8 @@ class CheckoutQueries(graphene.ObjectType):
         return resolve_checkouts(channel)
 
     def resolve_checkout_line(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, CheckoutLine)
+        _, id = from_global_id_or_error(id)
+        return resolve_checkout_line(id)
 
     @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
     @traced_resolver

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -64,7 +64,7 @@ class CheckoutQueries(graphene.ObjectType):
         return resolve_checkouts(channel)
 
     def resolve_checkout_line(self, info, id):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, CheckoutLine)
         return resolve_checkout_line(id)
 
     @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3012,9 +3012,7 @@ def test_query_checkout_line_by_invalid_id(staff_api_client, page_type):
     assert content["data"]["checkoutLine"] is None
 
 
-def test_query_checkout_line_object_with_given_id_does_not_exists(
-    staff_api_client, page_type
-):
+def test_query_checkout_line_with_invalid_object_type(staff_api_client, page_type):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(QUERY_CHECKOUT_LINE_BY_ID, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3013,7 +3013,7 @@ def test_query_checkout_line_by_invalid_id(staff_api_client, page_type):
 
 
 def test_query_checkout_line_with_invalid_object_type(staff_api_client, page_type):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", page_type.pk)}
     response = staff_api_client.post_graphql(QUERY_CHECKOUT_LINE_BY_ID, variables)
     content = get_graphql_content(response)
     assert content["data"]["checkoutLine"] is None

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -155,6 +155,18 @@ class BaseMutation(graphene.Mutation):
         return None
 
     @classmethod
+    def get_global_id_or_error(
+        cls, id: str, only_type: Union[ObjectType, str] = None, field: str = "id"
+    ):
+        try:
+            _object_type, pk = from_global_id_or_error(id, only_type, field=field)
+        except GraphQLError as e:
+            raise ValidationError(
+                {field: ValidationError(str(e), code="graphql_error")}
+            )
+        return pk
+
+    @classmethod
     def get_node_or_error(cls, info, node_id, field="id", only_type=None, qs=None):
         if not node_id:
             return None

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -140,7 +140,7 @@ class BaseMutation(graphene.Mutation):
         cls._meta.fields.update(fields)
 
     @classmethod
-    def get_node_by_pk(
+    def _get_node_by_pk(
         cls, info, graphene_type: ObjectType, pk: Union[int, str], qs=None
     ):
         """Attempt to resolve a node from the given internal ID.
@@ -179,7 +179,7 @@ class BaseMutation(graphene.Mutation):
             if isinstance(object_type, str):
                 object_type = info.schema.get_type(object_type).graphene_type
 
-            node = cls.get_node_by_pk(info, graphene_type=object_type, pk=pk, qs=qs)
+            node = cls._get_node_by_pk(info, graphene_type=object_type, pk=pk, qs=qs)
         except (AssertionError, GraphQLError) as e:
             raise ValidationError(
                 {field: ValidationError(str(e), code="graphql_error")}

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -159,7 +159,7 @@ class BaseMutation(graphene.Mutation):
         cls, id: str, only_type: Union[ObjectType, str] = None, field: str = "id"
     ):
         try:
-            _object_type, pk = from_global_id_or_error(id, only_type, field=field)
+            _object_type, pk = from_global_id_or_error(id, only_type, raise_error=True)
         except GraphQLError as e:
             raise ValidationError(
                 {field: ValidationError(str(e), code="graphql_error")}
@@ -172,7 +172,9 @@ class BaseMutation(graphene.Mutation):
             return None
 
         try:
-            object_type, pk = from_global_id_or_error(node_id, only_type, field=field)
+            object_type, pk = from_global_id_or_error(
+                node_id, only_type, raise_error=True
+            )
 
             if isinstance(object_type, str):
                 object_type = info.schema.get_type(object_type).graphene_type

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -4,7 +4,6 @@ from unittest.mock import Mock, patch
 import graphene
 import pytest
 from django.contrib.auth.models import AnonymousUser
-from django.core.exceptions import ValidationError
 from django.db.models import Q
 from django.shortcuts import reverse
 from graphql.error import GraphQLError
@@ -289,20 +288,20 @@ def test_from_global_id_or_error(product):
     invalid_id = "invalid"
     message = f"Couldn't resolve id: {invalid_id}."
 
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(GraphQLError) as error:
         from_global_id_or_error(invalid_id)
 
-    assert error.value.error_dict["id"][0].message == message
+    assert str(error.value) == message
 
 
 def test_from_global_id_or_error_wth_invalid_type(product):
     product_id = graphene.Node.to_global_id("Product", product.id)
     message = "Must receive a ProductVariant id."
 
-    with pytest.raises(ValidationError) as error:
+    with pytest.raises(GraphQLError) as error:
         from_global_id_or_error(product_id, "ProductVariant")
 
-    assert error.value.error_dict["id"][0].message == message
+    assert str(error.value) == message
 
 
 def test_from_global_id_or_error_wth_type(product):

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -252,7 +252,7 @@ def test_get_nodes(product_list):
     with pytest.raises(GraphQLError) as exc:
         get_nodes(global_ids, Product)
 
-    assert exc.value.args == (f"Must receive Product id: {invalid_item_global_id}",)
+    assert exc.value.args == (f"Must receive Product id: {invalid_item_global_id}.",)
 
     # Raise an error if no nodes were found
     global_ids = []

--- a/saleor/graphql/core/tests/test_graphql.py
+++ b/saleor/graphql/core/tests/test_graphql.py
@@ -299,7 +299,7 @@ def test_from_global_id_or_error_wth_invalid_type(product):
     message = "Must receive a ProductVariant id."
 
     with pytest.raises(GraphQLError) as error:
-        from_global_id_or_error(product_id, "ProductVariant")
+        from_global_id_or_error(product_id, "ProductVariant", raise_error=True)
 
     assert str(error.value) == message
 

--- a/saleor/graphql/core/tests/test_view.py
+++ b/saleor/graphql/core/tests/test_view.py
@@ -79,11 +79,8 @@ def test_graphql_view_query_with_invalid_object_type(
     }
     staff_api_client.user.user_permissions.add(permission_manage_orders)
     response = staff_api_client.post_graphql(query, variables=variables)
-
-    assert response.status_code == 200
-    assert graphql_log_handler.messages == [
-        "saleor.graphql.errors.handled[INFO].GraphQLError"
-    ]
+    content = get_graphql_content(response)
+    assert content["data"]["order"] is None
 
 
 @pytest.mark.parametrize("playground_on, status", [(True, 200), (False, 405)])

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -140,11 +140,12 @@ def validate_required_string_field(cleaned_input, field_name: str):
 
 
 def from_global_id_or_error(
-    id: str, only_type: Union[ObjectType, str] = None, field: str = "id"
+    id: str, only_type: Union[ObjectType, str] = None, raise_error: bool = False
 ):
     """Resolve database ID from global ID or raise ValidationError.
 
-    Optionally validate the object type, if `only_type` is provided.
+    Optionally validate the object type, if `only_type` is provided,
+    raise GraphQLError when `raise_error` is set to True.
     """
     try:
         _type, _id = graphene.Node.from_global_id(id)
@@ -152,6 +153,8 @@ def from_global_id_or_error(
         raise GraphQLError(f"Couldn't resolve id: {id}.")
 
     if only_type and str(_type) != str(only_type):
+        if not raise_error:
+            return _type, None
         raise GraphQLError(f"Must receive a {only_type} id.")
     return _type, _id
 

--- a/saleor/graphql/core/utils/__init__.py
+++ b/saleor/graphql/core/utils/__init__.py
@@ -7,6 +7,7 @@ import graphene
 from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from graphene import ObjectType
+from graphql.error import GraphQLError
 from PIL import Image
 
 from ....core.utils import generate_unique_slug
@@ -147,15 +148,11 @@ def from_global_id_or_error(
     """
     try:
         _type, _id = graphene.Node.from_global_id(id)
-    except (binascii.Error, UnicodeDecodeError):
-        raise ValidationError(
-            {field: ValidationError(f"Couldn't resolve id: {id}.", code="not_found")}
-        )
+    except (binascii.Error, UnicodeDecodeError, ValueError):
+        raise GraphQLError(f"Couldn't resolve id: {id}.")
 
     if only_type and str(_type) != str(only_type):
-        raise ValidationError(
-            {field: ValidationError(f"Must receive a {only_type} id.", code="invalid")}
-        )
+        raise GraphQLError(f"Must receive a {only_type} id.")
     return _type, _id
 
 

--- a/saleor/graphql/csv/mutations.py
+++ b/saleor/graphql/csv/mutations.py
@@ -14,7 +14,6 @@ from ..core.mutations import BaseMutation
 from ..core.types.common import ExportError
 from ..product.filters import ProductFilterInput
 from ..product.types import Product
-from ..utils import resolve_global_ids_to_primary_keys
 from ..warehouse.types import Warehouse
 from .enums import ExportScope, FileTypeEnum, ProductFieldEnum
 from .types import ExportFile
@@ -103,8 +102,8 @@ class ExportProducts(BaseMutation):
             return cls.clean_filter(input)
         return {"all": ""}
 
-    @staticmethod
-    def clean_ids(input) -> Dict[str, List[str]]:
+    @classmethod
+    def clean_ids(cls, input) -> Dict[str, List[str]]:
         ids = input.get("ids", [])
         if not ids:
             raise ValidationError(
@@ -115,7 +114,7 @@ class ExportProducts(BaseMutation):
                     )
                 }
             )
-        _, pks = resolve_global_ids_to_primary_keys(ids, graphene_type=Product)
+        pks = cls.get_global_ids_or_error(ids, only_type=Product, field="ids")
         return {"ids": pks}
 
     @staticmethod
@@ -150,10 +149,10 @@ class ExportProducts(BaseMutation):
 
         return export_info
 
-    @staticmethod
-    def get_items_pks(field, export_info_input, graphene_type):
+    @classmethod
+    def get_items_pks(cls, field, export_info_input, graphene_type):
         ids = export_info_input.get(field)
         if not ids:
             return
-        _, pks = resolve_global_ids_to_primary_keys(ids, graphene_type=graphene_type)
+        pks = cls.get_global_ids_or_error(ids, only_type=graphene_type, field=field)
         return pks

--- a/saleor/graphql/csv/resolvers.py
+++ b/saleor/graphql/csv/resolvers.py
@@ -1,0 +1,9 @@
+from ...csv import models
+
+
+def resolve_export_file(id):
+    return models.ExportFile.objects.filter(id=id).first()
+
+
+def resolve_export_files():
+    return models.ExportFile.objects.all()

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -4,6 +4,7 @@ from ...core.permissions import ProductPermissions
 from ...core.tracing import traced_resolver
 from ...csv import models
 from ..core.fields import FilterInputConnectionField
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .filters import ExportFileFilterInput
 from .mutations import ExportProducts
@@ -29,7 +30,8 @@ class CsvQueries(graphene.ObjectType):
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     @traced_resolver
     def resolve_export_file(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, ExportFile)
+        _, id = from_global_id_or_error(id)
+        return models.ExportFile.objects.filter(id=id).first()
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     @traced_resolver

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -1,13 +1,12 @@
 import graphene
 
 from ...core.permissions import ProductPermissions
-from ...core.tracing import traced_resolver
-from ...csv import models
 from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .filters import ExportFileFilterInput
 from .mutations import ExportProducts
+from .resolvers import resolve_export_file, resolve_export_files
 from .sorters import ExportFileSortingInput
 from .types import ExportFile
 
@@ -28,15 +27,13 @@ class CsvQueries(graphene.ObjectType):
     )
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_export_file(self, info, id):
         _, id = from_global_id_or_error(id, ExportFile)
-        return models.ExportFile.objects.filter(id=id).first()
+        return resolve_export_file(id)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_export_files(self, _info, **kwargs):
-        return models.ExportFile.objects.all()
+        return resolve_export_files()
 
 
 class CsvMutations(graphene.ObjectType):

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -30,7 +30,7 @@ class CsvQueries(graphene.ObjectType):
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     @traced_resolver
     def resolve_export_file(self, info, id):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, ExportFile)
         return models.ExportFile.objects.filter(id=id).first()
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -217,9 +217,7 @@ def test_export_products_mutation_ids_scope_invalid_object_type(
     products = product_list[:2]
 
     ids = []
-    pks = set()
     for product in products:
-        pks.add(str(product.pk))
         ids.append(graphene.Node.to_global_id("ProductVariant", product.pk))
 
     variables = {
@@ -347,9 +345,7 @@ def test_export_products_mutation_with_warehouse_ids_invalid_object_type(
     products = product_list[:2]
 
     ids = []
-    pks = set()
     for product in products:
-        pks.add(str(product.pk))
         ids.append(graphene.Node.to_global_id("Product", product.pk))
 
     warehouse_pks = [str(warehouse.pk) for warehouse in Warehouse.objects.all()]

--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -6,6 +6,7 @@ import pytest
 from .....attribute.models import Attribute
 from .....channel.models import Channel
 from .....csv import ExportEvents
+from .....csv.error_codes import ExportErrorCode
 from .....csv.models import ExportEvent
 from .....warehouse.models import Warehouse
 from ....tests.utils import get_graphql_content
@@ -204,6 +205,53 @@ def test_export_products_mutation_ids_scope(
 
 
 @patch("saleor.graphql.csv.mutations.export_products_task.delay")
+def test_export_products_mutation_ids_scope_invalid_object_type(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    query = EXPORT_PRODUCTS_MUTATION
+
+    products = product_list[:2]
+
+    ids = []
+    pks = set()
+    for product in products:
+        pks.add(str(product.pk))
+        ids.append(graphene.Node.to_global_id("ProductVariant", product.pk))
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "exportInfo": {
+                "fields": [ProductFieldEnum.NAME.name],
+                "warehouses": [],
+                "attributes": [],
+            },
+            "fileType": FileTypeEnum.XLSX.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == "ids"
+    assert errors[0]["code"] == ExportErrorCode.GRAPHQL_ERROR.name
+
+    export_products_mock.assert_not_called()
+
+
+@patch("saleor.graphql.csv.mutations.export_products_task.delay")
 def test_export_products_mutation_with_warehouse_and_attribute_ids(
     export_products_mock,
     staff_api_client,
@@ -282,6 +330,180 @@ def test_export_products_mutation_with_warehouse_and_attribute_ids(
     assert ExportEvent.objects.filter(
         user=user, app=None, type=ExportEvents.EXPORT_PENDING
     ).exists()
+
+
+@patch("saleor.graphql.csv.mutations.export_products_task.delay")
+def test_export_products_mutation_with_warehouse_ids_invalid_object_type(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    channel_PLN,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    query = EXPORT_PRODUCTS_MUTATION
+
+    products = product_list[:2]
+
+    ids = []
+    pks = set()
+    for product in products:
+        pks.add(str(product.pk))
+        ids.append(graphene.Node.to_global_id("Product", product.pk))
+
+    warehouse_pks = [str(warehouse.pk) for warehouse in Warehouse.objects.all()]
+    channel_pks = [str(channel.pk) for channel in Channel.objects.all()]
+
+    warehouse_ids = [
+        graphene.Node.to_global_id("Attribute", pk) for pk in warehouse_pks
+    ]
+    channel_ids = [graphene.Node.to_global_id("Channel", pk) for pk in channel_pks]
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "exportInfo": {
+                "fields": [ProductFieldEnum.NAME.name],
+                "warehouses": warehouse_ids,
+                "attributes": [],
+                "channels": channel_ids,
+            },
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == "warehouses"
+    assert errors[0]["code"] == ExportErrorCode.GRAPHQL_ERROR.name
+
+    export_products_mock.assert_not_called()
+
+
+@patch("saleor.graphql.csv.mutations.export_products_task.delay")
+def test_export_products_mutation_with_attribute_ids_invalid_object_type(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    channel_PLN,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    query = EXPORT_PRODUCTS_MUTATION
+
+    products = product_list[:2]
+
+    ids = []
+    pks = set()
+    for product in products:
+        pks.add(str(product.pk))
+        ids.append(graphene.Node.to_global_id("Product", product.pk))
+
+    attribute_pks = [str(attr.pk) for attr in Attribute.objects.all()]
+    channel_pks = [str(channel.pk) for channel in Channel.objects.all()]
+
+    attribute_ids = [
+        graphene.Node.to_global_id("Warehouse", pk) for pk in attribute_pks
+    ]
+    channel_ids = [graphene.Node.to_global_id("Channel", pk) for pk in channel_pks]
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "exportInfo": {
+                "fields": [ProductFieldEnum.NAME.name],
+                "warehouses": [],
+                "attributes": attribute_ids,
+                "channels": channel_ids,
+            },
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == "attributes"
+    assert errors[0]["code"] == ExportErrorCode.GRAPHQL_ERROR.name
+
+    export_products_mock.assert_not_called()
+
+
+@patch("saleor.graphql.csv.mutations.export_products_task.delay")
+def test_export_products_mutation_with_channel_ids_invalid_object_type(
+    export_products_mock,
+    staff_api_client,
+    product_list,
+    channel_USD,
+    channel_PLN,
+    permission_manage_products,
+    permission_manage_apps,
+):
+    query = EXPORT_PRODUCTS_MUTATION
+
+    products = product_list[:2]
+
+    ids = []
+    pks = set()
+    for product in products:
+        pks.add(str(product.pk))
+        ids.append(graphene.Node.to_global_id("Product", product.pk))
+
+    attribute_pks = [str(attr.pk) for attr in Attribute.objects.all()]
+    channel_pks = [str(channel.pk) for channel in Channel.objects.all()]
+
+    attribute_ids = [
+        graphene.Node.to_global_id("Attribute", pk) for pk in attribute_pks
+    ]
+    channel_ids = [graphene.Node.to_global_id("Warehouse", pk) for pk in channel_pks]
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "exportInfo": {
+                "fields": [ProductFieldEnum.NAME.name],
+                "warehouses": [],
+                "attributes": attribute_ids,
+                "channels": channel_ids,
+            },
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_products, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportProducts"]
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == "channels"
+    assert errors[0]["code"] == ExportErrorCode.GRAPHQL_ERROR.name
+
+    export_products_mock.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/csv/tests/mutations/test_export_products.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_products.py
@@ -401,9 +401,7 @@ def test_export_products_mutation_with_attribute_ids_invalid_object_type(
     products = product_list[:2]
 
     ids = []
-    pks = set()
     for product in products:
-        pks.add(str(product.pk))
         ids.append(graphene.Node.to_global_id("Product", product.pk))
 
     attribute_pks = [str(attr.pk) for attr in Attribute.objects.all()]
@@ -459,9 +457,7 @@ def test_export_products_mutation_with_channel_ids_invalid_object_type(
     products = product_list[:2]
 
     ids = []
-    pks = set()
     for product in products:
-        pks.add(str(product.pk))
         ids.append(graphene.Node.to_global_id("Product", product.pk))
 
     attribute_pks = [str(attr.pk) for attr in Attribute.objects.all()]

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -212,7 +212,7 @@ def test_query_export_file_by_invalid_id(
     assert content["data"]["exportFile"] is None
 
 
-def test_query_export_file_object_with_given_id_does_not_exists(
+def test_query_export_file_with_invalid_object_type(
     staff_api_client, user_export_file, permission_manage_products
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -2,7 +2,7 @@ import graphene
 
 from .....core import JobStatus
 from .....csv import ExportEvents
-from ....tests.utils import get_graphql_content
+from ....tests.utils import get_graphql_content, get_graphql_content_from_response
 
 EXPORT_FILE_QUERY = """
     query($id: ID!){
@@ -196,3 +196,28 @@ def test_query_export_file_as_app(
     assert event["type"] == ExportEvents.EXPORT_FAILED.upper()
     assert event["user"]["email"] == user_export_event.user.email
     assert event["app"] is None
+
+
+def test_query_export_file_by_invalid_id(
+    staff_api_client, user_export_file, permission_manage_products
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        EXPORT_FILE_QUERY, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["exportFile"] is None
+
+
+def test_query_export_file_object_with_given_id_does_not_exists(
+    staff_api_client, user_export_file, permission_manage_products
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        EXPORT_FILE_QUERY, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["exportFile"] is None

--- a/saleor/graphql/csv/tests/queries/test_export_file.py
+++ b/saleor/graphql/csv/tests/queries/test_export_file.py
@@ -215,7 +215,7 @@ def test_query_export_file_by_invalid_id(
 def test_query_export_file_with_invalid_object_type(
     staff_api_client, user_export_file, permission_manage_products
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", user_export_file.pk)}
     response = staff_api_client.post_graphql(
         EXPORT_FILE_QUERY, variables, permissions=[permission_manage_products]
     )

--- a/saleor/graphql/discount/resolvers.py
+++ b/saleor/graphql/discount/resolvers.py
@@ -1,6 +1,14 @@
 from ...core.tracing import traced_resolver
 from ...discount import models
-from ..channel import ChannelQsContext
+from ..channel import ChannelContext, ChannelQsContext
+
+VOUCHER_SEARCH_FIELDS = ("name", "code")
+SALE_SEARCH_FIELDS = ("name", "value", "type")
+
+
+def resolve_voucher(id, channel):
+    sale = models.Voucher.objects.filter(id=id).first()
+    return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
 @traced_resolver
@@ -9,6 +17,11 @@ def resolve_vouchers(info, channel_slug, **_kwargs) -> ChannelQsContext:
     if channel_slug:
         qs = qs.filter(channel_listings__channel__slug=channel_slug)
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
+
+
+def resolve_sale(id, channel):
+    sale = models.Sale.objects.filter(id=id).first()
+    return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
 @traced_resolver

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -2,9 +2,9 @@ import graphene
 
 from ...core.permissions import DiscountPermissions
 from ...core.tracing import traced_resolver
-from ..channel import ChannelContext
 from ..core.fields import ChannelContextFilterConnectionField
 from ..core.types import FilterInputObjectType
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from ..translations.mutations import SaleTranslate, VoucherTranslate
 from .bulk_mutations import SaleBulkDelete, VoucherBulkDelete
@@ -23,7 +23,7 @@ from .mutations import (
     VoucherRemoveCatalogues,
     VoucherUpdate,
 )
-from .resolvers import resolve_sales, resolve_vouchers
+from .resolvers import resolve_sale, resolve_sales, resolve_voucher, resolve_vouchers
 from .sorters import SaleSortingInput, VoucherSortingInput
 from .types import Sale, Voucher
 
@@ -81,18 +81,17 @@ class DiscountQueries(graphene.ObjectType):
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
     @traced_resolver
     def resolve_sale(self, info, id, channel=None):
-        sale = graphene.Node.get_node_from_global_id(info, id, Sale)
-        return ChannelContext(node=sale, channel_slug=channel) if sale else None
+        _, id = from_global_id_or_error(id)
+        return resolve_sale(id, channel)
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
     def resolve_sales(self, info, channel=None, **kwargs):
         return resolve_sales(info, channel_slug=channel, **kwargs)
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_voucher(self, info, id, channel=None):
-        voucher = graphene.Node.get_node_from_global_id(info, id, Voucher)
-        return ChannelContext(node=voucher, channel_slug=channel) if voucher else None
+        _, id = from_global_id_or_error(id)
+        return resolve_voucher(id, channel)
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
     def resolve_vouchers(self, info, channel=None, **kwargs):

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -81,7 +81,7 @@ class DiscountQueries(graphene.ObjectType):
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
     @traced_resolver
     def resolve_sale(self, info, id, channel=None):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, Sale)
         return resolve_sale(id, channel)
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
@@ -90,7 +90,7 @@ class DiscountQueries(graphene.ObjectType):
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
     def resolve_voucher(self, info, id, channel=None):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, Voucher)
         return resolve_voucher(id, channel)
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)

--- a/saleor/graphql/discount/tests/test_discount.py
+++ b/saleor/graphql/discount/tests/test_discount.py
@@ -1821,7 +1821,7 @@ def test_staff_query_sale_by_invalid_id(
     assert content["data"]["sale"] is None
 
 
-def test_staff_query_sale_object_with_given_id_does_not_exists(
+def test_staff_query_sale_with_invalid_object_type(
     staff_api_client, sale, permission_manage_discounts
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
@@ -1884,7 +1884,7 @@ def test_staff_query_voucher_by_invalid_id(
     assert content["data"]["voucher"] is None
 
 
-def test_staff_query_voucher_object_with_given_id_does_not_exists(
+def test_staff_query_voucher_with_invalid_object_type(
     staff_api_client, voucher, permission_manage_discounts
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/discount/tests/test_discount.py
+++ b/saleor/graphql/discount/tests/test_discount.py
@@ -9,7 +9,11 @@ from django_countries import countries
 from ....discount import DiscountValueType, VoucherType
 from ....discount.error_codes import DiscountErrorCode
 from ....discount.models import Sale, SaleChannelListing, Voucher
-from ...tests.utils import get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ..enums import DiscountValueTypeEnum, VoucherTypeEnum
 
 
@@ -1763,3 +1767,129 @@ def test_query_sales_with_sort(
 
     for order, sale_name in enumerate(result_order):
         assert sales[order]["node"]["name"] == sale_name
+
+
+QUERY_SALE_BY_ID = """
+    query Sale($id: ID!) {
+        sale(id: $id) {
+            id
+            name
+            type
+            discountValue
+        }
+    }
+"""
+
+
+def test_staff_query_sale(staff_api_client, sale, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("Sale", sale.pk)}
+    response = staff_api_client.post_graphql(
+        QUERY_SALE_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["sale"]["name"] == sale.name
+    assert content["data"]["sale"]["type"] == sale.type.upper()
+
+
+def test_query_sale_by_app(app_api_client, sale, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("Sale", sale.pk)}
+    response = app_api_client.post_graphql(
+        QUERY_SALE_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["sale"]["name"] == sale.name
+    assert content["data"]["sale"]["type"] == sale.type.upper()
+
+
+def test_query_sale_by_customer(api_client, sale, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("Sale", sale.pk)}
+    response = api_client.post_graphql(QUERY_SALE_BY_ID, variables)
+    assert_no_permission(response)
+
+
+def test_staff_query_sale_by_invalid_id(
+    staff_api_client, sale, permission_manage_discounts
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_SALE_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["sale"] is None
+
+
+def test_staff_query_sale_object_with_given_id_does_not_exists(
+    staff_api_client, sale, permission_manage_discounts
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        QUERY_SALE_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["sale"] is None
+
+
+QUERY_VOUCHER_BY_ID = """
+    query Voucher($id: ID!) {
+        voucher(id: $id) {
+            id
+            code
+            name
+            discountValue
+        }
+    }
+"""
+
+
+def test_staff_query_voucher(staff_api_client, voucher, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    response = staff_api_client.post_graphql(
+        QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["voucher"]["name"] == voucher.name
+    assert content["data"]["voucher"]["code"] == voucher.code
+
+
+def test_query_voucher_by_app(app_api_client, voucher, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    response = app_api_client.post_graphql(
+        QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["voucher"]["name"] == voucher.name
+    assert content["data"]["voucher"]["code"] == voucher.code
+
+
+def test_query_voucher_by_customer(api_client, voucher, permission_manage_discounts):
+    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    response = api_client.post_graphql(QUERY_VOUCHER_BY_ID, variables)
+    assert_no_permission(response)
+
+
+def test_staff_query_voucher_by_invalid_id(
+    staff_api_client, voucher, permission_manage_discounts
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["voucher"] is None
+
+
+def test_staff_query_voucher_object_with_given_id_does_not_exists(
+    staff_api_client, voucher, permission_manage_discounts
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["voucher"] is None

--- a/saleor/graphql/discount/tests/test_discount.py
+++ b/saleor/graphql/discount/tests/test_discount.py
@@ -1824,7 +1824,7 @@ def test_staff_query_sale_by_invalid_id(
 def test_staff_query_sale_with_invalid_object_type(
     staff_api_client, sale, permission_manage_discounts
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", sale.pk)}
     response = staff_api_client.post_graphql(
         QUERY_SALE_BY_ID, variables, permissions=[permission_manage_discounts]
     )
@@ -1845,7 +1845,7 @@ QUERY_VOUCHER_BY_ID = """
 
 
 def test_staff_query_voucher(staff_api_client, voucher, permission_manage_discounts):
-    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    variables = {"id": graphene.Node.to_global_id("Voucher", voucher.pk)}
     response = staff_api_client.post_graphql(
         QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
     )
@@ -1855,7 +1855,7 @@ def test_staff_query_voucher(staff_api_client, voucher, permission_manage_discou
 
 
 def test_query_voucher_by_app(app_api_client, voucher, permission_manage_discounts):
-    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    variables = {"id": graphene.Node.to_global_id("Voucher", voucher.pk)}
     response = app_api_client.post_graphql(
         QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
     )
@@ -1865,7 +1865,7 @@ def test_query_voucher_by_app(app_api_client, voucher, permission_manage_discoun
 
 
 def test_query_voucher_by_customer(api_client, voucher, permission_manage_discounts):
-    variables = {"id": graphene.Node.to_global_id("voucher", voucher.pk)}
+    variables = {"id": graphene.Node.to_global_id("Voucher", voucher.pk)}
     response = api_client.post_graphql(QUERY_VOUCHER_BY_ID, variables)
     assert_no_permission(response)
 
@@ -1887,7 +1887,7 @@ def test_staff_query_voucher_by_invalid_id(
 def test_staff_query_voucher_with_invalid_object_type(
     staff_api_client, voucher, permission_manage_discounts
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", voucher.pk)}
     response = staff_api_client.post_graphql(
         QUERY_VOUCHER_BY_ID, variables, permissions=[permission_manage_discounts]
     )

--- a/saleor/graphql/giftcard/resolvers.py
+++ b/saleor/graphql/giftcard/resolvers.py
@@ -1,13 +1,8 @@
-import graphene
-
-from ...core.tracing import traced_resolver
 from ...giftcard import models
-from .types import GiftCard
 
 
-@traced_resolver
-def resolve_gift_card(info, gift_card_global_id):
-    return graphene.Node.get_node_from_global_id(info, gift_card_global_id, GiftCard)
+def resolve_gift_card(gift_card_id):
+    return models.GiftCard.objects.filter(pk=gift_card_id).first()
 
 
 def resolve_gift_cards():

--- a/saleor/graphql/giftcard/resolvers.py
+++ b/saleor/graphql/giftcard/resolvers.py
@@ -1,8 +1,8 @@
 from ...giftcard import models
 
 
-def resolve_gift_card(gift_card_id):
-    return models.GiftCard.objects.filter(pk=gift_card_id).first()
+def resolve_gift_card(id):
+    return models.GiftCard.objects.filter(pk=id).first()
 
 
 def resolve_gift_cards():

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -3,6 +3,7 @@ import graphene
 from ...core.permissions import GiftcardPermissions
 from ...core.tracing import traced_resolver
 from ..core.fields import PrefetchingConnectionField
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .mutations import (
     GiftCardActivate,
@@ -26,7 +27,8 @@ class GiftCardQueries(graphene.ObjectType):
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
     def resolve_gift_card(self, info, **data):
-        return resolve_gift_card(info, data.get("id"))
+        _, id = from_global_id_or_error(data.get("id"))
+        return resolve_gift_card(id)
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
     @traced_resolver

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -27,7 +27,7 @@ class GiftCardQueries(graphene.ObjectType):
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
     def resolve_gift_card(self, info, **data):
-        _, id = from_global_id_or_error(data.get("id"))
+        _, id = from_global_id_or_error(data.get("id"), GiftCard)
         return resolve_gift_card(id)
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)

--- a/saleor/graphql/giftcard/tests/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/test_gift_card.py
@@ -117,7 +117,7 @@ def test_staff_query_gift_card_by_invalid_id(
     assert content["data"]["giftCard"] is None
 
 
-def test_staff_query_gift_card_object_with_given_id_does_not_exists(
+def test_staff_query_gift_card_with_invalid_object_type(
     staff_api_client, gift_card, permission_manage_users, permission_manage_gift_card
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/giftcard/tests/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/test_gift_card.py
@@ -3,23 +3,30 @@ from datetime import date
 import graphene
 
 from ....giftcard.error_codes import GiftCardErrorCode
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
-
-def test_query_gift_card_with_permissions(
-    staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
-):
-    query = """
+QUERY_GIFT_CARD_BY_ID = """
     query giftCard($id: ID!) {
         giftCard(id: $id){
             id
             displayCode
+            code
             user {
                 email
             }
         }
     }
-    """
+"""
+
+
+def test_query_gift_card_with_permissions(
+    staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
+):
+    query = QUERY_GIFT_CARD_BY_ID
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
 
@@ -48,18 +55,7 @@ def test_query_gift_card_code_without_user(
     permission_manage_gift_card,
     permission_manage_users,
 ):
-    query = """
-    query giftCard($id: ID!) {
-        giftCard(id: $id){
-            id
-            displayCode
-            code
-            user{
-                email
-            }
-        }
-    }
-    """
+    query = QUERY_GIFT_CARD_BY_ID
     gift_card = gift_card_created_by_staff
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
@@ -79,18 +75,7 @@ def test_query_gift_card_code_without_user(
 def test_query_gift_card_code_with_user(
     staff_api_client, gift_card, permission_manage_gift_card, permission_manage_users
 ):
-    query = """
-    query giftCard($id: ID!) {
-        giftCard(id: $id){
-            id
-            displayCode
-            code
-            user{
-                email
-            }
-        }
-    }
-    """
+    query = QUERY_GIFT_CARD_BY_ID
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.pk)
     variables = {"id": gift_card_id}
     response = staff_api_client.post_graphql(
@@ -109,17 +94,40 @@ def test_query_gift_card_code_with_user(
 def test_query_gift_card_without_premissions(
     user_api_client, gift_card_created_by_staff
 ):
-    query = """
-    query giftCard($id: ID!) {
-        giftCard(id: $id){
-            id
-        }
-    }
-    """
+    query = QUERY_GIFT_CARD_BY_ID
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card_created_by_staff.pk)
     variables = {"id": gift_card_id}
     response = user_api_client.post_graphql(query, variables)
     assert_no_permission(response)
+
+
+def test_staff_query_gift_card_by_invalid_id(
+    staff_api_client, gift_card, permission_manage_users, permission_manage_gift_card
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_GIFT_CARD_BY_ID,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["giftCard"] is None
+
+
+def test_staff_query_gift_card_object_with_given_id_does_not_exists(
+    staff_api_client, gift_card, permission_manage_users, permission_manage_gift_card
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        QUERY_GIFT_CARD_BY_ID,
+        variables,
+        permissions=[permission_manage_gift_card, permission_manage_users],
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["giftCard"] is None
 
 
 def test_query_gift_cards(

--- a/saleor/graphql/giftcard/tests/test_gift_card.py
+++ b/saleor/graphql/giftcard/tests/test_gift_card.py
@@ -120,7 +120,7 @@ def test_staff_query_gift_card_by_invalid_id(
 def test_staff_query_gift_card_with_invalid_object_type(
     staff_api_client, gift_card, permission_manage_users, permission_manage_gift_card
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", gift_card.pk)}
     response = staff_api_client.post_graphql(
         QUERY_GIFT_CARD_BY_ID,
         variables,

--- a/saleor/graphql/menu/mutations.py
+++ b/saleor/graphql/menu/mutations.py
@@ -15,7 +15,7 @@ from ...product import models as product_models
 from ..channel import ChannelContext
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.types.common import MenuError
-from ..core.utils import from_global_id_or_error, validate_slug_and_generate_if_needed
+from ..core.utils import validate_slug_and_generate_if_needed
 from ..core.utils.reordering import perform_reordering
 from ..page.types import Page
 from ..product.types import Category, Collection
@@ -357,7 +357,7 @@ class MenuItemMove(BaseMutation):
         new_parent, parent_changed = None, False
 
         if move.parent_id is not None:
-            _type, parent_pk = from_global_id_or_error(
+            parent_pk = cls.get_global_id_or_error(
                 move.parent_id, only_type=MenuItem, field="parent_id"
             )
             if int(parent_pk) != menu_item.parent_id:

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -1,10 +1,8 @@
-import graphene
-
 from ...core.tracing import traced_resolver
 from ...menu import models
 from ..channel import ChannelContext, ChannelQsContext
+from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
-from .types import Menu
 
 
 @traced_resolver
@@ -12,7 +10,8 @@ def resolve_menu(info, channel, menu_id=None, name=None, slug=None):
     validate_one_of_args_is_in_query("id", menu_id, "name", name, "slug", slug)
     menu = None
     if menu_id:
-        menu = graphene.Node.get_node_from_global_id(info, menu_id, Menu)
+        _, id = from_global_id_or_error(menu_id)
+        menu = models.Menu.objects.filter(id=id).first()
     if name:
         menu = models.Menu.objects.filter(name=name).first()
     if slug:
@@ -23,6 +22,11 @@ def resolve_menu(info, channel, menu_id=None, name=None, slug=None):
 @traced_resolver
 def resolve_menus(info, channel, **_kwargs):
     return ChannelQsContext(qs=models.Menu.objects.all(), channel_slug=channel)
+
+
+def resolve_menu_item(id, channel):
+    menu_item = models.MenuItem.objects.filter(pk=id).first()
+    return ChannelContext(node=menu_item, channel_slug=channel) if menu_item else None
 
 
 @traced_resolver

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -3,6 +3,7 @@ from ...menu import models
 from ..channel import ChannelContext, ChannelQsContext
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
+from .types import Menu
 
 
 @traced_resolver
@@ -10,7 +11,7 @@ def resolve_menu(info, channel, menu_id=None, name=None, slug=None):
     validate_one_of_args_is_in_query("id", menu_id, "name", name, "slug", slug)
     menu = None
     if menu_id:
-        _, id = from_global_id_or_error(menu_id)
+        _, id = from_global_id_or_error(menu_id, Menu)
         menu = models.Menu.objects.filter(id=id).first()
     if name:
         menu = models.Menu.objects.filter(name=name).first()

--- a/saleor/graphql/menu/schema.py
+++ b/saleor/graphql/menu/schema.py
@@ -82,7 +82,7 @@ class MenuQueries(graphene.ObjectType):
     def resolve_menu_item(self, info, channel=None, **data):
         if channel is None:
             channel = get_default_channel_slug_or_graphql_error()
-        _, id = from_global_id_or_error(data.get("id"))
+        _, id = from_global_id_or_error(data.get("id"), MenuItem)
         return resolve_menu_item(id, channel)
 
     def resolve_menu_items(self, info, channel=None, **kwargs):

--- a/saleor/graphql/menu/schema.py
+++ b/saleor/graphql/menu/schema.py
@@ -1,8 +1,9 @@
 import graphene
 
-from ..channel import ChannelContext, ChannelQsContext
+from ..channel import ChannelQsContext
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..core.fields import ChannelContextFilterConnectionField
+from ..core.utils import from_global_id_or_error
 from ..translations.mutations import MenuItemTranslate
 from .bulk_mutations import MenuBulkDelete, MenuItemBulkDelete
 from .filters import MenuFilterInput, MenuItemFilterInput
@@ -16,7 +17,12 @@ from .mutations import (
     MenuItemUpdate,
     MenuUpdate,
 )
-from .resolvers import resolve_menu, resolve_menu_items, resolve_menus
+from .resolvers import (
+    resolve_menu,
+    resolve_menu_item,
+    resolve_menu_items,
+    resolve_menus,
+)
 from .sorters import MenuItemSortingInput, MenuSortingInput
 from .types import Menu, MenuItem
 
@@ -76,10 +82,8 @@ class MenuQueries(graphene.ObjectType):
     def resolve_menu_item(self, info, channel=None, **data):
         if channel is None:
             channel = get_default_channel_slug_or_graphql_error()
-        menu_item = graphene.Node.get_node_from_global_id(
-            info, data.get("id"), MenuItem
-        )
-        return ChannelContext(node=menu_item, channel_slug=channel)
+        _, id = from_global_id_or_error(data.get("id"))
+        return resolve_menu_item(id, channel)
 
     def resolve_menu_items(self, info, channel=None, **kwargs):
         if channel is None:

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -63,7 +63,7 @@ def test_staff_query_menu_by_invalid_id(staff_api_client, menu):
     assert content["data"]["menu"] is None
 
 
-def test_staff_query_menu_object_with_given_id_does_not_exists(staff_api_client, menu):
+def test_staff_query_menu_with_invalid_object_type(staff_api_client, menu):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(QUERY_MENU, variables)
     content = get_graphql_content(response)
@@ -335,9 +335,7 @@ def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu):
     assert content["data"]["menuItem"] is None
 
 
-def test_staff_query_menu_item_object_with_given_id_does_not_exists(
-    staff_api_client, menu
-):
+def test_staff_query_menu_item_with_invalid_object_type(staff_api_client, menu):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -8,7 +8,11 @@ from ....menu.error_codes import MenuErrorCode
 from ....menu.models import Menu, MenuItem
 from ....product.models import Category
 from ...menu.mutations import NavigationType, _validate_menu_item_instance
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 
 def test_validate_menu_item_instance(category, page):
@@ -47,6 +51,23 @@ def test_menu_query_by_id(
     menu_data = content["data"]["menu"]
     assert menu_data is not None
     assert menu_data["name"] == menu.name
+
+
+def test_staff_query_menu_by_invalid_id(staff_api_client, menu):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(QUERY_MENU, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["menu"] is None
+
+
+def test_staff_query_menu_object_with_given_id_does_not_exists(staff_api_client, menu):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(QUERY_MENU, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["menu"] is None
 
 
 def test_menu_query_by_name(
@@ -302,6 +323,25 @@ def test_menu_item_query_with_invalid_channel(
     assert not data["category"]
     assert not data["page"]
     assert data["url"] is None
+
+
+def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["menuItem"] is None
+
+
+def test_staff_query_menu_item_object_with_given_id_does_not_exists(
+    staff_api_client, menu
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["menuItem"] is None
 
 
 def test_menu_items_query(

--- a/saleor/graphql/menu/tests/test_menu.py
+++ b/saleor/graphql/menu/tests/test_menu.py
@@ -64,7 +64,7 @@ def test_staff_query_menu_by_invalid_id(staff_api_client, menu):
 
 
 def test_staff_query_menu_with_invalid_object_type(staff_api_client, menu):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", menu.pk)}
     response = staff_api_client.post_graphql(QUERY_MENU, variables)
     content = get_graphql_content(response)
     assert content["data"]["menu"] is None
@@ -325,7 +325,7 @@ def test_menu_item_query_with_invalid_channel(
     assert data["url"] is None
 
 
-def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu):
+def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu_item):
     id = "bh/"
     variables = {"id": id}
     response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
@@ -335,8 +335,8 @@ def test_staff_query_menu_item_by_invalid_id(staff_api_client, menu):
     assert content["data"]["menuItem"] is None
 
 
-def test_staff_query_menu_item_with_invalid_object_type(staff_api_client, menu):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+def test_staff_query_menu_item_with_invalid_object_type(staff_api_client, menu_item):
+    variables = {"id": graphene.Node.to_global_id("Order", menu_item.pk)}
     response = staff_api_client.post_graphql(QUERY_MENU_ITEM_BY_ID, variables)
     content = get_graphql_content(response)
     assert content["data"]["menuItem"] is None

--- a/saleor/graphql/meta/mutations.py
+++ b/saleor/graphql/meta/mutations.py
@@ -2,6 +2,7 @@ from typing import List
 
 import graphene
 from django.core.exceptions import ValidationError
+from graphql.error.base import GraphQLError
 
 from ...core import models
 from ...core.error_codes import MetadataErrorCode
@@ -102,6 +103,11 @@ class BaseMetadataMutation(BaseMutation):
     def mutate(cls, root, info, **data):
         try:
             permissions = cls.get_permissions(info, **data)
+        except GraphQLError as e:
+            error = ValidationError(
+                {"id": ValidationError(str(e), code="graphql_error")}
+            )
+            return cls.handle_errors(error)
         except ValidationError as e:
             return cls.handle_errors(e)
         if not cls.check_permissions(info.context, permissions):

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -94,7 +94,7 @@ def filter_order_search(qs, _, value):
 
 def filter_channels(qs, _, values):
     if values:
-        _, channels_ids = resolve_global_ids_to_primary_keys(values)
+        _, channels_ids = resolve_global_ids_to_primary_keys(values, "Channel")
         qs = qs.filter(channel_id__in=channels_ids)
     return qs
 

--- a/saleor/graphql/order/filters.py
+++ b/saleor/graphql/order/filters.py
@@ -5,7 +5,6 @@ from graphene_django.filter import GlobalIDMultipleChoiceFilter
 from ...discount.models import OrderDiscount
 from ...order.models import Order
 from ...payment.models import Payment
-from ..channel.types import Channel
 from ..core.filters import ListObjectTypeFilter, MetadataFilterBase, ObjectTypeFilter
 from ..core.types.common import DateRangeInput
 from ..core.utils import from_global_id_or_error
@@ -23,7 +22,7 @@ def filter_payment_status(qs, _, value):
 
 def get_payment_id_from_query(value):
     try:
-        return from_global_id_or_error(value, only_type="Payment", field="pk")[1]
+        return from_global_id_or_error(value, only_type="Payment")[1]
     except Exception:
         return None
 
@@ -95,7 +94,7 @@ def filter_order_search(qs, _, value):
 
 def filter_channels(qs, _, values):
     if values:
-        _, channels_ids = resolve_global_ids_to_primary_keys(values, Channel)
+        _, channels_ids = resolve_global_ids_to_primary_keys(values)
         qs = qs.filter(channel_id__in=channels_ids)
     return qs
 

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -20,7 +20,7 @@ from ....order.notifications import send_fulfillment_update
 from ...core.mutations import BaseMutation
 from ...core.scalars import PositiveDecimal
 from ...core.types.common import OrderError
-from ...core.utils import from_global_id_or_error, get_duplicated_values
+from ...core.utils import get_duplicated_values
 from ...utils import get_user_or_app_from_context
 from ...warehouse.types import Warehouse
 from ..types import Fulfillment, FulfillmentLine, Order, OrderLine
@@ -190,7 +190,7 @@ class OrderFulfill(BaseMutation):
         for line, order_line in zip(lines, order_lines):
             for stock in line["stocks"]:
                 if stock["quantity"] > 0:
-                    _type, warehouse_pk = from_global_id_or_error(
+                    warehouse_pk = cls.get_global_id_or_error(
                         stock["warehouse"], only_type=Warehouse, field="warehouse"
                     )
                     lines_for_warehouses[warehouse_pk].append(

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -1,5 +1,3 @@
-import graphene
-
 from ...channel.models import Channel
 from ...core.tracing import traced_resolver
 from ...order import OrderStatus, models
@@ -8,7 +6,6 @@ from ...order.models import OrderEvent
 from ...order.utils import sum_order_totals
 from ..channel.utils import get_default_channel_slug_or_graphql_error
 from ..utils.filters import filter_by_period
-from .types import Order
 
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
@@ -43,9 +40,8 @@ def resolve_orders_total(_info, period, channel_slug):
     return sum_order_totals(qs, channel.currency_code)
 
 
-@traced_resolver
-def resolve_order(info, order_id):
-    return graphene.Node.get_node_from_global_id(info, order_id, Order)
+def resolve_order(order_id):
+    return models.Order.objects.filter(pk=order_id).first()
 
 
 def resolve_homepage_events():

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -40,8 +40,8 @@ def resolve_orders_total(_info, period, channel_slug):
     return sum_order_totals(qs, channel.currency_code)
 
 
-def resolve_order(order_id):
-    return models.Order.objects.filter(pk=order_id).first()
+def resolve_order(id):
+    return models.Order.objects.filter(pk=id).first()
 
 
 def resolve_homepage_events():

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -6,6 +6,7 @@ from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
 from ..core.types import FilterInputObjectType, TaxedMoney
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .bulk_mutations.draft_orders import DraftOrderBulkDelete, DraftOrderLinesBulkDelete
 from .bulk_mutations.orders import OrderBulkCancel
@@ -116,7 +117,8 @@ class OrderQueries(graphene.ObjectType):
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_order(self, info, **data):
-        return resolve_order(info, data.get("id"))
+        _, id = from_global_id_or_error(data.get("id"))
+        return resolve_order(id)
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_orders(self, info, channel=None, **_kwargs):

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -117,7 +117,7 @@ class OrderQueries(graphene.ObjectType):
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_order(self, info, **data):
-        _, id = from_global_id_or_error(data.get("id"))
+        _, id = from_global_id_or_error(data.get("id"), Order)
         return resolve_order(id)
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1315,7 +1315,7 @@ def test_staff_query_page_type_by_invalid_id(
     assert content["data"]["order"] is None
 
 
-def test_staff_query_page_type_object_with_given_id_does_not_exists(
+def test_staff_query_page_type_with_invalid_object_type(
     staff_api_client, order, permission_manage_orders
 ):
     variables = {"id": graphene.Node.to_global_id("Page", -1)}

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -1318,7 +1318,7 @@ def test_staff_query_page_type_by_invalid_id(
 def test_staff_query_page_type_with_invalid_object_type(
     staff_api_client, order, permission_manage_orders
 ):
-    variables = {"id": graphene.Node.to_global_id("Page", -1)}
+    variables = {"id": graphene.Node.to_global_id("Page", order.pk)}
     response = staff_api_client.post_graphql(
         QUERY_ORDER_BY_ID, variables, permissions=[permission_manage_orders]
     )

--- a/saleor/graphql/page/mutations/attributes.py
+++ b/saleor/graphql/page/mutations/attributes.py
@@ -17,7 +17,6 @@ from ...attribute.types import Attribute
 from ...core.inputs import ReorderInput
 from ...core.mutations import BaseMutation
 from ...core.types.common import PageError
-from ...core.utils import from_global_id_or_error
 from ...core.utils.reordering import perform_reordering
 from ...page.types import Page, PageType
 from ...utils import resolve_global_ids_to_primary_keys
@@ -171,9 +170,7 @@ class PageTypeReorderAttributes(BaseReorderAttributesMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         page_type_id = data["page_type_id"]
-        _type, pk = from_global_id_or_error(
-            page_type_id, only_type=PageType, field="pk"
-        )
+        pk = cls.get_global_id_or_error(page_type_id, only_type=PageType, field="pk")
 
         try:
             page_type = page_models.PageType.objects.prefetch_related(
@@ -234,11 +231,9 @@ class PageReorderAttributeValues(BaseReorderAttributeValuesMutation):
         page = cls.perform(page_id, "page", data, "pagevalueassignment", PageErrorCode)
         return PageReorderAttributeValues(page=page)
 
-    @staticmethod
-    def get_instance(instance_id: str):
-        _type, pk = from_global_id_or_error(
-            instance_id, only_type=Page, field="page_id"
-        )
+    @classmethod
+    def get_instance(cls, instance_id: str):
+        pk = cls.get_global_id_or_error(instance_id, only_type=Page, field="page_id")
 
         try:
             page = page_models.Page.objects.prefetch_related("attributes").get(pk=pk)

--- a/saleor/graphql/page/mutations/attributes.py
+++ b/saleor/graphql/page/mutations/attributes.py
@@ -92,10 +92,14 @@ class PageAttributeAssign(BaseMutation):
         attribute_ids = data["attribute_ids"]
 
         # retrieve the requested page type
-        page_type = cls.get_node_or_error(info, page_type_id, only_type=PageType)
+        page_type = cls.get_node_or_error(
+            info, page_type_id, only_type=PageType, field="page_type_id"
+        )
 
         # resolve all passed attributes IDs to attributes pks
-        _, attr_pks = resolve_global_ids_to_primary_keys(attribute_ids, Attribute)
+        attr_pks = cls.get_global_ids_or_error(
+            attribute_ids, Attribute, field="attribute_ids"
+        )
 
         # ensure the attributes are assignable
         cls.clean_attributes(errors, page_type, attr_pks)

--- a/saleor/graphql/page/mutations/pages.py
+++ b/saleor/graphql/page/mutations/pages.py
@@ -15,11 +15,7 @@ from ...attribute.types import AttributeValueInput
 from ...attribute.utils import AttributeAssignmentMixin
 from ...core.mutations import ModelDeleteMutation, ModelMutation
 from ...core.types.common import PageError, SeoInput
-from ...core.utils import (
-    clean_seo_fields,
-    from_global_id_or_error,
-    validate_slug_and_generate_if_needed,
-)
+from ...core.utils import clean_seo_fields, validate_slug_and_generate_if_needed
 from ...utils.validators import check_for_duplicates
 from ..types import PageType
 
@@ -320,7 +316,7 @@ class PageTypeDelete(ModelDeleteMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
         node_id = data.get("id")
-        _type, page_type_pk = from_global_id_or_error(
+        page_type_pk = cls.get_global_id_or_error(
             node_id, only_type=PageType, field="pk"
         )
         cls.delete_assigned_attribute_values(page_type_pk)

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -1,10 +1,7 @@
-import graphene
-
 from ...core.tracing import traced_resolver
 from ...page import models
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
-from .types import PageType
 
 
 @traced_resolver
@@ -26,9 +23,8 @@ def resolve_pages(info, **_kwargs):
     return models.Page.objects.visible_to_user(user)
 
 
-@traced_resolver
-def resolve_page_type(info, global_page_type_id):
-    return graphene.Node.get_node_from_global_id(info, global_page_type_id, PageType)
+def resolve_page_type(id):
+    return models.PageType.objects.filter(id=id).first()
 
 
 @traced_resolver

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -2,6 +2,7 @@ from ...core.tracing import traced_resolver
 from ...page import models
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
+from .types import Page
 
 
 @traced_resolver
@@ -12,7 +13,7 @@ def resolve_page(info, global_page_id=None, slug=None):
     if slug is not None:
         page = models.Page.objects.visible_to_user(user).filter(slug=slug).first()
     else:
-        _type, page_pk = from_global_id_or_error(global_page_id)
+        _type, page_pk = from_global_id_or_error(global_page_id, Page)
         page = models.Page.objects.visible_to_user(user).filter(pk=page_pk).first()
     return page
 

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ..core.fields import FilterInputConnectionField
+from ..core.utils import from_global_id_or_error
 from ..translations.mutations import PageTranslate
 from .bulk_mutations import PageBulkDelete, PageBulkPublish, PageTypeBulkDelete
 from .filters import PageFilterInput, PageTypeFilterInput
@@ -62,7 +63,8 @@ class PageQueries(graphene.ObjectType):
         return resolve_pages(info, **kwargs)
 
     def resolve_page_type(self, info, id):
-        return resolve_page_type(info, id)
+        _, id = from_global_id_or_error(id)
+        return resolve_page_type(id)
 
     def resolve_page_types(self, info, **kwargs):
         return resolve_page_types(info, **kwargs)

--- a/saleor/graphql/page/schema.py
+++ b/saleor/graphql/page/schema.py
@@ -63,7 +63,7 @@ class PageQueries(graphene.ObjectType):
         return resolve_pages(info, **kwargs)
 
     def resolve_page_type(self, info, id):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, PageType)
         return resolve_page_type(id)
 
     def resolve_page_types(self, info, **kwargs):

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -139,7 +139,7 @@ def test_staff_query_page_by_invalid_id(staff_api_client, page):
     assert content["data"]["page"] is None
 
 
-def test_staff_query_page_object_with_given_id_does_not_exists(staff_api_client, page):
+def test_staff_query_page_with_invalid_object_type(staff_api_client, page):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -14,7 +14,7 @@ from ....page.models import Page, PageType
 from ....tests.utils import dummy_editorjs
 from ....webhook.event_types import WebhookEventType
 from ....webhook.payloads import generate_page_payload
-from ...tests.utils import get_graphql_content
+from ...tests.utils import get_graphql_content, get_graphql_content_from_response
 
 PAGE_QUERY = """
     query PageQuery($id: ID, $slug: String) {
@@ -127,6 +127,23 @@ def test_staff_query_unpublished_page(staff_api_client, page):
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)
     assert content["data"]["page"] is not None
+
+
+def test_staff_query_page_by_invalid_id(staff_api_client, page):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(PAGE_QUERY, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["page"] is None
+
+
+def test_staff_query_page_object_with_given_id_does_not_exists(staff_api_client, page):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(PAGE_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["page"] is None
 
 
 def test_get_page_with_sorted_attribute_values(

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -140,7 +140,7 @@ def test_staff_query_page_by_invalid_id(staff_api_client, page):
 
 
 def test_staff_query_page_with_invalid_object_type(staff_api_client, page):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", page.id)}
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)
     assert content["data"]["page"] is None

--- a/saleor/graphql/page/tests/test_page_type_query.py
+++ b/saleor/graphql/page/tests/test_page_type_query.py
@@ -129,9 +129,7 @@ def test_staff_query_page_type_by_invalid_id(staff_api_client, page_type):
     assert content["data"]["pageType"] is None
 
 
-def test_staff_query_page_type_object_with_given_id_does_not_exists(
-    staff_api_client, page_type
-):
+def test_staff_query_page_type_with_invalid_object_type(staff_api_client, page_type):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}
     response = staff_api_client.post_graphql(PAGE_TYPE_QUERY, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/page/tests/test_page_type_query.py
+++ b/saleor/graphql/page/tests/test_page_type_query.py
@@ -130,7 +130,7 @@ def test_staff_query_page_type_by_invalid_id(staff_api_client, page_type):
 
 
 def test_staff_query_page_type_with_invalid_object_type(staff_api_client, page_type):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", page_type.pk)}
     response = staff_api_client.post_graphql(PAGE_TYPE_QUERY, variables)
     content = get_graphql_content(response)
     assert content["data"]["pageType"] is None

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -2,6 +2,10 @@ from ...core.tracing import traced_resolver
 from ...payment import models
 
 
+def resolve_payment_by_id(id):
+    return models.Payment.objects.filter(id=id).first()
+
+
 @traced_resolver
 def resolve_payments(info):
     return models.Payment.objects.all()

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -2,10 +2,11 @@ import graphene
 
 from ...core.permissions import OrderPermissions
 from ..core.fields import FilterInputConnectionField
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .filters import PaymentFilterInput
 from .mutations import PaymentCapture, PaymentInitialize, PaymentRefund, PaymentVoid
-from .resolvers import resolve_payments
+from .resolvers import resolve_payment_by_id, resolve_payments
 from .types import Payment
 
 
@@ -25,7 +26,8 @@ class PaymentQueries(graphene.ObjectType):
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_payment(self, info, **data):
-        return graphene.Node.get_node_from_global_id(info, data.get("id"), Payment)
+        _, id = from_global_id_or_error(data["id"])
+        return resolve_payment_by_id(id)
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_payments(self, info, **_kwargs):

--- a/saleor/graphql/payment/schema.py
+++ b/saleor/graphql/payment/schema.py
@@ -26,7 +26,7 @@ class PaymentQueries(graphene.ObjectType):
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_payment(self, info, **data):
-        _, id = from_global_id_or_error(data["id"])
+        _, id = from_global_id_or_error(data["id"], Payment)
         return resolve_payment_by_id(id)
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -768,7 +768,7 @@ def test_staff_query_payment_by_invalid_id(
     assert content["data"]["payment"] is None
 
 
-def test_staff_query_payment_object_with_given_id_does_not_exists(
+def test_staff_query_payment_with_invalid_object_type(
     staff_api_client, payment_dummy, permission_manage_orders
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -22,7 +22,11 @@ from ....payment.interface import (
 from ....payment.models import ChargeStatus, Payment, TransactionKind
 from ....payment.utils import fetch_customer_id, store_customer_id
 from ....plugins.manager import PluginsManager, get_plugins_manager
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ..enums import OrderAction, PaymentChargeStatusEnum
 
 DUMMY_GATEWAY = "mirumee.payments.dummy"
@@ -728,14 +732,17 @@ def test_payments_query(
     ]
 
 
-def test_query_payment(payment_dummy, user_api_client, permission_manage_orders):
-    query = """
+QUERY_PAYMENT_BY_ID = """
     query payment($id: ID!) {
         payment(id: $id) {
             id
         }
     }
-    """
+"""
+
+
+def test_query_payment(payment_dummy, user_api_client, permission_manage_orders):
+    query = QUERY_PAYMENT_BY_ID
     payment = payment_dummy
     payment_id = graphene.Node.to_global_id("Payment", payment.pk)
     variables = {"id": payment_id}
@@ -745,6 +752,31 @@ def test_query_payment(payment_dummy, user_api_client, permission_manage_orders)
     content = get_graphql_content(response)
     received_id = content["data"]["payment"]["id"]
     assert received_id == payment_id
+
+
+def test_staff_query_payment_by_invalid_id(
+    staff_api_client, payment_dummy, permission_manage_orders
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_BY_ID, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["payment"] is None
+
+
+def test_staff_query_payment_object_with_given_id_does_not_exists(
+    staff_api_client, payment_dummy, permission_manage_orders
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_BY_ID, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["payment"] is None
 
 
 def test_query_payments(payment_dummy, permission_manage_orders, staff_api_client):

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -771,7 +771,7 @@ def test_staff_query_payment_by_invalid_id(
 def test_staff_query_payment_with_invalid_object_type(
     staff_api_client, payment_dummy, permission_manage_orders
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", payment_dummy.pk)}
     response = staff_api_client.post_graphql(
         QUERY_PAYMENT_BY_ID, variables, permissions=[permission_manage_orders]
     )

--- a/saleor/graphql/plugins/resolvers.py
+++ b/saleor/graphql/plugins/resolvers.py
@@ -51,9 +51,9 @@ def aggregate_plugins_configuration(
     return global_plugins, plugins_per_channel
 
 
-def resolve_plugin(plugin_id, manager):
+def resolve_plugin(id, manager):
     global_plugins, plugins_per_channel = aggregate_plugins_configuration(manager)
-    plugin: BasePlugin = manager.get_plugin(plugin_id)
+    plugin: BasePlugin = manager.get_plugin(id)
     if not plugin:
         return None
 

--- a/saleor/graphql/product/mutations/attributes.py
+++ b/saleor/graphql/product/mutations/attributes.py
@@ -20,7 +20,6 @@ from ...channel import ChannelContext
 from ...core.inputs import ReorderInput
 from ...core.mutations import BaseMutation
 from ...core.types.common import ProductError
-from ...core.utils import from_global_id_or_error
 from ...core.utils.reordering import perform_reordering
 from ...product.types import Product, ProductType, ProductVariant
 from ..enums import ProductAttributeType
@@ -65,7 +64,7 @@ class ProductAttributeAssign(BaseMutation):
         variant_attrs_pks = []
 
         for operation in operations:
-            _type, pk = from_global_id_or_error(
+            pk = cls.get_global_id_or_error(
                 operation.id, only_type=Attribute, field="operations"
             )
             if operation.type == ProductAttributeType.PRODUCT:
@@ -254,9 +253,9 @@ class ProductAttributeUnassign(BaseMutation):
 
         # Resolve all the passed IDs to ints
         attribute_pks = [
-            from_global_id_or_error(
+            cls.get_global_id_or_error(
                 attribute_id, only_type=Attribute, field="attribute_id"
-            )[1]
+            )
             for attribute_id in attribute_ids
         ]
 
@@ -293,7 +292,7 @@ class ProductTypeReorderAttributes(BaseReorderAttributesMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, product_type_id, type, moves):
-        _type, pk = from_global_id_or_error(
+        pk = cls.get_global_id_or_error(
             product_type_id, only_type=ProductType, field="product_type_id"
         )
 
@@ -365,9 +364,9 @@ class ProductReorderAttributeValues(BaseReorderAttributeValuesMutation):
             product=ChannelContext(node=product, channel_slug=None)
         )
 
-    @staticmethod
-    def get_instance(instance_id: str):
-        _type, pk = from_global_id_or_error(
+    @classmethod
+    def get_instance(cls, instance_id: str):
+        pk = cls.get_global_id_or_error(
             instance_id, only_type=Product, field="product_id"
         )
 
@@ -421,9 +420,9 @@ class ProductVariantReorderAttributeValues(BaseReorderAttributeValuesMutation):
             product_variant=ChannelContext(node=variant, channel_slug=None)
         )
 
-    @staticmethod
-    def get_instance(instance_id: str):
-        _type, pk = from_global_id_or_error(
+    @classmethod
+    def get_instance(cls, instance_id: str):
+        pk = cls.get_global_id_or_error(
             instance_id, only_type=ProductVariant, field="variant_id"
         )
 

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -43,7 +43,6 @@ from ...core.types.common import CollectionError, ProductError
 from ...core.utils import (
     add_hash_to_file_name,
     clean_seo_fields,
-    from_global_id_or_error,
     get_duplicated_values,
     validate_image_file,
     validate_slug_and_generate_if_needed,
@@ -337,7 +336,7 @@ class CollectionReorderProducts(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, collection_id, moves):
-        _type, pk = from_global_id_or_error(
+        pk = cls.get_global_id_or_error(
             collection_id, only_type=Collection, field="collection_id"
         )
 
@@ -361,7 +360,7 @@ class CollectionReorderProducts(BaseMutation):
 
         # Resolve the products
         for move_info in moves:
-            _type, product_pk = from_global_id_or_error(
+            product_pk = cls.get_global_id_or_error(
                 move_info.product_id, only_type=Product, field="moves"
             )
 
@@ -1210,7 +1209,7 @@ class ProductTypeDelete(ModelDeleteMutation):
     @traced_atomic_transaction()
     def perform_mutation(cls, _root, info, **data):
         node_id = data.get("id")
-        _type, product_type_pk = from_global_id_or_error(
+        product_type_pk = cls.get_global_id_or_error(
             node_id, only_type=ProductType, field="pk"
         )
         variants_pks = models.Product.objects.filter(
@@ -1504,7 +1503,7 @@ class ProductVariantReorder(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, product_id, moves):
-        _type, pk = from_global_id_or_error(product_id, only_type=Product)
+        pk = cls.get_global_id_or_error(product_id, only_type=Product)
 
         try:
             product = models.Product.objects.prefetched_for_webhook().get(pk=pk)
@@ -1522,7 +1521,7 @@ class ProductVariantReorder(BaseMutation):
         operations = {}
 
         for move_info in moves:
-            _type, variant_pk = from_global_id_or_error(
+            variant_pk = cls.get_global_id_or_error(
                 move_info.id, only_type=ProductVariant, field="moves"
             )
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -12,6 +12,10 @@ from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_by_period
 
 
+def resolve_category_by_id(id):
+    return models.Category.objects.filter(pk=id).first()
+
+
 def resolve_category_by_slug(slug):
     return models.Category.objects.filter(slug=slug).first()
 
@@ -48,6 +52,10 @@ def resolve_collections(info, channel_slug):
     qs = models.Collection.objects.visible_to_user(requestor, channel_slug)
 
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
+
+
+def resolve_digital_content_by_id(id):
+    return models.DigitalContent.objects.filter(pk=id).first()
 
 
 @traced_resolver
@@ -101,6 +109,10 @@ def resolve_variant_by_id(
     return qs.filter(pk=id).first()
 
 
+def resolve_product_type_by_id(id):
+    return models.ProductType.objects.filter(pk=id).first()
+
+
 @traced_resolver
 def resolve_product_types(_info, **_kwargs):
     return models.ProductType.objects.all()
@@ -133,10 +145,7 @@ def resolve_product_variants(
         ).exclude(visible_in_listings=False)
         qs = qs.filter(product__in=visible_products).available_in_channel(channel_slug)
     if ids:
-        db_ids = [
-            from_global_id_or_error(node_id, only_type="ProductVariant")[1]
-            for node_id in ids
-        ]
+        db_ids = [from_global_id_or_error(node_id)[1] for node_id in ids]
         qs = qs.filter(pk__in=db_ids)
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -145,7 +145,9 @@ def resolve_product_variants(
         ).exclude(visible_in_listings=False)
         qs = qs.filter(product__in=visible_products).available_in_channel(channel_slug)
     if ids:
-        db_ids = [from_global_id_or_error(node_id)[1] for node_id in ids]
+        db_ids = [
+            from_global_id_or_error(node_id, "ProductVariant")[1] for node_id in ids
+        ]
         qs = qs.filter(pk__in=db_ids)
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -90,13 +90,16 @@ from .mutations.products import (
 )
 from .resolvers import (
     resolve_categories,
+    resolve_category_by_id,
     resolve_category_by_slug,
     resolve_collection_by_id,
     resolve_collection_by_slug,
     resolve_collections,
+    resolve_digital_content_by_id,
     resolve_digital_contents,
     resolve_product_by_id,
     resolve_product_by_slug,
+    resolve_product_type_by_id,
     resolve_product_types,
     resolve_product_variant_by_sku,
     resolve_product_variants,
@@ -251,7 +254,8 @@ class ProductQueries(graphene.ObjectType):
     def resolve_category(self, info, id=None, slug=None, **kwargs):
         validate_one_of_args_is_in_query("id", id, "slug", slug)
         if id:
-            return graphene.Node.get_node_from_global_id(info, id, Category)
+            _, id = from_global_id_or_error(id)
+            return resolve_category_by_id(id)
         if slug:
             return resolve_category_by_slug(slug=slug)
 
@@ -285,7 +289,8 @@ class ProductQueries(graphene.ObjectType):
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_digital_content(self, info, id):
-        return graphene.Node.get_node_from_global_id(info, id, DigitalContent)
+        _, id = from_global_id_or_error(id)
+        return resolve_digital_content_by_id(id)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_digital_contents(self, info, **_kwargs):
@@ -300,7 +305,7 @@ class ProductQueries(graphene.ObjectType):
         if channel is None and not is_staff:
             channel = get_default_channel_slug_or_graphql_error()
         if id:
-            _type, id = from_global_id_or_error(id, only_type="Product")
+            _type, id = from_global_id_or_error(id)
             product = resolve_product_by_id(
                 info, id, channel_slug=channel, requestor=requestor
             )
@@ -329,7 +334,8 @@ class ProductQueries(graphene.ObjectType):
         return resolve_products(info, requestor, channel_slug=channel, **kwargs)
 
     def resolve_product_type(self, info, id, **_kwargs):
-        return graphene.Node.get_node_from_global_id(info, id, ProductType)
+        _, id = from_global_id_or_error(id)
+        return resolve_product_type_by_id(id)
 
     def resolve_product_types(self, info, **kwargs):
         return resolve_product_types(info, **kwargs)

--- a/saleor/graphql/product/schema.py
+++ b/saleor/graphql/product/schema.py
@@ -254,7 +254,7 @@ class ProductQueries(graphene.ObjectType):
     def resolve_category(self, info, id=None, slug=None, **kwargs):
         validate_one_of_args_is_in_query("id", id, "slug", slug)
         if id:
-            _, id = from_global_id_or_error(id)
+            _, id = from_global_id_or_error(id, Category)
             return resolve_category_by_id(id)
         if slug:
             return resolve_category_by_slug(slug=slug)
@@ -268,7 +268,7 @@ class ProductQueries(graphene.ObjectType):
         if channel is None and not is_staff:
             channel = get_default_channel_slug_or_graphql_error()
         if id:
-            _, id = from_global_id_or_error(id)
+            _, id = from_global_id_or_error(id, Collection)
             collection = resolve_collection_by_id(info, id, channel, requestor)
         else:
             collection = resolve_collection_by_slug(
@@ -289,7 +289,7 @@ class ProductQueries(graphene.ObjectType):
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_digital_content(self, info, id):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, DigitalContent)
         return resolve_digital_content_by_id(id)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
@@ -305,7 +305,7 @@ class ProductQueries(graphene.ObjectType):
         if channel is None and not is_staff:
             channel = get_default_channel_slug_or_graphql_error()
         if id:
-            _type, id = from_global_id_or_error(id)
+            _type, id = from_global_id_or_error(id, Product)
             product = resolve_product_by_id(
                 info, id, channel_slug=channel, requestor=requestor
             )
@@ -334,7 +334,7 @@ class ProductQueries(graphene.ObjectType):
         return resolve_products(info, requestor, channel_slug=channel, **kwargs)
 
     def resolve_product_type(self, info, id, **_kwargs):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, ProductType)
         return resolve_product_type_by_id(id)
 
     def resolve_product_types(self, info, **kwargs):
@@ -354,7 +354,7 @@ class ProductQueries(graphene.ObjectType):
         if channel is None and not is_staff:
             channel = get_default_channel_slug_or_graphql_error()
         if id:
-            _, id = from_global_id_or_error(id)
+            _, id = from_global_id_or_error(id, ProductVariant)
             variant = resolve_variant_by_id(
                 info,
                 id,

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -10,7 +10,11 @@ from ....product.error_codes import ProductErrorCode
 from ....product.models import Category, Product, ProductChannelListing
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
 from ....tests.utils import dummy_editorjs
-from ...tests.utils import get_graphql_content, get_multipart_request_body
+from ...tests.utils import (
+    get_graphql_content,
+    get_graphql_content_from_response,
+    get_multipart_request_body,
+)
 
 QUERY_CATEGORY = """
     query ($id: ID, $slug: String, $channel: String){
@@ -60,6 +64,32 @@ def test_category_query_by_id(user_api_client, product, channel_USD):
     assert category_data["name"] == category.name
     assert len(category_data["ancestors"]["edges"]) == category.get_ancestors().count()
     assert len(category_data["children"]["edges"]) == category.get_children().count()
+
+
+def test_category_query_invalid_id(user_api_client, product, channel_USD):
+    category_id = "'"
+    variables = {
+        "id": category_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_CATEGORY, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {category_id}."
+    assert content["data"]["category"] is None
+
+
+def test_category_query_object_with_given_id_does_not_exist(
+    user_api_client, product, channel_USD
+):
+    category_id = graphene.Node.to_global_id("Product", -1)
+    variables = {
+        "id": category_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_CATEGORY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["category"] is None
 
 
 def test_category_query_description(user_api_client, product, channel_USD):

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -82,7 +82,21 @@ def test_category_query_invalid_id(user_api_client, product, channel_USD):
 def test_category_query_object_with_given_id_does_not_exist(
     user_api_client, product, channel_USD
 ):
-    category_id = graphene.Node.to_global_id("Product", -1)
+    category_id = graphene.Node.to_global_id("Category", -1)
+    variables = {
+        "id": category_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_CATEGORY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["category"] is None
+
+
+def test_category_query_object_with_invalid_object_type(
+    user_api_client, product, channel_USD
+):
+    category = Category.objects.first()
+    category_id = graphene.Node.to_global_id("Product", category.pk)
     variables = {
         "id": category_id,
         "channel": channel_USD.slug,

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -9,7 +9,11 @@ from ....product.error_codes import CollectionErrorCode, ProductErrorCode
 from ....product.models import Collection, Product
 from ....product.tests.utils import create_image, create_pdf_file_with_image_ext
 from ....tests.utils import dummy_editorjs
-from ...tests.utils import get_graphql_content, get_multipart_request_body
+from ...tests.utils import (
+    get_graphql_content,
+    get_graphql_content_from_response,
+    get_multipart_request_body,
+)
 
 QUERY_COLLECTION = """
     query ($id: ID, $slug: String, $channel: String){
@@ -1182,6 +1186,34 @@ def test_collection_image_query_without_associated_file(
     data = content["data"]["collection"]
     assert data["name"] == published_collection.name
     assert data["backgroundImage"] is None
+
+
+def test_collection_query_invalid_id(
+    user_api_client, published_collection, channel_USD
+):
+    collection_id = "'"
+    variables = {
+        "id": collection_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(FETCH_COLLECTION_QUERY, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {collection_id}."
+    assert content["data"]["collection"] is None
+
+
+def test_collection_query_object_with_given_id_does_not_exist(
+    user_api_client, published_collection, channel_USD
+):
+    collection_id = graphene.Node.to_global_id("Product", -1)
+    variables = {
+        "id": collection_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(FETCH_COLLECTION_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["collection"] is None
 
 
 def test_update_collection_mutation_remove_background_image(

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -1206,7 +1206,20 @@ def test_collection_query_invalid_id(
 def test_collection_query_object_with_given_id_does_not_exist(
     user_api_client, published_collection, channel_USD
 ):
-    collection_id = graphene.Node.to_global_id("Product", -1)
+    collection_id = graphene.Node.to_global_id("Collection", -1)
+    variables = {
+        "id": collection_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(FETCH_COLLECTION_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["collection"] is None
+
+
+def test_collection_query_object_with_invalid_object_type(
+    user_api_client, published_collection, channel_USD
+):
+    collection_id = graphene.Node.to_global_id("Product", published_collection.pk)
     variables = {
         "id": collection_id,
         "channel": channel_USD.slug,

--- a/saleor/graphql/product/tests/test_digital_content.py
+++ b/saleor/graphql/product/tests/test_digital_content.py
@@ -5,7 +5,11 @@ import graphene
 from ....product.error_codes import ProductErrorCode
 from ....product.models import DigitalContent, ProductVariant
 from ....product.tests.utils import create_image
-from ...tests.utils import get_graphql_content, get_multipart_request_body
+from ...tests.utils import (
+    get_graphql_content,
+    get_graphql_content_from_response,
+    get_multipart_request_body,
+)
 
 
 def test_fetch_all_digital_contents(
@@ -33,32 +37,68 @@ def test_fetch_all_digital_contents(
     assert len(edges) == digital_content_num
 
 
-def test_fetch_single_digital_content(
-    staff_api_client, digital_content, permission_manage_products
-):
-    query = """
-    query {
-        digitalContent(id:"%s"){
+QUERY_DIGITAL_CONTENT = """
+    query DigitalContent($id: ID!){
+        digitalContent(id: $id){
             id
             productVariant {
                 id
             }
         }
     }
-    """ % graphene.Node.to_global_id(
-        "DigitalContent", digital_content.id
-    )
+"""
+
+
+def test_fetch_single_digital_content(
+    staff_api_client, digital_content, permission_manage_products
+):
+    query = QUERY_DIGITAL_CONTENT
+    variables = {"id": graphene.Node.to_global_id("DigitalContent", digital_content.id)}
     variant_id = graphene.Node.to_global_id(
         "ProductVariant", digital_content.product_variant.id
     )
     response = staff_api_client.post_graphql(
-        query, permissions=[permission_manage_products]
+        query, variables, permissions=[permission_manage_products]
     )
     content = get_graphql_content(response)
 
     assert "digitalContent" in content["data"]
     assert "id" in content["data"]["digitalContent"]
     assert content["data"]["digitalContent"]["productVariant"]["id"] == variant_id
+
+
+def test_digital_content_query_invalid_id(
+    staff_api_client, product, channel_USD, permission_manage_products
+):
+    digital_content_id = "'"
+    variables = {
+        "id": digital_content_id,
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_DIGITAL_CONTENT, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert (
+        content["errors"][0]["message"] == f"Couldn't resolve id: {digital_content_id}."
+    )
+    assert content["data"]["digitalContent"] is None
+
+
+def test_digital_content_query_object_with_given_id_does_not_exist(
+    staff_api_client, product, channel_USD, permission_manage_products
+):
+    digital_content_id = graphene.Node.to_global_id("Product", -1)
+    variables = {
+        "id": digital_content_id,
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_DIGITAL_CONTENT, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["digitalContent"] is None
 
 
 def test_digital_content_create_mutation_custom_settings(

--- a/saleor/graphql/product/tests/test_digital_content.py
+++ b/saleor/graphql/product/tests/test_digital_content.py
@@ -89,7 +89,22 @@ def test_digital_content_query_invalid_id(
 def test_digital_content_query_object_with_given_id_does_not_exist(
     staff_api_client, product, channel_USD, permission_manage_products
 ):
-    digital_content_id = graphene.Node.to_global_id("Product", -1)
+    digital_content_id = graphene.Node.to_global_id("DigitalContent", -1)
+    variables = {
+        "id": digital_content_id,
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_DIGITAL_CONTENT, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["digitalContent"] is None
+
+
+def test_digital_content_query_with_invalid_object_type(
+    staff_api_client, product, digital_content, channel_USD, permission_manage_products
+):
+    digital_content_id = graphene.Node.to_global_id("Product", digital_content.pk)
     variables = {
         "id": digital_content_id,
         "channel": channel_USD.slug,

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -420,7 +420,18 @@ def test_product_query_invalid_id(user_api_client, product, channel_USD):
 def test_product_query_object_with_given_id_does_not_exist(
     user_api_client, product, channel_USD
 ):
-    product_id = graphene.Node.to_global_id("Collection", -1)
+    product_id = graphene.Node.to_global_id("Product", -1)
+    variables = {
+        "id": product_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_PRODUCT_BY_ID, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["product"] is None
+
+
+def test_product_query_with_invalid_object_type(user_api_client, product, channel_USD):
+    product_id = graphene.Node.to_global_id("Collection", product.pk)
     variables = {
         "id": product_id,
         "channel": channel_USD.slug,
@@ -6549,7 +6560,20 @@ def test_product_type_query_invalid_id(
 def test_product_type_query_object_with_given_id_does_not_exist(
     staff_api_client, product, channel_USD, permission_manage_products
 ):
-    product_type_id = graphene.Node.to_global_id("Product", -1)
+    product_type_id = graphene.Node.to_global_id("ProductType", -1)
+    variables = {
+        "id": product_type_id,
+        "channel": channel_USD.slug,
+    }
+    response = staff_api_client.post_graphql(PRODUCT_TYPE_QUERY, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["productType"] is None
+
+
+def test_product_type_query_with_invalid_object_type(
+    staff_api_client, product, channel_USD, permission_manage_products
+):
+    product_type_id = graphene.Node.to_global_id("Product", product.product_type.pk)
     variables = {
         "id": product_type_id,
         "channel": channel_USD.slug,
@@ -8043,7 +8067,18 @@ def test_variant_query_invalid_id(user_api_client, variant, channel_USD):
 def test_variant_query_object_with_given_id_does_not_exist(
     user_api_client, variant, channel_USD
 ):
-    variant_id = graphene.Node.to_global_id("Product", -1)
+    variant_id = graphene.Node.to_global_id("ProductVariant", -1)
+    variables = {
+        "id": variant_id,
+        "channel": channel_USD.slug,
+    }
+    response = user_api_client.post_graphql(QUERY_PRODUCT_VARAINT_BY_ID, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["productVariant"] is None
+
+
+def test_variant_query_with_invalid_object_type(user_api_client, variant, channel_USD):
+    variant_id = graphene.Node.to_global_id("Product", variant.pk)
     variables = {
         "id": variant_id,
         "channel": channel_USD.slug,

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -2436,7 +2436,7 @@ def test_query_product_image_by_id(user_api_client, product_with_image, channel_
     media = product_with_image.media.first()
     variables = {
         "productId": graphene.Node.to_global_id("Product", product_with_image.pk),
-        "imageId": graphene.Node.to_global_id("ProductMedia", media.pk),
+        "imageId": graphene.Node.to_global_id("ProductImage", media.pk),
         "channel": channel_USD.slug,
     }
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -767,13 +767,13 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_media_by_id(root: ChannelContext[models.Product], info, id):
-        _type, pk = from_global_id_or_error(id)
+        _type, pk = from_global_id_or_error(id, ProductMedia)
         return root.node.media.filter(pk=pk).first()
 
     @staticmethod
     @traced_resolver
     def resolve_image_by_id(root: ChannelContext[models.Product], info, id):
-        _type, pk = from_global_id_or_error(id)
+        _type, pk = from_global_id_or_error(id, ProductImage)
         return root.node.media.filter(pk=pk).first()
 
     @staticmethod

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django_countries.fields import Country
 from graphene import relay
 from graphene_federation import key
-from graphql.error import GraphQLError
 
 from ....account.utils import requestor_is_staff_member_or_app
 from ....attribute import models as attribute_models
@@ -539,7 +538,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         description="List of availability in channels for the product.",
     )
     media_by_id = graphene.Field(
-        graphene.NonNull(lambda: ProductMedia),
+        lambda: ProductMedia,
         id=graphene.Argument(graphene.ID, description="ID of a product media."),
         description="Get a single product media by ID.",
     )
@@ -768,20 +767,14 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_media_by_id(root: ChannelContext[models.Product], info, id):
-        _type, pk = from_global_id_or_error(id, only_type="ProductMedia")
-        try:
-            return root.node.media.get(pk=pk)
-        except models.ProductMedia.DoesNotExist:
-            raise GraphQLError("Product media not found.")
+        _type, pk = from_global_id_or_error(id)
+        return root.node.media.filter(pk=pk).first()
 
     @staticmethod
     @traced_resolver
     def resolve_image_by_id(root: ChannelContext[models.Product], info, id):
-        _type, pk = from_global_id_or_error(id, only_type="ProductMedia")
-        try:
-            return root.node.media.get(pk=pk)
-        except models.ProductMedia.DoesNotExist:
-            raise GraphQLError("Product image not found.")
+        _type, pk = from_global_id_or_error(id)
+        return root.node.media.filter(pk=pk).first()
 
     @staticmethod
     @traced_resolver

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4102,7 +4102,7 @@ type Product implements Node & ObjectWithMetadata {
   taxType: TaxType
   attributes: [SelectedAttribute!]!
   channelListings: [ProductChannelListing!]
-  mediaById(id: ID): ProductMedia!
+  mediaById(id: ID): ProductMedia
   imageById(id: ID): ProductImage @deprecated(reason: "Will be removed in Saleor 4.0. Use the `mediaById` field instead.")
   variants: [ProductVariant]
   media: [ProductMedia!]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1910,6 +1910,7 @@ type ExportError {
 }
 
 enum ExportErrorCode {
+  GRAPHQL_ERROR
   INVALID
   NOT_FOUND
   REQUIRED

--- a/saleor/graphql/shipping/mutations/shippings.py
+++ b/saleor/graphql/shipping/mutations/shippings.py
@@ -541,8 +541,8 @@ class ShippingPriceExcludeProducts(BaseMutation):
         input = data.get("input")
         product_ids = input.get("products", [])
 
-        _, product_db_ids = resolve_global_ids_to_primary_keys(
-            product_ids, product_types.Product
+        product_db_ids = cls.get_global_ids_or_error(
+            product_ids, product_types.Product, field="products"
         )
 
         product_to_exclude = product_models.Product.objects.filter(
@@ -585,8 +585,8 @@ class ShippingPriceRemoveProductFromExclude(BaseMutation):
         )
         product_ids = data.get("products")
         if product_ids:
-            _, product_db_ids = resolve_global_ids_to_primary_keys(
-                product_ids, product_types.Product
+            product_db_ids = cls.get_global_ids_or_error(
+                product_ids, product_types.Product, field="products"
             )
             shipping_method.excluded_products.set(
                 shipping_method.excluded_products.exclude(id__in=product_db_ids)

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -2,8 +2,10 @@ import graphene
 
 from ...core.permissions import ShippingPermissions
 from ...core.tracing import traced_resolver
+from ...shipping import models
 from ..channel.types import ChannelContext
 from ..core.fields import ChannelContextFilterConnectionField
+from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from ..translations.mutations import ShippingPriceTranslate
 from .bulk_mutations import ShippingPriceBulkDelete, ShippingZoneBulkDelete
@@ -48,7 +50,8 @@ class ShippingQueries(graphene.ObjectType):
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
     @traced_resolver
     def resolve_shipping_zone(self, info, id, channel=None):
-        instance = graphene.Node.get_node_from_global_id(info, id, ShippingZone)
+        _, id = from_global_id_or_error(id)
+        instance = models.ShippingZone.objects.filter(id=id).first()
         return ChannelContext(node=instance, channel_slug=channel) if instance else None
 
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -50,7 +50,7 @@ class ShippingQueries(graphene.ObjectType):
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
     @traced_resolver
     def resolve_shipping_zone(self, info, id, channel=None):
-        _, id = from_global_id_or_error(id)
+        _, id = from_global_id_or_error(id, ShippingZone)
         instance = models.ShippingZone.objects.filter(id=id).first()
         return ChannelContext(node=instance, channel_slug=channel) if instance else None
 

--- a/saleor/graphql/translations/mutations.py
+++ b/saleor/graphql/translations/mutations.py
@@ -14,7 +14,6 @@ from ..channel import ChannelContext
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import BaseMutation, ModelMutation, registry
 from ..core.types.common import TranslationError
-from ..core.utils import from_global_id_or_error
 from ..product.types import Product, ProductVariant
 from ..shop.types import Shop
 
@@ -105,7 +104,7 @@ class ProductTranslate(BaseTranslateMutation):
                 {"id": ValidationError("This field is required", code="required")}
             )
 
-        _type, product_pk = from_global_id_or_error(data["id"], only_type=Product)
+        product_pk = cls.get_global_id_or_error(data["id"], only_type=Product)
         product = product_models.Product.objects.get(pk=product_pk)
         product.translations.update_or_create(
             language_code=data["language_code"], defaults=data["input"]
@@ -159,9 +158,7 @@ class ProductVariantTranslate(BaseTranslateMutation):
                 {"id": ValidationError("This field is required", code="required")}
             )
 
-        _type, variant_pk = from_global_id_or_error(
-            data["id"], only_type=ProductVariant
-        )
+        variant_pk = cls.get_global_id_or_error(data["id"], only_type=ProductVariant)
         variant = product_models.ProductVariant.objects.prefetched_for_webhook().get(
             pk=variant_pk
         )

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -26,7 +26,9 @@ REVERSED_DIRECTION = {
 }
 
 
-def resolve_global_ids_to_primary_keys(ids, graphene_type=None):
+def resolve_global_ids_to_primary_keys(
+    ids, graphene_type=None, raise_error: bool = False
+):
     pks = []
     invalid_ids = []
     used_type = graphene_type
@@ -43,7 +45,9 @@ def resolve_global_ids_to_primary_keys(ids, graphene_type=None):
 
         # Raise GraphQL error if ID of a different type was passed
         if used_type and str(used_type) != str(node_type):
-            raise GraphQLError(f"Must receive {str(used_type)} id: {graphql_id}")
+            if not raise_error:
+                continue
+            raise GraphQLError(f"Must receive {str(used_type)} id: {graphql_id}.")
 
         used_type = node_type
         pks.append(_id)
@@ -73,7 +77,9 @@ def get_nodes(
 
     If the `graphene_type` is of type str, the model keyword argument must be provided.
     """
-    nodes_type, pks = resolve_global_ids_to_primary_keys(ids, graphene_type)
+    nodes_type, pks = resolve_global_ids_to_primary_keys(
+        ids, graphene_type, raise_error=True
+    )
 
     # If `graphene_type` was not provided, check if all resolved types are
     # the same. This prevents from accidentally mismatching IDs of different

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -15,7 +15,9 @@ REVERSED_DIRECTION = {
 
 def _sort_queryset_by_attribute(queryset, sorting_attribute, sorting_direction):
     if sorting_attribute != "":
-        graphene_type, sorting_attribute = from_global_id_or_error(sorting_attribute)
+        graphene_type, sorting_attribute = from_global_id_or_error(
+            sorting_attribute, "Attribute"
+        )
     descending = sorting_direction == OrderDirection.DESC
     queryset = queryset.sort_by_attribute(sorting_attribute, descending=descending)
     return queryset

--- a/saleor/graphql/warehouse/resolvers.py
+++ b/saleor/graphql/warehouse/resolvers.py
@@ -1,0 +1,17 @@
+from ...warehouse import models
+
+
+def resolve_stock(id):
+    return models.Stock.objects.filter(id=id).first()
+
+
+def resolve_stocks():
+    return models.Stock.objects.all()
+
+
+def resolve_warehouse(id):
+    return models.Warehouse.objects.filter(id=id).first()
+
+
+def resolve_warehouses():
+    return models.Warehouse.objects.all()

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -8,6 +8,7 @@ from ...core.permissions import (
 from ...core.tracing import traced_resolver
 from ...warehouse import models
 from ..core.fields import FilterInputConnectionField
+from ..core.utils import from_global_id_or_error
 from ..decorators import one_of_permissions_required, permission_required
 from .filters import StockFilterInput, WarehouseFilterInput
 from .mutations import (
@@ -46,8 +47,8 @@ class WarehouseQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_warehouse(self, info, **data):
         warehouse_pk = data.get("id")
-        warehouse = graphene.Node.get_node_from_global_id(info, warehouse_pk, Warehouse)
-        return warehouse
+        _, id = from_global_id_or_error(warehouse_pk)
+        return models.Warehouse.objects.filter(id=id).first()
 
     @one_of_permissions_required(
         [
@@ -83,8 +84,8 @@ class StockQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_stock(self, info, **kwargs):
         stock_id = kwargs.get("id")
-        stock = graphene.Node.get_node_from_global_id(info, stock_id, Stock)
-        return stock
+        _, id = from_global_id_or_error(stock_id)
+        return models.Stock.objects.filter(id=id).first()
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     @traced_resolver

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -6,7 +6,6 @@ from ...core.permissions import (
     ShippingPermissions,
 )
 from ...core.tracing import traced_resolver
-from ...warehouse import models
 from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
 from ..decorators import one_of_permissions_required, permission_required
@@ -17,6 +16,12 @@ from .mutations import (
     WarehouseShippingZoneAssign,
     WarehouseShippingZoneUnassign,
     WarehouseUpdate,
+)
+from .resolvers import (
+    resolve_stock,
+    resolve_stocks,
+    resolve_warehouse,
+    resolve_warehouses,
 )
 from .sorters import WarehouseSortingInput
 from .types import Stock, Warehouse
@@ -48,7 +53,7 @@ class WarehouseQueries(graphene.ObjectType):
     def resolve_warehouse(self, info, **data):
         warehouse_pk = data.get("id")
         _, id = from_global_id_or_error(warehouse_pk, Warehouse)
-        return models.Warehouse.objects.filter(id=id).first()
+        return resolve_warehouse(id)
 
     @one_of_permissions_required(
         [
@@ -59,7 +64,7 @@ class WarehouseQueries(graphene.ObjectType):
     )
     @traced_resolver
     def resolve_warehouses(self, info, **_kwargs):
-        return models.Warehouse.objects.all()
+        return resolve_warehouses()
 
 
 class WarehouseMutations(graphene.ObjectType):
@@ -85,9 +90,9 @@ class StockQueries(graphene.ObjectType):
     def resolve_stock(self, info, **kwargs):
         stock_id = kwargs.get("id")
         _, id = from_global_id_or_error(stock_id, Stock)
-        return models.Stock.objects.filter(id=id).first()
+        return resolve_stock(id)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     @traced_resolver
     def resolve_stocks(self, info, **_kwargs):
-        return models.Stock.objects.all()
+        return resolve_stocks()

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -47,7 +47,7 @@ class WarehouseQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_warehouse(self, info, **data):
         warehouse_pk = data.get("id")
-        _, id = from_global_id_or_error(warehouse_pk)
+        _, id = from_global_id_or_error(warehouse_pk, Warehouse)
         return models.Warehouse.objects.filter(id=id).first()
 
     @one_of_permissions_required(
@@ -84,7 +84,7 @@ class StockQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_stock(self, info, **kwargs):
         stock_id = kwargs.get("id")
-        _, id = from_global_id_or_error(stock_id)
+        _, id = from_global_id_or_error(stock_id, Stock)
         return models.Stock.objects.filter(id=id).first()
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -3,7 +3,11 @@ import graphene
 from ....core.permissions import ProductPermissions
 from ....warehouse.models import Stock, Warehouse
 from ....warehouse.tests.utils import get_quantity_allocated_for_stock
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 QUERY_STOCK = """
 query stock($id: ID!) {
@@ -80,6 +84,31 @@ def test_query_stock(staff_api_client, stock, permission_manage_products):
     assert content_stock["warehouse"]["name"] == stock.warehouse.name
     assert content_stock["quantity"] == stock.quantity
     assert content_stock["quantityAllocated"] == get_quantity_allocated_for_stock(stock)
+
+
+def test_staff_query_stock_by_invalid_id(
+    staff_api_client, stock, permission_manage_products
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_STOCK, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["stock"] is None
+
+
+def test_staff_query_stock_object_given_id_does_not_exists(
+    staff_api_client, stock, permission_manage_products
+):
+    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    response = staff_api_client.post_graphql(
+        QUERY_STOCK, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["stock"] is None
 
 
 def test_query_stocks_requires_permissions(staff_api_client):

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -100,7 +100,7 @@ def test_staff_query_stock_by_invalid_id(
     assert content["data"]["stock"] is None
 
 
-def test_staff_query_stock_object_given_id_does_not_exists(
+def test_staff_query_stock_object_with_given_id_does_not_exists(
     staff_api_client, stock, permission_manage_products
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -100,7 +100,7 @@ def test_staff_query_stock_by_invalid_id(
     assert content["data"]["stock"] is None
 
 
-def test_staff_query_stock_object_with_given_id_does_not_exists(
+def test_staff_query_stock_with_invalid_object_type(
     staff_api_client, stock, permission_manage_products
 ):
     variables = {"id": graphene.Node.to_global_id("Order", -1)}

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -103,7 +103,7 @@ def test_staff_query_stock_by_invalid_id(
 def test_staff_query_stock_with_invalid_object_type(
     staff_api_client, stock, permission_manage_products
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", -1)}
+    variables = {"id": graphene.Node.to_global_id("Order", stock.pk)}
     response = staff_api_client.post_graphql(
         QUERY_STOCK, variables, permissions=[permission_manage_products]
     )

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -1,10 +1,16 @@
+from uuid import UUID
+
 import graphene
 import pytest
 
 from ....account.models import Address
 from ....warehouse.error_codes import WarehouseErrorCode
 from ....warehouse.models import Warehouse
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 
 QUERY_WAREHOUSES = """
 query {
@@ -294,6 +300,31 @@ def test_warehouse_query_as_customer(user_api_client, warehouse):
     )
 
     assert_no_permission(response)
+
+
+def test_staff_query_warehouse_by_invalid_id(
+    staff_api_client, warehouse, permission_manage_shipping
+):
+    id = "bh/"
+    variables = {"id": id}
+    response = staff_api_client.post_graphql(
+        QUERY_WAREHOUSE, variables, permissions=[permission_manage_shipping]
+    )
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {id}."
+    assert content["data"]["warehouse"] is None
+
+
+def test_staff_query_warehouse_object_given_id_does_not_exists(
+    staff_api_client, permission_manage_shipping
+):
+    variables = {"id": graphene.Node.to_global_id("Order", UUID(int=1))}
+    response = staff_api_client.post_graphql(
+        QUERY_WAREHOUSE, variables, permissions=[permission_manage_shipping]
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["warehouse"] is None
 
 
 def test_query_warehouses_as_staff_with_manage_orders(

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -316,7 +316,7 @@ def test_staff_query_warehouse_by_invalid_id(
     assert content["data"]["warehouse"] is None
 
 
-def test_staff_query_warehouse_object_with_given_id_does_not_exists(
+def test_staff_query_warehouse_with_invalid_object_type(
     staff_api_client, permission_manage_shipping
 ):
     variables = {"id": graphene.Node.to_global_id("Order", UUID(int=1))}

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -316,7 +316,7 @@ def test_staff_query_warehouse_by_invalid_id(
     assert content["data"]["warehouse"] is None
 
 
-def test_staff_query_warehouse_object_given_id_does_not_exists(
+def test_staff_query_warehouse_object_with_given_id_does_not_exists(
     staff_api_client, permission_manage_shipping
 ):
     variables = {"id": graphene.Node.to_global_id("Order", UUID(int=1))}

--- a/saleor/graphql/warehouse/tests/test_warehouse.py
+++ b/saleor/graphql/warehouse/tests/test_warehouse.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import graphene
 import pytest
 
@@ -317,9 +315,9 @@ def test_staff_query_warehouse_by_invalid_id(
 
 
 def test_staff_query_warehouse_with_invalid_object_type(
-    staff_api_client, permission_manage_shipping
+    staff_api_client, permission_manage_shipping, warehouse
 ):
-    variables = {"id": graphene.Node.to_global_id("Order", UUID(int=1))}
+    variables = {"id": graphene.Node.to_global_id("Order", warehouse.pk)}
     response = staff_api_client.post_graphql(
         QUERY_WAREHOUSE, variables, permissions=[permission_manage_shipping]
     )

--- a/saleor/graphql/webhook/mutations.py
+++ b/saleor/graphql/webhook/mutations.py
@@ -6,7 +6,6 @@ from ...webhook import models
 from ...webhook.error_codes import WebhookErrorCode
 from ..core.mutations import ModelDeleteMutation, ModelMutation
 from ..core.types.common import WebhookError
-from ..core.utils import from_global_id_or_error
 from .enums import WebhookEventTypeEnum
 
 
@@ -183,7 +182,7 @@ class WebhookDelete(ModelDeleteMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         node_id = data["id"]
-        _, object_id = from_global_id_or_error(node_id)
+        object_id = cls.get_global_id_or_error(node_id)
 
         app = info.context.app
         if app:

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -1,12 +1,10 @@
-import graphene
-
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AppPermission
 from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
 from ...webhook.event_types import WebhookEventType
 from ..core.utils import from_global_id_or_error
-from .types import Webhook, WebhookEvent
+from .types import WebhookEvent
 
 
 @traced_resolver
@@ -25,12 +23,12 @@ def resolve_webhooks(info, **_kwargs):
 @traced_resolver
 def resolve_webhook(info, webhook_id):
     app = info.context.app
+    _, webhook_id = from_global_id_or_error(webhook_id)
     if app:
-        _, webhook_id = from_global_id_or_error(webhook_id)
         return app.webhooks.filter(id=webhook_id).first()
     user = info.context.user
     if user.has_perm(AppPermission.MANAGE_APPS):
-        return graphene.Node.get_node_from_global_id(info, webhook_id, Webhook)
+        return models.Webhook.objects.filter(pk=webhook_id).first()
     raise PermissionDenied()
 
 

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -4,7 +4,7 @@ from ...core.tracing import traced_resolver
 from ...webhook import models, payloads
 from ...webhook.event_types import WebhookEventType
 from ..core.utils import from_global_id_or_error
-from .types import WebhookEvent
+from .types import Webhook, WebhookEvent
 
 
 @traced_resolver
@@ -23,7 +23,7 @@ def resolve_webhooks(info, **_kwargs):
 @traced_resolver
 def resolve_webhook(info, webhook_id):
     app = info.context.app
-    _, webhook_id = from_global_id_or_error(webhook_id)
+    _, webhook_id = from_global_id_or_error(webhook_id, Webhook)
     if app:
         return app.webhooks.filter(id=webhook_id).first()
     user = info.context.user

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -21,14 +21,14 @@ def resolve_webhooks(info, **_kwargs):
 
 
 @traced_resolver
-def resolve_webhook(info, webhook_id):
+def resolve_webhook(info, id):
     app = info.context.app
-    _, webhook_id = from_global_id_or_error(webhook_id, Webhook)
+    _, id = from_global_id_or_error(id, Webhook)
     if app:
-        return app.webhooks.filter(id=webhook_id).first()
+        return app.webhooks.filter(id=id).first()
     user = info.context.user
     if user.has_perm(AppPermission.MANAGE_APPS):
-        return models.Webhook.objects.filter(pk=webhook_id).first()
+        return models.Webhook.objects.filter(pk=id).first()
     raise PermissionDenied()
 
 

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -6,7 +6,11 @@ import pytest
 from ....app.models import App
 from ....webhook.event_types import WebhookEventType
 from ....webhook.models import Webhook
-from ...tests.utils import assert_no_permission, get_graphql_content
+from ...tests.utils import (
+    assert_no_permission,
+    get_graphql_content,
+    get_graphql_content_from_response,
+)
 from ..enums import WebhookEventTypeEnum, WebhookSampleEventTypeEnum
 
 WEBHOOK_CREATE_BY_APP = """
@@ -356,9 +360,7 @@ def test_query_webhook_by_app(app_api_client, webhook):
     assert events[0].event_type == WebhookEventTypeEnum.ORDER_CREATED.value
 
 
-def test_query_webhook_by_app_without_permission(
-    app_api_client,
-):
+def test_query_webhook_by_app_without_permission(app_api_client):
     second_app = App.objects.create(name="Sample app account", is_active=True)
     webhook = Webhook.objects.create(
         app=second_app, target_url="http://www.example.com/test"
@@ -372,6 +374,30 @@ def test_query_webhook_by_app_without_permission(
     content = get_graphql_content(response)
     webhook_response = content["data"]["webhook"]
     assert webhook_response is None
+
+
+def test_webhook_query_invalid_id(staff_api_client, webhook, permission_manage_apps):
+    webhook_id = "'"
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    variables = {
+        "id": webhook_id,
+    }
+    response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
+    content = get_graphql_content_from_response(response)
+    assert len(content["errors"]) == 1
+    assert content["errors"][0]["message"] == f"Couldn't resolve id: {webhook_id}."
+    assert content["data"]["webhook"] is None
+
+
+def test_webhook_query_object_with_given_id_does_not_exist(
+    staff_api_client, webhook, permission_manage_apps
+):
+    webhook_id = graphene.Node.to_global_id("Product", -1)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    variables = {"id": webhook_id}
+    response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["webhook"] is None
 
 
 WEBHOOK_EVENTS_QUERY = """

--- a/saleor/graphql/webhook/tests/test_webhook.py
+++ b/saleor/graphql/webhook/tests/test_webhook.py
@@ -392,7 +392,18 @@ def test_webhook_query_invalid_id(staff_api_client, webhook, permission_manage_a
 def test_webhook_query_object_with_given_id_does_not_exist(
     staff_api_client, webhook, permission_manage_apps
 ):
-    webhook_id = graphene.Node.to_global_id("Product", -1)
+    webhook_id = graphene.Node.to_global_id("Webhook", -1)
+    staff_api_client.user.user_permissions.add(permission_manage_apps)
+    variables = {"id": webhook_id}
+    response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)
+    content = get_graphql_content(response)
+    assert content["data"]["webhook"] is None
+
+
+def test_webhook_with_invalid_object_type(
+    staff_api_client, webhook, permission_manage_apps
+):
+    webhook_id = graphene.Node.to_global_id("Product", webhook.pk)
     staff_api_client.user.user_permissions.add(permission_manage_apps)
     variables = {"id": webhook_id}
     response = staff_api_client.post_graphql(QUERY_WEBHOOK, variables)


### PR DESCRIPTION
- For queries:
  -  with valid `ID` but object not found - return `null`
  - with valid `ID` of different object type - return `null`
   - with invalid `ID` - raise GraphQLError
- For mutations:
  -  with valid `ID` but object not found - return `ValidationError`
  -  with invalid `ID` - raise `ValidationError`
  - with valid `ID` different object type - raise `ValidationError`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
