### PR TITLE
Add support for offline payments in Stripe

### DIFF
--- a/saleor/payment/gateways/stripe/consts.py
+++ b/saleor/payment/gateways/stripe/consts.py
@@ -26,6 +26,7 @@ ACTION_REQUIRED_STATUSES = [
     "requires_confirmation",
     "requires_action",
 ]
+
 FAILED_STATUSES = ["requires_payment_method" "canceled"]
 
 SUCCESS_STATUS = "succeeded"

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -178,6 +178,7 @@ class StripeGatewayPlugin(BasePlugin):
 
         payment_method_id = data.get("payment_method_id") if data else None
         setup_future_usage = data.get("setup_future_usage") if data else None
+        off_session = data.get("off_session") if data else None
 
         customer = get_or_create_customer(
             api_key=api_key,
@@ -196,6 +197,7 @@ class StripeGatewayPlugin(BasePlugin):
                 "payment_id": payment_information.graphql_payment_id,
             },
             setup_future_usage=setup_future_usage,
+            off_session=off_session,
         )
 
         if error and payment_method_id and not intent:

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -118,6 +118,7 @@ def create_payment_intent(
     payment_method_id: Optional[str] = None,
     metadata: Optional[dict] = None,
     setup_future_usage: Optional[str] = None,
+    off_session: Optional[bool] = None,
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
 
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
@@ -128,8 +129,10 @@ def create_payment_intent(
 
     if payment_method_id and customer:
         additional_params["payment_method"] = payment_method_id
-        additional_params["confirm"] = True
-        additional_params["off_session"] = True
+
+        additional_params["off_session"] = off_session if off_session else False
+        if off_session:
+            additional_params["confirm"] = True
 
     if setup_future_usage in ["on_session", "off_session"] and not payment_method_id:
         additional_params["setup_future_usage"] = setup_future_usage

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -117,6 +117,7 @@ def create_payment_intent(
     customer: Optional[StripeObject] = None,
     payment_method_id: Optional[str] = None,
     metadata: Optional[dict] = None,
+    setup_future_usage: Optional[str] = None,
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
 
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
@@ -126,12 +127,12 @@ def create_payment_intent(
         additional_params["customer"] = customer
 
     if payment_method_id and customer:
-        additional_params.update(
-            {
-                "setup_future_usage": "on_session",
-                "payment_method": payment_method_id,
-            }
-        )
+        additional_params["payment_method"] = payment_method_id
+        additional_params["confirm"] = True
+        additional_params["off_session"] = True
+
+    if setup_future_usage in ["on_session", "off_session"] and not payment_method_id:
+        additional_params["setup_future_usage"] = setup_future_usage
 
     if metadata:
         additional_params["metadata"] = metadata

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -178,6 +178,7 @@ def test_process_payment(
     payment_intent.id = payment_intent_id
     payment_intent.client_secret = client_secret
     payment_intent.last_response.data = dummy_response
+    payment_intent.status = "requires_payment_method"
 
     plugin = stripe_plugin(auto_capture=True)
 
@@ -241,6 +242,7 @@ def test_process_payment_with_customer(
     payment_intent.id = payment_intent_id
     payment_intent.client_secret = client_secret
     payment_intent.last_response.data = dummy_response
+    payment_intent.status = "requires_payment_method"
 
     plugin = stripe_plugin(auto_capture=True)
 
@@ -287,6 +289,76 @@ def test_process_payment_with_customer(
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_customer_and_future_usage(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+    payment_intent.status = SUCCESS_STATUS
+
+    plugin = stripe_plugin(auto_capture=True)
+
+    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        customer_id=None,
+        store_source=True,
+        additional_data={"setup_future_usage": "off_session"},
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is False
+    assert response.kind == TransactionKind.CAPTURE
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        setup_future_usage="off_session",
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email="admin@example.com",
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
 def test_process_payment_with_customer_and_payment_method(
     mocked_payment_intent,
     mocked_customer_create,
@@ -308,6 +380,7 @@ def test_process_payment_with_customer_and_payment_method(
     payment_intent.id = payment_intent_id
     payment_intent.client_secret = client_secret
     payment_intent.last_response.data = dummy_response
+    payment_intent.status = SUCCESS_STATUS
 
     plugin = stripe_plugin(auto_capture=True)
 
@@ -322,8 +395,8 @@ def test_process_payment_with_customer_and_payment_method(
     response = plugin.process_payment(payment_info, None)
 
     assert response.is_success is True
-    assert response.action_required is True
-    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.action_required is False
+    assert response.kind == TransactionKind.CAPTURE
     assert response.amount == payment_info.amount
     assert response.currency == payment_info.currency
     assert response.transaction_id == payment_intent_id
@@ -341,8 +414,84 @@ def test_process_payment_with_customer_and_payment_method(
         currency=payment_info.currency,
         capture_method=AUTOMATIC_CAPTURE_METHOD,
         customer=customer,
-        setup_future_usage="on_session",
         payment_method="pm_ID",
+        confirm=True,
+        off_session=True,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email="admin@example.com",
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_customer_and_payment_method_raises_card_error(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    stripe_error_object = StripeError()
+    stripe_error_object.error = StripeError()
+    stripe_error_object.error.payment_intent = payment_intent
+    mocked_payment_intent.side_effect = stripe_error_object
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+    payment_intent.status = SUCCESS_STATUS
+
+    plugin = stripe_plugin(auto_capture=True)
+
+    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        customer_id=None,
+        store_source=True,
+        additional_data={"payment_method_id": "pm_ID"},
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is False
+    assert response.kind == TransactionKind.CAPTURE
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        payment_method="pm_ID",
+        confirm=True,
+        off_session=True,
         metadata={
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
@@ -373,6 +522,7 @@ def test_process_payment_with_disabled_order_auto_confirmation(
     payment_intent.id = payment_intent_id
     payment_intent.client_secret = client_secret
     payment_intent.last_response.data = dummy_response
+    payment_intent.status = "requires_payment_method"
 
     plugin = stripe_plugin(auto_capture=True)
 

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -415,6 +415,77 @@ def test_process_payment_with_customer_and_payment_method(
         capture_method=AUTOMATIC_CAPTURE_METHOD,
         customer=customer,
         payment_method="pm_ID",
+        off_session=False,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email="admin@example.com",
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_offline(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+    payment_intent.status = SUCCESS_STATUS
+
+    plugin = stripe_plugin(auto_capture=True)
+
+    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        customer_id=None,
+        store_source=True,
+        additional_data={"payment_method_id": "pm_ID", "off_session": True},
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is True
+    assert response.action_required is False
+    assert response.kind == TransactionKind.CAPTURE
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert response.transaction_id == payment_intent_id
+    assert response.error is None
+    assert response.raw_response == dummy_response
+    assert response.action_required_data == {
+        "client_secret": client_secret,
+        "id": payment_intent_id,
+    }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        payment_method="pm_ID",
         confirm=True,
         off_session=True,
         metadata={
@@ -464,7 +535,7 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
         payment_stripe_for_checkout,
         customer_id=None,
         store_source=True,
-        additional_data={"payment_method_id": "pm_ID"},
+        additional_data={"payment_method_id": "pm_ID", "off_session": True},
     )
 
     response = plugin.process_payment(payment_info, None)


### PR DESCRIPTION
I want to merge this change because it allows using stored payment_method_ids.
Stripe plugin expects three optional parameters passed in paymentData:

- `setup_future_usage`  [stripe_docs](https://stripe.com/docs/payments/payment-intents#future-usage). When provided, Saleor will append all details to Stripe's request required to save the card for future payments in Stripe
- `payment_method_id` the ID of saved payment method which when provided will be used to confirm offline payment
- `off_session` - [stripe_docs](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-off_session) boolean

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
