### PR TITLE
Fix choices resolver on Attribute type

### DIFF
--- a/saleor/graphql/attribute/tests/queries/test_attribute_query.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_query.py
@@ -62,7 +62,7 @@ def test_get_single_attribute_by_slug_as_customer(
 
 
 QUERY_ATTRIBUTE = """
-    query($id: ID!) {
+    query($id: ID!, $query: String) {
         attribute(id: $id) {
             id
             slug
@@ -71,7 +71,7 @@ QUERY_ATTRIBUTE = """
             entityType
             type
             unit
-            choices(first: 10) {
+            choices(first: 10, filter: {search: $query}) {
                 edges {
                     node {
                         slug
@@ -280,7 +280,7 @@ def test_get_single_reference_attribute_by_staff(
     )
     query = QUERY_ATTRIBUTE
     content = get_graphql_content(
-        staff_api_client.post_graphql(query, {"id": attribute_gql_id})
+        staff_api_client.post_graphql(query, {"id": attribute_gql_id, "query": ""})
     )
 
     assert content["data"]["attribute"], "Should have found an attribute"
@@ -317,6 +317,7 @@ def test_get_single_reference_attribute_by_staff(
         content["data"]["attribute"]["entityType"]
         == product_type_page_reference_attribute.entity_type.upper()
     )
+    assert not content["data"]["attribute"]["choices"]["edges"]
 
 
 def test_get_single_numeric_attribute_by_staff(

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -150,7 +150,7 @@ class Attribute(CountableDjangoObjectType):
     def resolve_choices(root: models.Attribute, info, **_kwargs):
         if root.input_type in AttributeInputType.TYPES_WITH_CHOICES:
             return root.values.all()
-        return []
+        return models.AttributeValue.objects.none()
 
     @staticmethod
     @check_attribute_required_permissions()


### PR DESCRIPTION
`Attribute.choices` resolver was failing when choices were empty and filter was included in query.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
