### PR TITLE
Allow to set preorder settings in API

### DIFF
--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -264,6 +264,14 @@ class ProductVariantBulkCreate(BaseMutation):
         if stocks:
             cls.clean_stocks(stocks, errors, variant_index)
 
+        preorder_settings = cleaned_input.get("preorder")
+        if preorder_settings:
+            cleaned_input["is_preorder"] = True
+            cleaned_input["preorder_global_threshold"] = preorder_settings.get(
+                "global_threshold"
+            )
+            cleaned_input["preorder_end_date"] = preorder_settings.get("end_date")
+
         return cleaned_input
 
     @classmethod

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -457,6 +457,7 @@ class ProductVariantBulkCreate(BaseMutation):
             channel = channel_listing_data["channel"]
             price = channel_listing_data["price"]
             cost_price = channel_listing_data.get("cost_price")
+            preorder_quantity_threshold = channel_listing_data.get("preorder_threshold")
             variant_channel_listings.append(
                 models.ProductVariantChannelListing(
                     channel=channel,
@@ -464,6 +465,7 @@ class ProductVariantBulkCreate(BaseMutation):
                     price_amount=price,
                     cost_price_amount=cost_price,
                     currency=channel.currency_code,
+                    preorder_quantity_threshold=preorder_quantity_threshold,
                 )
             )
         models.ProductVariantChannelListing.objects.bulk_create(

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -305,6 +305,9 @@ class ProductVariantChannelListingAddInput(graphene.InputObjectType):
         required=True, description="Price of the particular variant in channel."
     )
     cost_price = PositiveDecimal(description="Cost price of the variant in channel.")
+    preorder_threshold = graphene.Int(
+        description="The threshold for preorder variant in channel."
+    )
 
 
 class ProductVariantChannelListingUpdate(BaseMutation):

--- a/saleor/graphql/product/mutations/channels.py
+++ b/saleor/graphql/product/mutations/channels.py
@@ -428,6 +428,10 @@ class ProductVariantChannelListingUpdate(BaseMutation):
                 defaults["cost_price_amount"] = channel_listing_data.get(
                     "cost_price", None
                 )
+            if "preorder_threshold" in channel_listing_data.keys():
+                defaults["preorder_quantity_threshold"] = channel_listing_data.get(
+                    "preorder_threshold", None
+                )
             ProductVariantChannelListing.objects.update_or_create(
                 variant=variant,
                 channel=channel,

--- a/saleor/graphql/product/mutations/products.py
+++ b/saleor/graphql/product/mutations/products.py
@@ -744,6 +744,13 @@ class ProductDelete(ModelDeleteMutation):
         ).delete()
 
 
+class PreorderSettingsInput(graphene.InputObjectType):
+    global_threshold = graphene.Int(
+        description="The global threshold for preorder variant."
+    )
+    end_date = graphene.DateTime(description="The end date for preorder.")
+
+
 class ProductVariantInput(graphene.InputObjectType):
     attributes = graphene.List(
         graphene.NonNull(AttributeValueInput),
@@ -758,6 +765,9 @@ class ProductVariantInput(graphene.InputObjectType):
         )
     )
     weight = WeightScalar(description="Weight of the Product Variant.", required=False)
+    preorder = PreorderSettingsInput(
+        description="Determines if variant is in preorder."
+    )
 
 
 class ProductVariantCreateInput(ProductVariantInput):
@@ -882,6 +892,14 @@ class ProductVariantCreate(ModelMutation):
                     )
             except ValidationError as exc:
                 raise ValidationError({"attributes": exc})
+
+        preorder_settings = cleaned_input.get("preorder")
+        if preorder_settings:
+            cleaned_input["is_preorder"] = True
+            cleaned_input["preorder_global_threshold"] = preorder_settings.get(
+                "global_threshold"
+            )
+            cleaned_input["preorder_end_date"] = preorder_settings.get("end_date")
 
         return cleaned_input
 

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -2539,6 +2539,101 @@ def test_update_product_variant_with_price_does_not_raise_price_validation_error
     assert not content["data"]["productVariantUpdate"]["errors"]
 
 
+QUERY_UPDATE_VARIANT_PREORDER = """
+    mutation updateVariant (
+        $id: ID!,
+        $sku: String!,
+        $preorder: PreorderSettingsInput) {
+            productVariantUpdate(
+                id: $id,
+                input: {
+                    sku: $sku,
+                    preorder: $preorder,
+                }) {
+                productVariant {
+                    sku
+                    preorder {
+                        isPreorder
+                        globalThreshold
+                        endDate
+                    }
+                }
+            }
+        }
+"""
+
+
+def test_update_product_variant_change_preorder_data(
+    staff_api_client,
+    permission_manage_products,
+    preorder_variant_global_threshold,
+):
+    variant = preorder_variant_global_threshold
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    sku = "test sku"
+
+    new_global_threshold = variant.preorder_global_threshold + 5
+    assert variant.preorder_end_date is None
+    new_preorder_end_date = (
+        (datetime.now() + timedelta(days=3))
+        .astimezone()
+        .replace(microsecond=0)
+        .isoformat()
+    )
+    variables = {
+        "id": variant_id,
+        "sku": sku,
+        "preorder": {
+            "globalThreshold": new_global_threshold,
+            "endDate": new_preorder_end_date,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_PREORDER,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    variant.refresh_from_db()
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantUpdate"]["productVariant"]
+
+    assert data["sku"] == sku
+    assert data["preorder"]["isPreorder"] is True
+    assert data["preorder"]["globalThreshold"] == new_global_threshold
+    assert data["preorder"]["endDate"] == new_preorder_end_date
+
+
+def test_update_product_variant_can_not_turn_off_preorder(
+    staff_api_client,
+    permission_manage_products,
+    preorder_variant_global_threshold,
+):
+    """Passing None with `preorder` field can not turn off preorder,
+    it could be done only with ProductVariantPreorderDeactivate mutation."""
+    variant = preorder_variant_global_threshold
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.pk)
+    sku = "test sku"
+
+    variables = {"id": variant_id, "sku": sku, "preorder": None}
+
+    response = staff_api_client.post_graphql(
+        QUERY_UPDATE_VARIANT_PREORDER,
+        variables,
+        permissions=[permission_manage_products],
+    )
+    variant.refresh_from_db()
+    content = get_graphql_content(response)
+    flush_post_commit_hooks()
+    data = content["data"]["productVariantUpdate"]["productVariant"]
+
+    assert data["sku"] == sku
+    assert data["preorder"]["isPreorder"] is True
+    assert data["preorder"]["globalThreshold"] == variant.preorder_global_threshold
+    assert data["preorder"]["endDate"] is None
+
+
 DELETE_VARIANT_MUTATION = """
     mutation variantDelete($id: ID!) {
         productVariantDelete(id: $id) {

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta
 from unittest.mock import ANY, patch
 from uuid import uuid4
 
@@ -440,7 +441,8 @@ CREATE_VARIANT_MUTATION = """
             $stocks: [StockInput!],
             $attributes: [AttributeValueInput!]!,
             $weight: WeightScalar,
-            $trackInventory: Boolean) {
+            $trackInventory: Boolean,
+            $preorder: PreorderSettingsInput) {
                 productVariantCreate(
                     input: {
                         product: $productId,
@@ -448,7 +450,8 @@ CREATE_VARIANT_MUTATION = """
                         stocks: $stocks,
                         attributes: $attributes,
                         trackInventory: $trackInventory,
-                        weight: $weight
+                        weight: $weight,
+                        preorder: $preorder
                     }) {
                     errors {
                       field
@@ -485,6 +488,11 @@ CREATE_VARIANT_MUTATION = """
                             warehouse {
                                 slug
                             }
+                        }
+                        preorder {
+                            isPreorder
+                            globalThreshold
+                            endDate
                         }
                     }
                 }
@@ -545,6 +553,58 @@ def test_create_variant(
     assert len(data["stocks"]) == 1
     assert data["stocks"][0]["quantity"] == stocks[0]["quantity"]
     assert data["stocks"][0]["warehouse"]["slug"] == warehouse.slug
+    created_webhook_mock.assert_called_once_with(product.variants.last())
+    updated_webhook_mock.assert_not_called()
+
+
+@patch("saleor.plugins.manager.PluginsManager.product_variant_created")
+@patch("saleor.plugins.manager.PluginsManager.product_variant_updated")
+def test_create_variant_preorder(
+    updated_webhook_mock,
+    created_webhook_mock,
+    staff_api_client,
+    product,
+    product_type,
+    permission_manage_products,
+):
+    query = CREATE_VARIANT_MUTATION
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    variant_id = graphene.Node.to_global_id(
+        "Attribute", product_type.variant_attributes.first().pk
+    )
+    variant_value = "test-value"
+    global_threshold = 10
+    end_date = (
+        (datetime.now() + timedelta(days=3))
+        .astimezone()
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+    variables = {
+        "productId": product_id,
+        "sku": "1",
+        "weight": 10.22,
+        "attributes": [{"id": variant_id, "values": [variant_value]}],
+        "preorder": {
+            "globalThreshold": global_threshold,
+            "endDate": end_date,
+        },
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_products]
+    )
+    content = get_graphql_content(response)["data"]["productVariantCreate"]
+    flush_post_commit_hooks()
+
+    assert not content["errors"]
+    data = content["productVariant"]
+    assert data["name"] == variant_value
+
+    assert data["preorder"]["isPreorder"] is True
+    assert data["preorder"]["globalThreshold"] == global_threshold
+    assert data["preorder"]["endDate"] == end_date
     created_webhook_mock.assert_called_once_with(product.variants.last())
     updated_webhook_mock.assert_not_called()
 
@@ -3115,6 +3175,11 @@ PRODUCT_VARIANT_BULK_CREATE_MUTATION = """
                         amount
                     }
                 }
+                preorder {
+                    isPreorder
+                    globalThreshold
+                    endDate
+                }
             }
             count
         }
@@ -3552,6 +3617,154 @@ def test_product_variant_bulk_create_channel_listings_input(
                 for channelListing in variant_data["channelListings"]
             ]
         )
+
+
+def test_product_variant_bulk_create_preorder_channel_listings_input(
+    staff_api_client,
+    product_available_in_many_channels,
+    permission_manage_products,
+    size_attribute,
+    channel_USD,
+    channel_PLN,
+):
+    product = product_available_in_many_channels
+    ProductChannelListing.objects.filter(product=product, channel=channel_PLN).update(
+        is_published=False
+    )
+    product_variant_count = ProductVariant.objects.count()
+    product_id = graphene.Node.to_global_id("Product", product.pk)
+    attribute_value_count = size_attribute.values.count()
+    size_attribute_id = graphene.Node.to_global_id("Attribute", size_attribute.pk)
+    attribute_value = size_attribute.values.last()
+
+    global_threshold = 10
+    end_date = (
+        (datetime.now() + timedelta(days=3))
+        .astimezone()
+        .replace(microsecond=0)
+        .isoformat()
+    )
+
+    variants = [
+        {
+            "sku": str(uuid4())[:12],
+            "channelListings": [
+                {
+                    "price": 10.0,
+                    "costPrice": 11.0,
+                    "channelId": graphene.Node.to_global_id("Channel", channel_USD.pk),
+                }
+            ],
+            "attributes": [{"id": size_attribute_id, "values": [attribute_value.name]}],
+            "preorder": {
+                "globalThreshold": global_threshold,
+                "endDate": end_date,
+            },
+        },
+        {
+            "sku": str(uuid4())[:12],
+            "attributes": [{"id": size_attribute_id, "values": ["Test-attribute"]}],
+            "channelListings": [
+                {
+                    "price": 15.0,
+                    "costPrice": 16.0,
+                    "channelId": graphene.Node.to_global_id("Channel", channel_USD.pk),
+                },
+                {
+                    "price": 12.0,
+                    "costPrice": 13.0,
+                    "channelId": graphene.Node.to_global_id("Channel", channel_PLN.pk),
+                },
+            ],
+            "preorder": {
+                "globalThreshold": global_threshold,
+                "endDate": end_date,
+            },
+        },
+    ]
+
+    variables = {"productId": product_id, "variants": variants}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(
+        PRODUCT_VARIANT_BULK_CREATE_MUTATION, variables
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariantBulkCreate"]
+    assert not data["errors"]
+    assert data["count"] == 2
+    assert product_variant_count + 2 == ProductVariant.objects.count()
+    assert attribute_value_count + 1 == size_attribute.values.count()
+
+    expected_result = {
+        variants[0]["sku"]: {
+            "sku": variants[0]["sku"],
+            "channelListings": [
+                {
+                    "channel": {"slug": channel_USD.slug},
+                    "price": {
+                        "amount": variants[0]["channelListings"][0]["price"],
+                        "currency": channel_USD.currency_code,
+                    },
+                    "costPrice": {
+                        "amount": variants[0]["channelListings"][0]["costPrice"],
+                        "currency": channel_USD.currency_code,
+                    },
+                }
+            ],
+            "preorder": {
+                "isPreorder": True,
+                "globalThreshold": global_threshold,
+                "endDate": end_date,
+            },
+        },
+        variants[1]["sku"]: {
+            "sku": variants[1]["sku"],
+            "channelListings": [
+                {
+                    "channel": {"slug": channel_USD.slug},
+                    "price": {
+                        "amount": variants[1]["channelListings"][0]["price"],
+                        "currency": channel_USD.currency_code,
+                    },
+                    "costPrice": {
+                        "amount": variants[1]["channelListings"][0]["costPrice"],
+                        "currency": channel_USD.currency_code,
+                    },
+                },
+                {
+                    "channel": {"slug": channel_PLN.slug},
+                    "price": {
+                        "amount": variants[1]["channelListings"][1]["price"],
+                        "currency": channel_PLN.currency_code,
+                    },
+                    "costPrice": {
+                        "amount": variants[1]["channelListings"][1]["costPrice"],
+                        "currency": channel_PLN.currency_code,
+                    },
+                },
+            ],
+            "preorder": {
+                "isPreorder": True,
+                "globalThreshold": global_threshold,
+                "endDate": end_date,
+            },
+        },
+    }
+    for variant_data in data["productVariants"]:
+        variant_data.pop("id")
+        assert variant_data["sku"] in expected_result
+        expected_variant = expected_result[variant_data["sku"]]
+        expected_channel_listing = expected_variant["channelListings"]
+        assert all(
+            [
+                channelListing in expected_channel_listing
+                for channelListing in variant_data["channelListings"]
+            ]
+        )
+        preorder_data = variant_data["preorder"]
+        assert preorder_data["isPreorder"] is True
+        assert preorder_data["globalThreshold"] == global_threshold
+        assert preorder_data["endDate"] == end_date
 
 
 def test_product_variant_bulk_create_duplicated_channels(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4090,6 +4090,11 @@ type PreorderData {
   endDate: DateTime
 }
 
+input PreorderSettingsInput {
+  globalThreshold: Int
+  endDate: DateTime
+}
+
 type PreorderThreshold {
   quantity: Int
   soldUnits: Int!
@@ -4591,6 +4596,7 @@ input ProductVariantBulkCreateInput {
   sku: String!
   trackInventory: Boolean
   weight: WeightScalar
+  preorder: PreorderSettingsInput
   stocks: [StockInput!]
   channelListings: [ProductVariantChannelListingAddInput!]
 }
@@ -4644,6 +4650,7 @@ input ProductVariantCreateInput {
   sku: String
   trackInventory: Boolean
   weight: WeightScalar
+  preorder: PreorderSettingsInput
   product: ID!
   stocks: [StockInput!]
 }
@@ -4665,6 +4672,7 @@ input ProductVariantInput {
   sku: String
   trackInventory: Boolean
   weight: WeightScalar
+  preorder: PreorderSettingsInput
 }
 
 type ProductVariantReorder {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4620,6 +4620,7 @@ input ProductVariantChannelListingAddInput {
   channelId: ID!
   price: PositiveDecimal!
   costPrice: PositiveDecimal
+  preorderThreshold: Int
 }
 
 type ProductVariantChannelListingUpdate {


### PR DESCRIPTION
I want to merge this change because it adjusts existing mutations to set/update preorder settings.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
