### PR TITLE
Allow translating rich-text attributes values

### DIFF
--- a/saleor/attribute/__init__.py
+++ b/saleor/attribute/__init__.py
@@ -38,6 +38,11 @@ class AttributeInputType:
         NUMERIC,
     ]
 
+    # list of the translatable attributes
+    TRANSLATABLE_ATTRIBUTES = [
+        RICH_TEXT,
+    ]
+
 
 # list of input types that are allowed for given attribute property
 ATTRIBUTE_PROPERTIES_CONFIGURATION = {

--- a/saleor/attribute/__init__.py
+++ b/saleor/attribute/__init__.py
@@ -38,7 +38,7 @@ class AttributeInputType:
         NUMERIC,
     ]
 
-    # list of the translatable attributes
+    # list of the translatable attributes, excluding attributes with choices.
     TRANSLATABLE_ATTRIBUTES = [
         RICH_TEXT,
     ]

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -666,6 +666,7 @@ input AttributeValueInput {
 type AttributeValueTranslatableContent implements Node {
   id: ID!
   name: String!
+  richText: JSONString
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
   attributeValue: AttributeValue @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
 }
@@ -4423,6 +4424,7 @@ type ProductTranslatableContent implements Node {
   descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   product: Product @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductTranslate {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3678,6 +3678,7 @@ type PageTranslatableContent implements Node {
   contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   page: Page @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type PageTranslate {
@@ -4699,6 +4700,7 @@ type ProductVariantTranslatableContent implements Node {
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   productVariant: ProductVariant @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductVariantTranslate {

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -2325,46 +2325,26 @@ def test_product_attribute_value_rich_text_translation(
     )
 
     query = """
-    query translation(
-        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
-    ){
-        translation(kind: $kind, id: $id){
-            __typename
-            ...on ProductTranslatableContent{
-                name
-                attributeValues{
-                name
-                richText
-                translation(languageCode: $languageCode){
+        query translation(
+            $kind: TranslatableKinds!
+            $id: ID!
+            $languageCode: LanguageCodeEnum!
+        ) {
+            translation(kind: $kind, id: $id) {
+                ... on ProductTranslatableContent {
                     name
-                    richText
+                    attributeValues {
+                        name
+                        richText
+                        translation(languageCode: $languageCode) {
+                            name
+                            richText
+                        }
                     }
                 }
             }
         }
-    }
-"""
-    # """
-    # {
-    #     translations(kind: PRODUCT, first: 1) {
-    #         edges {
-    #             node {
-    #                 ... on ProductTranslatableContent {
-    #                     name
-    #                     attributeValues{
-    #                     name
-    #                     richText
-    #                     translation(languageCode: PL) {
-    #                         name
-    #                         richText
-    #                         }
-    #                     }
-    #                 }
-    #             }
-    #         }
-    #     }
-    # }
-    # """
+    """
     variables = {
         "id": product_id,
         "kind": TranslatableKinds.PRODUCT.name,
@@ -2378,12 +2358,8 @@ def test_product_attribute_value_rich_text_translation(
 
     attribute_value_response = data["translation"]["attributeValues"][0]
     assert attribute_value_response["name"] == attribute_value.name
-    assert attribute_value_response["richText"] == dummy_editorjs(
-        "Rich text attribute content.", json_format=True
-    )
-    assert attribute_value_response["translation"]["richText"] == dummy_editorjs(
-        "Test_dummy_data", json_format=True
-    )
+    assert attribute_value_response["richText"] == json.dumps(attribute_value.rich_text)
+    assert attribute_value_response["translation"]["richText"] == json.dumps(rich_text)
 
 
 def test_product_variant_attribute_value_rich_text_translation(
@@ -2402,24 +2378,25 @@ def test_product_variant_attribute_value_rich_text_translation(
     )
 
     query = """
-    query translation(
-        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
-    ){
-        translation(kind: $kind, id: $id){
-            __typename
-            ...on ProductVariantTranslatableContent{
-                        name
-                        attributeValues{
+        query translation(
+            $kind: TranslatableKinds!
+            $id: ID!
+            $languageCode: LanguageCodeEnum!
+        ) {
+            translation(kind: $kind, id: $id) {
+                ... on ProductVariantTranslatableContent {
+                    name
+                    attributeValues {
                         name
                         richText
                         translation(languageCode: $languageCode) {
                             name
                             richText
-                            }
                         }
+                    }
+                }
             }
         }
-    }
     """
     variables = {
         "id": variant_id,
@@ -2434,12 +2411,8 @@ def test_product_variant_attribute_value_rich_text_translation(
 
     translations_response = data["translation"]["attributeValues"][0]
     assert translations_response["name"] == attribute_value.name
-    assert translations_response["richText"] == dummy_editorjs(
-        "Rich text attribute content.", json_format=True
-    )
-    assert translations_response["translation"]["richText"] == dummy_editorjs(
-        "Test_dummy_data", json_format=True
-    )
+    assert translations_response["richText"] == json.dumps(attribute_value.rich_text)
+    assert translations_response["translation"]["richText"] == json.dumps(rich_text)
 
 
 def test_page_attribute_value_rich_text_translation(
@@ -2457,24 +2430,26 @@ def test_page_attribute_value_rich_text_translation(
     page_id = graphene.Node.to_global_id("Page", page_with_rich_text_attribute.id)
 
     query = """
-    query translation(
-        $   kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
-        ){
-            translation(kind: $kind, id: $id){
-                __typename
-                ...on PageTranslatableContent{
-                            attributeValues{
+        query translation(
+            $kind: TranslatableKinds!
+            $id: ID!
+            $languageCode: LanguageCodeEnum!
+        ) {
+            translation(kind: $kind, id: $id) {
+                ... on PageTranslatableContent {
+                    attributeValues {
+                        name
+                        richText
+                        translation(languageCode: $languageCode) {
                             name
                             richText
-                            translation(languageCode: $languageCode) {
-                                name
-                                richText
-                                }
-                            }
                         }
                     }
                 }
-        """
+            }
+        }
+
+    """
 
     variables = {
         "id": page_id,
@@ -2488,9 +2463,5 @@ def test_page_attribute_value_rich_text_translation(
 
     attribute_value_response = data["translation"]["attributeValues"][0]
     assert attribute_value_response["name"] == attribute_value.name
-    assert attribute_value_response["richText"] == dummy_editorjs(
-        "Rich text attribute content.", json_format=True
-    )
-    assert attribute_value_response["translation"]["richText"] == dummy_editorjs(
-        "Test_dummy_data", json_format=True
-    )
+    assert attribute_value_response["richText"] == json.dumps(attribute_value.rich_text)
+    assert attribute_value_response["translation"]["richText"] == json.dumps(rich_text)

--- a/saleor/graphql/translations/tests/test_translations.py
+++ b/saleor/graphql/translations/tests/test_translations.py
@@ -2308,3 +2308,189 @@ def test_product_and_attribute_translation(user_api_client, product, channel_USD
     ]
     assert attribute_translation_data["name"] == "Kolor"
     assert attribute_translation_data["language"]["code"] == "PL"
+
+
+def test_product_attribute_value_rich_text_translation(
+    staff_api_client,
+    product_with_rich_text_attribute,
+    permission_manage_translations,
+):
+    rich_text = dummy_editorjs("Test_dummy_data")
+    assigned_attribute = product_with_rich_text_attribute[0].attributes.first()
+    attribute_value = assigned_attribute.attribute.values.first()
+    attribute_value.translations.create(language_code="pl", rich_text=rich_text)
+
+    product_id = graphene.Node.to_global_id(
+        "Product", product_with_rich_text_attribute[0].id
+    )
+
+    query = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on ProductTranslatableContent{
+                name
+                attributeValues{
+                name
+                richText
+                translation(languageCode: $languageCode){
+                    name
+                    richText
+                    }
+                }
+            }
+        }
+    }
+"""
+    # """
+    # {
+    #     translations(kind: PRODUCT, first: 1) {
+    #         edges {
+    #             node {
+    #                 ... on ProductTranslatableContent {
+    #                     name
+    #                     attributeValues{
+    #                     name
+    #                     richText
+    #                     translation(languageCode: PL) {
+    #                         name
+    #                         richText
+    #                         }
+    #                     }
+    #                 }
+    #             }
+    #         }
+    #     }
+    # }
+    # """
+    variables = {
+        "id": product_id,
+        "kind": TranslatableKinds.PRODUCT.name,
+        "languageCode": LanguageCodeEnum.PL.name,
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_translations]
+    )
+    data = get_graphql_content(response)["data"]
+
+    attribute_value_response = data["translation"]["attributeValues"][0]
+    assert attribute_value_response["name"] == attribute_value.name
+    assert attribute_value_response["richText"] == dummy_editorjs(
+        "Rich text attribute content.", json_format=True
+    )
+    assert attribute_value_response["translation"]["richText"] == dummy_editorjs(
+        "Test_dummy_data", json_format=True
+    )
+
+
+def test_product_variant_attribute_value_rich_text_translation(
+    staff_api_client,
+    product_with_rich_text_attribute,
+    permission_manage_translations,
+    product_type_with_rich_text_attribute,
+):
+    rich_text = dummy_editorjs("Test_dummy_data")
+    variant_attr = product_type_with_rich_text_attribute.variant_attributes.first()
+    attribute_value = variant_attr.values.first()
+    attribute_value.translations.create(language_code="pl", rich_text=rich_text)
+
+    variant_id = graphene.Node.to_global_id(
+        "ProductVariant", product_with_rich_text_attribute[1].id
+    )
+
+    query = """
+    query translation(
+        $kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+    ){
+        translation(kind: $kind, id: $id){
+            __typename
+            ...on ProductVariantTranslatableContent{
+                        name
+                        attributeValues{
+                        name
+                        richText
+                        translation(languageCode: $languageCode) {
+                            name
+                            richText
+                            }
+                        }
+            }
+        }
+    }
+    """
+    variables = {
+        "id": variant_id,
+        "kind": TranslatableKinds.VARIANT.name,
+        "languageCode": LanguageCodeEnum.PL.name,
+    }
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_translations]
+    )
+    data = get_graphql_content(response)["data"]
+
+    translations_response = data["translation"]["attributeValues"][0]
+    assert translations_response["name"] == attribute_value.name
+    assert translations_response["richText"] == dummy_editorjs(
+        "Rich text attribute content.", json_format=True
+    )
+    assert translations_response["translation"]["richText"] == dummy_editorjs(
+        "Test_dummy_data", json_format=True
+    )
+
+
+def test_page_attribute_value_rich_text_translation(
+    staff_api_client,
+    page_with_rich_text_attribute,
+    permission_manage_translations,
+    page_type_with_rich_text_attribute,
+    permission_manage_pages,
+):
+    rich_text = dummy_editorjs("Test_dummy_data")
+    variant_attr = page_type_with_rich_text_attribute.page_attributes.first()
+    attribute_value = variant_attr.values.first()
+    attribute_value.translations.create(language_code="pl", rich_text=rich_text)
+
+    page_id = graphene.Node.to_global_id("Page", page_with_rich_text_attribute.id)
+
+    query = """
+    query translation(
+        $   kind: TranslatableKinds!, $id: ID!, $languageCode: LanguageCodeEnum!
+        ){
+            translation(kind: $kind, id: $id){
+                __typename
+                ...on PageTranslatableContent{
+                            attributeValues{
+                            name
+                            richText
+                            translation(languageCode: $languageCode) {
+                                name
+                                richText
+                                }
+                            }
+                        }
+                    }
+                }
+        """
+
+    variables = {
+        "id": page_id,
+        "kind": TranslatableKinds.PAGE.name,
+        "languageCode": LanguageCodeEnum.PL.name,
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_translations]
+    )
+    data = get_graphql_content(response)["data"]
+
+    attribute_value_response = data["translation"]["attributeValues"][0]
+    assert attribute_value_response["name"] == attribute_value.name
+    assert attribute_value_response["richText"] == dummy_editorjs(
+        "Rich text attribute content.", json_format=True
+    )
+    assert attribute_value_response["translation"]["richText"] == dummy_editorjs(
+        "Test_dummy_data", json_format=True
+    )

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -859,6 +859,27 @@ def rich_text_attribute(db):
 
 
 @pytest.fixture
+def rich_text_attribute_page_type(db):
+    attribute = Attribute.objects.create(
+        slug="text",
+        name="Text",
+        type=AttributeType.PAGE_TYPE,
+        input_type=AttributeInputType.RICH_TEXT,
+        filterable_in_storefront=False,
+        filterable_in_dashboard=False,
+        available_in_grid=False,
+    )
+    text = "Rich text attribute content."
+    AttributeValue.objects.create(
+        attribute=attribute,
+        name=truncatechars(clean_editor_js(dummy_editorjs(text), to_string=True), 50),
+        slug=f"instance_{attribute.id}",
+        rich_text=dummy_editorjs(text),
+    )
+    return attribute
+
+
+@pytest.fixture
 def rich_text_attribute_with_many_values(rich_text_attribute):
     attribute = rich_text_attribute
     values = []
@@ -1274,6 +1295,21 @@ def product_type(color_attribute, size_attribute):
 
 
 @pytest.fixture
+def product_type_with_rich_text_attribute(
+    rich_text_attribute, color_attribute, size_attribute
+):
+    product_type = ProductType.objects.create(
+        name="Default Type",
+        slug="default-type",
+        has_variants=True,
+        is_shipping_required=True,
+    )
+    product_type.product_attributes.add(rich_text_attribute)
+    product_type.variant_attributes.add(rich_text_attribute)
+    return product_type
+
+
+@pytest.fixture
 def product_type_without_variant():
     product_type = ProductType.objects.create(
         name="Type", slug="type", has_variants=False, is_shipping_required=True
@@ -1319,6 +1355,48 @@ def product(product_type, category, warehouse, channel_USD):
 
     associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
     return product
+
+
+@pytest.fixture
+def product_with_rich_text_attribute(
+    product_type_with_rich_text_attribute, category, warehouse, channel_USD
+):
+    product_attr = product_type_with_rich_text_attribute.product_attributes.first()
+    product_attr_value = product_attr.values.first()
+
+    product = Product.objects.create(
+        name="Test product",
+        slug="test-product-11",
+        product_type=product_type_with_rich_text_attribute,
+        category=category,
+    )
+    ProductChannelListing.objects.create(
+        product=product,
+        channel=channel_USD,
+        is_published=True,
+        discounted_price_amount="10.00",
+        currency=channel_USD.currency_code,
+        visible_in_listings=True,
+        available_for_purchase=datetime.date(1999, 1, 1),
+    )
+
+    associate_attribute_values_to_instance(product, product_attr, product_attr_value)
+
+    variant_attr = product_type_with_rich_text_attribute.variant_attributes.first()
+    variant_attr_value = variant_attr.values.first()
+
+    variant = ProductVariant.objects.create(product=product, sku="123")
+    ProductVariantChannelListing.objects.create(
+        variant=variant,
+        channel=channel_USD,
+        price_amount=Decimal(10),
+        cost_price_amount=Decimal(1),
+        currency=channel_USD.currency_code,
+    )
+    Stock.objects.create(warehouse=warehouse, product_variant=variant, quantity=10)
+
+    associate_attribute_values_to_instance(variant, variant_attr, variant_attr_value)
+    return [product, variant]
 
 
 @pytest.fixture
@@ -3224,6 +3302,26 @@ def page(db, page_type):
 
 
 @pytest.fixture
+def page_with_rich_text_attribute(db, page_type_with_rich_text_attribute):
+    data = {
+        "slug": "test-url",
+        "title": "Test page",
+        "content": dummy_editorjs("Test content."),
+        "is_published": True,
+        "page_type": page_type_with_rich_text_attribute,
+    }
+    page = Page.objects.create(**data)
+
+    # associate attribute value
+    page_attr = page_type_with_rich_text_attribute.page_attributes.first()
+    page_attr_value = page_attr.values.first()
+
+    associate_attribute_values_to_instance(page, page_attr, page_attr_value)
+
+    return page
+
+
+@pytest.fixture
 def page_list(db, page_type):
     data_1 = {
         "slug": "test-url",
@@ -3267,6 +3365,13 @@ def page_type(db, size_page_attribute, tag_page_attribute):
     page_type.page_attributes.add(size_page_attribute)
     page_type.page_attributes.add(tag_page_attribute)
 
+    return page_type
+
+
+@pytest.fixture
+def page_type_with_rich_text_attribute(db, rich_text_attribute_page_type):
+    page_type = PageType.objects.create(name="Test page type", slug="test-page-type")
+    page_type.page_attributes.add(rich_text_attribute_page_type)
     return page_type
 
 


### PR DESCRIPTION
I want to merge this change because it allows to translate product and page attributes.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
