### PR TITLE
Add exception handler in Update Product mutation for collection with empty ID

### DIFF
--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -5551,24 +5551,24 @@ def test_update_product_with_empty_input_collections(
 ):
     # given
     query = """
-mutation updateProduct($productId: ID!, $input: ProductInput!) {
-  productUpdate(id: $productId, input: $input) {
-    productErrors {
-      field
-      message
-      code
+    mutation updateProduct($productId: ID!, $input: ProductInput!) {
+      productUpdate(id: $productId, input: $input) {
+        productErrors {
+          field
+          message
+          code
+        }
+        product {
+          id
+        }
+      }
     }
-    product {
-      id
-    }
-  }
-}
 
     """
     product_id = graphene.Node.to_global_id("Product", product.pk)
     variables = {
         "productId": product_id,
-        "input": {"collections": ""},
+        "input": {"collections": [""]},
     }
     # when
     response = staff_api_client.post_graphql(
@@ -5578,8 +5578,8 @@ mutation updateProduct($productId: ID!, $input: ProductInput!) {
     content = get_graphql_content(response)
     data = content["data"]["productUpdate"]
     assert len(data["productErrors"]) == 1
-    productErrors = data["productErrors"][0]
-    assert productErrors["code"] == "GRAPHQL_ERROR"
+    product_errors = data["productErrors"][0]
+    assert product_errors["code"] == ProductErrorCode.GRAPHQL_ERROR.name
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_updated")

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -35,6 +35,7 @@ def resolve_global_ids_to_primary_keys(
 
     for graphql_id in ids:
         if not graphql_id:
+            invalid_ids.append(graphql_id)
             continue
 
         try:


### PR DESCRIPTION
I want to merge this change because it add exception handler in Product Update mutation for collection with empty ID

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
