### PR TITLE
Add translation benchmarks

### DIFF
--- a/saleor/graphql/attribute/tests/benchmark/test_attribute.py
+++ b/saleor/graphql/attribute/tests/benchmark/test_attribute.py
@@ -1,6 +1,8 @@
 import graphene
 import pytest
 
+from .....attribute.models import AttributeTranslation, AttributeValueTranslation
+from ....attribute.utils import associate_attribute_values_to_instance
 from ....tests.utils import get_graphql_content
 
 
@@ -92,3 +94,85 @@ def test_query_attributes(
     content = get_graphql_content(response)
     data = content["data"]["attributes"]
     assert data
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_attribute_translation(
+    staff_api_client,
+    size_attribute,
+    weight_attribute,
+    color_attribute,
+    permission_manage_products,
+    count_queries,
+):
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    query = """
+        {
+            attributes(first: 20) {
+                edges {
+                    node {
+                        name
+                        translation(languageCode: EN) {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    attributes = [size_attribute, weight_attribute, color_attribute]
+    translations = []
+    for attribute in attributes:
+        translations.append(
+            AttributeTranslation(attribute=attribute, language_code="en")
+        )
+    AttributeTranslation.objects.bulk_create(translations)
+
+    get_graphql_content(staff_api_client.post_graphql(query, {}))
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_attribute_value_translation(
+    staff_api_client,
+    rich_text_attribute_with_many_values,
+    product,
+    permission_manage_products,
+    count_queries,
+):
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    query = """
+        query($slug:String){
+            product(slug:$slug){
+                attributes{
+                    values{
+                        name
+                        translation(languageCode:EN){
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    attribute_values = rich_text_attribute_with_many_values.values.all()
+    translations = []
+    for attribute_value in attribute_values:
+        translations.append(
+            AttributeValueTranslation(
+                attribute_value=attribute_value, language_code="en"
+            )
+        )
+    AttributeValueTranslation.objects.bulk_create(translations)
+
+    product.product_type.product_attributes.add(rich_text_attribute_with_many_values)
+    associate_attribute_values_to_instance(
+        product, rich_text_attribute_with_many_values, *attribute_values
+    )
+
+    variables = {"slug": product.slug}
+
+    get_graphql_content(staff_api_client.post_graphql(query, variables))

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -859,6 +859,26 @@ def rich_text_attribute(db):
 
 
 @pytest.fixture
+def rich_text_attribute_with_many_values(rich_text_attribute):
+    attribute = rich_text_attribute
+    values = []
+    for i in range(5):
+        text = f"Rich text attribute content{i}."
+        values.append(
+            AttributeValue(
+                attribute=attribute,
+                name=truncatechars(
+                    clean_editor_js(dummy_editorjs(text), to_string=True), 50
+                ),
+                slug=f"instance_{attribute.id}_{i}",
+                rich_text=dummy_editorjs(text),
+            )
+        )
+    AttributeValue.objects.bulk_create(values)
+    return rich_text_attribute
+
+
+@pytest.fixture
 def color_attribute_without_values(db):  # pylint: disable=W0613
     return Attribute.objects.create(
         slug="color",


### PR DESCRIPTION
I want to merge this change because of adding translation benchmarks

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
