### PR TITLE
Fix bug with ShipingZones query returns all zones

### DIFF
--- a/saleor/graphql/shipping/resolvers.py
+++ b/saleor/graphql/shipping/resolvers.py
@@ -5,7 +5,10 @@ from ..channel import ChannelQsContext
 
 
 def resolve_shipping_zones(channel_slug):
-    instances = models.ShippingZone.objects.all()
+    if channel_slug:
+        instances = models.ShippingZone.objects.filter(channels__slug=channel_slug)
+    else:
+        instances = models.ShippingZone.objects.all()
     return ChannelQsContext(qs=instances, channel_slug=channel_slug)
 
 

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -310,7 +310,7 @@ def test_query_shipping_zone_search_by_channels(
     assert data[0]["node"]["id"] == shipping_zone_usd_id
 
 
-def test_query_shipping_zones_search_by_channels_no_matter_of_input(
+def test_query_shipping_zone_search_by_channels_no_matter_of_input(
     staff_api_client,
     shipping_zones_with_different_channels,
     permission_manage_shipping,

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -310,15 +310,15 @@ def test_query_shipping_zone_search_by_channels(
     assert data[0]["node"]["id"] == shipping_zone_usd_id
 
 
-def test_query_shipping_zone_search_by_channels_no_matter_of_input(
+def test_query_shipping_zones_search_by_channels_no_matter_of_input(
     staff_api_client,
-    shipping_zone_with_different_channels,
+    shipping_zones_with_different_channels,
     permission_manage_shipping,
     channel_USD,
     channel_PLN,
 ):
     # given
-    shipping_zones = shipping_zone_with_different_channels
+    shipping_zones = shipping_zones_with_different_channels
     channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
     shipping_zone_pln = shipping_zones[0]
     shipping_zone_pln_id = graphene.Node.to_global_id(
@@ -335,5 +335,6 @@ def test_query_shipping_zone_search_by_channels_no_matter_of_input(
     content = get_graphql_content(response)
     data = content["data"]["shippingZones"]["edges"]
 
+    assert len(data) == 1
     assert data[0]["node"]["name"] == shipping_zone_pln.name
     assert data[0]["node"]["id"] == shipping_zone_pln_id

--- a/saleor/graphql/shipping/tests/test_shipping_zones_query.py
+++ b/saleor/graphql/shipping/tests/test_shipping_zones_query.py
@@ -308,3 +308,32 @@ def test_query_shipping_zone_search_by_channels(
 
     assert data[0]["node"]["name"] == shipping_zone_usd.name
     assert data[0]["node"]["id"] == shipping_zone_usd_id
+
+
+def test_query_shipping_zone_search_by_channels_no_matter_of_input(
+    staff_api_client,
+    shipping_zone_with_different_channels,
+    permission_manage_shipping,
+    channel_USD,
+    channel_PLN,
+):
+    # given
+    shipping_zones = shipping_zone_with_different_channels
+    channel_id = graphene.Node.to_global_id("Channel", channel_PLN.id)
+    shipping_zone_pln = shipping_zones[0]
+    shipping_zone_pln_id = graphene.Node.to_global_id(
+        "ShippingZone", shipping_zone_pln.id
+    )
+    variables = {"filter": {"channels": [channel_id]}}
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_SHIPPING_ZONES_WITH_FILTER,
+        variables=variables,
+        permissions=[permission_manage_shipping],
+    )
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["shippingZones"]["edges"]
+
+    assert data[0]["node"]["name"] == shipping_zone_pln.name
+    assert data[0]["node"]["id"] == shipping_zone_pln_id

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -705,7 +705,7 @@ def shipping_zones(db, channel_USD, channel_PLN):
 
 
 @pytest.fixture
-def shipping_zone_with_different_channels(db, channel_USD, channel_PLN):
+def shipping_zones_with_different_channels(db, channel_USD, channel_PLN):
     shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(
         [
             ShippingZone(name="Poland", countries=["PL"]),

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -705,6 +705,61 @@ def shipping_zones(db, channel_USD, channel_PLN):
 
 
 @pytest.fixture
+def shipping_zone_with_different_channels(db, channel_USD, channel_PLN):
+    shipping_zone_poland, shipping_zone_usa = ShippingZone.objects.bulk_create(
+        [
+            ShippingZone(name="Poland", countries=["PL"]),
+            ShippingZone(name="USA", countries=["US"]),
+        ]
+    )
+
+    shipping_zone_poland.channels.add(channel_PLN, channel_USD)
+    shipping_zone_usa.channels.add(channel_USD)
+
+    method = shipping_zone_poland.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    second_method = shipping_zone_usa.shipping_methods.create(
+        name="DHL",
+        type=ShippingMethodType.PRICE_BASED,
+        shipping_zone=shipping_zone,
+    )
+    ShippingMethodChannelListing.objects.bulk_create(
+        [
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=method,
+                minimum_order_price=Money(0, "USD"),
+                price=Money(10, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_USD,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "USD"),
+                currency=channel_USD.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=method,
+                minimum_order_price=Money(0, "PLN"),
+                price=Money(40, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+            ShippingMethodChannelListing(
+                channel=channel_PLN,
+                shipping_method=second_method,
+                minimum_order_price=Money(0, "PLN"),
+                currency=channel_PLN.currency_code,
+            ),
+        ]
+    )
+    return [shipping_zone_poland, shipping_zone_usa]
+
+
+@pytest.fixture
 def shipping_zone_without_countries(db, channel_USD):  # pylint: disable=W0613
     shipping_zone = ShippingZone.objects.create(name="Europe", countries=[])
     method = shipping_zone.shipping_methods.create(


### PR DESCRIPTION
I want to merge this change because...it fix bug with ShippingZones query

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
