### PR TITLE
Fix translation dataloadres in a.30

### DIFF
--- a/saleor/graphql/translations/dataloaders.py
+++ b/saleor/graphql/translations/dataloaders.py
@@ -43,6 +43,7 @@ class BaseTranslationByIdAndLanguageCodeLoader(DataLoader):
 class AttributeTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "attribute_translation_by_id_and_language_code"
     model = attribute_models.AttributeTranslation
     relation_name = "attribute_id"
 
@@ -50,6 +51,7 @@ class AttributeTranslationByIdAndLanguageCodeLoader(
 class AttributeValueTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "attribute_value_translation_by_id_and_language_code"
     model = attribute_models.AttributeValueTranslation
     relation_name = "attribute_value_id"
 
@@ -57,6 +59,7 @@ class AttributeValueTranslationByIdAndLanguageCodeLoader(
 class CategoryTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "category_translation_by_id_and_language_code"
     model = product_models.CategoryTranslation
     relation_name = "category_id"
 
@@ -64,6 +67,7 @@ class CategoryTranslationByIdAndLanguageCodeLoader(
 class CollectionTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "collection_translation_by_id_and_language_code"
     model = product_models.CollectionTranslation
     relation_name = "collection_id"
 
@@ -71,6 +75,7 @@ class CollectionTranslationByIdAndLanguageCodeLoader(
 class MenuItemTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "menu_item_translation_by_id_and_language_code"
     model = menu_models.MenuItemTranslation
     relation_name = "menu_item_id"
 
@@ -78,6 +83,7 @@ class MenuItemTranslationByIdAndLanguageCodeLoader(
 class PageTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "page_translation_by_id_and_language_code"
     model = page_models.PageTranslation
     relation_name = "page_id"
 
@@ -85,6 +91,7 @@ class PageTranslationByIdAndLanguageCodeLoader(
 class ProductTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "product_translation_by_id_and_language_code"
     model = product_models.ProductTranslation
     relation_name = "product_id"
 
@@ -92,6 +99,7 @@ class ProductTranslationByIdAndLanguageCodeLoader(
 class ProductVariantTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "product_variant_translation_by_id_and_language_code"
     model = product_models.ProductVariantTranslation
     relation_name = "product_variant_id"
 
@@ -99,6 +107,7 @@ class ProductVariantTranslationByIdAndLanguageCodeLoader(
 class SaleTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "sale_translation_by_id_and_language_code"
     model = discount_models.SaleTranslation
     relation_name = "sale_id"
 
@@ -106,6 +115,7 @@ class SaleTranslationByIdAndLanguageCodeLoader(
 class ShippingMethodTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "shipping_method_translation_by_id_and_language_code"
     model = shipping_models.ShippingMethodTranslation
     relation_name = "shipping_method_id"
 
@@ -113,6 +123,7 @@ class ShippingMethodTranslationByIdAndLanguageCodeLoader(
 class SiteSettingsTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "site_settings_translation_by_id_and_language_code"
     model = site_models.SiteSettingsTranslation
     relation_name = "site_settings_id"
 
@@ -120,5 +131,6 @@ class SiteSettingsTranslationByIdAndLanguageCodeLoader(
 class VoucherTranslationByIdAndLanguageCodeLoader(
     BaseTranslationByIdAndLanguageCodeLoader
 ):
+    context_key = "voucher_translation_by_id_and_language_code"
     model = discount_models.VoucherTranslation
     relation_name = "voucher_id"

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -2304,3 +2304,59 @@ def test_translation_query_no_permission(staff_api_client, menu_item):
     }
     response = staff_api_client.post_graphql(QUERY_TRANSLATION_MENU_ITEM, variables)
     assert_no_permission(response)
+
+
+def test_product_and_attribute_translation(user_api_client, product, channel_USD):
+    description = dummy_editorjs("test desription")
+    product.translations.create(
+        language_code="pl", name="Produkt", description=description
+    )
+    assigned_attribute = product.attributes.first()
+    attribute = assigned_attribute.attribute
+    attribute.translations.create(language_code="pl", name="Kolor")
+
+    query = """
+        query productById($productId: ID!, $channel: String) {
+            product(id: $productId, channel: $channel) {
+                translation(languageCode: PL) {
+                    name
+                    description
+                    descriptionJson
+                    language {
+                        code
+                    }
+                }
+                attributes{
+                    attribute{
+                        translation(languageCode: PL){
+                            id
+                            name
+                            language{
+                                code
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    response = user_api_client.post_graphql(
+        query, {"productId": product_id, "channel": channel_USD.slug}
+    )
+    data = get_graphql_content(response)["data"]
+
+    product_translation_data = data["product"]["translation"]
+    assert product_translation_data["name"] == "Produkt"
+    assert product_translation_data["language"]["code"] == "PL"
+    assert (
+        product_translation_data["description"]
+        == product_translation_data["descriptionJson"]
+        == dummy_editorjs("test desription", json_format=True)
+    )
+    attribute_translation_data = data["product"]["attributes"][0]["attribute"][
+        "translation"
+    ]
+    assert attribute_translation_data["name"] == "Kolor"
+    assert attribute_translation_data["language"]["code"] == "PL"


### PR DESCRIPTION
I want to merge this change because of fixing translation dataloadres in a.30

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
