### PR TITLE
Expose preorder data in API

### DIFF
--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -234,7 +234,8 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
     def batch_load(self, keys):
         variant_channel_listings = ProductVariantChannelListing.objects.filter(
             variant_id__in=keys
-        )
+        ).annotate_available_preorder_quantities()
+
         variant_id_variant_channel_listings_map = defaultdict(list)
         for variant_channel_listing in variant_channel_listings:
             variant_id_variant_channel_listings_map[

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -284,7 +284,9 @@ class VariantChannelListingByVariantIdAndChannelLoader(
             "variant_id__in": variant_ids,
             "price_amount__isnull": False,
         }
-        variant_channel_listings = ProductVariantChannelListing.objects.filter(**filter)
+        variant_channel_listings = ProductVariantChannelListing.objects.filter(
+            **filter
+        ).annotate_available_preorder_quantities()
 
         variant_channel_listings_map: Dict[int, ProductVariantChannelListing] = {}
         for variant_channel_listing in variant_channel_listings.iterator():

--- a/saleor/graphql/product/dataloaders/products.py
+++ b/saleor/graphql/product/dataloaders/products.py
@@ -234,7 +234,7 @@ class VariantChannelListingByVariantIdLoader(DataLoader):
     def batch_load(self, keys):
         variant_channel_listings = ProductVariantChannelListing.objects.filter(
             variant_id__in=keys
-        ).annotate_available_preorder_quantities()
+        ).annotate_preorder_quantity_allocated()
 
         variant_id_variant_channel_listings_map = defaultdict(list)
         for variant_channel_listing in variant_channel_listings:
@@ -286,7 +286,7 @@ class VariantChannelListingByVariantIdAndChannelLoader(
         }
         variant_channel_listings = ProductVariantChannelListing.objects.filter(
             **filter
-        ).annotate_available_preorder_quantities()
+        ).annotate_preorder_quantity_allocated()
 
         variant_channel_listings_map: Dict[int, ProductVariantChannelListing] = {}
         for variant_channel_listing in variant_channel_listings.iterator():

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -147,6 +147,10 @@ QUERY_PRODUCT_VARIANT_CHANNEL_LISTING = """
                     currency
                     amount
                 }
+                preorderThreshold {
+                    quantity
+                    soldUnits
+                }
             }
         }
     }
@@ -184,6 +188,10 @@ def test_get_product_variant_channel_listing_as_staff_user(
                 "currency": channel_listing.currency,
                 "amount": channel_listing.cost_price_amount,
             },
+            "preorderThreshold": {
+                "quantity": channel_listing.preorder_quantity_threshold,
+                "soldUnits": 0,
+            },
         } in data["channelListings"]
     assert len(data["channelListings"]) == variant.channel_listings.count()
 
@@ -218,6 +226,10 @@ def test_get_product_variant_channel_listing_as_app(
             "costPrice": {
                 "currency": channel_listing.currency,
                 "amount": channel_listing.cost_price_amount,
+            },
+            "preorderThreshold": {
+                "quantity": channel_listing.preorder_quantity_threshold,
+                "soldUnits": 0,
             },
         } in data["channelListings"]
     assert len(data["channelListings"]) == variant.channel_listings.count()

--- a/saleor/graphql/product/tests/test_variant_availability.py
+++ b/saleor/graphql/product/tests/test_variant_availability.py
@@ -214,3 +214,62 @@ def test_variant_quantity_available_without_inventory_tracking_and_stocks(
     variant_data = content["data"]["productVariant"]
     assert variant_data["deprecatedByCountry"] == settings.MAX_CHECKOUT_LINE_QUANTITY
     assert variant_data["byAddress"] == settings.MAX_CHECKOUT_LINE_QUANTITY
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_variant_quantity_available_preorder_with_channel_threshold(
+    api_client,
+    preorder_variant_channel_threshold,
+    channel_USD,
+):
+    variant = preorder_variant_channel_threshold
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": COUNTRY_CODE,
+        "channel": channel_USD.slug,
+    }
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    channel_listing = variant.channel_listings.get()
+    assert (
+        variant_data["deprecatedByCountry"]
+        == channel_listing.preorder_quantity_threshold
+    )
+    assert variant_data["byAddress"] == channel_listing.preorder_quantity_threshold
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_variant_quantity_available_preorder_with_global_threshold(
+    api_client, preorder_variant_global_threshold, channel_USD
+):
+    variant = preorder_variant_global_threshold
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": COUNTRY_CODE,
+        "channel": channel_USD.slug,
+    }
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data["deprecatedByCountry"] == variant.preorder_global_threshold
+    assert variant_data["byAddress"] == variant.preorder_global_threshold
+
+
+@override_settings(MAX_CHECKOUT_LINE_QUANTITY=15)
+def test_variant_quantity_available_preorder_without_threshold(
+    api_client, preorder_variant_global_threshold, settings, channel_USD
+):
+    variant = preorder_variant_global_threshold
+    variant.preorder_global_threshold = None
+    variant.save(update_fields=["preorder_global_threshold"])
+    variables = {
+        "id": graphene.Node.to_global_id("ProductVariant", variant.pk),
+        "country": COUNTRY_CODE,
+        "channel": channel_USD.slug,
+    }
+    response = api_client.post_graphql(QUERY_VARIANT_AVAILABILITY, variables)
+    content = get_graphql_content(response)
+    variant_data = content["data"]["productVariant"]
+    assert variant_data["deprecatedByCountry"] == settings.MAX_CHECKOUT_LINE_QUANTITY
+    assert variant_data["byAddress"] == settings.MAX_CHECKOUT_LINE_QUANTITY

--- a/saleor/graphql/product/tests/test_variant_channel_listing_update.py
+++ b/saleor/graphql/product/tests/test_variant_channel_listing_update.py
@@ -218,14 +218,24 @@ def test_variant_channel_listing_update_as_staff_user(
     variant_data = data["variant"]
     assert not data["errors"]
     assert variant_data["id"] == variant_id
-    assert variant_data["channelListings"][0]["price"]["currency"] == "USD"
-    assert variant_data["channelListings"][0]["price"]["amount"] == price
-    assert variant_data["channelListings"][0]["costPrice"]["amount"] == price
-    assert variant_data["channelListings"][0]["channel"]["slug"] == channel_USD.slug
-    assert variant_data["channelListings"][1]["price"]["currency"] == "PLN"
-    assert variant_data["channelListings"][1]["price"]["amount"] == second_price
-    assert variant_data["channelListings"][1]["costPrice"]["amount"] == second_price
-    assert variant_data["channelListings"][1]["channel"]["slug"] == channel_PLN.slug
+    channel_usd_data = next(
+        channel_data
+        for channel_data in variant_data["channelListings"]
+        if channel_data["channel"]["id"] == channel_usd_id
+    )
+    channel_pln_data = next(
+        channel_data
+        for channel_data in variant_data["channelListings"]
+        if channel_data["channel"]["id"] == channel_pln_id
+    )
+    assert channel_usd_data["price"]["currency"] == "USD"
+    assert channel_usd_data["price"]["amount"] == price
+    assert channel_usd_data["costPrice"]["amount"] == price
+    assert channel_usd_data["channel"]["slug"] == channel_USD.slug
+    assert channel_pln_data["price"]["currency"] == "PLN"
+    assert channel_pln_data["price"]["amount"] == second_price
+    assert channel_pln_data["costPrice"]["amount"] == second_price
+    assert channel_pln_data["channel"]["slug"] == channel_PLN.slug
 
 
 @patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
@@ -308,12 +318,22 @@ def test_variant_channel_listing_update_as_app(
     variant_data = data["variant"]
     assert not data["errors"]
     assert variant_data["id"] == variant_id
-    assert variant_data["channelListings"][0]["price"]["currency"] == "USD"
-    assert variant_data["channelListings"][0]["price"]["amount"] == 1
-    assert variant_data["channelListings"][0]["channel"]["slug"] == channel_USD.slug
-    assert variant_data["channelListings"][1]["price"]["currency"] == "PLN"
-    assert variant_data["channelListings"][1]["price"]["amount"] == 20
-    assert variant_data["channelListings"][1]["channel"]["slug"] == channel_PLN.slug
+    channel_usd_data = next(
+        channel_data
+        for channel_data in variant_data["channelListings"]
+        if channel_data["channel"]["id"] == channel_usd_id
+    )
+    channel_pln_data = next(
+        channel_data
+        for channel_data in variant_data["channelListings"]
+        if channel_data["channel"]["id"] == channel_pln_id
+    )
+    assert channel_usd_data["price"]["currency"] == "USD"
+    assert channel_usd_data["price"]["amount"] == 1
+    assert channel_usd_data["channel"]["slug"] == channel_USD.slug
+    assert channel_pln_data["price"]["currency"] == "PLN"
+    assert channel_pln_data["price"]["amount"] == 20
+    assert channel_pln_data["channel"]["slug"] == channel_PLN.slug
 
 
 def test_variant_channel_listing_update_as_customer(

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -229,9 +229,26 @@ class ProductChannelListing(CountableDjangoObjectType):
         )
 
 
+class PreorderThreshold(graphene.ObjectType):
+    quantity = graphene.Int(
+        required=False,
+        description="Preorder threshold for product variant in this channel.",
+    )
+    sold_units = graphene.Int(
+        required=True,
+        description="Number of sold product variant in this channel.",
+    )
+
+    class Meta:
+        description = "Represents preorder variant data for channel."
+
+
 class ProductVariantChannelListing(CountableDjangoObjectType):
     cost_price = graphene.Field(Money, description="Cost price of the variant.")
     margin = graphene.Int(description="Gross margin percentage value.")
+    preorder_threshold = graphene.Field(
+        PreorderThreshold, required=False, description="Preorder variant data."
+    )
 
     class Meta:
         description = "Represents product varaint channel listing."
@@ -247,6 +264,17 @@ class ProductVariantChannelListing(CountableDjangoObjectType):
     @permission_required(ProductPermissions.MANAGE_PRODUCTS)
     def resolve_margin(root: models.ProductVariantChannelListing, *_args):
         return get_margin_for_variant_channel_listing(root)
+
+    @staticmethod
+    def resolve_preorder_threshold(
+        root: models.ProductVariantChannelListing, info, **_kwargs
+    ):
+        # This field is added through annotation when using the
+        # `resolve_channel_listings` resolver.
+        return PreorderThreshold(
+            quantity=root.preorder_quantity_threshold,
+            sold_units=getattr(root, "preorder_quantity_allocated", 0),
+        )
 
 
 class CollectionChannelListing(CountableDjangoObjectType):

--- a/saleor/graphql/product/types/channels.py
+++ b/saleor/graphql/product/types/channels.py
@@ -269,8 +269,8 @@ class ProductVariantChannelListing(CountableDjangoObjectType):
     def resolve_preorder_threshold(
         root: models.ProductVariantChannelListing, info, **_kwargs
     ):
-        # This field is added through annotation when using the
-        # `resolve_channel_listings` resolver.
+        # The preorder_quantity_allocated field is added through annotation
+        # when using the `resolve_channel_listings` resolver.
         return PreorderThreshold(
             quantity=root.preorder_quantity_threshold,
             sold_units=getattr(root, "preorder_quantity_allocated", 0),

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -177,7 +177,7 @@ class PreorderData(graphene.ObjectType):
         required=False, description="The global preorder threshold for product variant."
     )
     global_sold_units = graphene.Int(
-        required=False,
+        required=True,
         description="Total number of sold product variant during preorder.",
     )
     end_date = graphene.DateTime(required=False, description="Preorder end date.")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -168,6 +168,34 @@ class ProductPricingInfo(BasePricingInfo):
         description = "Represents availability of a product in the storefront."
 
 
+class PreorderData(graphene.ObjectType):
+    is_preorder = graphene.Boolean(
+        required=True,
+        description="Indicates whether the product variant is in preorder.",
+    )
+    global_threshold = graphene.Int(
+        required=False, description="The global preorder threshold for product variant."
+    )
+    global_sold_units = graphene.Int(
+        required=False,
+        description="Total number of sold product variant during preorder.",
+    )
+    end_date = graphene.DateTime(required=False, description="Preorder end date.")
+
+    class Meta:
+        description = "Represents preorder settings for product variant."
+
+    @staticmethod
+    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
+    def resolve_global_threshold(root, *_args):
+        return root.global_threshold
+
+    @staticmethod
+    @permission_required(ProductPermissions.MANAGE_PRODUCTS)
+    def resolve_global_sold_units(root, *_args):
+        return root.global_sold_units
+
+
 @key(fields="id")
 class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     channel_listings = graphene.List(
@@ -246,6 +274,9 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                 "quantity from all shipping zones."
             ),
         ),
+    )
+    preorder = graphene.Field(
+        PreorderData, required=True, description="Preorder data for product variant."
     )
 
     class Meta:
@@ -498,6 +529,29 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @traced_resolver
     def resolve_weight(root: ChannelContext[models.ProductVariant], _info, **_kwargs):
         return convert_weight_to_default_weight_unit(root.node.weight)
+
+    @staticmethod
+    @traced_resolver
+    def resolve_preorder(root: ChannelContext[models.ProductVariant], _info, **_kwargs):
+        variant = root.node
+
+        variant_channel_listings = VariantChannelListingByVariantIdLoader(
+            _info.context
+        ).load(variant.id)
+
+        def calculate_global_sold_units(variant_channel_listings):
+            global_sold_units = sum(
+                channel_listing.preorder_quantity_allocated
+                for channel_listing in variant_channel_listings
+            )
+            return PreorderData(
+                is_preorder=variant.is_preorder,
+                global_threshold=variant.preorder_global_threshold,
+                global_sold_units=global_sold_units,
+                end_date=variant.preorder_end_date,
+            )
+
+        return variant_channel_listings.then(calculate_global_sold_units)
 
 
 @key(fields="id")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -321,6 +321,40 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                 address, info.context.site.settings.company_address
             )
 
+        if root.node.is_preorder:
+            variant = root.node
+            channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
+                info.context
+            ).load((variant.id, str(root.channel_slug)))
+
+            def calculate_available_per_channel(channel_listing):
+                if channel_listing.preorder_quantity_threshold is not None:
+                    return min(
+                        channel_listing.preorder_quantity_threshold
+                        - channel_listing.preorder_quantity_allocated,
+                        settings.MAX_CHECKOUT_LINE_QUANTITY,
+                    )
+                if variant.preorder_global_threshold is not None:
+                    variant_channel_listings = VariantChannelListingByVariantIdLoader(
+                        info.context
+                    ).load(variant.id)
+
+                    def calculate_available_global(variant_channel_listings):
+                        global_sold_units = sum(
+                            channel_listing.preorder_quantity_allocated
+                            for channel_listing in variant_channel_listings
+                        )
+                        return min(
+                            variant.preorder_global_threshold - global_sold_units,
+                            settings.MAX_CHECKOUT_LINE_QUANTITY,
+                        )
+
+                    return variant_channel_listings.then(calculate_available_global)
+
+                return settings.MAX_CHECKOUT_LINE_QUANTITY
+
+            return channel_listing.then(calculate_available_per_channel)
+
         if not root.node.track_inventory:
             return settings.MAX_CHECKOUT_LINE_QUANTITY
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4083,6 +4083,13 @@ enum PostalCodeRuleInclusionTypeEnum {
   EXCLUDE
 }
 
+type PreorderData {
+  isPreorder: Boolean!
+  globalThreshold: Int
+  globalSoldUnits: Int
+  endDate: DateTime
+}
+
 input PriceRangeInput {
   gte: Float
   lte: Float
@@ -4564,6 +4571,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   digitalContent: DigitalContent
   stocks(address: AddressInput, countryCode: CountryCode): [Stock]
   quantityAvailable(address: AddressInput, countryCode: CountryCode): Int!
+  preorder: PreorderData!
 }
 
 type ProductVariantBulkCreate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4086,7 +4086,7 @@ enum PostalCodeRuleInclusionTypeEnum {
 type PreorderData {
   isPreorder: Boolean!
   globalThreshold: Int
-  globalSoldUnits: Int
+  globalSoldUnits: Int!
   endDate: DateTime
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4090,6 +4090,11 @@ type PreorderData {
   endDate: DateTime
 }
 
+type PreorderThreshold {
+  quantity: Int
+  soldUnits: Int!
+}
+
 input PriceRangeInput {
   gte: Float
   lte: Float
@@ -4602,6 +4607,7 @@ type ProductVariantChannelListing implements Node {
   price: Money
   costPrice: Money
   margin: Int
+  preorderThreshold: PreorderThreshold
 }
 
 input ProductVariantChannelListingAddInput {

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -596,10 +596,8 @@ class ProductVariantTranslation(models.Model):
 
 
 class ProductVariantChannelListingQuerySet(models.QuerySet):
-    def annotate_available_preorder_quantities(self):
+    def annotate_preorder_quantity_allocated(self):
         return self.annotate(
-            available_preorder_quantity=F("preorder_quantity_threshold")
-            - Coalesce(Sum("preorder_allocations__quantity"), 0),
             preorder_quantity_allocated=Coalesce(
                 Sum("preorder_allocations__quantity"), 0
             ),

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -638,7 +638,7 @@ class ProductVariantChannelListing(models.Model):
 
     preorder_quantity_threshold = models.IntegerField(blank=True, null=True)
 
-    objects = ProductVariantChannelListingQuerySet.as_manager()
+    objects = models.Manager.from_queryset(ProductVariantChannelListingQuerySet)()
 
     class Meta:
         unique_together = [["variant", "channel"]]

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple
 
-from django.db.models import F, Sum
+from django.db.models import Sum
 from django.db.models.functions import Coalesce
 
 from ..core.exceptions import InsufficientStock, InsufficientStockData
@@ -173,13 +173,7 @@ def check_preorder_threshold_bulk(
     """
     all_variants_channel_listings = (
         ProductVariantChannelListing.objects.filter(variant__in=variants)
-        .annotate(
-            available_preorder_quantity=F("preorder_quantity_threshold")
-            - Coalesce(Sum("preorder_allocations__quantity"), 0),
-            preorder_quantity_allocated=Coalesce(
-                Sum("preorder_allocations__quantity"), 0
-            ),
-        )
+        .annotate_available_preorder_quantities()
         .select_related("channel")
     )
     variants_channel_availability = {

--- a/saleor/warehouse/tests/test_preorder_availability.py
+++ b/saleor/warehouse/tests/test_preorder_availability.py
@@ -126,11 +126,7 @@ def test_check_preorder_threshold_bulk_global_and_channel_threshold(
     variant = preorder_variant_global_and_channel_threshold
 
     channel_listings = variant.channel_listings.all()
-    channel_listings = channel_listings.annotate(
-        available_preorder_quantity=F("preorder_quantity_threshold")
-        - Coalesce(Sum("preorder_allocations__quantity"), 0),
-        preorder_quantity_allocated=Coalesce(Sum("preorder_allocations__quantity"), 0),
-    )
+    channel_listings = channel_listings.annotate_available_preorder_quantities()
     channel_listing_USD = channel_listings.get(channel=channel_USD)
     channel_listing_PLN = channel_listings.get(channel=channel_PLN)
 


### PR DESCRIPTION
I want to merge this change because it exposes in API `ProductVariant` preorder settings and number of globally sold units / per channel. It also modifies `productVariant.quantityAvailable` behavior for preorder variants.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
