### PR TITLE
Preorder allocations

### DIFF
--- a/saleor/checkout/complete_checkout.py
+++ b/saleor/checkout/complete_checkout.py
@@ -37,7 +37,7 @@ from ..payment.models import Payment, Transaction
 from ..payment.utils import fetch_customer_id, store_customer_id
 from ..product.models import ProductTranslation, ProductVariantTranslation
 from ..warehouse.availability import check_stock_and_preorder_quantity_bulk
-from ..warehouse.management import allocate_stocks
+from ..warehouse.management import allocate_preorders, allocate_stocks
 from . import AddressType
 from .checkout_cleaner import clean_checkout_payment, clean_checkout_shipping
 from .models import Checkout
@@ -398,6 +398,7 @@ def _create_order(
 
     country_code = checkout_info.get_country()
     allocate_stocks(order_lines_info, country_code, checkout_info.channel.slug)
+    allocate_preorders(order_lines_info, checkout_info.channel.slug)
 
     # Add gift cards to the order
     for gift_card in checkout.gift_cards.select_for_update():

--- a/saleor/checkout/tests/test_checkout_complete.py
+++ b/saleor/checkout/tests/test_checkout_complete.py
@@ -795,7 +795,7 @@ def test_create_order_with_variant_tracking_false(
 
 
 @override_settings(LANGUAGE_CODE="fr")
-def test_create_order_use_tanslations(
+def test_create_order_use_translations(
     checkout_with_item, customer_user, shipping_method
 ):
     translated_product_name = "French name"

--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -113,3 +113,46 @@ def checkout_with_charged_payment(checkout_with_voucher):
     )
 
     return checkout
+
+
+@pytest.fixture()
+def checkout_preorder_with_charged_payment(
+    checkout_with_billing_address,
+    preorder_variant_channel_threshold,
+    preorder_variant_global_threshold,
+):
+    checkout = checkout_with_billing_address
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
+    add_variant_to_checkout(checkout_info, preorder_variant_global_threshold, 1)
+
+    lines = fetch_checkout_lines(checkout)
+    manager = get_plugins_manager()
+    taxed_total = calculations.checkout_total(
+        manager=manager,
+        checkout_info=checkout_info,
+        lines=lines,
+        address=checkout.shipping_address,
+    )
+    payment = Payment.objects.create(
+        gateway="mirumee.payments.dummy",
+        is_active=True,
+        total=taxed_total.gross.amount,
+        currency="USD",
+    )
+
+    payment.charge_status = ChargeStatus.FULLY_CHARGED
+    payment.captured_amount = payment.total
+    payment.checkout = checkout
+    payment.save()
+
+    payment.transactions.create(
+        amount=payment.total,
+        kind=TransactionKind.CAPTURE,
+        gateway_response={},
+        is_success=True,
+    )
+
+    return checkout

--- a/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_checkout_mutations.py
@@ -729,3 +729,18 @@ def test_customer_complete_checkout(
 
     response = get_graphql_content(api_client.post_graphql(query, variables))
     assert not response["data"]["checkoutComplete"]["errors"]
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_complete_checkout_preorder(
+    api_client, checkout_preorder_with_charged_payment, count_queries
+):
+    query = COMPLETE_CHECKOUT_MUTATION
+
+    variables = {
+        "token": checkout_preorder_with_charged_payment.token,
+    }
+
+    response = get_graphql_content(api_client.post_graphql(query, variables))
+    assert not response["data"]["checkoutComplete"]["errors"]

--- a/saleor/graphql/checkout/tests/test_checkout_complete.py
+++ b/saleor/graphql/checkout/tests/test_checkout_complete.py
@@ -1188,3 +1188,79 @@ def test_checkout_complete_0_total_value(
     assert not Checkout.objects.filter(
         pk=checkout.pk
     ).exists(), "Checkout should have been deleted"
+
+
+@pytest.mark.integration
+@patch("saleor.plugins.manager.PluginsManager.order_confirmed")
+def test_checkout_complete_with_preorder_variant(
+    order_confirmed_mock,
+    site_settings,
+    user_api_client,
+    checkout_with_item_and_preorder_item,
+    payment_dummy,
+    address,
+    shipping_method,
+):
+    checkout = checkout_with_item_and_preorder_item
+    checkout.shipping_address = address
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address
+    checkout.save()
+
+    variants_and_quantities = {line.variant_id: line.quantity for line in checkout}
+
+    manager = get_plugins_manager()
+    lines = fetch_checkout_lines(checkout)
+    checkout_info = fetch_checkout_info(checkout, lines, [], manager)
+    total = calculations.calculate_checkout_total_with_gift_cards(
+        manager, checkout_info, lines, address
+    )
+    site_settings.automatically_confirm_all_new_orders = True
+    site_settings.save()
+    payment = payment_dummy
+    payment.is_active = True
+    payment.order = None
+    payment.total = total.gross.amount
+    payment.currency = total.gross.currency
+    payment.checkout = checkout
+    payment.save()
+    assert not payment.transactions.exists()
+
+    orders_count = Order.objects.count()
+    variables = {"token": checkout.token, "redirectUrl": "https://www.example.com"}
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_COMPLETE, variables)
+
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutComplete"]
+    assert not data["errors"]
+
+    order_token = data["order"]["token"]
+    assert Order.objects.count() == orders_count + 1
+    order = Order.objects.first()
+    assert order.status == OrderStatus.UNFULFILLED
+    assert order.origin == OrderOrigin.CHECKOUT
+    assert not order.original
+    assert order.token == order_token
+    assert order.total.gross == total.gross
+
+    assert order.lines.count() == len(variants_and_quantities)
+    for variant_id, quantity in variants_and_quantities.items():
+        order.lines.get(variant_id=variant_id).quantity == quantity
+    assert order.shipping_address == address
+    assert order.shipping_method == checkout.shipping_method
+    assert order.payments.exists()
+    assert payment.transactions.count() == 1
+
+    preorder_line = order.lines.filter(variant__is_preorder=True).first()
+    assert not preorder_line.allocations.exists()
+    preorder_allocation = preorder_line.preorder_allocations.get()
+    assert preorder_allocation.quantity == quantity
+
+    stock_line = order.lines.filter(variant__is_preorder=False).first()
+    assert stock_line.allocations.exists()
+    assert not stock_line.preorder_allocations.exists()
+
+    assert not Checkout.objects.filter(
+        pk=checkout.pk
+    ).exists(), "Checkout should have been deleted"
+    order_confirmed_mock.assert_called_once_with(order)

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -18,7 +18,7 @@ from ....order.utils import (
     recalculate_order,
     update_order_prices,
 )
-from ....warehouse.management import allocate_stocks
+from ....warehouse.management import allocate_preorders, allocate_stocks
 from ...account.i18n import I18nMixin
 from ...account.types import AddressInput
 from ...channel.types import Channel
@@ -393,12 +393,13 @@ class DraftOrderComplete(BaseMutation):
         order.save()
 
         for line in order.lines.all():
-            if line.variant.track_inventory:
+            if line.variant.track_inventory or line.variant.is_preorder:
                 line_data = OrderLineData(
                     line=line, quantity=line.quantity, variant=line.variant
                 )
                 try:
                     allocate_stocks([line_data], country, order.channel.slug)
+                    allocate_preorders([line_data], order.channel.slug)
                 except InsufficientStock as exc:
                     errors = prepare_insufficient_stock_order_validation_errors(exc)
                     raise ValidationError({"lines": errors})

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -30,7 +30,7 @@ from ....payment import ChargeStatus, PaymentError
 from ....payment.models import Payment
 from ....plugins.manager import PluginsManager
 from ....shipping.models import ShippingMethod, ShippingMethodChannelListing
-from ....warehouse.models import Allocation, Stock
+from ....warehouse.models import Allocation, PreorderAllocation, Stock
 from ....warehouse.tests.utils import get_available_quantity_for_stock
 from ...order.mutations.orders import (
     clean_order_cancel,
@@ -3136,6 +3136,82 @@ def test_draft_order_complete_unavailable_for_purchase(
 
     assert error["field"] == "lines"
     assert error["code"] == OrderErrorCode.PRODUCT_UNAVAILABLE_FOR_PURCHASE.name
+
+
+def test_draft_order_complete_preorders(
+    staff_api_client,
+    permission_manage_orders,
+    staff_user,
+    draft_order_with_preorder_lines,
+):
+    order = draft_order_with_preorder_lines
+
+    # Ensure no events were created
+    assert not OrderEvent.objects.exists()
+
+    # Ensure no preorder allocation were created
+    assert not PreorderAllocation.objects.filter(order_line__order=order).exists()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_COMPLETE_MUTATION, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["draftOrderComplete"]["order"]
+    order.refresh_from_db()
+    assert data["status"] == order.status.upper()
+    assert data["origin"] == OrderOrigin.DRAFT.upper()
+
+    for line in order.lines.all():
+        preorder_allocation = line.preorder_allocations.get()
+        assert preorder_allocation.quantity == line.quantity_unfulfilled
+
+    # ensure there are only 2 events with correct types
+    event_params = {
+        "user": staff_user,
+        "type__in": [
+            order_events.OrderEvents.PLACED_FROM_DRAFT,
+            order_events.OrderEvents.CONFIRMED,
+        ],
+        "parameters": {},
+    }
+    matching_events = OrderEvent.objects.filter(**event_params)
+    assert matching_events.count() == 2
+    assert matching_events[0].type != matching_events[1].type
+    assert not OrderEvent.objects.exclude(**event_params).exists()
+
+
+def test_draft_order_complete_insufficient_stock_preorders(
+    staff_api_client,
+    permission_manage_orders,
+    staff_user,
+    draft_order_with_preorder_lines,
+    channel_USD,
+):
+    order = draft_order_with_preorder_lines
+
+    # Ensure no events were created
+    assert not OrderEvent.objects.exists()
+
+    line = order.lines.order_by("-quantity").first()
+    channel_listing = line.variant.channel_listings.get(channel_id=channel_USD.id)
+    line.quantity = channel_listing.preorder_quantity_threshold + 1
+    line.save()
+
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+    response = staff_api_client.post_graphql(
+        DRAFT_ORDER_COMPLETE_MUTATION, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    error = content["data"]["draftOrderComplete"]["errors"][0]
+    order.refresh_from_db()
+    assert order.status == OrderStatus.DRAFT
+    assert order.origin == OrderOrigin.DRAFT
+
+    assert error["field"] == "lines"
+    assert error["code"] == OrderErrorCode.INSUFFICIENT_STOCK.name
 
 
 ORDER_LINES_CREATE_MUTATION = """

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -467,7 +467,6 @@ def checkout_with_item_and_preorder_item(
         checkout_with_item, [], [], get_plugins_manager()
     )
     add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
-    checkout_with_item.save()
     return checkout_with_item
 
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2765,6 +2765,77 @@ def order_with_line_without_inventory_tracking(
 
 
 @pytest.fixture
+def order_with_preorder_lines(
+    order, product_type, category, shipping_zone, warehouse, channel_USD
+):
+    product = Product.objects.create(
+        name="Test product",
+        slug="test-product-8",
+        product_type=product_type,
+        category=category,
+    )
+    ProductChannelListing.objects.create(
+        product=product,
+        channel=channel_USD,
+        is_published=True,
+        visible_in_listings=True,
+        available_for_purchase=datetime.date.today(),
+    )
+    variant = ProductVariant.objects.create(
+        product=product, sku="SKU_AA_P", is_preorder=True
+    )
+    channel_listing = ProductVariantChannelListing.objects.create(
+        variant=variant,
+        channel=channel_USD,
+        price_amount=Decimal(10),
+        cost_price_amount=Decimal(1),
+        currency=channel_USD.currency_code,
+        preorder_quantity_threshold=10,
+    )
+
+    net = variant.get_price(product, [], channel_USD, channel_listing)
+    currency = net.currency
+    gross = Money(amount=net.amount * Decimal(1.23), currency=currency)
+    quantity = 3
+    unit_price = TaxedMoney(net=net, gross=gross)
+    line = order.lines.create(
+        product_name=str(variant.product),
+        variant_name=str(variant),
+        product_sku=variant.sku,
+        is_shipping_required=variant.is_shipping_required(),
+        quantity=quantity,
+        variant=variant,
+        unit_price=unit_price,
+        total_price=unit_price * quantity,
+        undiscounted_unit_price=unit_price,
+        undiscounted_total_price=unit_price * quantity,
+        tax_rate=Decimal("0.23"),
+    )
+    PreorderAllocation.objects.create(
+        order_line=line,
+        product_variant_channel_listing=channel_listing,
+        quantity=line.quantity,
+    )
+
+    order.shipping_address = order.billing_address.get_copy()
+    order.channel = channel_USD
+    shipping_method = shipping_zone.shipping_methods.first()
+    shipping_price = shipping_method.channel_listings.get(channel_id=channel_USD.id)
+    order.shipping_method_name = shipping_method.name
+    order.shipping_method = shipping_method
+
+    net = shipping_price.get_total()
+    gross = Money(amount=net.amount * Decimal(1.23), currency=net.currency)
+    order.shipping_price = TaxedMoney(net=net, gross=gross)
+    order.save()
+
+    recalculate_order(order)
+
+    order.refresh_from_db()
+    return order
+
+
+@pytest.fixture
 def order_events(order):
     for event_type, _ in OrderEvents.CHOICES:
         OrderEvent.objects.create(type=event_type, order=order)
@@ -2878,6 +2949,17 @@ def draft_order_without_inventory_tracking(order_with_line_without_inventory_tra
     order_with_line_without_inventory_tracking.origin = OrderStatus.DRAFT
     order_with_line_without_inventory_tracking.save(update_fields=["status", "origin"])
     return order_with_line_without_inventory_tracking
+
+
+@pytest.fixture
+def draft_order_with_preorder_lines(order_with_preorder_lines):
+    PreorderAllocation.objects.filter(
+        order_line__order=order_with_preorder_lines
+    ).delete()
+    order_with_preorder_lines.status = OrderStatus.DRAFT
+    order_with_preorder_lines.origin = OrderOrigin.DRAFT
+    order_with_preorder_lines.save(update_fields=["status", "origin"])
+    return order_with_preorder_lines
 
 
 @pytest.fixture

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -1701,7 +1701,7 @@ def variant_with_many_stocks(variant, warehouses_with_shipping_zone):
 @pytest.fixture
 def preorder_variant_global_threshold(product, channel_USD):
     product_variant = ProductVariant.objects.create(
-        product=product, sku="SKU_A", is_preorder=True, preorder_global_threshold=10
+        product=product, sku="SKU_A_P", is_preorder=True, preorder_global_threshold=10
     )
     ProductVariantChannelListing.objects.create(
         variant=product_variant,
@@ -1716,7 +1716,7 @@ def preorder_variant_global_threshold(product, channel_USD):
 @pytest.fixture
 def preorder_variant_channel_threshold(product, channel_USD):
     product_variant = ProductVariant.objects.create(
-        product=product, sku="SKU_B", is_preorder=True, preorder_global_threshold=None
+        product=product, sku="SKU_B_P", is_preorder=True, preorder_global_threshold=None
     )
     ProductVariantChannelListing.objects.create(
         variant=product_variant,
@@ -1732,7 +1732,7 @@ def preorder_variant_channel_threshold(product, channel_USD):
 @pytest.fixture
 def preorder_variant_global_and_channel_threshold(product, channel_USD, channel_PLN):
     product_variant = ProductVariant.objects.create(
-        product=product, sku="SKU_C", is_preorder=True, preorder_global_threshold=10
+        product=product, sku="SKU_C_P", is_preorder=True, preorder_global_threshold=10
     )
     ProductVariantChannelListing.objects.bulk_create(
         [

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -460,6 +460,18 @@ def checkout_with_payments(checkout):
 
 
 @pytest.fixture
+def checkout_with_item_and_preorder_item(
+    checkout_with_item, product, preorder_variant_channel_threshold
+):
+    checkout_info = fetch_checkout_info(
+        checkout_with_item, [], [], get_plugins_manager()
+    )
+    add_variant_to_checkout(checkout_info, preorder_variant_channel_threshold, 1)
+    checkout_with_item.save()
+    return checkout_with_item
+
+
+@pytest.fixture
 def address(db):  # pylint: disable=W0613
     return Address.objects.create(
         first_name="John",

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -365,7 +365,9 @@ def get_order_lines_with_track_inventory(
     return [
         line_info
         for line_info in order_lines_info
-        if line_info.variant and line_info.variant.track_inventory
+        if line_info.variant
+        and line_info.variant.track_inventory
+        and not line_info.variant.is_preorder
     ]
 
 

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -382,7 +382,7 @@ def deallocate_stock_for_order(order: "Order"):
 
 @traced_atomic_transaction()
 def allocate_preorders(order_lines_info: Iterable["OrderLineData"], channel_slug: str):
-    """Allocate preorder variant for given `order_lines` in give channel."""
+    """Allocate preorder variant for given `order_lines` in given channel."""
     order_lines_info = get_order_lines_with_preorder(order_lines_info)
     if not order_lines_info:
         return


### PR DESCRIPTION
I want to merge this change because it adds logic for allocating preorder variants. It's used during completing checkout and creating order from draft order.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
