### PR TITLE
Fixed bug with create_warehouse random data after removing companyNam…

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -1207,7 +1207,7 @@ def create_warehouses():
         warehouse, _ = Warehouse.objects.update_or_create(
             name=shipping_zone_name,
             slug=slugify(shipping_zone_name),
-            defaults={"company_name": fake.company(), "address": create_address()},
+            defaults={"address": create_address()},
         )
         warehouse.shipping_zones.add(shipping_zone)
 


### PR DESCRIPTION
Fixed bug with create_warehouse() random data after removing companyName field in #7481

I want to merge this change because...

Removing the field companyName (and putting it as part of the address) introduced a bug at the `populatedb` custom admin command - specifically at the create_warehouse() function.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
