### PR TITLE
Update resolver for address validation rules

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -99,7 +99,7 @@ def resolve_address_validation_rules(
         ],
         city_type=rules.city_type,
         city_choices=[ChoiceValue(area[0], area[1]) for area in rules.city_choices],
-        city_area_type=rules.city_type,
+        city_area_type=rules.city_area_type,
         city_area_choices=[
             ChoiceValue(area[0], area[1]) for area in rules.city_area_choices
         ],

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -3433,6 +3433,8 @@ def test_address_validation_rules(user_api_client):
             addressFormat
             addressLatinFormat
             postalCodeMatchers
+            cityType
+            cityAreaType
         }
     }
     """
@@ -3444,6 +3446,8 @@ def test_address_validation_rules(user_api_client):
     assert data["countryName"] == "POLAND"
     assert data["addressFormat"] is not None
     assert data["addressLatinFormat"] is not None
+    assert data["cityType"] == "city"
+    assert data["cityAreaType"] == "suburb"
     matcher = data["postalCodeMatchers"][0]
     matcher = re.compile(matcher)
     assert matcher.match("00-123")
@@ -3491,7 +3495,7 @@ def test_address_validation_rules_with_country_area(user_api_client):
     assert data["countryAreaChoices"]
     assert data["cityType"] == "city"
     assert data["cityChoices"]
-    assert data["cityAreaType"] == "city"
+    assert data["cityAreaType"] == "district"
     assert not data["cityAreaChoices"]
 
 


### PR DESCRIPTION
Update `resolve_address_validation_rules`. Previously in the `cityAreaType` value of `cityType` was returned.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
