### PR TITLE
Add possibility to use different type of payment methods than card

### DIFF
--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -179,6 +179,8 @@ class StripeGatewayPlugin(BasePlugin):
         setup_future_usage = data.get("setup_future_usage") if data else None
         off_session = data.get("off_session") if data else None
 
+        payment_method_types = data.get("payment_method_types") if data else None
+
         customer = get_or_create_customer(
             api_key=api_key,
             customer_email=payment_information.customer_email,
@@ -197,6 +199,7 @@ class StripeGatewayPlugin(BasePlugin):
             },
             setup_future_usage=setup_future_usage,
             off_session=off_session,
+            payment_method_types=payment_method_types,
         )
 
         if error and payment_method_id and not intent:

--- a/saleor/payment/gateways/stripe/stripe_api.py
+++ b/saleor/payment/gateways/stripe/stripe_api.py
@@ -1,7 +1,7 @@
 import logging
 from contextlib import contextmanager
 from decimal import Decimal
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 from urllib.parse import urljoin
 
 import stripe
@@ -119,6 +119,7 @@ def create_payment_intent(
     metadata: Optional[dict] = None,
     setup_future_usage: Optional[str] = None,
     off_session: Optional[bool] = None,
+    payment_method_types: Optional[List[str]] = None,
 ) -> Tuple[Optional[StripeObject], Optional[StripeError]]:
 
     capture_method = AUTOMATIC_CAPTURE_METHOD if auto_capture else MANUAL_CAPTURE_METHOD
@@ -139,6 +140,9 @@ def create_payment_intent(
 
     if metadata:
         additional_params["metadata"] = metadata
+
+    if payment_method_types and isinstance(payment_method_types, list):
+        additional_params["payment_method_types"] = payment_method_types
 
     try:
         with stripe_opentracing_trace("stripe.PaymentIntent.create"):


### PR DESCRIPTION
I want to merge this change because it allows using a different types of payment methods which use PaymentIntent. 
https://stripe.com/docs/payments/payment-methods/overview

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
