### PR TITLE
Fixed handling of App requesters in `saleor.order.events`

### DIFF
--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -3,14 +3,13 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from ..account import events as account_events
 from ..account.models import User
-from ..app.models import App
 from ..discount.models import OrderDiscount
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..payment.models import Payment
 from . import OrderEvents, OrderEventsEmails
 from .models import OrderEvent
 
-UserType = Union[None, User, App]
+UserType = Optional[User]
 
 
 def _line_per_quantity_to_line_object(quantity, line):
@@ -35,7 +34,7 @@ def _get_payment_data(amount: Optional[Decimal], payment: Payment) -> Dict:
 
 
 def _user_is_valid(user: UserType) -> bool:
-    return bool(user and not isinstance(user, App) and not user.is_anonymous)
+    return bool(user and not user.is_anonymous)
 
 
 def event_order_refunded_notification(

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -3,13 +3,14 @@ from typing import Dict, List, Optional, Tuple, Union
 
 from ..account import events as account_events
 from ..account.models import User
+from ..app.models import App
 from ..discount.models import OrderDiscount
 from ..order.models import Fulfillment, FulfillmentLine, Order, OrderLine
 from ..payment.models import Payment
 from . import OrderEvents, OrderEventsEmails
 from .models import OrderEvent
 
-UserType = Optional[User]
+UserType = Union[None, User, App]
 
 
 def _line_per_quantity_to_line_object(quantity, line):
@@ -34,7 +35,7 @@ def _get_payment_data(amount: Optional[Decimal], payment: Payment) -> Dict:
 
 
 def _user_is_valid(user: UserType) -> bool:
-    return bool(user and not user.is_anonymous)
+    return bool(user and not isinstance(user, App) and not user.is_anonymous)
 
 
 def event_order_refunded_notification(


### PR DESCRIPTION
This object was improperly assumed to be a User, when a requester can also be an App.

I ran across an AttributeError caused when an App makes a `orderDiscountAdd` request through GraphQL, and it was trivial to fix, so I did so.

However, I was not able to figure out where would be appropriate to add a test to ensure this doesn't suffer from regressions. I would love guidance on this (or information on where to find an overview of the testing strategy for Saleor).