### PR TITLE
Adjust amount of spans in resolvers

### DIFF
--- a/saleor/graphql/account/resolvers.py
+++ b/saleor/graphql/account/resolvers.py
@@ -31,7 +31,6 @@ USER_SEARCH_FIELDS = (
 )
 
 
-@traced_resolver
 def resolve_customers(info, **_kwargs):
     return models.User.objects.customers()
 
@@ -40,12 +39,10 @@ def resolve_permission_group(id):
     return auth_models.Group.objects.filter(id=id).first()
 
 
-@traced_resolver
 def resolve_permission_groups(info, **_kwargs):
     return auth_models.Group.objects.all()
 
 
-@traced_resolver
 def resolve_staff_users(info, **_kwargs):
     return models.User.objects.staff()
 

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -321,7 +321,6 @@ class User(CountableDjangoObjectType):
         return resolve_permissions(root)
 
     @staticmethod
-    @traced_resolver
     def resolve_permission_groups(root: models.User, _info, **_kwargs):
         return root.groups.all()
 

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -3,7 +3,6 @@ from graphene_federation import key
 
 from ...app import models
 from ...core.permissions import AppPermission
-from ...core.tracing import traced_resolver
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import Permission
 from ..core.types.common import Job
@@ -116,12 +115,10 @@ class App(CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_webhooks(root: models.App, _info):
         return root.webhooks.all()
 
     @staticmethod
-    @traced_resolver
     def resolve_access_token(root: models.App, info):
         return resolve_access_token(info, root)
 

--- a/saleor/graphql/core/types/common.py
+++ b/saleor/graphql/core/types/common.py
@@ -381,7 +381,6 @@ class File(graphene.ObjectType):
     )
 
     @staticmethod
-    @traced_resolver
     def resolve_url(root, info):
         return info.context.build_absolute_uri(urljoin(settings.MEDIA_URL, root.url))
 

--- a/saleor/graphql/core/types/money.py
+++ b/saleor/graphql/core/types/money.py
@@ -2,7 +2,6 @@ import graphene
 from django_prices.templatetags import prices
 
 from ....core.prices import quantize_price
-from ....core.tracing import traced_resolver
 
 
 class Money(graphene.ObjectType):
@@ -13,12 +12,10 @@ class Money(graphene.ObjectType):
         description = "Represents amount of money in specific currency."
 
     @staticmethod
-    @traced_resolver
     def resolve_amount(root, _info):
         return quantize_price(root.amount, root.currency)
 
     @staticmethod
-    @traced_resolver
     def resolve_localized(root, _info):
         return prices.amount(root)
 
@@ -69,12 +66,10 @@ class VAT(graphene.ObjectType):
         description = "Represents a VAT rate for a country."
 
     @staticmethod
-    @traced_resolver
     def resolve_standard_rate(root, _info):
         return root.data.get("standard_rate")
 
     @staticmethod
-    @traced_resolver
     def resolve_reduced_rates(root, _info):
         reduced_rates = root.data.get("reduced_rates", {}) or {}
         return [

--- a/saleor/graphql/product/resolvers.py
+++ b/saleor/graphql/product/resolvers.py
@@ -20,7 +20,6 @@ def resolve_category_by_slug(slug):
     return models.Category.objects.filter(slug=slug).first()
 
 
-@traced_resolver
 def resolve_categories(_info, level=None, **_kwargs):
     qs = models.Category.objects.prefetch_related("children")
     if level is not None:
@@ -28,7 +27,6 @@ def resolve_categories(_info, level=None, **_kwargs):
     return qs.distinct()
 
 
-@traced_resolver
 def resolve_collection_by_id(info, id, channel_slug, requestor):
     return (
         models.Collection.objects.visible_to_user(requestor, channel_slug=channel_slug)
@@ -37,7 +35,6 @@ def resolve_collection_by_id(info, id, channel_slug, requestor):
     )
 
 
-@traced_resolver
 def resolve_collection_by_slug(info, slug, channel_slug, requestor):
     return (
         models.Collection.objects.visible_to_user(requestor, channel_slug)
@@ -46,7 +43,6 @@ def resolve_collection_by_slug(info, slug, channel_slug, requestor):
     )
 
 
-@traced_resolver
 def resolve_collections(info, channel_slug):
     requestor = get_user_or_app_from_context(info.context)
     qs = models.Collection.objects.visible_to_user(requestor, channel_slug)
@@ -58,12 +54,10 @@ def resolve_digital_content_by_id(id):
     return models.DigitalContent.objects.filter(pk=id).first()
 
 
-@traced_resolver
 def resolve_digital_contents(_info):
     return models.DigitalContent.objects.all()
 
 
-@traced_resolver
 def resolve_product_by_id(info, id, channel_slug, requestor):
     return (
         models.Product.objects.visible_to_user(requestor, channel_slug=channel_slug)
@@ -72,7 +66,6 @@ def resolve_product_by_id(info, id, channel_slug, requestor):
     )
 
 
-@traced_resolver
 def resolve_product_by_slug(info, product_slug, channel_slug, requestor):
     return (
         models.Product.objects.visible_to_user(requestor, channel_slug=channel_slug)
@@ -113,7 +106,6 @@ def resolve_product_type_by_id(id):
     return models.ProductType.objects.filter(pk=id).first()
 
 
-@traced_resolver
 def resolve_product_types(_info, **_kwargs):
     return models.ProductType.objects.all()
 

--- a/saleor/graphql/product/types/digital_contents.py
+++ b/saleor/graphql/product/types/digital_contents.py
@@ -1,7 +1,6 @@
 import graphene
 from graphene import relay
 
-from ....core.tracing import traced_resolver
 from ....product import models
 from ...channel import ChannelContext
 from ...core.connection import CountableDjangoObjectType
@@ -22,7 +21,6 @@ class DigitalContentUrl(CountableDjangoObjectType):
         interfaces = (relay.Node,)
 
     @staticmethod
-    @traced_resolver
     def resolve_url(root: models.DigitalContentUrl, *_args):
         return root.get_absolute_url()
 

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -995,7 +995,6 @@ class ProductType(CountableDjangoObjectType):
         return graphene.Node.get_node_from_global_id(_info, root.id)
 
     @staticmethod
-    @traced_resolver
     def resolve_weight(root: models.ProductType, _info, **_kwargs):
         return convert_weight_to_default_weight_unit(root.weight)
 


### PR DESCRIPTION
I want to merge this change because in PR #7661 I left spans that should be removed.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
