### PR TITLE
Send to stripe only logged-in customers

### DIFF
--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -142,7 +142,6 @@ def create_payment_intent(
     if metadata:
         additional_params["metadata"] = metadata
 
-
     if payment_method_types and isinstance(payment_method_types, list):
         additional_params["payment_method_types"] = payment_method_types
 

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -120,6 +120,7 @@ def create_payment_intent(
     setup_future_usage: Optional[str] = None,
     off_session: Optional[bool] = None,
     payment_method_types: Optional[List[str]] = None,
+    customer_email: Optional[str] = None,
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
 
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
@@ -141,8 +142,12 @@ def create_payment_intent(
     if metadata:
         additional_params["metadata"] = metadata
 
+
     if payment_method_types and isinstance(payment_method_types, list):
         additional_params["payment_method_types"] = payment_method_types
+
+    if customer_email:
+        additional_params["receipt_email"] = customer_email
 
     try:
         with stripe_opentracing_trace("stripe.PaymentIntent.create"):

--- a/saleor/payment/gateways/stripe/tests/conftest.py
+++ b/saleor/payment/gateways/stripe/tests/conftest.py
@@ -15,6 +15,7 @@ def payment_stripe_for_checkout(checkout_with_items, address, shipping_method):
     checkout_with_items.billing_address = address
     checkout_with_items.shipping_address = address
     checkout_with_items.shipping_method = shipping_method
+    checkout_with_items.email = "test@example.com"
     checkout_with_items.save()
     manager = get_plugins_manager()
     lines = fetch_checkout_lines(checkout_with_items)

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -440,6 +440,7 @@ def test_process_payment_with_payment_method_types(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = Mock()
     mocked_customer_create.return_value = customer
@@ -459,7 +460,9 @@ def test_process_payment_with_payment_method_types(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
+    payment_stripe_for_checkout.save()
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -494,11 +497,12 @@ def test_process_payment_with_payment_method_types(
             "payment_id": payment_info.graphql_payment_id,
         },
         payment_method_types=["p24", "card"],
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -166,8 +166,6 @@ def test_process_payment(
     payment_stripe_for_checkout,
     channel_USD,
 ):
-    customer = StripeObject(id="cus_id")
-    mocked_customer.return_value = customer
     payment_intent = Mock()
     mocked_payment_intent.return_value = payment_intent
     client_secret = "client-secret"
@@ -207,16 +205,13 @@ def test_process_payment(
         amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
         currency=payment_info.currency,
         capture_method=AUTOMATIC_CAPTURE_METHOD,
-        customer=customer,
         metadata={
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
-
-    mocked_customer.assert_called_once_with(
-        api_key=api_key, email=payment_info.customer_email
-    )
+    assert not mocked_customer.called
 
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
@@ -227,6 +222,7 @@ def test_process_payment_with_customer(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = StripeObject(id="cus_id")
     mocked_customer_create.return_value = customer
@@ -246,7 +242,8 @@ def test_process_payment_with_customer(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -279,11 +276,12 @@ def test_process_payment_with_customer(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=customer_user.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 
@@ -295,6 +293,7 @@ def test_process_payment_with_customer_and_future_usage(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = Mock()
     mocked_customer_create.return_value = customer
@@ -314,7 +313,8 @@ def test_process_payment_with_customer_and_future_usage(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -349,11 +349,12 @@ def test_process_payment_with_customer_and_future_usage(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 
@@ -365,6 +366,7 @@ def test_process_payment_with_customer_and_payment_method(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = Mock()
     mocked_customer_create.return_value = customer
@@ -384,7 +386,8 @@ def test_process_payment_with_customer_and_payment_method(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -420,11 +423,12 @@ def test_process_payment_with_customer_and_payment_method(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 
@@ -506,6 +510,7 @@ def test_process_payment_offline(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = Mock()
     mocked_customer_create.return_value = customer
@@ -525,7 +530,8 @@ def test_process_payment_offline(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -562,11 +568,12 @@ def test_process_payment_offline(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 
@@ -578,6 +585,7 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
     stripe_plugin,
     payment_stripe_for_checkout,
     channel_USD,
+    customer_user,
 ):
     customer = Mock()
     mocked_customer_create.return_value = customer
@@ -600,7 +608,9 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
 
     plugin = stripe_plugin(auto_capture=True)
 
-    payment_stripe_for_checkout.checkout.email = "admin@example.com"
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
+
     payment_info = create_payment_information(
         payment_stripe_for_checkout,
         customer_id=None,
@@ -637,11 +647,12 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
     mocked_customer_create.assert_called_once_with(
         api_key="secret_key",
-        email="admin@example.com",
+        email=customer_user.email,
     )
 
 
@@ -697,6 +708,7 @@ def test_process_payment_with_disabled_order_auto_confirmation(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
 
@@ -733,6 +745,7 @@ def test_process_payment_with_manual_capture(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
 
@@ -770,6 +783,7 @@ def test_process_payment_with_error(
             "channel": channel_USD.slug,
             "payment_id": payment_info.graphql_payment_id,
         },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
     )
 
 

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -77,9 +77,10 @@ class PaymentData:
     customer_ip_address: Optional[str]
     customer_email: str
     token: Optional[str] = None
-    customer_id: Optional[str] = None
+    customer_id: Optional[str] = None  # stores payment gateway customer ID
     reuse_source: bool = False
     data: Optional[dict] = None
+    graphql_customer_id: Optional[str] = None
 
 
 @dataclass

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -44,18 +44,24 @@ def create_payment_information(
         billing = checkout.billing_address
         shipping = checkout.shipping_address
         email = checkout.get_customer_email()
+        user_id = checkout.user_id
     elif payment.order:
         billing = payment.order.billing_address
         shipping = payment.order.shipping_address
         email = payment.order.user_email
+        user_id = payment.order.user_id
     else:
-        billing, shipping, email = None, None, payment.billing_email
+        billing, shipping, email, user_id = None, None, payment.billing_email, None
 
     billing_address = AddressData(**billing.as_data()) if billing else None
     shipping_address = AddressData(**shipping.as_data()) if shipping else None
 
     order_id = payment.order.pk if payment.order else None
     graphql_payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+
+    graphql_customer_id = None
+    if user_id:
+        graphql_customer_id = graphene.Node.to_global_id("User", user_id)
 
     return PaymentData(
         gateway=payment.gateway,
@@ -72,6 +78,7 @@ def create_payment_information(
         customer_email=email,
         reuse_source=store_source,
         data=additional_data or {},
+        graphql_customer_id=graphql_customer_id,
     )
 
 


### PR DESCRIPTION
I want to merge this change because it allows storing only logged-in customers on Stripe side.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
