### PR TITLE
Deprecate nested objects in TranslatableContent types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ All notable, unreleased changes to this project will be documented in this file.
   - Extend Order type with errors: [OrderError!]! field
   - Create tasks for deleting order lines by deleting products or variants
 - Fix doubled checkout total price for one line and zero shipping price - #7532 by @IKarbowiak
+- Deprecate nested objects in TranslatableContent types - #7522 by @IKarbowiak
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -558,7 +558,7 @@ type AttributeTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
-  attribute: Attribute
+  attribute: Attribute @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type AttributeTranslate {
@@ -667,7 +667,7 @@ type AttributeValueTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
-  attributeValue: AttributeValue
+  attributeValue: AttributeValue @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type AttributeValueTranslate {
@@ -808,7 +808,7 @@ type CategoryTranslatableContent implements Node {
   description: JSONString
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
-  category: Category
+  category: Category @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type CategoryTranslate {
@@ -1280,7 +1280,7 @@ type CollectionTranslatableContent implements Node {
   description: JSONString
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
-  collection: Collection
+  collection: Collection @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type CollectionTranslate {
@@ -2616,7 +2616,7 @@ type MenuItemTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
-  menuItem: MenuItem
+  menuItem: MenuItem @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type MenuItemTranslate {
@@ -3674,7 +3674,7 @@ type PageTranslatableContent implements Node {
   content: JSONString
   contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
-  page: Page
+  page: Page @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type PageTranslate {
@@ -4419,7 +4419,7 @@ type ProductTranslatableContent implements Node {
   description: JSONString
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
-  product: Product
+  product: Product @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type ProductTranslate {
@@ -4693,7 +4693,7 @@ type ProductVariantTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
-  productVariant: ProductVariant
+  productVariant: ProductVariant @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type ProductVariantTranslate {
@@ -4944,7 +4944,7 @@ type SaleTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
-  sale: Sale
+  sale: Sale @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type SaleTranslate {
@@ -5066,7 +5066,7 @@ type ShippingMethodTranslatableContent implements Node {
   name: String!
   description: JSONString
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
-  shippingMethod: ShippingMethod
+  shippingMethod: ShippingMethod @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type ShippingMethodTranslation implements Node {
@@ -5890,7 +5890,7 @@ type VoucherTranslatableContent implements Node {
   id: ID!
   name: String
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  voucher: Voucher
+  voucher: Voucher @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
 
 type VoucherTranslate {

--- a/saleor/graphql/translations/tests/deprecated/test_translations.py
+++ b/saleor/graphql/translations/tests/deprecated/test_translations.py
@@ -1,0 +1,531 @@
+import graphene
+import pytest
+
+from ....core.enums import LanguageCodeEnum
+from ....tests.utils import get_graphql_content
+from ...schema import TranslatableKinds
+
+QUERY_TRANSLATION_PRODUCT = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on ProductTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                product{
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_product(
+    staff_api_client,
+    permission_manage_translations,
+    product,
+    product_translation_fr,
+):
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    variables = {
+        "id": product_id,
+        "kind": TranslatableKinds.PRODUCT.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_PRODUCT,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == product.name
+    assert data["translation"]["name"] == product_translation_fr.name
+    assert data["product"]["name"] == product.name
+
+
+QUERY_TRANSLATION_COLLECTION = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on CollectionTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                collection{
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_collection(
+    staff_api_client,
+    published_collection,
+    collection_translation_fr,
+    permission_manage_translations,
+    channel_USD,
+):
+    channel_listing = published_collection.channel_listings.get()
+    channel_listing.save()
+    collection_id = graphene.Node.to_global_id("Collection", published_collection.id)
+    variables = {
+        "id": collection_id,
+        "kind": TranslatableKinds.COLLECTION.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_COLLECTION,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == published_collection.name
+    assert data["translation"]["name"] == collection_translation_fr.name
+    assert data["collection"]["name"] == published_collection.name
+
+
+QUERY_TRANSLATION_CATEGORY = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on CategoryTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                category {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_category(
+    staff_api_client, category, category_translation_fr, permission_manage_translations
+):
+    category_id = graphene.Node.to_global_id("Category", category.id)
+    variables = {
+        "id": category_id,
+        "kind": TranslatableKinds.CATEGORY.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_CATEGORY,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == category.name
+    assert data["translation"]["name"] == category_translation_fr.name
+    assert data["category"]["name"] == category.name
+
+
+QUERY_TRANSLATION_ATTRIBUTE = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on AttributeTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                attribute {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_attribute(
+    staff_api_client, translated_attribute, permission_manage_translations
+):
+    attribute = translated_attribute.attribute
+    attribute_id = graphene.Node.to_global_id("Attribute", attribute.id)
+    variables = {
+        "id": attribute_id,
+        "kind": TranslatableKinds.ATTRIBUTE.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_ATTRIBUTE,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == attribute.name
+    assert data["translation"]["name"] == translated_attribute.name
+    assert data["attribute"]["name"] == attribute.name
+
+
+QUERY_TRANSLATION_ATTRIBUTE_VALUE = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on AttributeValueTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                attributeValue {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_attribute_value(
+    staff_api_client,
+    pink_attribute_value,
+    translated_attribute_value,
+    permission_manage_translations,
+):
+    attribute_value_id = graphene.Node.to_global_id(
+        "AttributeValue", pink_attribute_value.id
+    )
+    variables = {
+        "id": attribute_value_id,
+        "kind": TranslatableKinds.ATTRIBUTE_VALUE.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_ATTRIBUTE_VALUE,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == pink_attribute_value.name
+    assert data["translation"]["name"] == translated_attribute_value.name
+    assert data["attributeValue"]["name"] == pink_attribute_value.name
+
+
+QUERY_TRANSLATION_VARIANT = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on ProductVariantTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                productVariant {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_variant(
+    staff_api_client,
+    permission_manage_translations,
+    product,
+    variant,
+    variant_translation_fr,
+):
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {
+        "id": variant_id,
+        "kind": TranslatableKinds.VARIANT.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_VARIANT,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == variant.name
+    assert data["translation"]["name"] == variant_translation_fr.name
+    assert data["productVariant"]["name"] == variant.name
+
+
+QUERY_TRANSLATION_PAGE = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on PageTranslatableContent{
+                id
+                title
+                translation(languageCode: $languageCode){
+                    title
+                }
+                page {
+                    id
+                    title
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_page(
+    staff_api_client,
+    page,
+    page_translation_fr,
+    permission_manage_translations,
+    permission_manage_pages,
+):
+    page.is_published = True
+    page.save()
+    page_id = graphene.Node.to_global_id("Page", page.id)
+    variables = {
+        "id": page_id,
+        "kind": TranslatableKinds.PAGE.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_PAGE,
+        variables,
+        permissions=[permission_manage_translations, permission_manage_pages],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["title"] == page.title
+    assert data["translation"]["title"] == page_translation_fr.title
+    assert data["page"]["title"] == page.title
+
+
+QUERY_TRANSLATION_SHIPPING_METHOD = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on ShippingMethodTranslatableContent{
+                id
+                name
+                description
+                translation(languageCode: $languageCode){
+                    name
+                }
+                shippingMethod {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_shipping_method(
+    staff_api_client,
+    shipping_method,
+    shipping_method_translation_fr,
+    permission_manage_translations,
+    permission_manage_shipping,
+):
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.id
+    )
+    variables = {
+        "id": shipping_method_id,
+        "kind": TranslatableKinds.SHIPPING_METHOD.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_SHIPPING_METHOD,
+        variables,
+        permissions=[permission_manage_translations, permission_manage_shipping],
+    )
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["translation"]
+    assert data["name"] == shipping_method.name
+    assert data["description"] == shipping_method.description
+    assert data["translation"]["name"] == shipping_method_translation_fr.name
+    assert data["shippingMethod"]["name"] == shipping_method.name
+
+
+QUERY_TRANSLATION_SALE = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on SaleTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                sale {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "perm_codenames, return_sale",
+    [
+        (["manage_translations"], False),
+        (["manage_translations", "manage_discounts"], True),
+    ],
+)
+def test_translation_query_sale(
+    staff_api_client,
+    sale,
+    sale_translation_fr,
+    perm_codenames,
+    return_sale,
+    permission_manage_translations,
+    permission_manage_discounts,
+):
+    sale_id = graphene.Node.to_global_id("Sale", sale.id)
+    variables = {
+        "id": sale_id,
+        "kind": TranslatableKinds.SALE.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_SALE,
+        variables,
+        permissions=[permission_manage_discounts, permission_manage_translations],
+    )
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["translation"]
+    assert data["name"] == sale.name
+    assert data["translation"]["name"] == sale_translation_fr.name
+    assert data["sale"]["name"] == sale.name
+
+
+QUERY_TRANSLATION_VOUCHER = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on VoucherTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                voucher {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_voucher(
+    staff_api_client,
+    voucher,
+    voucher_translation_fr,
+    permission_manage_discounts,
+    permission_manage_translations,
+):
+    voucher_id = graphene.Node.to_global_id("Voucher", voucher.id)
+    variables = {
+        "id": voucher_id,
+        "kind": TranslatableKinds.VOUCHER.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_VOUCHER,
+        variables,
+        permissions=[permission_manage_discounts, permission_manage_translations],
+    )
+    content = get_graphql_content(response, ignore_errors=True)
+    data = content["data"]["translation"]
+    assert data["name"] == voucher.name
+    assert data["translation"]["name"] == voucher_translation_fr.name
+    assert data["voucher"]["name"] == voucher.name
+
+
+QUERY_TRANSLATION_MENU_ITEM = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on MenuItemTranslatableContent{
+                id
+                name
+                translation(languageCode: $languageCode){
+                    name
+                }
+                menuItem {
+                    id
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
+def test_translation_query_menu_item(
+    staff_api_client,
+    menu_item,
+    menu_item_translation_fr,
+    permission_manage_translations,
+):
+    menu_item_id = graphene.Node.to_global_id("MenuItem", menu_item.id)
+    variables = {
+        "id": menu_item_id,
+        "kind": TranslatableKinds.MENU_ITEM.name,
+        "languageCode": LanguageCodeEnum.FR.name,
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_TRANSLATION_MENU_ITEM,
+        variables,
+        permissions=[permission_manage_translations],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["translation"]
+    assert data["name"] == menu_item.name
+    assert data["translation"]["name"] == menu_item_translation_fr.name
+    assert data["menuItem"]["name"] == menu_item.name

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -1743,10 +1743,6 @@ QUERY_TRANSLATION_PRODUCT = """
                 translation(languageCode: $languageCode){
                     name
                 }
-                product{
-                    id
-                    name
-                }
             }
         }
     }
@@ -1776,7 +1772,6 @@ def test_translation_query_product(
     data = content["data"]["translation"]
     assert data["name"] == product.name
     assert data["translation"]["name"] == product_translation_fr.name
-    assert data["product"]["name"] == product.name
 
 
 QUERY_TRANSLATION_COLLECTION = """
@@ -1789,10 +1784,6 @@ QUERY_TRANSLATION_COLLECTION = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                collection{
-                    id
                     name
                 }
             }
@@ -1827,7 +1818,6 @@ def test_translation_query_collection(
     data = content["data"]["translation"]
     assert data["name"] == published_collection.name
     assert data["translation"]["name"] == collection_translation_fr.name
-    assert data["collection"]["name"] == published_collection.name
 
 
 QUERY_TRANSLATION_CATEGORY = """
@@ -1840,10 +1830,6 @@ QUERY_TRANSLATION_CATEGORY = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                category {
-                    id
                     name
                 }
             }
@@ -1871,7 +1857,6 @@ def test_translation_query_category(
     data = content["data"]["translation"]
     assert data["name"] == category.name
     assert data["translation"]["name"] == category_translation_fr.name
-    assert data["category"]["name"] == category.name
 
 
 QUERY_TRANSLATION_ATTRIBUTE = """
@@ -1884,10 +1869,6 @@ QUERY_TRANSLATION_ATTRIBUTE = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                attribute {
-                    id
                     name
                 }
             }
@@ -1916,7 +1897,6 @@ def test_translation_query_attribute(
     data = content["data"]["translation"]
     assert data["name"] == attribute.name
     assert data["translation"]["name"] == translated_attribute.name
-    assert data["attribute"]["name"] == attribute.name
 
 
 QUERY_TRANSLATION_ATTRIBUTE_VALUE = """
@@ -1929,10 +1909,6 @@ QUERY_TRANSLATION_ATTRIBUTE_VALUE = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                attributeValue {
-                    id
                     name
                 }
             }
@@ -1965,7 +1941,6 @@ def test_translation_query_attribute_value(
     data = content["data"]["translation"]
     assert data["name"] == pink_attribute_value.name
     assert data["translation"]["name"] == translated_attribute_value.name
-    assert data["attributeValue"]["name"] == pink_attribute_value.name
 
 
 QUERY_TRANSLATION_VARIANT = """
@@ -1978,10 +1953,6 @@ QUERY_TRANSLATION_VARIANT = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                productVariant {
-                    id
                     name
                 }
             }
@@ -2012,7 +1983,6 @@ def test_translation_query_variant(
     data = content["data"]["translation"]
     assert data["name"] == variant.name
     assert data["translation"]["name"] == variant_translation_fr.name
-    assert data["productVariant"]["name"] == variant.name
 
 
 QUERY_TRANSLATION_PAGE = """
@@ -2025,10 +1995,6 @@ QUERY_TRANSLATION_PAGE = """
                 id
                 title
                 translation(languageCode: $languageCode){
-                    title
-                }
-                page {
-                    id
                     title
                 }
             }
@@ -2070,7 +2036,6 @@ def test_translation_query_page(
     data = content["data"]["translation"]
     assert data["title"] == page.title
     assert data["translation"]["title"] == page_translation_fr.title
-    assert data["page"]["title"] == page.title
 
 
 QUERY_TRANSLATION_SHIPPING_METHOD = """
@@ -2084,10 +2049,6 @@ QUERY_TRANSLATION_SHIPPING_METHOD = """
                 name
                 description
                 translation(languageCode: $languageCode){
-                    name
-                }
-                shippingMethod {
-                    id
                     name
                 }
             }
@@ -2128,10 +2089,6 @@ def test_translation_query_shipping_method(
     assert data["name"] == shipping_method.name
     assert data["description"] == shipping_method.description
     assert data["translation"]["name"] == shipping_method_translation_fr.name
-    if return_shipping_method:
-        assert data["shippingMethod"]["name"] == shipping_method.name
-    else:
-        assert not data["shippingMethod"]
 
 
 QUERY_TRANSLATION_SALE = """
@@ -2144,10 +2101,6 @@ QUERY_TRANSLATION_SALE = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                sale {
-                    id
                     name
                 }
             }
@@ -2181,10 +2134,6 @@ def test_translation_query_sale(
     data = content["data"]["translation"]
     assert data["name"] == sale.name
     assert data["translation"]["name"] == sale_translation_fr.name
-    if return_sale:
-        assert data["sale"]["name"] == sale.name
-    else:
-        assert not data["sale"]
 
 
 QUERY_TRANSLATION_VOUCHER = """
@@ -2197,10 +2146,6 @@ QUERY_TRANSLATION_VOUCHER = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                voucher {
-                    id
                     name
                 }
             }
@@ -2234,10 +2179,6 @@ def test_translation_query_voucher(
     data = content["data"]["translation"]
     assert data["name"] == voucher.name
     assert data["translation"]["name"] == voucher_translation_fr.name
-    if return_voucher:
-        assert data["voucher"]["name"] == voucher.name
-    else:
-        assert not data["voucher"]
 
 
 QUERY_TRANSLATION_MENU_ITEM = """
@@ -2250,10 +2191,6 @@ QUERY_TRANSLATION_MENU_ITEM = """
                 id
                 name
                 translation(languageCode: $languageCode){
-                    name
-                }
-                menuItem {
-                    id
                     name
                 }
             }
@@ -2284,7 +2221,6 @@ def test_translation_query_menu_item(
     data = content["data"]["translation"]
     assert data["name"] == menu_item.name
     assert data["translation"]["name"] == menu_item_translation_fr.name
-    assert data["menuItem"]["name"] == menu_item.name
 
 
 def test_translation_query_incorrect_kind(

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -66,6 +66,9 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
     attribute_value = graphene.Field(
         "saleor.graphql.attribute.types.AttributeValue",
         description="Represents a value of an attribute.",
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -90,6 +93,9 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
     attribute = graphene.Field(
         "saleor.graphql.attribute.types.Attribute",
         description="Custom attribute of a product.",
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -117,6 +123,9 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
         "saleor.graphql.product.types.products.ProductVariant",
         description=(
             "Represents a version of a product such as different size or color."
+        ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
         ),
     )
 
@@ -160,6 +169,9 @@ class ProductTranslatableContent(CountableDjangoObjectType):
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
         description="Represents an individual item for sale in the storefront.",
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -207,6 +219,9 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
     collection = graphene.Field(
         "saleor.graphql.product.types.products.Collection",
         description="Represents a collection of products.",
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -258,6 +273,9 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
     category = graphene.Field(
         "saleor.graphql.product.types.products.Category",
         description="Represents a single category of products.",
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -314,6 +332,9 @@ class PageTranslatableContent(CountableDjangoObjectType):
             "A static page that can be manually added by a shop operator ",
             "through the dashboard.",
         ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -358,6 +379,9 @@ class VoucherTranslatableContent(CountableDjangoObjectType):
             "collections or specific products. They can be used during checkout by "
             "providing valid voucher codes."
         ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -385,6 +409,9 @@ class SaleTranslatableContent(CountableDjangoObjectType):
         description=(
             "Sales allow creating discounts for categories, collections "
             "or products and are visible to all the customers."
+        ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
         ),
     )
 
@@ -421,6 +448,9 @@ class MenuItemTranslatableContent(CountableDjangoObjectType):
             "Represents a single item of the related menu. Can store categories, "
             "collection or pages."
         ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+        ),
     )
 
     class Meta:
@@ -449,6 +479,9 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
         description=(
             "Shipping method are the methods you'll use to get customer's orders "
             " to them. They are directly exposed to the customers."
+        ),
+        deprecation_reason=(
+            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
         ),
     )
 


### PR DESCRIPTION
Updated types:
- `AttributeTranslatableContent`
- `AttributeValueTranslatableContent`
- `CategoryTranslatableContent`
- `CollectionTranslatableContent`
- `MenuItemTranslatableContent`
- `PageTranslatableContent`
- `ProductTranslatableContent`
- `ProductVariantTranslatableContent`
- `SaleTranslatableContent`
- `ShippingMethodTranslatableContent`
- `VoucherTranslatableContent`

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
