### PR TITLE
Adjust amount of spans in resolvers

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -79,12 +79,10 @@ class Address(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_country(root: models.Address, _info):
         return CountryDisplay(code=root.country.code, country=root.country.name)
 
     @staticmethod
-    @traced_resolver
     def resolve_is_default_shipping_address(root: models.Address, _info):
         """Look if the address is the default shipping address of the user.
 
@@ -104,7 +102,6 @@ class Address(CountableDjangoObjectType):
         return False
 
     @staticmethod
-    @traced_resolver
     def resolve_is_default_billing_address(root: models.Address, _info):
         """Look if the address is the default billing address of the user.
 
@@ -151,7 +148,6 @@ class CustomerEvent(CountableDjangoObjectType):
         only_fields = ["id"]
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.CustomerEvent, info):
         user = info.context.user
         if (
@@ -163,7 +159,6 @@ class CustomerEvent(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_app(root: models.CustomerEvent, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
@@ -181,7 +176,6 @@ class CustomerEvent(CountableDjangoObjectType):
         return root.parameters.get("count", None)
 
     @staticmethod
-    @traced_resolver
     def resolve_order_line(root: models.CustomerEvent, info):
         if "order_line_pk" in root.parameters:
             try:
@@ -286,12 +280,10 @@ class User(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_addresses(root: models.User, _info, **_kwargs):
         return root.addresses.annotate_default(root).all()  # type: ignore
 
     @staticmethod
-    @traced_resolver
     def resolve_checkout(root: models.User, _info, **_kwargs):
         return get_user_checkout(root)
 
@@ -319,12 +311,10 @@ class User(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_gift_cards(root: models.User, info, **_kwargs):
         return GiftCardsByUserLoader(info.context).load(root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_user_permissions(root: models.User, _info, **_kwargs):
         from .resolvers import resolve_permissions
 
@@ -336,7 +326,6 @@ class User(CountableDjangoObjectType):
         return root.groups.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_editable_groups(root: models.User, _info, **_kwargs):
         return get_groups_which_user_can_manage(root)
 
@@ -351,12 +340,10 @@ class User(CountableDjangoObjectType):
     @one_of_permissions_required(
         [AccountPermissions.MANAGE_USERS, AccountPermissions.MANAGE_STAFF]
     )
-    @traced_resolver
     def resolve_events(root: models.User, info):
         return CustomerEventsByUserLoader(info.context).load(root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_orders(root: models.User, info, **_kwargs):
         def _resolve_orders(orders):
             requester = get_user_or_app_from_context(info.context)
@@ -367,7 +354,6 @@ class User(CountableDjangoObjectType):
         return OrdersByUserLoader(info.context).load(root.id).then(_resolve_orders)
 
     @staticmethod
-    @traced_resolver
     def resolve_avatar(root: models.User, info, size=None, **_kwargs):
         if root.avatar:
             return Image.get_adjusted(
@@ -379,7 +365,6 @@ class User(CountableDjangoObjectType):
             )
 
     @staticmethod
-    @traced_resolver
     def resolve_stored_payment_sources(root: models.User, info, channel=None):
         from .resolvers import resolve_payment_sources
 
@@ -388,7 +373,6 @@ class User(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_wishlist(root: models.User, info, **_kwargs):
         return resolve_wishlist_items_from_user(root)
 
@@ -399,7 +383,6 @@ class User(CountableDjangoObjectType):
         return get_user_model().objects.get(email=root.email)
 
     @staticmethod
-    @traced_resolver
     def resolve_language_code(root, _info, **_kwargs):
         return LanguageCodeEnum[str_to_enum(root.language_code)]
 
@@ -454,7 +437,6 @@ class StaffNotificationRecipient(CountableDjangoObjectType):
         only_fields = ["user", "active"]
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.StaffNotificationRecipient, info):
         user = info.context.user
         if user == root.user or user.has_perm(AccountPermissions.MANAGE_STAFF):
@@ -462,7 +444,6 @@ class StaffNotificationRecipient(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_email(root: models.StaffNotificationRecipient, _info):
         return root.get_email()
 
@@ -486,12 +467,10 @@ class Group(CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(AccountPermissions.MANAGE_STAFF)
-    @traced_resolver
     def resolve_users(root: auth_models.Group, _info):
         return root.user_set.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_permissions(root: auth_models.Group, _info):
         permissions = root.permissions.prefetch_related("content_type").order_by(
             "codename"
@@ -499,7 +478,6 @@ class Group(CountableDjangoObjectType):
         return format_permissions_for_display(permissions)
 
     @staticmethod
-    @traced_resolver
     def resolve_user_can_manage(root: auth_models.Group, info):
         user = info.context.user
         return can_user_manage_group(user, root)

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -1,23 +1,19 @@
 from ...app import models
 from ...core.jwt import create_access_token_for_app
 from ...core.permissions import AppPermission
-from ...core.tracing import traced_resolver
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .enums import AppTypeEnum
 
 
-@traced_resolver
 def resolve_apps_installations(info, **_kwargs):
     return models.AppInstallation.objects.all()
 
 
-@traced_resolver
 def resolve_apps(info, **_kwargs):
     return models.App.objects.all()
 
 
-@traced_resolver
 def resolve_access_token(info, root, **_kwargs):
     if root.type != AppTypeEnum.THIRDPARTY.value:
         return None
@@ -28,7 +24,6 @@ def resolve_access_token(info, root, **_kwargs):
     return create_access_token_for_app(root, user)
 
 
-@traced_resolver
 @permission_required(AppPermission.MANAGE_APPS)
 def resolve_app(_info, id):
     if not id:

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -108,7 +108,6 @@ class App(CountableDjangoObjectType):
         return format_permissions_for_display(permissions)
 
     @staticmethod
-    @traced_resolver
     def resolve_tokens(root: models.App, _info, **_kwargs):
         return root.tokens.all()  # type: ignore
 
@@ -122,6 +121,7 @@ class App(CountableDjangoObjectType):
         return root.webhooks.all()
 
     @staticmethod
+    @traced_resolver
     def resolve_access_token(root: models.App, info):
         return resolve_access_token(info, root)
 

--- a/saleor/graphql/attribute/resolvers.py
+++ b/saleor/graphql/attribute/resolvers.py
@@ -1,9 +1,7 @@
 from ...attribute import models
-from ...core.tracing import traced_resolver
 from ..utils import get_user_or_app_from_context
 
 
-@traced_resolver
 def resolve_attributes(info, qs=None, **_kwargs):
     requestor = get_user_or_app_from_context(info.context)
     qs = qs or models.Attribute.objects.get_visible_to_user(requestor)

--- a/saleor/graphql/attribute/schema.py
+++ b/saleor/graphql/attribute/schema.py
@@ -1,6 +1,5 @@
 import graphene
 
-from ...core.tracing import traced_resolver
 from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
 from ..translations.mutations import AttributeTranslate, AttributeValueTranslate
@@ -44,7 +43,6 @@ class AttributeQueries(graphene.ObjectType):
     def resolve_attributes(self, info, **kwargs):
         return resolve_attributes(info, **kwargs)
 
-    @traced_resolver
     def resolve_attribute(self, info, id=None, slug=None):
         if id:
             _, id = from_global_id_or_error(id, Attribute)

--- a/saleor/graphql/attribute/types.py
+++ b/saleor/graphql/attribute/types.py
@@ -52,6 +52,7 @@ class AttributeValue(CountableDjangoObjectType):
         model = models.AttributeValue
 
     @staticmethod
+    @traced_resolver
     def resolve_input_type(root: models.AttributeValue, info, *_args):
         def _resolve_input_type(attribute):
             requester = get_user_or_app_from_context(info.context)
@@ -70,14 +71,12 @@ class AttributeValue(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_file(root: models.AttributeValue, *_args):
         if not root.file_url:
             return
         return File(url=root.file_url, content_type=root.content_type)
 
     @staticmethod
-    @traced_resolver
     def resolve_reference(root: models.AttributeValue, info, **_kwargs):
         def prepare_reference(attribute):
             if attribute.input_type != AttributeInputType.REFERENCE:
@@ -146,7 +145,6 @@ class Attribute(CountableDjangoObjectType):
         model = models.Attribute
 
     @staticmethod
-    @traced_resolver
     def resolve_choices(root: models.Attribute, info, **_kwargs):
         if root.input_type in AttributeInputType.TYPES_WITH_CHOICES:
             return root.values.all()

--- a/saleor/graphql/channel/schema.py
+++ b/saleor/graphql/channel/schema.py
@@ -1,6 +1,5 @@
 import graphene
 
-from ...core.tracing import traced_resolver
 from ..core.utils import from_global_id_or_error
 from ..decorators import staff_member_or_app_required
 from .mutations import (
@@ -30,7 +29,6 @@ class ChannelQueries(graphene.ObjectType):
         return resolve_channel(id)
 
     @staff_member_or_app_required
-    @traced_resolver
     def resolve_channels(self, _info, **kwargs):
         return resolve_channels()
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -4,7 +4,6 @@ from graphene_django import DjangoObjectType
 
 from ...channel import models
 from ...core.permissions import ChannelPermissions
-from ...core.tracing import traced_resolver
 from ..core.connection import CountableDjangoObjectType
 from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
@@ -74,7 +73,6 @@ class Channel(CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ChannelPermissions.MANAGE_CHANNELS)
-    @traced_resolver
     def resolve_has_orders(root: models.Channel, info):
         return (
             ChannelWithHasOrdersByIdLoader(info.context)

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import CheckoutPermissions
-from ...core.tracing import traced_resolver
 from ..core.fields import BaseDjangoConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
 from ..decorators import permission_required
@@ -48,12 +47,10 @@ class CheckoutQueries(graphene.ObjectType):
         return resolve_checkout(info, token)
 
     @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
-    @traced_resolver
     def resolve_checkouts(self, *_args, channel=None, **_kwargs):
         return resolve_checkouts(channel)
 
     @permission_required(CheckoutPermissions.MANAGE_CHECKOUTS)
-    @traced_resolver
     def resolve_checkout_lines(self, *_args, **_kwargs):
         return resolve_checkout_lines()
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -84,7 +84,6 @@ class CheckoutLine(CountableDjangoObjectType):
         filter_fields = ["id"]
 
     @staticmethod
-    @traced_resolver
     def resolve_variant(root: models.CheckoutLine, info):
         variant = ProductVariantByIdLoader(info.context).load(root.variant_id)
         channel = ChannelByCheckoutLineIDLoader(info.context).load(root.id)
@@ -144,7 +143,6 @@ class CheckoutLine(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_requires_shipping(root: models.CheckoutLine, info):
         def is_shipping_required(product_type):
             return product_type.is_shipping_required
@@ -228,21 +226,18 @@ class Checkout(CountableDjangoObjectType):
         filter_fields = ["token"]
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_address(root: models.Checkout, info):
         if not root.shipping_address_id:
             return
         return AddressByIdLoader(info.context).load(root.shipping_address_id)
 
     @staticmethod
-    @traced_resolver
     def resolve_billing_address(root: models.Checkout, info):
         if not root.billing_address_id:
             return
         return AddressByIdLoader(info.context).load(root.billing_address_id)
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.Checkout, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_USERS):
@@ -250,12 +245,10 @@ class Checkout(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_email(root: models.Checkout, _info):
         return root.get_customer_email()
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_method(root: models.Checkout, info):
         if not root.shipping_method_id:
             return None
@@ -371,7 +364,6 @@ class Checkout(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_lines(root: models.Checkout, info):
         return CheckoutLinesByCheckoutTokenLoader(info.context).load(root.token)
 
@@ -454,19 +446,16 @@ class Checkout(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_available_payment_gateways(root: models.Checkout, info):
         return info.context.plugins.list_payment_gateways(
             currency=root.currency, checkout=root, channel_slug=root.channel.slug
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_gift_cards(root: models.Checkout, _info):
         return root.gift_cards.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_is_shipping_required(root: models.Checkout, info):
         def is_shipping_required(lines):
             product_ids = [line_info.product.id for line_info in lines]
@@ -487,6 +476,5 @@ class Checkout(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_language_code(root, _info, **_kwargs):
         return LanguageCodeEnum[str_to_enum(root.language_code)]

--- a/saleor/graphql/core/schema.py
+++ b/saleor/graphql/core/schema.py
@@ -1,6 +1,5 @@
 import graphene
 
-from ...core.tracing import traced_resolver
 from .mutations import FileUpload
 from .types.common import TaxType
 
@@ -10,7 +9,6 @@ class CoreQueries(graphene.ObjectType):
         TaxType, description="List of all tax rates available from tax gateway."
     )
 
-    @traced_resolver
     def resolve_tax_types(self, info):
         manager = info.context.plugins
         return [

--- a/saleor/graphql/csv/types.py
+++ b/saleor/graphql/csv/types.py
@@ -2,7 +2,6 @@ import graphene
 
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions, AppPermission
-from ...core.tracing import traced_resolver
 from ...csv import models
 from ..account.types import User
 from ..account.utils import requestor_has_access
@@ -38,7 +37,6 @@ class ExportEvent(CountableDjangoObjectType):
         only_fields = ["id"]
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.ExportEvent, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_STAFF):
@@ -46,7 +44,6 @@ class ExportEvent(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_app(root: models.ExportEvent, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
@@ -72,7 +69,6 @@ class ExportFile(CountableDjangoObjectType):
         only_fields = ["id", "user", "app", "url"]
 
     @staticmethod
-    @traced_resolver
     def resolve_url(root: models.ExportFile, info):
         content_file = root.content_file
         if not content_file:
@@ -80,7 +76,6 @@ class ExportFile(CountableDjangoObjectType):
         return info.context.build_absolute_uri(content_file.url)
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.ExportFile, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_STAFF):
@@ -88,7 +83,6 @@ class ExportFile(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_app(root: models.ExportFile, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_STAFF):
@@ -98,6 +92,5 @@ class ExportFile(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_events(root: models.ExportFile, _info):
         return root.events.all().order_by("pk")

--- a/saleor/graphql/discount/resolvers.py
+++ b/saleor/graphql/discount/resolvers.py
@@ -1,4 +1,3 @@
-from ...core.tracing import traced_resolver
 from ...discount import models
 from ..channel import ChannelContext, ChannelQsContext
 
@@ -11,7 +10,6 @@ def resolve_voucher(id, channel):
     return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
-@traced_resolver
 def resolve_vouchers(info, channel_slug, **_kwargs) -> ChannelQsContext:
     qs = models.Voucher.objects.all()
     if channel_slug:
@@ -24,7 +22,6 @@ def resolve_sale(id, channel):
     return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
-@traced_resolver
 def resolve_sales(info, channel_slug, **_kwargs) -> ChannelQsContext:
     qs = models.Sale.objects.all()
     if channel_slug:

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import DiscountPermissions
-from ...core.tracing import traced_resolver
 from ..core.fields import ChannelContextFilterConnectionField
 from ..core.types import FilterInputObjectType
 from ..core.utils import from_global_id_or_error
@@ -79,7 +78,6 @@ class DiscountQueries(graphene.ObjectType):
     )
 
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_sale(self, info, id, channel=None):
         _, id = from_global_id_or_error(id, Sale)
         return resolve_sale(id, channel)

--- a/saleor/graphql/discount/types.py
+++ b/saleor/graphql/discount/types.py
@@ -2,7 +2,6 @@ import graphene
 from graphene import relay
 
 from ...core.permissions import DiscountPermissions, OrderPermissions
-from ...core.tracing import traced_resolver
 from ...discount import models
 from ..channel.dataloaders import ChannelByIdLoader
 from ..channel.types import ChannelContext, ChannelContextType
@@ -36,7 +35,6 @@ class SaleChannelListing(CountableDjangoObjectType):
         only_fields = ["id", "channel", "discount_value", "currency"]
 
     @staticmethod
-    @traced_resolver
     def resolve_channel(root: models.SaleChannelListing, info, **_kwargs):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
@@ -74,32 +72,27 @@ class Sale(ChannelContextType, CountableDjangoObjectType):
         only_fields = ["end_date", "id", "name", "start_date", "type"]
 
     @staticmethod
-    @traced_resolver
     def resolve_categories(root: ChannelContext[models.Sale], *_args, **_kwargs):
         return root.node.categories.all()
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_channel_listings(root: ChannelContext[models.Sale], info, **_kwargs):
         return SaleChannelListingBySaleIdLoader(info.context).load(root.node.id)
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_collections(root: ChannelContext[models.Sale], info, *_args, **_kwargs):
         qs = root.node.collections.all()
         return ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_products(root: ChannelContext[models.Sale], info, **_kwargs):
         qs = root.node.products.all()
         return ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
 
     @staticmethod
-    @traced_resolver
     def resolve_discount_value(root: ChannelContext[models.Sale], info, **_kwargs):
         if not root.channel_slug:
             return None
@@ -115,7 +108,6 @@ class Sale(ChannelContextType, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_currency(root: ChannelContext[models.Sale], info, **_kwargs):
         if not root.channel_slug:
             return None
@@ -139,7 +131,6 @@ class VoucherChannelListing(CountableDjangoObjectType):
         only_fields = ["id", "channel", "discount_value", "currency", "min_spent"]
 
     @staticmethod
-    @traced_resolver
     def resolve_channel(root: models.VoucherChannelListing, info, **_kwargs):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
@@ -204,13 +195,11 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
         model = models.Voucher
 
     @staticmethod
-    @traced_resolver
     def resolve_categories(root: ChannelContext[models.Voucher], *_args, **_kwargs):
         return root.node.categories.all()
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_collections(
         root: ChannelContext[models.Voucher], _info, *_args, **_kwargs
     ):
@@ -219,13 +208,11 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_products(root: ChannelContext[models.Voucher], info, **_kwargs):
         qs = root.node.products.all()
         return ChannelQsContext(qs=qs, channel_slug=root.channel_slug)
 
     @staticmethod
-    @traced_resolver
     def resolve_countries(root: ChannelContext[models.Voucher], *_args, **_kwargs):
         return [
             types.CountryDisplay(code=country.code, country=country.name)
@@ -233,7 +220,6 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_discount_value(root: ChannelContext[models.Voucher], info, **_kwargs):
         if not root.channel_slug:
             return None
@@ -249,7 +235,6 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_currency(root: ChannelContext[models.Voucher], info, **_kwargs):
         if not root.channel_slug:
             return None
@@ -265,7 +250,6 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_min_spent(root: ChannelContext[models.Voucher], info, **_kwargs):
         if not root.channel_slug:
             return None
@@ -282,7 +266,6 @@ class Voucher(ChannelContextType, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(DiscountPermissions.MANAGE_DISCOUNTS)
-    @traced_resolver
     def resolve_channel_listings(root: ChannelContext[models.Voucher], info, **_kwargs):
         return VoucherChannelListingByVoucherIdLoader(info.context).load(root.node.id)
 

--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import GiftcardPermissions
-from ...core.tracing import traced_resolver
 from ..core.fields import PrefetchingConnectionField
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
@@ -31,7 +30,6 @@ class GiftCardQueries(graphene.ObjectType):
         return resolve_gift_card(id)
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
-    @traced_resolver
     def resolve_gift_cards(self, info, **_kwargs):
         return resolve_gift_cards()
 

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -39,12 +39,10 @@ class GiftCard(CountableDjangoObjectType):
         model = models.GiftCard
 
     @staticmethod
-    @traced_resolver
     def resolve_display_code(root: models.GiftCard, *_args, **_kwargs):
         return root.display_code
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.GiftCard, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AccountPermissions.MANAGE_USERS):

--- a/saleor/graphql/menu/resolvers.py
+++ b/saleor/graphql/menu/resolvers.py
@@ -1,4 +1,3 @@
-from ...core.tracing import traced_resolver
 from ...menu import models
 from ..channel import ChannelContext, ChannelQsContext
 from ..core.utils import from_global_id_or_error
@@ -6,7 +5,6 @@ from ..core.validators import validate_one_of_args_is_in_query
 from .types import Menu
 
 
-@traced_resolver
 def resolve_menu(info, channel, menu_id=None, name=None, slug=None):
     validate_one_of_args_is_in_query("id", menu_id, "name", name, "slug", slug)
     menu = None
@@ -20,7 +18,6 @@ def resolve_menu(info, channel, menu_id=None, name=None, slug=None):
     return ChannelContext(node=menu, channel_slug=channel) if menu else None
 
 
-@traced_resolver
 def resolve_menus(info, channel, **_kwargs):
     return ChannelQsContext(qs=models.Menu.objects.all(), channel_slug=channel)
 
@@ -30,6 +27,5 @@ def resolve_menu_item(id, channel):
     return ChannelContext(node=menu_item, channel_slug=channel) if menu_item else None
 
 
-@traced_resolver
 def resolve_menu_items(info, **_kwargs):
     return models.MenuItem.objects.all()

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -3,7 +3,6 @@ from graphene import relay
 
 from ...account.utils import requestor_is_staff_member_or_app
 from ...core.permissions import PagePermissions
-from ...core.tracing import traced_resolver
 from ...menu import models
 from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.types import (
@@ -44,7 +43,6 @@ class Menu(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         model = models.Menu
 
     @staticmethod
-    @traced_resolver
     def resolve_items(root: ChannelContext[models.Menu], info, **_kwargs):
         menu_items = MenuItemsByParentMenuLoader(info.context).load(root.node.id)
         return menu_items.then(
@@ -85,14 +83,12 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         model = models.MenuItem
 
     @staticmethod
-    @traced_resolver
     def resolve_category(root: ChannelContext[models.MenuItem], info, **_kwargs):
         if root.node.category_id:
             return CategoryByIdLoader(info.context).load(root.node.category_id)
         return None
 
     @staticmethod
-    @traced_resolver
     def resolve_children(root: ChannelContext[models.MenuItem], info, **_kwargs):
         menus = MenuItemChildrenLoader(info.context).load(root.node.id)
         return menus.then(
@@ -103,7 +99,6 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_collection(root: ChannelContext[models.MenuItem], info, **_kwargs):
         if not root.node.collection_id:
             return None
@@ -160,7 +155,6 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_menu(root: ChannelContext[models.MenuItem], info, **_kwargs):
         if root.node.menu_id:
             menu = MenuByIdLoader(info.context).load(root.node.menu_id)
@@ -170,7 +164,6 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return None
 
     @staticmethod
-    @traced_resolver
     def resolve_parent(root: ChannelContext[models.MenuItem], info, **_kwargs):
         if root.node.parent_id:
             menu = MenuItemByIdLoader(info.context).load(root.node.parent_id)
@@ -180,7 +173,6 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return None
 
     @staticmethod
-    @traced_resolver
     def resolve_page(root: ChannelContext[models.MenuItem], info, **kwargs):
         if root.node.page_id:
             requestor = get_user_or_app_from_context(info.context)

--- a/saleor/graphql/order/resolvers.py
+++ b/saleor/graphql/order/resolvers.py
@@ -10,7 +10,6 @@ from ..utils.filters import filter_by_period
 ORDER_SEARCH_FIELDS = ("id", "discount_name", "token", "user_email", "user__email")
 
 
-@traced_resolver
 def resolve_orders(_info, channel_slug, **_kwargs):
     qs = models.Order.objects.non_draft()
     if channel_slug:
@@ -18,7 +17,6 @@ def resolve_orders(_info, channel_slug, **_kwargs):
     return qs
 
 
-@traced_resolver
 def resolve_draft_orders(_info, **_kwargs):
     qs = models.Order.objects.drafts()
     return qs

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import OrderPermissions
-from ...core.tracing import traced_resolver
 from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
@@ -111,7 +110,6 @@ class OrderQueries(graphene.ObjectType):
     )
 
     @permission_required(OrderPermissions.MANAGE_ORDERS)
-    @traced_resolver
     def resolve_homepage_events(self, *_args, **_kwargs):
         return resolve_homepage_events()
 
@@ -132,7 +130,6 @@ class OrderQueries(graphene.ObjectType):
     def resolve_orders_total(self, info, period, channel=None, **_kwargs):
         return resolve_orders_total(info, period, channel)
 
-    @traced_resolver
     def resolve_order_by_token(self, _info, token):
         return resolve_order_by_token(token)
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -192,7 +192,6 @@ class OrderEvent(CountableDjangoObjectType):
         only_fields = ["id"]
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.OrderEvent, info):
         def _resolve_user(event_user):
             requester = get_user_or_app_from_context(info.context)
@@ -210,7 +209,6 @@ class OrderEvent(CountableDjangoObjectType):
         return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
 
     @staticmethod
-    @traced_resolver
     def resolve_app(root: models.OrderEvent, info):
         requestor = get_user_or_app_from_context(info.context)
         if requestor_has_access(requestor, root.user, AppPermission.MANAGE_APPS):
@@ -304,7 +302,6 @@ class OrderEvent(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_fulfilled_items(root: models.OrderEvent, info):
         fulfillment_lines_ids = root.parameters.get("fulfilled_items", [])
 
@@ -314,7 +311,6 @@ class OrderEvent(CountableDjangoObjectType):
         return FulfillmentLinesByIdLoader(info.context).load_many(fulfillment_lines_ids)
 
     @staticmethod
-    @traced_resolver
     def resolve_warehouse(root: models.OrderEvent, info):
         if warehouse_pk := root.parameters.get("warehouse"):
             return WarehouseByIdLoader(info.context).load(warehouse_pk)
@@ -336,7 +332,6 @@ class OrderEvent(CountableDjangoObjectType):
         return OrderByIdLoader(info.context).load(order_pk)
 
     @staticmethod
-    @traced_resolver
     def resolve_discount(root: models.OrderEvent, info):
         discount_obj = root.parameters.get("discount")
         if not discount_obj:
@@ -354,7 +349,6 @@ class FulfillmentLine(CountableDjangoObjectType):
         only_fields = ["id", "quantity"]
 
     @staticmethod
-    @traced_resolver
     def resolve_order_line(root: models.FulfillmentLine, info):
         return OrderLineByIdLoader(info.context).load(root.order_line_id)
 
@@ -383,17 +377,14 @@ class Fulfillment(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_lines(root: models.Fulfillment, _info):
         return root.lines.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_status_display(root: models.Fulfillment, _info):
         return root.get_status_display()
 
     @staticmethod
-    @traced_resolver
     def resolve_warehouse(root: models.Fulfillment, _info):
         line = root.lines.first()
         return line.stock.warehouse if line and line.stock else None
@@ -739,7 +730,6 @@ class Order(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_discounts(root: models.Order, info):
         return OrderDiscountsByOrderIDLoader(info.context).load(root.id)
 
@@ -854,7 +844,6 @@ class Order(CountableDjangoObjectType):
         return root.shipping_price
 
     @staticmethod
-    @traced_resolver
     def resolve_actions(root: models.Order, info):
         def _resolve_actions(payments):
             actions = []
@@ -913,7 +902,6 @@ class Order(CountableDjangoObjectType):
         return root.total_balance
 
     @staticmethod
-    @traced_resolver
     def resolve_fulfillments(root: models.Order, info):
         def _resolve_fulfillments(fulfillments):
             user = info.context.user
@@ -931,18 +919,15 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_lines(root: models.Order, info):
         return OrderLinesByOrderIdLoader(info.context).load(root.id)
 
     @staticmethod
     @permission_required(OrderPermissions.MANAGE_ORDERS)
-    @traced_resolver
     def resolve_events(root: models.Order, _info):
         return OrderEventsByOrderIdLoader(_info.context).load(root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_is_paid(root: models.Order, _info):
         return root.is_fully_paid()
 
@@ -965,7 +950,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_payment_status_display(root: models.Order, info):
         def _resolve_payment_status(payments):
             if last_payment := max(payments, default=None, key=attrgetter("pk")):
@@ -979,12 +963,10 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_payments(root: models.Order, _info):
         return root.payments.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_status_display(root: models.Order, _info):
         return root.get_status_display()
 
@@ -1000,7 +982,6 @@ class Order(CountableDjangoObjectType):
         return True
 
     @staticmethod
-    @traced_resolver
     def resolve_user_email(root: models.Order, info):
         def _resolve_user_email(user):
             requester = get_user_or_app_from_context(info.context)
@@ -1018,7 +999,6 @@ class Order(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_user(root: models.Order, info):
         def _resolve_user(user):
             requester = get_user_or_app_from_context(info.context)
@@ -1032,7 +1012,6 @@ class Order(CountableDjangoObjectType):
         return UserByUserIdLoader(info.context).load(root.user_id).then(_resolve_user)
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_method(root: models.Order, info):
         if not root.shipping_method_id:
             return None
@@ -1086,7 +1065,6 @@ class Order(CountableDjangoObjectType):
         return instances
 
     @staticmethod
-    @traced_resolver
     def resolve_invoices(root: models.Order, info):
         requester = get_user_or_app_from_context(info.context)
         if requestor_has_access(requester, root.user, OrderPermissions.MANAGE_ORDERS):
@@ -1094,17 +1072,14 @@ class Order(CountableDjangoObjectType):
         raise PermissionDenied()
 
     @staticmethod
-    @traced_resolver
     def resolve_is_shipping_required(root: models.Order, _info):
         return root.is_shipping_required()
 
     @staticmethod
-    @traced_resolver
     def resolve_gift_cards(root: models.Order, _info):
         return root.gift_cards.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_voucher(root: models.Order, info):
         if not root.voucher_id:
             return None
@@ -1119,12 +1094,10 @@ class Order(CountableDjangoObjectType):
         return Promise.all([voucher, channel]).then(wrap_voucher_with_channel_context)
 
     @staticmethod
-    @traced_resolver
     def resolve_language_code_enum(root, _info, **_kwargs):
         return LanguageCodeEnum[str_to_enum(root.language_code)]
 
     @staticmethod
-    @traced_resolver
     def resolve_original(root, info, **_kwargs):
         if not root.original_id:
             return None

--- a/saleor/graphql/page/resolvers.py
+++ b/saleor/graphql/page/resolvers.py
@@ -1,11 +1,9 @@
-from ...core.tracing import traced_resolver
 from ...page import models
 from ..core.utils import from_global_id_or_error
 from ..core.validators import validate_one_of_args_is_in_query
 from .types import Page
 
 
-@traced_resolver
 def resolve_page(info, global_page_id=None, slug=None):
     validate_one_of_args_is_in_query("id", global_page_id, "slug", slug)
     user = info.context.user
@@ -18,7 +16,6 @@ def resolve_page(info, global_page_id=None, slug=None):
     return page
 
 
-@traced_resolver
 def resolve_pages(info, **_kwargs):
     user = info.context.user
     return models.Page.objects.visible_to_user(user)
@@ -28,6 +25,5 @@ def resolve_page_type(id):
     return models.PageType.objects.filter(id=id).first()
 
 
-@traced_resolver
 def resolve_page_types(info, **_kwargs):
     return models.PageType.objects.all()

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -3,7 +3,6 @@ from graphene_federation import key
 
 from ...attribute import models as attribute_models
 from ...core.permissions import PagePermissions
-from ...core.tracing import traced_resolver
 from ...page import models
 from ..attribute.filters import AttributeFilterInput
 from ..attribute.types import Attribute, SelectedAttribute
@@ -57,18 +56,15 @@ class Page(CountableDjangoObjectType):
         model = models.Page
 
     @staticmethod
-    @traced_resolver
     def resolve_page_type(root: models.Page, info):
         return PageTypeByIdLoader(info.context).load(root.page_type_id)
 
     @staticmethod
-    @traced_resolver
     def resolve_content_json(root: models.Page, info):
         content = root.content
         return content if content is not None else {}
 
     @staticmethod
-    @traced_resolver
     def resolve_attributes(root: models.Page, info):
         return SelectedAttributesByPageIdLoader(info.context).load(root.id)
 
@@ -95,13 +91,11 @@ class PageType(CountableDjangoObjectType):
         only_fields = ["id", "name", "slug"]
 
     @staticmethod
-    @traced_resolver
     def resolve_attributes(root: models.PageType, info):
         return PageAttributesByPageTypeIdLoader(info.context).load(root.pk)
 
     @staticmethod
     @permission_required(PagePermissions.MANAGE_PAGES)
-    @traced_resolver
     def resolve_available_attributes(root: models.PageType, info, **kwargs):
         return attribute_models.Attribute.objects.get_unassigned_page_type_attributes(
             root.pk
@@ -109,7 +103,6 @@ class PageType(CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(PagePermissions.MANAGE_PAGES)
-    @traced_resolver
     def resolve_has_pages(root: models.PageType, info, **kwargs):
         return (
             PagesByPageTypeIdLoader(info.context)

--- a/saleor/graphql/payment/resolvers.py
+++ b/saleor/graphql/payment/resolvers.py
@@ -1,4 +1,3 @@
-from ...core.tracing import traced_resolver
 from ...payment import models
 
 
@@ -6,6 +5,5 @@ def resolve_payment_by_id(id):
     return models.Payment.objects.filter(id=id).first()
 
 
-@traced_resolver
 def resolve_payments(info):
     return models.Payment.objects.all()

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -28,7 +28,6 @@ class Transaction(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_amount(root: models.Transaction, _info):
         return root.get_amount()
 
@@ -112,7 +111,6 @@ class Payment(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_actions(root: models.Payment, _info):
         actions = []
         if root.can_capture():
@@ -129,17 +127,14 @@ class Payment(CountableDjangoObjectType):
         return root.get_total()
 
     @staticmethod
-    @traced_resolver
     def resolve_captured_amount(root: models.Payment, _info):
         return root.get_captured_amount()
 
     @staticmethod
-    @traced_resolver
     def resolve_transactions(root: models.Payment, _info):
         return root.transactions.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_available_refund_amount(root: models.Payment, _info):
         # FIXME TESTME
         if not root.can_refund():
@@ -147,7 +142,6 @@ class Payment(CountableDjangoObjectType):
         return root.get_captured_amount()
 
     @staticmethod
-    @traced_resolver
     def resolve_available_capture_amount(root: models.Payment, _info):
         # FIXME TESTME
         if not root.can_capture():
@@ -155,7 +149,6 @@ class Payment(CountableDjangoObjectType):
         return root.get_charge_amount()
 
     @staticmethod
-    @traced_resolver
     def resolve_credit_card(root: models.Payment, _info):
         data = {
             "brand": root.cc_brand,

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -73,11 +73,11 @@ class ProductChannelListing(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_channel(root: models.ProductChannelListing, info, **_kwargs):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
     @staticmethod
+    @traced_resolver
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_purchase_cost(root: models.ProductChannelListing, info, *_kwargs):
         channel = ChannelByIdLoader(info.context).load(root.channel_id)
@@ -115,6 +115,7 @@ class ProductChannelListing(CountableDjangoObjectType):
         )
 
     @staticmethod
+    @traced_resolver
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_margin(root: models.ProductChannelListing, info, *_kwargs):
         channel = ChannelByIdLoader(info.context).load(root.channel_id)
@@ -156,6 +157,7 @@ class ProductChannelListing(CountableDjangoObjectType):
         return root.is_available_for_purchase()
 
     @staticmethod
+    @traced_resolver
     def resolve_pricing(root: models.ProductChannelListing, info, address=None):
         context = info.context
         country_code = get_user_country_context(

--- a/saleor/graphql/product/types/digital_contents.py
+++ b/saleor/graphql/product/types/digital_contents.py
@@ -51,12 +51,10 @@ class DigitalContent(CountableDjangoObjectType):
         interfaces = (relay.Node, ObjectWithMetadata)
 
     @staticmethod
-    @traced_resolver
     def resolve_urls(root: models.DigitalContent, **_kwargs):
         return root.urls.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_product_variant(root: models.DigitalContent, info):
         return (
             ProductVariantByIdLoader(info.context)

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -261,7 +261,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @one_of_permissions_required(
         [ProductPermissions.MANAGE_PRODUCTS, OrderPermissions.MANAGE_ORDERS]
     )
-    @traced_resolver
     def resolve_stocks(
         root: ChannelContext[models.ProductVariant],
         info,
@@ -278,7 +277,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         ).load((root.node.id, country_code, root.channel_slug))
 
     @staticmethod
-    @traced_resolver
     def resolve_quantity_available(
         root: ChannelContext[models.ProductVariant],
         info,
@@ -299,7 +297,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_digital_content(root: ChannelContext[models.ProductVariant], *_args):
         return getattr(root.node, "digital_content", None)
 
@@ -338,7 +335,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @staff_member_or_app_required
-    @traced_resolver
     def resolve_channel_listings(
         root: ChannelContext[models.ProductVariant], info, **_kwargs
     ):
@@ -421,7 +417,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_product(root: ChannelContext[models.ProductVariant], info):
         product = ProductByIdLoader(info.context).load(root.node.product_id)
         return product.then(
@@ -430,7 +425,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_quantity_ordered(root: ChannelContext[models.ProductVariant], *_args):
         # This field is added through annotation when using the
         # `resolve_report_product_sales` resolver.
@@ -479,12 +473,10 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_media(root: ChannelContext[models.ProductVariant], info, *_args):
         return MediaByProductVariantIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_images(root: ChannelContext[models.ProductVariant], info, *_args):
         return ImagesByProductVariantIdLoader(info.context).load(root.node.id)
 
@@ -495,7 +487,6 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_weight(root: ChannelContext[models.ProductVariant], _info, **_kwargs):
         return convert_weight_to_default_weight_unit(root.node.weight)
 
@@ -601,7 +592,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_default_variant(root: ChannelContext[models.Product], info):
         default_variant_id = root.node.default_variant_id
         if default_variant_id is None:
@@ -617,7 +607,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_category(root: ChannelContext[models.Product], info):
         category_id = root.node.category_id
         if category_id is None:
@@ -625,13 +614,11 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return CategoryByIdLoader(info.context).load(category_id)
 
     @staticmethod
-    @traced_resolver
     def resolve_description_json(root: ChannelContext[models.Product], info):
         description = root.node.description
         return description if description is not None else {}
 
     @staticmethod
-    @traced_resolver
     def resolve_tax_type(root: ChannelContext[models.Product], info):
         tax_data = info.context.plugins.get_tax_code_from_object_meta(root.node)
         return TaxType(tax_code=tax_data.code, description=tax_data.description)
@@ -760,29 +747,24 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_attributes(root: ChannelContext[models.Product], info):
         return SelectedAttributesByProductIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_media_by_id(root: ChannelContext[models.Product], info, id):
         _type, pk = from_global_id_or_error(id, ProductMedia)
         return root.node.media.filter(pk=pk).first()
 
     @staticmethod
-    @traced_resolver
     def resolve_image_by_id(root: ChannelContext[models.Product], info, id):
         _type, pk = from_global_id_or_error(id, ProductImage)
         return root.node.media.filter(pk=pk).first()
 
     @staticmethod
-    @traced_resolver
     def resolve_media(root: ChannelContext[models.Product], info, **_kwargs):
         return MediaByProductIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_images(root: ChannelContext[models.Product], info, **_kwargs):
         return ImagesByProductIdLoader(info.context).load(root.node.id)
 
@@ -812,7 +794,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_channel_listings(root: ChannelContext[models.Product], info, **_kwargs):
         return ProductChannelListingByProductIdLoader(info.context).load(root.node.id)
 
@@ -870,7 +851,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_weight(root: ChannelContext[models.Product], _info, **_kwargs):
         return convert_weight_to_default_weight_unit(root.node.weight)
 
@@ -911,7 +891,6 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_product_type(root: ChannelContext[models.Product], info):
         return ProductTypeByIdLoader(info.context).load(root.node.product_type_id)
 
@@ -966,13 +945,11 @@ class ProductType(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_tax_type(root: models.ProductType, info):
         tax_data = info.context.plugins.get_tax_code_from_object_meta(root)
         return TaxType(tax_code=tax_data.code, description=tax_data.description)
 
     @staticmethod
-    @traced_resolver
     def resolve_product_attributes(root: models.ProductType, info):
         return ProductAttributesByProductTypeIdLoader(info.context).load(root.pk)
 
@@ -998,7 +975,6 @@ class ProductType(CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_products(root: models.ProductType, info, channel=None, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
         if channel is None:
@@ -1008,7 +984,6 @@ class ProductType(CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_available_attributes(root: models.ProductType, info, **kwargs):
         qs = attribute_models.Attribute.objects.get_unassigned_product_type_attributes(
             root.pk
@@ -1067,7 +1042,6 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         model = models.Collection
 
     @staticmethod
-    @traced_resolver
     def resolve_background_image(
         root: ChannelContext[models.Collection], info, size=None, **_kwargs
     ):
@@ -1082,7 +1056,6 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             )
 
     @staticmethod
-    @traced_resolver
     def resolve_products(root: ChannelContext[models.Collection], info, **kwargs):
         requestor = get_user_or_app_from_context(info.context)
         qs = root.node.products.visible_to_user(  # type: ignore
@@ -1092,7 +1065,6 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_channel_listings(root: ChannelContext[models.Collection], info):
         return CollectionChannelListingByCollectionIdLoader(info.context).load(
             root.node.id
@@ -1154,7 +1126,6 @@ class Category(CountableDjangoObjectType):
         model = models.Category
 
     @staticmethod
-    @traced_resolver
     def resolve_ancestors(root: models.Category, info, **_kwargs):
         return root.get_ancestors()
 
@@ -1164,7 +1135,6 @@ class Category(CountableDjangoObjectType):
         return description if description is not None else {}
 
     @staticmethod
-    @traced_resolver
     def resolve_background_image(root: models.Category, info, size=None, **_kwargs):
         if root.background_image:
             return Image.get_adjusted(
@@ -1176,7 +1146,6 @@ class Category(CountableDjangoObjectType):
             )
 
     @staticmethod
-    @traced_resolver
     def resolve_children(root: models.Category, info, **_kwargs):
         return CategoryChildrenByCategoryIdLoader(info.context).load(root.pk)
 
@@ -1226,7 +1195,6 @@ class ProductMedia(CountableDjangoObjectType):
         model = models.ProductMedia
 
     @staticmethod
-    @traced_resolver
     def resolve_url(root: models.ProductMedia, info, *, size=None):
         if root.external_url:
             return root.external_url
@@ -1268,7 +1236,6 @@ class ProductImage(graphene.ObjectType):
         return graphene.Node.to_global_id("ProductMedia", root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_url(root: models.ProductMedia, info, *, size=None):
         if size:
             url = get_thumbnail(root.image, size, method="thumbnail")

--- a/saleor/graphql/shipping/schema.py
+++ b/saleor/graphql/shipping/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import ShippingPermissions
-from ...core.tracing import traced_resolver
 from ...shipping import models
 from ..channel.types import ChannelContext
 from ..core.fields import ChannelContextFilterConnectionField
@@ -48,14 +47,12 @@ class ShippingQueries(graphene.ObjectType):
     )
 
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
-    @traced_resolver
     def resolve_shipping_zone(self, info, id, channel=None):
         _, id = from_global_id_or_error(id, ShippingZone)
         instance = models.ShippingZone.objects.filter(id=id).first()
         return ChannelContext(node=instance, channel_slug=channel) if instance else None
 
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
-    @traced_resolver
     def resolve_shipping_zones(self, info, channel=None, **_kwargs):
         return resolve_shipping_zones(channel)
 

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -47,7 +47,6 @@ class ShippingMethodChannelListing(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_channel(root: models.ShippingMethodChannelListing, info, **_kwargs):
         return ChannelByIdLoader(info.context).load(root.channel_id)
 
@@ -120,7 +119,6 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_price(root: ChannelContext[models.ShippingMethod], info, **_kwargs):
         # Price field are dynamically generated in available_shipping_methods resolver
         price = getattr(root.node, "price", None)
@@ -139,7 +137,6 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_maximum_order_price(
         root: ChannelContext[models.ShippingMethod], info, **_kwargs
     ):
@@ -155,7 +152,6 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_minimum_order_price(
         root: ChannelContext[models.ShippingMethod], info, **_kwargs
     ):
@@ -171,21 +167,18 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_maximum_order_weight(
         root: ChannelContext[models.ShippingMethod], *_args
     ):
         return convert_weight_to_default_weight_unit(root.node.maximum_order_weight)
 
     @staticmethod
-    @traced_resolver
     def resolve_postal_code_rules(
         root: ChannelContext[models.ShippingMethod], info, **_kwargs
     ):
         return PostalCodeRulesByShippingMethodIdLoader(info.context).load(root.node.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_minimum_order_weight(
         root: ChannelContext[models.ShippingMethod], *_args
     ):
@@ -193,7 +186,6 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
-    @traced_resolver
     def resolve_channel_listings(
         root: ChannelContext[models.ShippingMethod], info, **_kwargs
     ):
@@ -203,7 +195,6 @@ class ShippingMethod(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 
     @staticmethod
     @permission_required(ShippingPermissions.MANAGE_SHIPPING)
-    @traced_resolver
     def resolve_excluded_products(
         root: ChannelContext[models.ShippingMethod], _info, **_kwargs
     ):
@@ -253,7 +244,6 @@ class ShippingZone(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         return resolve_price_range(root.channel_slug)
 
     @staticmethod
-    @traced_resolver
     def resolve_countries(root: ChannelContext[models.ShippingZone], *_args):
         return [
             CountryDisplay(code=country.code, country=country.name)
@@ -261,7 +251,6 @@ class ShippingZone(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_methods(
         root: ChannelContext[models.ShippingZone], info, **_kwargs
     ):
@@ -287,7 +276,6 @@ class ShippingZone(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         )
 
     @staticmethod
-    @traced_resolver
     def resolve_warehouses(root: ChannelContext[models.ShippingZone], *_args):
         return root.node.warehouses.all()
 

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -215,12 +215,10 @@ class Shop(graphene.ObjectType):
         return info.context.plugins.list_external_authentications(active_only=True)
 
     @staticmethod
-    @traced_resolver
     def resolve_available_shipping_methods(_, info, channel, address=None):
         return resolve_available_shipping_methods(info, channel, address)
 
     @staticmethod
-    @traced_resolver
     def resolve_countries(_, _info, language_code=None):
         taxes = {vat.country_code: vat for vat in VAT.objects.all()}
         with translation.override(language_code):
@@ -232,7 +230,6 @@ class Shop(graphene.ObjectType):
             ]
 
     @staticmethod
-    @traced_resolver
     def resolve_domain(_, info):
         site = info.context.site
         return Domain(
@@ -246,7 +243,6 @@ class Shop(graphene.ObjectType):
         return info.context.site.settings.description
 
     @staticmethod
-    @traced_resolver
     def resolve_languages(_, _info):
         return [
             LanguageDisplay(
@@ -347,7 +343,6 @@ class Shop(graphene.ObjectType):
 
     @staticmethod
     @permission_required(SitePermissions.MANAGE_SETTINGS)
-    @traced_resolver
     def resolve_staff_notification_recipients(_, info):
         return account_models.StaffNotificationRecipient.objects.all()
 

--- a/saleor/graphql/translations/resolvers.py
+++ b/saleor/graphql/translations/resolvers.py
@@ -1,5 +1,4 @@
 from ...attribute import models as attribute_models
-from ...core.tracing import traced_resolver
 from ...discount import models as discount_models
 from ...menu import models as menu_models
 from ...page import models as page_models
@@ -45,36 +44,29 @@ def resolve_translation(instance, info, language_code):
     raise TypeError(f"No dataloader found to {type(instance)}")
 
 
-@traced_resolver
 def resolve_shipping_methods(info):
     return shipping_models.ShippingMethod.objects.all()
 
 
-@traced_resolver
 def resolve_attribute_values(info):
     return attribute_models.AttributeValue.objects.all()
 
 
-@traced_resolver
 def resolve_products(_info):
     return product_models.Product.objects.all()
 
 
-@traced_resolver
 def resolve_product_variants(_info):
     return product_models.ProductVariant.objects.all()
 
 
-@traced_resolver
 def resolve_sales(_info):
     return discount_models.Sale.objects.all()
 
 
-@traced_resolver
 def resolve_vouchers(_info):
     return discount_models.Voucher.objects.all()
 
 
-@traced_resolver
 def resolve_collections(_info):
     return product_models.Collection.objects.all()

--- a/saleor/graphql/translations/schema.py
+++ b/saleor/graphql/translations/schema.py
@@ -2,7 +2,6 @@ import graphene
 
 from ...attribute.models import Attribute, AttributeValue
 from ...core.permissions import SitePermissions
-from ...core.tracing import traced_resolver
 from ...discount.models import Sale, Voucher
 from ...menu.models import MenuItem
 from ...page.models import Page
@@ -85,7 +84,6 @@ class TranslationQueries(graphene.ObjectType):
     )
 
     @permission_required(SitePermissions.MANAGE_TRANSLATIONS)
-    @traced_resolver
     def resolve_translations(self, info, kind, **_kwargs):
         if kind == TranslatableKinds.PRODUCT:
             return resolve_products(info)
@@ -111,7 +109,6 @@ class TranslationQueries(graphene.ObjectType):
             return resolve_sales(info)
 
     @permission_required(SitePermissions.MANAGE_TRANSLATIONS)
-    @traced_resolver
     def resolve_translation(self, info, id, kind, **_kwargs):
         _type, kind_id = from_global_id_or_error(id)
         if not _type == kind:

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -230,7 +230,6 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
         only_fields = EXTENDED_TRANSLATABLE_FIELDS
 
     @staticmethod
-    @traced_resolver
     def resolve_collection(root: product_models.Collection, info):
         collection = product_models.Collection.objects.all().filter(pk=root.id).first()
         return (
@@ -349,7 +348,6 @@ class PageTranslatableContent(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_page(root: page_models.Page, info):
         return (
             page_models.Page.objects.visible_to_user(info.context.user)

--- a/saleor/graphql/warehouse/schema.py
+++ b/saleor/graphql/warehouse/schema.py
@@ -5,7 +5,6 @@ from ...core.permissions import (
     ProductPermissions,
     ShippingPermissions,
 )
-from ...core.tracing import traced_resolver
 from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
 from ..decorators import one_of_permissions_required, permission_required
@@ -49,7 +48,6 @@ class WarehouseQueries(graphene.ObjectType):
             ShippingPermissions.MANAGE_SHIPPING,
         ]
     )
-    @traced_resolver
     def resolve_warehouse(self, info, **data):
         warehouse_pk = data.get("id")
         _, id = from_global_id_or_error(warehouse_pk, Warehouse)
@@ -62,7 +60,6 @@ class WarehouseQueries(graphene.ObjectType):
             ShippingPermissions.MANAGE_SHIPPING,
         ]
     )
-    @traced_resolver
     def resolve_warehouses(self, info, **_kwargs):
         return resolve_warehouses()
 
@@ -86,13 +83,11 @@ class StockQueries(graphene.ObjectType):
     )
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_stock(self, info, **kwargs):
         stock_id = kwargs.get("id")
         _, id = from_global_id_or_error(stock_id, Stock)
         return resolve_stock(id)
 
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
-    @traced_resolver
     def resolve_stocks(self, info, **_kwargs):
         return resolve_stocks()

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -3,7 +3,6 @@ from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from ...core.permissions import OrderPermissions, ProductPermissions
-from ...core.tracing import traced_resolver
 from ...warehouse import models
 from ..account.dataloaders import AddressByIdLoader
 from ..channel import ChannelContext
@@ -61,7 +60,6 @@ class Warehouse(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_shipping_zones(root, *_args, **_kwargs):
         instances = root.shipping_zones.all()
         shipping_zones = [
@@ -138,7 +136,6 @@ class Allocation(CountableDjangoObjectType):
             OrderPermissions.MANAGE_ORDERS,
         ]
     )
-    @traced_resolver
     def resolve_warehouse(root, *_args):
         return root.stock.warehouse
 

--- a/saleor/graphql/webhook/resolvers.py
+++ b/saleor/graphql/webhook/resolvers.py
@@ -7,7 +7,6 @@ from ..core.utils import from_global_id_or_error
 from .types import Webhook, WebhookEvent
 
 
-@traced_resolver
 def resolve_webhooks(info, **_kwargs):
     app = info.context.app
     if app:
@@ -20,7 +19,6 @@ def resolve_webhooks(info, **_kwargs):
     return qs
 
 
-@traced_resolver
 def resolve_webhook(info, id):
     app = info.context.app
     _, id = from_global_id_or_error(id, Webhook)

--- a/saleor/graphql/webhook/schema.py
+++ b/saleor/graphql/webhook/schema.py
@@ -1,7 +1,6 @@
 import graphene
 
 from ...core.permissions import AppPermission
-from ...core.tracing import traced_resolver
 from ..decorators import permission_required
 from .enums import WebhookSampleEventTypeEnum
 from .mutations import WebhookCreate, WebhookDelete, WebhookUpdate
@@ -43,7 +42,6 @@ class WebhookQueries(graphene.ObjectType):
 
     @staticmethod
     @permission_required(AppPermission.MANAGE_APPS)
-    @traced_resolver
     def resolve_webhook_events(_, *_args, **_data):
         return resolve_webhook_events()
 

--- a/saleor/graphql/webhook/types.py
+++ b/saleor/graphql/webhook/types.py
@@ -1,6 +1,5 @@
 import graphene
 
-from ...core.tracing import traced_resolver
 from ...webhook import models
 from ...webhook.event_types import WebhookEventType
 from ..core.connection import CountableDjangoObjectType
@@ -44,6 +43,5 @@ class Webhook(CountableDjangoObjectType):
         ]
 
     @staticmethod
-    @traced_resolver
     def resolve_events(root: models.Webhook, *_args, **_kwargs):
         return root.events.all()


### PR DESCRIPTION
I want to merge this change because of adjusting the amount of spans in resolvers.


- [x]  Accounts
- [x]  App
- [x]  Attribute
- [x]  Channel
- [x]  Checkout
- [x]  Core
- [x]  Csv
- [x]  Discount
- [x]  Giftcard
- [x]  Menu
- [x]  Meta
- [x]  Order
- [x]  Page
- [x]  Payment
- [x]  Plugins
- [x]  Product
- [x]  Shipping
- [x]  Shop
- [x]  Translations
- [x]  Warehouse
- [x]  Webhook



<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
