### PR TITLE
Fix validating product without category

### DIFF
--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -137,7 +137,11 @@ class ProductChannelListingUpdate(BaseChannelListingMutation):
     def validate_product_without_category(cls, cleaned_input, errors: ErrorType):
         channels_with_published_product_without_category = []
         for update_channel in cleaned_input.get("update_channels", []):
-            if update_channel.get("is_published") is True:
+            is_published = update_channel.get("is_published") is True
+            is_available_for_purchase = (
+                update_channel.get("is_available_for_purchase") is True
+            )
+            if is_published or is_available_for_purchase:
                 channels_with_published_product_without_category.append(
                     update_channel["channel_id"]
                 )


### PR DESCRIPTION
I want to merge this change because...I want to validate product without category when isAvailableForPurchase is set to True.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
