### PR TITLE
Get `psp_reference` value from GatewayResponse

### DIFF
--- a/saleor/payment/gateway.py
+++ b/saleor/payment/gateway.py
@@ -12,7 +12,7 @@ from .utils import (
     create_transaction,
     gateway_postprocess,
     get_already_processed_transaction_or_create_new_transaction,
-    update_payment_method_details,
+    update_payment,
     validate_gateway_response,
 )
 
@@ -94,8 +94,8 @@ def process_payment(
         channel_slug=channel_slug,
     )
     action_required = response is not None and response.action_required
-    if response and response.payment_method_info:
-        update_payment_method_details(payment, response)
+    if response:
+        update_payment(payment, response)
     return get_already_processed_transaction_or_create_new_transaction(
         payment=payment,
         kind=TransactionKind.CAPTURE,
@@ -131,8 +131,8 @@ def authorize(
         payment_data,
         channel_slug=channel_slug,
     )
-    if response and response.payment_method_info:
-        update_payment_method_details(payment, response)
+    if response:
+        update_payment(payment, response)
     return get_already_processed_transaction_or_create_new_transaction(
         payment=payment,
         kind=TransactionKind.AUTH,
@@ -172,8 +172,8 @@ def capture(
         payment_data,
         channel_slug=channel_slug,
     )
-    if response and response.payment_method_info:
-        update_payment_method_details(payment, response)
+    if response:
+        update_payment(payment, response)
     return get_already_processed_transaction_or_create_new_transaction(
         payment=payment,
         kind=TransactionKind.CAPTURE,
@@ -273,8 +273,8 @@ def confirm(
         channel_slug=channel_slug,
     )
     action_required = response is not None and response.action_required
-    if response and response.payment_method_info:
-        update_payment_method_details(payment, response)
+    if response:
+        update_payment(payment, response)
     return get_already_processed_transaction_or_create_new_transaction(
         payment=payment,
         kind=TransactionKind.CONFIRM,

--- a/saleor/payment/tests/test_payment.py
+++ b/saleor/payment/tests/test_payment.py
@@ -18,6 +18,7 @@ from ..utils import (
     create_payment_information,
     create_transaction,
     is_currency_supported,
+    update_payment,
     validate_gateway_response,
 )
 
@@ -28,7 +29,12 @@ EXAMPLE_ERROR = "Example dummy error"
 @pytest.fixture
 def payment_method_details():
     return PaymentMethodInfo(
-        last_4="1234", exp_year=2020, exp_month=8, brand="visa", name="Joe Doe"
+        last_4="1234",
+        exp_year=2020,
+        exp_month=8,
+        brand="visa",
+        name="Joe Doe",
+        type="test",
     )
 
 
@@ -47,6 +53,7 @@ def gateway_response(settings, payment_method_details):
             "transaction-id": "transaction-token",
         },
         payment_method_info=payment_method_details,
+        psp_reference="test_reference",
     )
 
 
@@ -529,3 +536,17 @@ def test_is_currency_supported(
 
     # then
     assert response == exp_response
+
+
+def test_update_payment(gateway_response, payment_txn_captured):
+    payment = payment_txn_captured
+
+    update_payment(payment_txn_captured, gateway_response)
+
+    payment.refresh_from_db()
+    assert payment.psp_reference == gateway_response.psp_reference
+    assert payment.cc_brand == gateway_response.payment_method_info.brand
+    assert payment.cc_last_digits == gateway_response.payment_method_info.last_4
+    assert payment.cc_exp_year == gateway_response.payment_method_info.exp_year
+    assert payment.cc_exp_month == gateway_response.payment_method_info.exp_month
+    assert payment.payment_method_type == gateway_response.payment_method_info.type


### PR DESCRIPTION
`PspReference` value shouldn't be taken from `raw_response` as it may have a different name in other gateways'.

Right now it will be taken from `GatewayResponse` dataclass.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
