### PR TITLE
Drop top-level checkoutLine query with related resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,6 +226,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Unify checkout identifier in checkout mutations and queries - #7511 by @IKarbowiak
 - Use root level channel argument for filtering and sorting - #7374 by @IKarbowiak
   - drop `channel` field from filters and sorters
+- Drop top-level `checkoutLine` query from the schema with related resolver - #3832 by @dexon44
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Unify checkout identifier in checkout mutations and queries - #7511 by @IKarbowiak
 - Use root level channel argument for filtering and sorting - #7374 by @IKarbowiak
   - drop `channel` field from filters and sorters
-- Drop top-level `checkoutLine` query from the schema with related resolver - #3832 by @dexon44
+- Drop top-level `checkoutLine` query from the schema with related resolver, use `checkout` query instead - #3832 by @dexon44
 
 ### Other
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -226,7 +226,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Unify checkout identifier in checkout mutations and queries - #7511 by @IKarbowiak
 - Use root level channel argument for filtering and sorting - #7374 by @IKarbowiak
   - drop `channel` field from filters and sorters
-- Drop top-level `checkoutLine` query from the schema with related resolver, use `checkout` query instead - #3832 by @dexon44
+- Drop top-level `checkoutLine` query from the schema with related resolver, use `checkout` query instead - #7623 by @dexon44
 
 ### Other
 

--- a/saleor/graphql/checkout/resolvers.py
+++ b/saleor/graphql/checkout/resolvers.py
@@ -4,10 +4,6 @@ from ...core.tracing import traced_resolver
 from ..utils import get_user_or_app_from_context
 
 
-def resolve_checkout_line(id):
-    return models.CheckoutLine.objects.filter(id=id).first()
-
-
 def resolve_checkout_lines():
     queryset = models.CheckoutLine.objects.all()
     return queryset

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -4,7 +4,6 @@ from ...core.permissions import CheckoutPermissions
 from ...core.tracing import traced_resolver
 from ..core.fields import BaseDjangoConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
-from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from ..payment.mutations import CheckoutPaymentCreate
 from .mutations import (
@@ -23,12 +22,7 @@ from .mutations import (
     CheckoutShippingAddressUpdate,
     CheckoutShippingMethodUpdate,
 )
-from .resolvers import (
-    resolve_checkout,
-    resolve_checkout_line,
-    resolve_checkout_lines,
-    resolve_checkouts,
-)
+from .resolvers import resolve_checkout, resolve_checkout_lines, resolve_checkouts
 from .types import Checkout, CheckoutLine
 
 
@@ -46,11 +40,6 @@ class CheckoutQueries(graphene.ObjectType):
             description="Slug of a channel for which the data should be returned."
         ),
     )
-    checkout_line = graphene.Field(
-        CheckoutLine,
-        id=graphene.Argument(graphene.ID, description="ID of the checkout line."),
-        description="Look up a checkout line by ID.",
-    )
     checkout_lines = PrefetchingConnectionField(
         CheckoutLine, description="List of checkout lines."
     )
@@ -62,10 +51,6 @@ class CheckoutQueries(graphene.ObjectType):
     @traced_resolver
     def resolve_checkouts(self, *_args, channel=None, **_kwargs):
         return resolve_checkouts(channel)
-
-    def resolve_checkout_line(self, info, id):
-        _, id = from_global_id_or_error(id, CheckoutLine)
-        return resolve_checkout_line(id)
 
     @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
     @traced_resolver

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4776,7 +4776,6 @@ type Query {
   taxTypes: [TaxType]
   checkout(token: UUID): Checkout
   checkouts(channel: String, before: String, after: String, first: Int, last: Int): CheckoutCountableConnection
-  checkoutLine(id: ID): CheckoutLine
   checkoutLines(before: String, after: String, first: Int, last: Int): CheckoutLineCountableConnection
   channel(id: ID): Channel
   channels: [Channel!]


### PR DESCRIPTION
I want to merge this change because it drop deprecated query.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [X] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [X] Changes are mentioned in the changelog
