### PR TITLE
Fix CheckoutCustomerAttach mutation behaviour with possibility to be used by another user.

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -639,6 +639,8 @@ class CheckoutCustomerAttach(BaseMutation):
             checkout = cls.get_node_or_error(
                 info, checkout_id or token, only_type=Checkout, field="checkout_id"
             )
+        if checkout.user:
+            raise PermissionDenied()
 
         checkout.user = info.context.user
         checkout.email = info.context.user.email

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -639,6 +639,9 @@ class CheckoutCustomerAttach(BaseMutation):
             checkout = cls.get_node_or_error(
                 info, checkout_id or token, only_type=Checkout, field="checkout_id"
             )
+
+        # Raise error when trying to attach a user to a checkout
+        # that is already owned by another user.
         if checkout.user:
             raise PermissionDenied()
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2639,3 +2639,40 @@ def test_get_checkout_with_vatlayer_set(
     # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
+
+
+def test_checkout_customer_attach_user_to_checkout_with_user(
+    user_api_client, checkout_with_item, customer_user, user_checkout, address
+):
+    checkout = user_checkout
+
+    query = """
+    mutation checkoutCustomerAttach($checkoutId: ID, $token: UUID) {
+        checkoutCustomerAttach(checkoutId: $checkoutId, token: $token) {
+            checkout {
+                token
+            }
+            errors {
+                field
+                message
+                code
+            }
+        }
+    }
+"""
+
+    default_address = address.get_copy()
+    second_user = User.objects.create_user(
+        "test2@example.com",
+        "password",
+        default_billing_address=default_address,
+        default_shipping_address=default_address,
+        first_name="Test2",
+        last_name="Tested",
+    )
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    customer_id = graphene.Node.to_global_id("User", second_user.pk)
+    variables = {"checkoutId": checkout_id, "customerId": customer_id}
+    response = user_api_client.post_graphql(query, variables)
+    assert_no_permission(response)

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1506,6 +1506,43 @@ def test_checkout_customer_attach(
     assert checkout.email == customer_user.email
 
 
+def test_checkout_customer_attach_user_to_checkout_with_user(
+    user_api_client, customer_user, user_checkout, address
+):
+    checkout = user_checkout
+
+    query = """
+    mutation checkoutCustomerAttach($checkoutId: ID, $token: UUID) {
+        checkoutCustomerAttach(checkoutId: $checkoutId, token: $token) {
+            checkout {
+                token
+            }
+            errors {
+                field
+                message
+                code
+            }
+        }
+    }
+"""
+
+    default_address = address.get_copy()
+    second_user = User.objects.create_user(
+        "test2@example.com",
+        "password",
+        default_billing_address=default_address,
+        default_shipping_address=default_address,
+        first_name="Test2",
+        last_name="Tested",
+    )
+
+    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
+    customer_id = graphene.Node.to_global_id("User", second_user.pk)
+    variables = {"checkoutId": checkout_id, "customerId": customer_id}
+    response = user_api_client.post_graphql(query, variables)
+    assert_no_permission(response)
+
+
 MUTATION_CHECKOUT_CUSTOMER_DETACH = """
     mutation checkoutCustomerDetach($token: UUID) {
         checkoutCustomerDetach(token: $token) {
@@ -2639,40 +2676,3 @@ def test_get_checkout_with_vatlayer_set(
     # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
-
-
-def test_checkout_customer_attach_user_to_checkout_with_user(
-    user_api_client, checkout_with_item, customer_user, user_checkout, address
-):
-    checkout = user_checkout
-
-    query = """
-    mutation checkoutCustomerAttach($checkoutId: ID, $token: UUID) {
-        checkoutCustomerAttach(checkoutId: $checkoutId, token: $token) {
-            checkout {
-                token
-            }
-            errors {
-                field
-                message
-                code
-            }
-        }
-    }
-"""
-
-    default_address = address.get_copy()
-    second_user = User.objects.create_user(
-        "test2@example.com",
-        "password",
-        default_billing_address=default_address,
-        default_shipping_address=default_address,
-        first_name="Test2",
-        last_name="Tested",
-    )
-
-    checkout_id = graphene.Node.to_global_id("Checkout", checkout.pk)
-    customer_id = graphene.Node.to_global_id("User", second_user.pk)
-    variables = {"checkoutId": checkout_id, "customerId": customer_id}
-    response = user_api_client.post_graphql(query, variables)
-    assert_no_permission(response)


### PR DESCRIPTION
I want to merge this change because it fix CheckoutCustomerAttach mutation behaviour.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [x] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
