### PR TITLE
Return brand of stored card

### DIFF
--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -426,6 +426,7 @@ class StripeGatewayPlugin(BasePlugin):
                         exp_month=c.card.exp_month,
                         last_4=c.card.last4,
                         name=None,
+                        brand=c.card.brand,
                     ),
                 )
                 for c in payment_methods


### PR DESCRIPTION
I want to merge this change because it adds card brand when returning stored card details

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
