### PR TITLE
Introduce CSP policies for GraphQL Playground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -286,6 +286,7 @@ All notable, unreleased changes to this project will be documented in this file.
     - remove `companyName` on `WarehouseInput` type
     - remove `WarehouseAddressInput` on `WarehouseUpdateInput` and `WarehouseCreateInput`, and change it to `AddressInput`
 - Fix passing incorrect customer email to payment gateways - #7486 by @korycins
+- Add HTTP meta tag for Content-Security-Policy in GraphQL Playground - #7662 by @NyanKiyoshi
 
 # 2.11.1
 

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -113,7 +113,11 @@ class GraphQLView(View):
         return response
 
     def render_playground(self, request):
-        return render(request, "graphql/playground.html", {})
+        return render(
+            request,
+            "graphql/playground.html",
+            {"api_url": request.build_absolute_uri(str(API_PATH))},
+        )
 
     def _handle_query(self, request: HttpRequest) -> JsonResponse:
         try:

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -4,12 +4,16 @@
   <meta charset=utf-8/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/static/css/index.css" />
-  <link rel="shortcut icon" href="//cdn.jsdelivr.net/npm/graphql-playground-react/build/favicon.png" />
-  <script src="//cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
+  {# sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= #}
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css" />
+  <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
+  {# sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI= #}
+  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png 'self'">
 </head>
 <body>
   <div id="root" {% if api_url %}data-endpoint="{{ api_url }}"{% endif %} {% if query %}data-query="{{ query|safe }}"{% endif %}>
+    {# sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4= #}
     <style>
       body {
         background-color: rgb(23, 42, 58);
@@ -37,11 +41,13 @@
         font-weight: 400;
       }
     </style>
-    <img src='//cdn.jsdelivr.net/npm/graphql-playground-react/build/logo.png' alt=''>
+    {# sha256-o2yyZe08MRJmp33Nmb0pj7P+kOSiMxx0WfzYMVUbImQ= #}
+    <img src='https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png' alt=''>
     <div class="loading"> Loading
       <span class="title">GraphQL Playground</span>
     </div>
   </div>
+  {# sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ= #}
   <script>window.addEventListener('load', function (event) {
       const settings = {
         "schema.polling.enable": false
@@ -54,3 +60,4 @@
     })</script>
 </body>
 </html>
+

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -4,14 +4,13 @@
   <meta charset=utf-8/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css" />
+  <link rel="stylesheet" crossorigin="anonymous" integrity="sha256-dKnNLEFwKSVFpkpjRWe+o/jQDM6n/JsvQ0J3l5Dk3fc" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css" />
   <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
-  {# sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI= #}
-  <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png 'self'">
+  <script crossorigin="anonymous" integrity="sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=" src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
-  <div id="root" {% if api_url %}data-endpoint="{{ api_url }}"{% endif %} {% if query %}data-query="{{ query|safe }}"{% endif %}>
+  <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query|safe }}"{% endif %}>
     {# sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4= #}
     <style>
       body {
@@ -40,7 +39,6 @@
         font-weight: 400;
       }
     </style>
-    {# sha256-o2yyZe08MRJmp33Nmb0pj7P+kOSiMxx0WfzYMVUbImQ= #}
     <img src='https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png' alt=''>
     <div class="loading"> Loading
       <span class="title">GraphQL Playground</span>

--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -4,12 +4,11 @@
   <meta charset=utf-8/>
   <meta name="viewport" content="user-scalable=no, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, minimal-ui">
   <title>GraphQL Playground</title>
-  {# sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU= #}
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css" />
   <link rel="shortcut icon" href="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png" />
   {# sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI= #}
   <script src="https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/js/middleware.js"></script>
-  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src 'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png 'self'">
+  <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png 'self'">
 </head>
 <body>
   <div id="root" {% if api_url %}data-endpoint="{{ api_url }}"{% endif %} {% if query %}data-query="{{ query|safe }}"{% endif %}>
@@ -60,4 +59,3 @@
     })</script>
 </body>
 </html>
-


### PR DESCRIPTION
- img-src:
  - allow usage of `data:` due to playground using inline SVG files
  - allow loading of favicon and playground logo
- script-src and style-src: allow loading of the external resources but require SHA256 checksum to match, otherwise they are to be rejected
- connect-src:
  - (breaking change) only allow full URL for /graphql/ endpoint based on the current server location (HTTP host) - note: relative paths are not allowed in CSP
- External sources: always use HTTPS, HTTP should never be used due to security risks


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
