### PR TITLE
Fix attaching params for address form errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Order events performance - #7424 by tomaszszymanski129
 - Add hash to uploading images #7453 by @IKarbowiak
 - Add file format validation for uploaded images - #7447 by @IKarbowiak
+- Fix attaching params for address form errors - #7485 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/account/i18n.py
+++ b/saleor/graphql/account/i18n.py
@@ -54,7 +54,10 @@ class I18nMixin:
         errors_dict = address_form.errors.as_data()
         for errors in errors_dict.values():
             for error in errors:
-                error.params = params
+                if not error.params:
+                    error.params = params
+                else:
+                    error.params.update(params)
         return errors_dict
 
     @classmethod

--- a/saleor/graphql/account/tests/test_i18n.py
+++ b/saleor/graphql/account/tests/test_i18n.py
@@ -1,0 +1,97 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from ....checkout import AddressType
+from ..i18n import I18nMixin
+
+
+def test_validate_address():
+    # given
+    address_data = {
+        "first_name": "John Saleor",
+        "last_name": "Doe Mirumee",
+        "company_name": "Mirumee Software",
+        "street_address_1": "Tęczowa 7",
+        "street_address_2": "",
+        "postal_code": "53-601",
+        "country": "PL",
+        "city": "Wrocław",
+        "country_area": "",
+        "phone": "+48321321888",
+    }
+    # when
+    address = I18nMixin.validate_address(
+        address_data, address_type=AddressType.SHIPPING
+    )
+
+    # then
+    assert address
+
+
+def test_validate_address_invalid_postal_code():
+    # given
+    address_data = {
+        "first_name": "John Saleor",
+        "last_name": "Doe Mirumee",
+        "company_name": "Mirumee Software",
+        "street_address_1": "Tęczowa 7",
+        "street_address_2": "",
+        "postal_code": "Test Test 111 Test Road  BEDFORD  AM23 0UP",
+        "country": "PL",
+        "city": "Wrocław",
+        "country_area": "",
+        "phone": "+48321321888",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as error:
+        I18nMixin.validate_address(address_data, address_type=AddressType.SHIPPING)
+
+    # then
+    assert len(error.value.error_dict["postal_code"]) == 2
+
+
+def test_validate_address_no_country_code():
+    # given
+    address_data = {
+        "first_name": "John Saleor",
+        "last_name": "Doe Mirumee",
+        "company_name": "Mirumee Software",
+        "street_address_1": "Tęczowa 7",
+        "street_address_2": "",
+        "postal_code": "53-601",
+        "country": "",
+        "city": "Wrocław",
+        "country_area": "",
+        "phone": "+48321321888",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as error:
+        I18nMixin.validate_address(address_data, address_type=AddressType.SHIPPING)
+
+    # then
+    assert len(error.value.error_dict["country"]) == 1
+
+
+def test_validate_address_no_city():
+    # given
+    address_data = {
+        "first_name": "John Saleor",
+        "last_name": "Doe Mirumee",
+        "company_name": "Mirumee Software",
+        "street_address_1": "Tęczowa 7",
+        "street_address_2": "",
+        "postal_code": "53-601",
+        "country": "PL",
+        "city": "",
+        "country_area": "",
+        "phone": "+48321321888",
+    }
+
+    # when
+    with pytest.raises(ValidationError) as error:
+        I18nMixin.validate_address(address_data, address_type=AddressType.SHIPPING)
+
+    # then
+    assert len(error.value.error_dict["city"]) == 1


### PR DESCRIPTION
Attaching params to validation errors for address form was failing when the error already had params. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
