### PR TITLE
Return paymentMethodId, brand and firstDigits from user.storedPaymentSource

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -141,12 +141,13 @@ def prepare_graphql_payment_sources_type(payment_sources):
         sources.append(
             {
                 "gateway": src.gateway,
+                "payment_method_id": src.id,
                 "credit_card_info": {
                     "last_digits": src.credit_card_info.last_4,
                     "exp_year": src.credit_card_info.exp_year,
                     "exp_month": src.credit_card_info.exp_month,
-                    "brand": "",
-                    "first_digits": "",
+                    "brand": src.credit_card_info.brand,
+                    "first_digits": src.credit_card_info.first_4,
                 },
             }
         )

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -59,6 +59,7 @@ class PaymentSource(graphene.ObjectType):
         )
 
     gateway = graphene.String(description="Payment gateway name.", required=True)
+    payment_method_id = graphene.String(description="ID of stored payment method.")
     credit_card_info = graphene.Field(
         CreditCard, description="Stored credit card details if available."
     )

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3900,6 +3900,7 @@ type PaymentRefund {
 
 type PaymentSource {
   gateway: String!
+  paymentMethodId: String
   creditCardInfo: CreditCard
 }
 

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -10,6 +10,7 @@ JSONType = Union[Dict[str, JSONValue], List[JSONValue]]
 class PaymentMethodInfo:
     """Uniform way to represent payment method information."""
 
+    first_4: Optional[str] = None
     last_4: Optional[str] = None
     exp_year: Optional[int] = None
     exp_month: Optional[int] = None


### PR DESCRIPTION
I want to merge this change because:
- add field paymentMethodId to `user.storedPaymentSource` query
- use values  returned by payment gateway to fulfill `brand` and `firstDigits` fields

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
