### PR TITLE
Drop giftCard expiry_type default value

### DIFF
--- a/saleor/giftcard/migrations/0005_auto_20210719_1116.py
+++ b/saleor/giftcard/migrations/0005_auto_20210719_1116.py
@@ -73,7 +73,6 @@ class Migration(migrations.Migration):
                     ("expiry_period", "Expiry period"),
                     ("expiry_date", "Expiry date"),
                 ],
-                default="expiry_date",
                 max_length=32,
             ),
         ),

--- a/saleor/giftcard/models.py
+++ b/saleor/giftcard/models.py
@@ -54,8 +54,6 @@ class GiftCard(ModelWithMetadata):
     expiry_type = models.CharField(
         max_length=32,
         choices=GiftCardExpiryType.CHOICES,
-        # to removed after updating GiftCard mutations
-        default=GiftCardExpiryType.EXPIRY_DATE,
     )
     expiry_period_type = models.CharField(
         max_length=32, choices=TimePeriodType.CHOICES, null=True, blank=True


### PR DESCRIPTION
Drom `GiftCard` `expiry_type` deault value from model

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
