### PR TITLE
Allow to filter by metadata key

### DIFF
--- a/saleor/graphql/meta/tests/test_meta_filters.py
+++ b/saleor/graphql/meta/tests/test_meta_filters.py
@@ -1,3 +1,7 @@
+import pytest
+
+from saleor.product.models import Product
+
 from ...tests.utils import get_graphql_content
 
 FILTER_BY_META_QUERY = """
@@ -17,39 +21,111 @@ query filterProductsByMetadata ($filter:ProductFilterInput, $channel: String){
 """
 
 
-def key_sort(item):
-    return item["key"]
-
-
-METADATA = sorted(
+@pytest.mark.parametrize(
+    "metadata, total_count",
     [
-        {
-            "key": "A",
-            "value": "X",
-        },
-        {
-            "key": "B",
-            "value": "Y",
-        },
-        {"key": "C", "value": "Z"},
+        (
+            [
+                {
+                    "key": "A",
+                    "value": "1",
+                },
+                {
+                    "key": "B",
+                    "value": "2",
+                },
+                {
+                    "key": "C",
+                    "value": "3",
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "key": "A",
+                    "value": "1",
+                },
+                {
+                    "key": "B",
+                    "value": "2",
+                },
+            ],
+            1,
+        ),
+        (
+            [
+                {
+                    "key": "C",
+                    "value": "3",
+                },
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "key": "C",
+                    "value": "44",
+                },
+            ],
+            0,
+        ),
+        (
+            [
+                {
+                    "key": "C",
+                    "value": None,
+                },
+            ],
+            2,
+        ),
+        (
+            [
+                {
+                    "key": "A",
+                    "value": None,
+                },
+                {
+                    "key": "B",
+                },
+            ],
+            1,
+        ),
     ],
-    key=key_sort,
 )
-
-
-def test_filter_by_meta(api_client, product, channel_USD):
-    # given
-    for item in METADATA:
-        product.store_value_in_metadata({item["key"]: item["value"]})
-
-    product.save(update_fields=["metadata"])
-
+def test_filter_by_meta_total_returned_objects(
+    metadata, total_count, api_client, product_list, channel_USD
+):
+    product1, product2, product3 = product_list
     variables = {
         "channel": channel_USD.slug,
         "filter": {
-            "metadata": METADATA,
+            "metadata": metadata,
         },
     }
+    product1.store_value_in_metadata({"A": "1", "B": "2", "C": "3"})
+    product2.store_value_in_metadata({"C": "3", "Z": "4"})
+    Product.objects.bulk_update([product1, product2], ["metadata"])
+
+    response = api_client.post_graphql(FILTER_BY_META_QUERY, variables)
+    content = get_graphql_content(response)
+    assert len(content["data"]["products"]["edges"]) == total_count
+
+
+def test_filter_by_meta_expected_product_for_key_and_value(
+    api_client, product_list, channel_USD
+):
+    product = product_list[0]
+    variables = {
+        "channel": channel_USD.slug,
+        "filter": {
+            "metadata": [{"key": "A", "value": "1"}],
+        },
+    }
+    product.store_value_in_metadata({"A": "1", "B": "2", "C": "3"})
+    product.save()
 
     # when
     response = api_client.post_graphql(FILTER_BY_META_QUERY, variables)
@@ -57,8 +133,28 @@ def test_filter_by_meta(api_client, product, channel_USD):
 
     # then
     product_data = content["data"]["products"]["edges"][0]["node"]
-    metadata = product_data["metadata"]
 
-    # to guarantee order
-    assert METADATA == sorted(metadata, key=key_sort)
+    assert product_data["slug"] == product.slug
+
+
+def test_filter_by_meta_expected_product_for_only_key(
+    api_client, product_list, channel_USD
+):
+    product = product_list[0]
+    variables = {
+        "channel": channel_USD.slug,
+        "filter": {
+            "metadata": [{"key": "A"}],
+        },
+    }
+    product.store_value_in_metadata({"A": "1", "B": "2", "C": "3"})
+    product.save(update_fields=["metadata"])
+
+    # when
+    response = api_client.post_graphql(FILTER_BY_META_QUERY, variables)
+    content = get_graphql_content(response)
+
+    # then
+    product_data = content["data"]["products"]["edges"][0]["node"]
+
     assert product_data["slug"] == product.slug

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -506,7 +506,7 @@ input AttributeFilterInput {
   filterableInStorefront: Boolean
   filterableInDashboard: Boolean
   availableInGrid: Boolean
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   search: String
   ids: [ID]
   type: AttributeTypeEnum
@@ -777,7 +777,7 @@ type CategoryDelete {
 
 input CategoryFilterInput {
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   ids: [ID]
 }
 
@@ -1230,7 +1230,7 @@ enum CollectionErrorCode {
 input CollectionFilterInput {
   published: CollectionPublished
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   ids: [ID]
   channel: String
 }
@@ -1670,7 +1670,7 @@ input CustomerFilterInput {
   numberOfOrders: IntRangeInput
   placedOrders: DateRangeInput
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
 }
 
 input CustomerInput {
@@ -2523,7 +2523,7 @@ enum MenuErrorCode {
 input MenuFilterInput {
   search: String
   slug: [String]
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
 }
 
 input MenuInput {
@@ -2588,7 +2588,7 @@ type MenuItemDelete {
 
 input MenuItemFilterInput {
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
 }
 
 input MenuItemInput {
@@ -2672,6 +2672,11 @@ enum MetadataErrorCode {
   INVALID
   NOT_FOUND
   REQUIRED
+}
+
+input MetadataFilter {
+  key: String!
+  value: String
 }
 
 input MetadataInput {
@@ -3131,7 +3136,7 @@ input OrderDraftFilterInput {
   customer: String
   created: DateRangeInput
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   channels: [ID]
 }
 
@@ -3290,7 +3295,7 @@ input OrderFilterInput {
   customer: String
   created: DateRangeInput
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   channels: [ID]
 }
 
@@ -3621,7 +3626,7 @@ enum PageErrorCode {
 
 input PageFilterInput {
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   pageTypes: [ID]
   ids: [ID]
 }
@@ -4281,7 +4286,7 @@ input ProductFilterInput {
   stockAvailability: StockAvailability
   stocks: ProductStockFilterInput
   search: String
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
   productTypes: [ID]
@@ -4496,7 +4501,7 @@ input ProductTypeFilterInput {
   search: String
   configurable: ProductTypeConfigurable
   productType: ProductTypeEnum
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
   ids: [ID]
 }
 
@@ -4641,7 +4646,7 @@ type ProductVariantDelete {
 input ProductVariantFilterInput {
   search: String
   sku: [String]
-  metadata: [MetadataInput]
+  metadata: [MetadataFilter]
 }
 
 input ProductVariantInput {


### PR DESCRIPTION
I want to merge this change because it allows filtering by metadata key (previously filter was accepting only a pair of value - ("key", "value")

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
