### PR TITLE
Checkout lines add fix

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -130,8 +130,8 @@ def add_variants_to_checkout(
     """Add variants to checkout.
 
     If a variant is not placed in checkout, a new checkout line will be created.
-    Otherwise, its quantity will be replaced (if greater than 0).
     If quantity is set to 0, checkout line will be deleted.
+    Otherwise, quantity will be added or replaced (if replace argument is True).
     """
 
     # check quantities

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -125,7 +125,7 @@ def calculate_checkout_quantity(lines: Iterable["CheckoutLineInfo"]):
 
 
 def add_variants_to_checkout(
-    checkout, variants, quantities, channel_slug, skip_stock_check=False
+    checkout, variants, quantities, channel_slug, skip_stock_check=False, replace=False
 ):
     """Add variants to checkout.
 
@@ -159,7 +159,10 @@ def add_variants_to_checkout(
         if variant.pk in variant_ids_in_lines:
             line = variant_ids_in_lines[variant.pk]
             if quantity > 0:
-                line.quantity = quantity
+                if replace:
+                    line.quantity = quantity
+                else:
+                    line.quantity += quantity
                 to_update.append(line)
             else:
                 to_delete.append(line)

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -432,7 +432,10 @@ class CheckoutLinesAdd(BaseMutation):
         )
 
     class Meta:
-        description = "Adds a checkout line to the existing checkout."
+        description = (
+            "Adds a checkout line to the existing checkout."
+            "If line was already in checkout, its quantity will be increased."
+        )
         error_type_class = CheckoutError
         error_type_field = "checkout_errors"
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -442,7 +442,7 @@ class CheckoutLinesAdd(BaseMutation):
 
     @classmethod
     def clean_input(
-        cls, checkout, variants, quantities, checkout_info, manager, discounts
+        cls, checkout, variants, quantities, checkout_info, manager, discounts, replace
     ):
         channel_slug = checkout_info.channel.slug
         cls.validate_checkout_lines(
@@ -464,6 +464,7 @@ class CheckoutLinesAdd(BaseMutation):
                     quantities,
                     channel_slug,
                     skip_stock_check=True,  # already checked by validate_checkout_lines
+                    replace=replace,
                 )
             except ProductNotPublished as exc:
                 raise ValidationError(
@@ -479,7 +480,9 @@ class CheckoutLinesAdd(BaseMutation):
         )
 
     @classmethod
-    def perform_mutation(cls, _root, info, lines, checkout_id=None, token=None):
+    def perform_mutation(
+        cls, _root, info, lines, checkout_id=None, token=None, replace=False
+    ):
         # DEPRECATED
         validate_one_of_args_is_in_mutation(
             CheckoutErrorCode, "checkout_id", checkout_id, "token", token
@@ -502,7 +505,7 @@ class CheckoutLinesAdd(BaseMutation):
 
         checkout_info = fetch_checkout_info(checkout, [], discounts, manager)
         cls.clean_input(
-            checkout, variants, quantities, checkout_info, manager, discounts
+            checkout, variants, quantities, checkout_info, manager, discounts, replace
         )
 
         lines = fetch_checkout_lines(checkout)
@@ -536,7 +539,9 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
 
     @classmethod
     def perform_mutation(cls, root, info, lines, checkout_id=None, token=None):
-        return super().perform_mutation(root, info, lines, checkout_id, token)
+        return super().perform_mutation(
+            root, info, lines, checkout_id, token, replace=True
+        )
 
 
 class CheckoutLineDelete(BaseMutation):


### PR DESCRIPTION
I want to merge this change because checkoutLinesAdd behaved like checkoutLinesUpdate and it should cumulate quantities in checkout if a line with particular variant was already there (it was replacing it).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
