### PR TITLE
Update upperFields in addressValidationRules resolver

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -16,6 +16,7 @@ from .types import Address, AddressValidationData, ChoiceValue, User
 from .utils import (
     get_allowed_fields_camel_case,
     get_required_fields_camel_case,
+    get_upper_fields_camel_case,
     get_user_permissions,
 )
 
@@ -92,7 +93,7 @@ def resolve_address_validation_rules(
         address_latin_format=rules.address_latin_format,
         allowed_fields=get_allowed_fields_camel_case(rules.allowed_fields),
         required_fields=get_required_fields_camel_case(rules.required_fields),
-        upper_fields=rules.upper_fields,
+        upper_fields=get_upper_fields_camel_case(rules.upper_fields),
         country_area_type=rules.country_area_type,
         country_area_choices=[
             ChoiceValue(area[0], area[1]) for area in rules.country_area_choices

--- a/saleor/graphql/account/utils.py
+++ b/saleor/graphql/account/utils.py
@@ -154,6 +154,11 @@ def get_required_fields_camel_case(required_fields: set) -> set:
     return {validation_field_to_camel_case(field) for field in required_fields}
 
 
+def get_upper_fields_camel_case(upper_fields: set) -> set:
+    """Return set of AddressValidationRules upper fields in camel case."""
+    return {validation_field_to_camel_case(field) for field in upper_fields}
+
+
 def validation_field_to_camel_case(name: str) -> str:
     """Convert name of the field from snake case to camel case."""
     name = to_camel_case(name)


### PR DESCRIPTION
Update `upperFields` in `addressValidationRules` resolver - return `upperFields` in camel case.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
