### PR TITLE
Fix INVOICE_GENERATED event creation for app clients

### DIFF
--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -145,6 +145,8 @@ def invoice_generated_event(
     user: Optional[UserType],
     invoice_number: str,
 ) -> OrderEvent:
+    if not user_is_valid(user):
+        user = None
     return OrderEvent.objects.create(
         order=order,
         type=OrderEvents.INVOICE_GENERATED,


### PR DESCRIPTION
I want to merge this change because I need an app client to be able to create invoice without errors during INVOICE_GENERATED event creation. For the app clients, the user is anonymous and therefore cannot be set as a database relation of invoice event.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
