### PR TITLE
Fix failing queries with nested filters that require channel slug

### DIFF
--- a/saleor/graphql/core/fields.py
+++ b/saleor/graphql/core/fields.py
@@ -175,6 +175,10 @@ class FilterInputConnectionField(BaseDjangoConnectionField):
             cls.resolve_connection, connection, args, max_limit=max_limit
         )
 
+        # for nested filters get channel from ChannelContext object
+        if "channel" not in args and hasattr(root, "channel_slug"):
+            args["channel"] = root.channel_slug
+
         iterable = cls.filter_iterable(
             iterable, filterset_class, filters_name, info, **args
         )

--- a/saleor/graphql/product/tests/test_collection.py
+++ b/saleor/graphql/product/tests/test_collection.py
@@ -314,7 +314,7 @@ query CollectionProducts($id: ID!,$channel: String, $filters: ProductFilterInput
 
 
 def test_filter_collection_products(
-    user_api_client, product_list, published_collection, channel_USD
+    user_api_client, product_list, published_collection, channel_USD, channel_PLN
 ):
     # given
     query = GET_FILTERED_PRODUCTS_COLLECTION_QUERY
@@ -338,6 +338,39 @@ def test_filter_collection_products(
     product_data = content["data"]["collection"]["products"]["edges"][0]["node"]
 
     assert product_data["id"] == graphene.Node.to_global_id("Product", product.pk)
+
+
+def test_filter_collection_published_products(
+    user_api_client, product_list, published_collection, channel_USD, channel_PLN
+):
+    # given
+    query = GET_FILTERED_PRODUCTS_COLLECTION_QUERY
+
+    for product in product_list:
+        published_collection.products.add(product)
+
+    product = product_list[0]
+    listing = product.channel_listings.first()
+    listing.is_published = False
+    listing.save(update_fields=["is_published"])
+
+    product_id = graphene.Node.to_global_id("Product", product.id)
+
+    variables = {
+        "id": graphene.Node.to_global_id("Collection", published_collection.pk),
+        "filters": {"isPublished": True},
+        "channel": channel_USD.slug,
+    }
+
+    # when
+    response = user_api_client.post_graphql(query, variables)
+
+    # then
+    content = get_graphql_content(response)
+    products = content["data"]["collection"]["products"]["edges"]
+
+    assert len(products) == len(product_list) - 1
+    assert product_id not in {node["node"]["id"] for node in products}
 
 
 def test_filter_collection_products_by_multiple_attributes(


### PR DESCRIPTION
Use top-level channel argument for nested filters like: 
```
{
  collection(slug: "winter-sale", channel: "default-channel") {
    id
    products(first:5, filter: {isPublished: true}) {
      edges {
        node {
          id
        }
      }
    }
  }
}

```
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
