### PR TITLE
Add AppExtenstion queries and filters for them

### DIFF
--- a/saleor/app/types.py
+++ b/saleor/app/types.py
@@ -6,12 +6,23 @@ class AppType:
 
 
 class AppExtensionView:
+    """All available place where app's iframe can be mounted.
+
+    PRODUCT - app's iframe will be mounted in product section
+    """
+
     PRODUCT = "product"
 
     CHOICES = [(PRODUCT, "product")]
 
 
 class AppExtensionType:
+    """All available type where app's iframe can be mounted.
+
+    OVERVIEW - app's iframe will be mounted on list view.
+    DETAILS - app's iframe will be mounted on detail view
+    """
+
     OVERVIEW = "overview"
     DETAILS = "details"
 
@@ -19,6 +30,12 @@ class AppExtensionType:
 
 
 class AppExtensionTarget:
+    """All available places where app's iframe can be mounted.
+
+    MORE_ACTIONS - three dots button
+    CREATE - create button
+    """
+
     MORE_ACTIONS = "more_actions"
     CREATE = "create"
 

--- a/saleor/app/types.py
+++ b/saleor/app/types.py
@@ -32,7 +32,7 @@ class AppExtensionType:
 class AppExtensionTarget:
     """All available places where app's iframe can be mounted.
 
-    MORE_ACTIONS - three dots button
+    MORE_ACTIONS - more actions button
     CREATE - create button
     """
 

--- a/saleor/graphql/app/dataloaders.py
+++ b/saleor/graphql/app/dataloaders.py
@@ -1,0 +1,33 @@
+from collections import defaultdict
+
+from ...app.models import App, AppExtension
+from ..core.dataloaders import DataLoader
+
+
+class AppByIdLoader(DataLoader):
+    context_key = "app_by_id"
+
+    def batch_load(self, keys):
+        apps = App.objects.in_bulk(keys)
+        return [apps.get(key) for key in keys]
+
+
+class AppExtensionByIdLoader(DataLoader):
+    context_key = "app_extension_by_id"
+
+    def batch_load(self, keys):
+        extensions = AppExtension.objects.in_bulk(keys)
+        return [extensions.get(key) for key in keys]
+
+
+class AppExtensionByAppIdLoader(DataLoader):
+    context_key = "app_extension_by_app_id"
+
+    def batch_load(self, keys):
+        extensions = AppExtension.objects.filter(app_id__in=keys)
+        extensions_map = defaultdict(list)
+        app_extension_loader = AppExtensionByIdLoader(self.context)
+        for extension in extensions.iterator():
+            extensions_map[extension.app_id].append(extension)
+            app_extension_loader.prime(extension.id, extension)
+        return [extensions_map.get(app_id, []) for app_id in keys]

--- a/saleor/graphql/app/enums.py
+++ b/saleor/graphql/app/enums.py
@@ -1,4 +1,4 @@
-from ...app.types import AppType
+from ...app.types import AppExtensionTarget, AppExtensionType, AppExtensionView, AppType
 from ..core.enums import to_enum
 
 
@@ -20,3 +20,7 @@ def description(enum):
 
 
 AppTypeEnum = to_enum(AppType, description=description)
+
+AppExtensionTypeEnum = to_enum(AppExtensionType)
+AppExtensionViewEnum = to_enum(AppExtensionView)
+AppExtensionTargetEnum = to_enum(AppExtensionTarget)

--- a/saleor/graphql/app/filters.py
+++ b/saleor/graphql/app/filters.py
@@ -31,7 +31,7 @@ def filter_app_extension_view(qs, _, value):
 
 
 def filter_app_extension_type(qs, _, value):
-    if value in [t for t, _ in AppExtensionType.CHOICES]:
+    if value in [type for type, _ in AppExtensionType.CHOICES]:
         qs = qs.filter(type=value)
     return qs
 

--- a/saleor/graphql/app/filters.py
+++ b/saleor/graphql/app/filters.py
@@ -1,10 +1,15 @@
 import django_filters
 
 from ...app import models
-from ...app.types import AppType
+from ...app.types import AppExtensionTarget, AppExtensionType, AppExtensionView, AppType
 from ..core.filters import EnumFilter
 from ..utils.filters import filter_by_query_param
-from .enums import AppTypeEnum
+from .enums import (
+    AppExtensionTargetEnum,
+    AppExtensionTypeEnum,
+    AppExtensionViewEnum,
+    AppTypeEnum,
+)
 
 
 def filter_app_search(qs, _, value):
@@ -13,17 +18,55 @@ def filter_app_search(qs, _, value):
     return qs
 
 
-def filter_type(qs, _, value):
+def filter_app_type(qs, _, value):
     if value in [AppType.LOCAL, AppType.THIRDPARTY]:
         qs = qs.filter(type=value)
     return qs
 
 
+def filter_app_extension_view(qs, _, value):
+    if value in [view for view, _ in AppExtensionView.CHOICES]:
+        qs = qs.filter(view=value)
+    return qs
+
+
+def filter_app_extension_type(qs, _, value):
+    if value in [t for t, _ in AppExtensionType.CHOICES]:
+        qs = qs.filter(type=value)
+    return qs
+
+
+def filter_app_extension_target(qs, _, value):
+    if value in [target for target, _ in AppExtensionTarget.CHOICES]:
+        qs = qs.filter(target=value)
+    return qs
+
+
 class AppFilter(django_filters.FilterSet):
-    type = EnumFilter(input_class=AppTypeEnum, method=filter_type)
+    type = EnumFilter(input_class=AppTypeEnum, method=filter_app_type)
     search = django_filters.CharFilter(method=filter_app_search)
     is_active = django_filters.BooleanFilter()
 
     class Meta:
         model = models.App
         fields = ["search", "is_active"]
+
+
+class AppExtensionFilter(django_filters.FilterSet):
+    view = EnumFilter(
+        input_class=AppExtensionViewEnum, method=filter_app_extension_view
+    )
+    type = EnumFilter(
+        input_class=AppExtensionTypeEnum, method=filter_app_extension_type
+    )
+    target = EnumFilter(
+        input_class=AppExtensionTargetEnum, method=filter_app_extension_target
+    )
+
+    class Meta:
+        model = models.AppExtension
+        fields = [
+            "view",
+            "type",
+            "target",
+        ]

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -35,3 +35,14 @@ def resolve_app(_info, id):
         return None
     _, id = from_global_id_or_error(id, "App")
     return models.App.objects.filter(id=id).first()
+
+
+@traced_resolver
+def resolve_app_extensions(_info):
+    return models.AppExtension.objects.filter(app__is_active=True)
+
+
+@traced_resolver
+def resolve_app_extension(_info, id):
+    _, id = from_global_id_or_error(id, "AppExtension")
+    return models.AppExtension.objects.filter(id=id, app__is_active=True).first()

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -37,12 +37,5 @@ def resolve_app(_info, id):
     return models.App.objects.filter(id=id).first()
 
 
-@traced_resolver
 def resolve_app_extensions(_info):
     return models.AppExtension.objects.filter(app__is_active=True)
-
-
-@traced_resolver
-def resolve_app_extension(_info, id):
-    _, id = from_global_id_or_error(id, "AppExtension")
-    return models.AppExtension.objects.filter(id=id, app__is_active=True).first()

--- a/saleor/graphql/app/schema.py
+++ b/saleor/graphql/app/schema.py
@@ -105,7 +105,7 @@ class AppQueries(graphene.ObjectType):
 
             if not app_extension:
                 return None
-            print(app_extension)
+
             return (
                 AppByIdLoader(info.context).load(app_extension.app_id).then(is_active)
             )

--- a/saleor/graphql/app/tests/benchmarks/test_app_extensions.py
+++ b/saleor/graphql/app/tests/benchmarks/test_app_extensions.py
@@ -1,0 +1,168 @@
+import pytest
+
+from .....app.models import AppExtension
+from .....app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from ....tests.utils import get_graphql_content
+from ...enums import AppExtensionTargetEnum, AppExtensionTypeEnum, AppExtensionViewEnum
+
+
+@pytest.mark.count_queries(autouse=False)
+def test_app_extensions(
+    staff_api_client,
+    app,
+    permission_manage_products,
+    count_queries,
+):
+    # given
+    query = """
+    query{
+        appExtensions(first: 10){
+        edges{
+          node{
+            label
+            url
+            view
+            target
+            id
+            type
+            permissions{
+              code
+            }
+          }
+        }
+      }
+    }
+    """
+
+    app_extensions = AppExtension.objects.bulk_create(
+        [
+            AppExtension(
+                app=app,
+                label="Create product with App1",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App2",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.DETAILS,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App3",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.CREATE,
+            ),
+        ]
+    )
+    app_extensions[0].permissions.add(permission_manage_products)
+    app_extensions[1].permissions.add(permission_manage_products)
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    extensions_data = content["data"]["appExtensions"]["edges"]
+
+    assert len(extensions_data) == 3
+
+
+@pytest.mark.parametrize(
+    "filter",
+    [
+        {},
+        {"view": AppExtensionViewEnum.PRODUCT.name},
+        {"target": AppExtensionTargetEnum.CREATE.name},
+        {"type": AppExtensionTypeEnum.OVERVIEW.name},
+        {
+            "type": AppExtensionTypeEnum.OVERVIEW.name,
+            "view": AppExtensionViewEnum.PRODUCT.name,
+        },
+        {
+            "type": AppExtensionTypeEnum.DETAILS.name,
+            "target": AppExtensionTargetEnum.CREATE.name,
+        },
+        {
+            "type": AppExtensionTypeEnum.DETAILS.name,
+            "target": AppExtensionTargetEnum.MORE_ACTIONS.name,
+        },
+    ],
+)
+@pytest.mark.count_queries(autouse=False)
+def test_app_extensions_with_filter(
+    filter,
+    staff_api_client,
+    app,
+    permission_manage_products,
+    count_queries,
+):
+    # given
+    query = """
+    query ($filter: AppExtensionFilterInput){
+        appExtensions(first: 10, filter: $filter){
+        edges{
+          node{
+            label
+            url
+            view
+            target
+            id
+            type
+            permissions{
+              code
+            }
+          }
+        }
+      }
+    }
+    """
+    app_extensions = AppExtension.objects.bulk_create(
+        [
+            AppExtension(
+                app=app,
+                label="Create product with App1",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App2",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.DETAILS,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App3",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.CREATE,
+            ),
+        ]
+    )
+    app_extensions[0].permissions.add(permission_manage_products)
+    variables = {"filter": filter}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+    )
+
+    # then
+    get_graphql_content(response)

--- a/saleor/graphql/app/tests/queries/test_app_extension.py
+++ b/saleor/graphql/app/tests/queries/test_app_extension.py
@@ -1,0 +1,269 @@
+import graphene
+
+from saleor.app.models import AppExtension
+from saleor.app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+
+QUERY_APP_EXTENSION = """
+query ($id: ID!){
+    appExtension(id: $id){
+        label
+        url
+        view
+        target
+        type
+        id
+        permissions{
+            code
+        }
+    }
+}
+"""
+
+
+def test_app_extension_staff_user(app, staff_api_client, permission_manage_products):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSION,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    extension_data = content["data"]["appExtension"]
+    assert app_extension.label == extension_data["label"]
+    assert app_extension.url == extension_data["url"]
+    assert app_extension.view == extension_data["view"].lower()
+    assert app_extension.target == extension_data["target"].lower()
+    assert app_extension.type == extension_data["type"].lower()
+
+    assert app_extension.permissions.count() == 1
+    assert len(extension_data["permissions"]) == 1
+    permission_code = extension_data["permissions"][0]["code"].lower()
+    assert app_extension.permissions.first().codename == permission_code
+
+
+def test_app_extension_by_app(app, app_api_client, permission_manage_products):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_APP_EXTENSION,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    extension_data = content["data"]["appExtension"]
+    assert app_extension.label == extension_data["label"]
+    assert app_extension.url == extension_data["url"]
+    assert app_extension.view == extension_data["view"].lower()
+    assert app_extension.target == extension_data["target"].lower()
+    assert app_extension.type == extension_data["type"].lower()
+
+    assert app_extension.permissions.count() == 1
+    assert len(extension_data["permissions"]) == 1
+    permission_code = extension_data["permissions"][0]["code"].lower()
+    assert app_extension.permissions.first().codename == permission_code
+
+
+def test_app_extension_normal_user(app, user_api_client, permission_manage_products):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = user_api_client.post_graphql(
+        QUERY_APP_EXTENSION,
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+QUERY_APP_EXTENSION_WITH_APP = """
+query ($id: ID!){
+    appExtension(id: $id){
+        label
+        url
+        view
+        target
+        type
+        id
+        permissions{
+            code
+        }
+        app{
+            id
+        }
+    }
+}
+"""
+
+
+def test_app_extension_with_app_query_by_staff_without_permissions(
+    app, staff_api_client, permission_manage_products
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSION_WITH_APP,
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_app_extension_with_app_query_by_app_without_permissions(
+    external_app, app_api_client, permission_manage_products
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=external_app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_APP_EXTENSION_WITH_APP,
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_app_extension_with_app_query_by_app_with_permissions(
+    external_app,
+    app,
+    permission_manage_apps,
+    app_api_client,
+    permission_manage_products,
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=external_app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    app.permissions.add(permission_manage_apps)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_APP_EXTENSION_WITH_APP,
+        variables,
+    )
+
+    # then
+    get_graphql_content(response)
+
+
+def test_app_extension_with_app_query_by_owner_app(
+    app, app_api_client, permission_manage_products
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_APP_EXTENSION_WITH_APP,
+        variables,
+    )
+
+    # then
+    get_graphql_content(response)
+
+
+def test_app_extension_with_app_query_by_staff_with_permissions(
+    external_app, app, permission_manage_apps, staff_api_client
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=external_app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+
+    id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+    variables = {"id": id}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSION_WITH_APP, variables, permissions=[permission_manage_apps]
+    )
+
+    # then
+    get_graphql_content(response)

--- a/saleor/graphql/app/tests/queries/test_app_extensions.py
+++ b/saleor/graphql/app/tests/queries/test_app_extensions.py
@@ -1,0 +1,203 @@
+import pytest
+
+from saleor.app.models import AppExtension
+from saleor.app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from saleor.graphql.app.enums import (
+    AppExtensionTargetEnum,
+    AppExtensionTypeEnum,
+    AppExtensionViewEnum,
+)
+from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+
+QUERY_APP_EXTENSIONS = """
+query ($filter: AppExtensionFilterInput){
+    appExtensions(first: 10, filter: $filter){
+    edges{
+      node{
+        label
+        url
+        view
+        target
+        id
+        type
+        permissions{
+          code
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def test_app_extensions(staff_api_client, app, permission_manage_products):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    variables = {}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSIONS,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    extensions_data = content["data"]["appExtensions"]["edges"]
+
+    assert len(extensions_data) == 1
+    extension_data = extensions_data[0]["node"]
+    assert app_extension.label == extension_data["label"]
+    assert app_extension.url == extension_data["url"]
+    assert app_extension.view == extension_data["view"].lower()
+    assert app_extension.target == extension_data["target"].lower()
+    assert app_extension.type == extension_data["type"].lower()
+
+    assert app_extension.permissions.count() == 1
+    assert len(extension_data["permissions"]) == 1
+    permission_code = extension_data["permissions"][0]["code"].lower()
+    assert app_extension.permissions.first().codename == permission_code
+
+
+def test_app_extensions_app_not_active(
+    staff_api_client, app, permission_manage_products
+):
+    # given
+    app.is_active = False
+    app.save()
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    variables = {}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSIONS,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    extensions_data = content["data"]["appExtensions"]["edges"]
+
+    assert len(extensions_data) == 0
+
+
+def test_app_extensions_user_not_staff(
+    user_api_client, app, permission_manage_products
+):
+    # given
+    app_extension = AppExtension.objects.create(
+        app=app,
+        label="Create product with App",
+        url="https://www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    app_extension.permissions.add(permission_manage_products)
+    variables = {}
+
+    # when
+    response = user_api_client.post_graphql(
+        QUERY_APP_EXTENSIONS,
+        variables,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+@pytest.mark.parametrize(
+    "filter, expected_count",
+    [
+        ({}, 3),
+        ({"view": AppExtensionViewEnum.PRODUCT.name}, 3),
+        ({"target": AppExtensionTargetEnum.CREATE.name}, 1),
+        ({"type": AppExtensionTypeEnum.OVERVIEW.name}, 2),
+        (
+            {
+                "type": AppExtensionTypeEnum.OVERVIEW.name,
+                "view": AppExtensionViewEnum.PRODUCT.name,
+            },
+            2,
+        ),
+        (
+            {
+                "type": AppExtensionTypeEnum.DETAILS.name,
+                "target": AppExtensionTargetEnum.CREATE.name,
+            },
+            0,
+        ),
+        (
+            {
+                "type": AppExtensionTypeEnum.DETAILS.name,
+                "target": AppExtensionTargetEnum.MORE_ACTIONS.name,
+            },
+            1,
+        ),
+    ],
+)
+def test_app_extensions_with_filter(
+    filter, expected_count, staff_api_client, app, permission_manage_products
+):
+    # given
+    app_extensions = AppExtension.objects.bulk_create(
+        [
+            AppExtension(
+                app=app,
+                label="Create product with App1",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App2",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.DETAILS,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+            AppExtension(
+                app=app,
+                label="Create product with App3",
+                url="https://www.example.com/app-product",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.OVERVIEW,
+                target=AppExtensionTarget.CREATE,
+            ),
+        ]
+    )
+    app_extensions[0].permissions.add(permission_manage_products)
+    variables = {"filter": filter}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APP_EXTENSIONS,
+        variables,
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    extensions_data = content["data"]["appExtensions"]["edges"]
+
+    assert len(extensions_data) == expected_count

--- a/saleor/graphql/app/tests/queries/test_apps.py
+++ b/saleor/graphql/app/tests/queries/test_apps.py
@@ -1,3 +1,4 @@
+import graphene
 import pytest
 from freezegun import freeze_time
 
@@ -32,6 +33,17 @@ QUERY_APPS_WITH_FILTER = """
                     supportUrl
                     configurationUrl
                     appUrl
+                    extensions{
+                        id
+                        label
+                        url
+                        view
+                        type
+                        target
+                        permissions{
+                            code
+                        }
+                    }
                 }
             }
         }
@@ -53,11 +65,12 @@ def test_apps_query(
     staff_api_client,
     permission_manage_apps,
     permission_manage_orders,
-    app,
+    app_with_extensions,
     external_app,
     app_filter,
     count,
 ):
+    app, app_extensions = app_with_extensions
     external_app.is_active = False
     external_app.save()
     webhooks = Webhook.objects.bulk_create(
@@ -85,6 +98,50 @@ def test_apps_query(
         assert len(webhooks) == 1
         assert webhooks[0]["name"] in webhooks_names
     assert len(apps_data) == count
+
+
+def test_apps_with_extensions_query(
+    staff_api_client,
+    permission_manage_apps,
+    permission_manage_orders,
+    app_with_extensions,
+):
+    # given
+    app, app_extensions = app_with_extensions
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_APPS_WITH_FILTER,
+        permissions=[permission_manage_apps, permission_manage_orders],
+    )
+
+    # then
+    content = get_graphql_content(response)
+
+    apps_data = content["data"]["apps"]["edges"]
+
+    assert len(apps_data) == 1
+    app_data = apps_data[0]["node"]
+
+    extensions_data = app_data["extensions"]
+    returned_ids = {e["id"] for e in extensions_data}
+    returned_labels = {e["label"] for e in extensions_data}
+    returned_urls = {e["url"] for e in extensions_data}
+    returned_views = {e["view"].lower() for e in extensions_data}
+    returned_types = {e["type"].lower() for e in extensions_data}
+    returned_targets = {e["target"].lower() for e in extensions_data}
+    returned_permission_codes = [e["permissions"] for e in extensions_data]
+    for app_extension in app_extensions:
+        global_id = graphene.Node.to_global_id("AppExtension", app_extension.id)
+        assert global_id in returned_ids
+        assert app_extension.label in returned_labels
+        assert app_extension.url in returned_urls
+        assert app_extension.view in returned_views
+        assert app_extension.type in returned_types
+        assert app_extension.target in returned_targets
+        assigned_permissions = [p.codename for p in app_extension.permissions.all()]
+        assigned_permissions = [{"code": p.upper()} for p in assigned_permissions]
+        assert assigned_permissions in returned_permission_codes
 
 
 QUERY_APPS_WITH_SORT = """

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -2,16 +2,59 @@ import graphene
 from graphene_federation import key
 
 from ...app import models
+from ...core.exceptions import PermissionDenied
 from ...core.permissions import AppPermission
 from ...core.tracing import traced_resolver
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import Permission
 from ..core.types.common import Job
 from ..meta.types import ObjectWithMetadata
-from ..utils import format_permissions_for_display
+from ..utils import format_permissions_for_display, get_user_or_app_from_context
 from ..webhook.types import Webhook
+from .dataloaders import AppByIdLoader, AppExtensionByAppIdLoader
 from .enums import AppTypeEnum
 from .resolvers import resolve_access_token
+
+
+class AppExtension(CountableDjangoObjectType):
+    app = graphene.Field("saleor.graphql.app.types.App", required=True)
+    permissions = graphene.List(
+        Permission, description="List of the app extension's permissions."
+    )
+
+    class Meta:
+        description = "Represents app data."
+        interfaces = [graphene.relay.Node]
+        model = models.AppExtension
+        only_fields = [
+            "label",
+            "url",
+            "view",
+            "type",
+            "target",
+        ]
+
+    @staticmethod
+    def resolve_app(root, info):
+        app_id = None
+        app = info.context.app
+        if app and app.id == root.app_id:
+            app_id = root.app_id
+
+        requestor = get_user_or_app_from_context(info.context)
+        if requestor.has_perm(AppPermission.MANAGE_APPS):
+            app_id = root.app_id
+
+        if not app_id:
+            raise PermissionDenied()
+        return AppByIdLoader(info.context).load(app_id)
+
+    @staticmethod
+    def resolve_permissions(root: models.AppExtension, _info, **_kwargs):
+        permissions = root.permissions.prefetch_related("content_type").order_by(
+            "codename"
+        )
+        return format_permissions_for_display(permissions)
 
 
 class Manifest(graphene.ObjectType):
@@ -84,6 +127,9 @@ class App(CountableDjangoObjectType):
     access_token = graphene.String(
         description="JWT token used to authenticate by thridparty app."
     )
+    extensions = graphene.List(
+        graphene.NonNull(AppExtension), description="App's dashboard extensions."
+    )
 
     class Meta:
         description = "Represents app data."
@@ -124,6 +170,10 @@ class App(CountableDjangoObjectType):
     @staticmethod
     def resolve_access_token(root: models.App, info):
         return resolve_access_token(info, root)
+
+    @staticmethod
+    def resolve_extensions(root: models.App, info):
+        return AppExtensionByAppIdLoader(info.context).load(root.id)
 
 
 class AppInstallation(CountableDjangoObjectType):

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -19,7 +19,9 @@ from .resolvers import resolve_access_token
 class AppExtension(CountableDjangoObjectType):
     app = graphene.Field("saleor.graphql.app.types.App", required=True)
     permissions = graphene.List(
-        Permission, description="List of the app extension's permissions."
+        graphene.NonNull(Permission),
+        description="List of the app extension's permissions.",
+        required=True,
     )
 
     class Meta:
@@ -40,10 +42,10 @@ class AppExtension(CountableDjangoObjectType):
         app = info.context.app
         if app and app.id == root.app_id:
             app_id = root.app_id
-
-        requestor = get_user_or_app_from_context(info.context)
-        if requestor.has_perm(AppPermission.MANAGE_APPS):
-            app_id = root.app_id
+        else:
+            requestor = get_user_or_app_from_context(info.context)
+            if requestor.has_perm(AppPermission.MANAGE_APPS):
+                app_id = root.app_id
 
         if not app_id:
             raise PermissionDenied()
@@ -128,7 +130,9 @@ class App(CountableDjangoObjectType):
         description="JWT token used to authenticate by thridparty app."
     )
     extensions = graphene.List(
-        graphene.NonNull(AppExtension), description="App's dashboard extensions."
+        graphene.NonNull(AppExtension),
+        description="App's dashboard extensions.",
+        required=True,
     )
 
     class Meta:

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -222,6 +222,7 @@ type App implements Node & ObjectWithMetadata {
   appUrl: String
   version: String
   accessToken: String
+  extensions: [AppExtension!]
 }
 
 type AppActivate {
@@ -287,6 +288,62 @@ enum AppErrorCode {
   UNIQUE
   OUT_OF_SCOPE_APP
   OUT_OF_SCOPE_PERMISSION
+}
+
+type AppExtension implements Node {
+  label: String!
+  url: String!
+  view: AppExtensionView!
+  type: AppExtensionType!
+  target: AppExtensionTarget!
+  id: ID!
+  app: App!
+  permissions: [Permission]
+}
+
+type AppExtensionCountableConnection {
+  pageInfo: PageInfo!
+  edges: [AppExtensionCountableEdge!]!
+  totalCount: Int
+}
+
+type AppExtensionCountableEdge {
+  node: AppExtension!
+  cursor: String!
+}
+
+input AppExtensionFilterInput {
+  view: AppExtensionViewEnum
+  type: AppExtensionTypeEnum
+  target: AppExtensionTargetEnum
+}
+
+enum AppExtensionTarget {
+  MORE_ACTIONS
+  CREATE
+}
+
+enum AppExtensionTargetEnum {
+  MORE_ACTIONS
+  CREATE
+}
+
+enum AppExtensionType {
+  OVERVIEW
+  DETAILS
+}
+
+enum AppExtensionTypeEnum {
+  OVERVIEW
+  DETAILS
+}
+
+enum AppExtensionView {
+  PRODUCT
+}
+
+enum AppExtensionViewEnum {
+  PRODUCT
 }
 
 type AppFetchManifest {
@@ -4784,6 +4841,8 @@ type Query {
   appsInstallations: [AppInstallation!]!
   apps(filter: AppFilterInput, sortBy: AppSortingInput, before: String, after: String, first: Int, last: Int): AppCountableConnection
   app(id: ID): App
+  appExtensions(filter: AppExtensionFilterInput, before: String, after: String, first: Int, last: Int): AppExtensionCountableConnection
+  appExtension(id: ID!): AppExtension
   addressValidationRules(countryCode: CountryCode!, countryArea: String, city: String, cityArea: String): AddressValidationData
   address(id: ID!): Address
   customers(filter: CustomerFilterInput, sortBy: UserSortingInput, before: String, after: String, first: Int, last: Int): UserCountableConnection

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -222,7 +222,7 @@ type App implements Node & ObjectWithMetadata {
   appUrl: String
   version: String
   accessToken: String
-  extensions: [AppExtension!]
+  extensions: [AppExtension!]!
 }
 
 type AppActivate {
@@ -298,7 +298,7 @@ type AppExtension implements Node {
   target: AppExtensionTarget!
   id: ID!
   app: App!
-  permissions: [Permission]
+  permissions: [Permission!]!
 }
 
 type AppExtensionCountableConnection {

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -26,8 +26,8 @@ from PIL import Image
 from prices import Money, TaxedMoney, fixed_discount
 
 from ..account.models import Address, StaffNotificationRecipient, User
-from ..app.models import App, AppInstallation
-from ..app.types import AppType
+from ..app.models import App, AppExtension, AppInstallation
+from ..app.types import AppExtensionTarget, AppExtensionType, AppExtensionView, AppType
 from ..attribute import AttributeEntityType, AttributeInputType, AttributeType
 from ..attribute.models import (
     Attribute,
@@ -3692,6 +3692,33 @@ def app(db):
     app = App.objects.create(name="Sample app objects", is_active=True)
     app.tokens.create(name="Default")
     return app
+
+
+@pytest.fixture
+def app_with_extensions(app, permission_manage_products):
+    first_app_extension = AppExtension(
+        app=app,
+        label="Create product with App",
+        url="www.example.com/app-product",
+        view=AppExtensionView.PRODUCT,
+        type=AppExtensionType.OVERVIEW,
+        target=AppExtensionTarget.MORE_ACTIONS,
+    )
+    extensions = AppExtension.objects.bulk_create(
+        [
+            first_app_extension,
+            AppExtension(
+                app=app,
+                label="Update product with App",
+                url="www.example.com/app-product-update",
+                view=AppExtensionView.PRODUCT,
+                type=AppExtensionType.DETAILS,
+                target=AppExtensionTarget.MORE_ACTIONS,
+            ),
+        ]
+    )
+    first_app_extension.permissions.add(permission_manage_products)
+    return app, extensions
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because:
- add `appExtension` query
- add `appExtenstions` query
- extend App type to return assigned extensions
- tests to cover new part of the logic

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
