### PR TITLE
Remove context key from base dataloaders

### DIFF
--- a/saleor/graphql/product/dataloaders/attributes.py
+++ b/saleor/graphql/product/dataloaders/attributes.py
@@ -20,7 +20,6 @@ from .products import ProductByIdLoader, ProductVariantByIdLoader
 class BaseProductAttributesByProductTypeIdLoader(DataLoader):
     """Loads product attributes by product type ID."""
 
-    context_key = "product_attributes_by_producttype"
     model_name = None
 
     def batch_load(self, keys):

--- a/saleor/graphql/translations/dataloaders.py
+++ b/saleor/graphql/translations/dataloaders.py
@@ -11,7 +11,6 @@ from ..core.dataloaders import DataLoader
 
 
 class BaseTranslationByIdAndLanguageCodeLoader(DataLoader):
-    context_key = "translation_by_id_and_language_code"
     model = None
     relation_name = None
 


### PR DESCRIPTION
I want to merge this change because of removing the context key from base dataloaders. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
