### PR TITLE
Fulfillment API - quantity to fulfill

### DIFF
--- a/saleor/graphql/order/dataloaders.py
+++ b/saleor/graphql/order/dataloaders.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 from django.db.models import F
 
+from ...order import FulfillmentStatus
 from ...order.models import Fulfillment, FulfillmentLine, Order, OrderEvent, OrderLine
 from ...warehouse.models import Allocation
 from ..core.dataloaders import DataLoader
@@ -103,3 +104,17 @@ class FulfillmentLinesByIdLoader(DataLoader):
     def batch_load(self, keys):
         fulfillment_lines = FulfillmentLine.objects.in_bulk(keys)
         return [fulfillment_lines.get(line_id) for line_id in keys]
+
+
+class FulfillmentLinesAwaitingApprovalByOrderLineIdLoader(DataLoader):
+    context_key = "fulfillment_lines_awaitng_approval_by_orderline"
+
+    def batch_load(self, keys):
+        fulfillments = FulfillmentLine.objects.filter(
+            order_line_id__in=keys,
+            fulfillment__status=FulfillmentStatus.WAITING_FOR_APPROVAL,
+        ).order_by("pk")
+        fulfillments_map = defaultdict(list)
+        for fulfillment in fulfillments.iterator():
+            fulfillments_map[fulfillment.order_line_id].append(fulfillment)
+        return [fulfillments_map.get(order_line_id, []) for order_line_id in keys]

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -442,7 +442,7 @@ class OrderLine(CountableDjangoObjectType):
         description="List of allocations across warehouses.",
     )
     quantity_to_fulfill = graphene.Int(
-        description="A quantity of items remaining to be fulfilled."
+        required=True, description="A quantity of items remaining to be fulfilled."
     )
     unit_discount_type = graphene.Field(
         DiscountValueTypeEnum,

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -442,7 +442,7 @@ class OrderLine(CountableDjangoObjectType):
         description="List of allocations across warehouses.",
     )
     quantity_to_fulfill = graphene.Int(
-        description="A quantity of items remaining to be fulflled."
+        description="A quantity of items remaining to be fulfilled."
     )
     unit_discount_type = graphene.Field(
         DiscountValueTypeEnum,

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3355,6 +3355,7 @@ type OrderLine implements Node {
   translatedProductName: String!
   translatedVariantName: String!
   allocations: [Allocation!]
+  quantityToFulfill: Int
   unitDiscountType: DiscountValueTypeEnum
 }
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -3355,7 +3355,7 @@ type OrderLine implements Node {
   translatedProductName: String!
   translatedVariantName: String!
   allocations: [Allocation!]
-  quantityToFulfill: Int
+  quantityToFulfill: Int!
   unitDiscountType: DiscountValueTypeEnum
 }
 


### PR DESCRIPTION
I want to merge this change because it adds a new field to `orderLine` type, which is `quantityToFulfill`.
This new fields shows the number of fulfillments to be made, using rule:
`quantityToFulfill = total order line quantity - fulfilled quantity - quantity of items awaiting approval`
Frontend should be adjusted. For now on frontend we calculate manually `quantity - fulfilled quantity` and as the logic gets bigger, it should be better to have the calculation on backend.

Frontend should be adjusted - drop the calculation and simply use the `quantityToFulfill` field on order page and fulfillment create page (input limits and summary).

⚠️ This is a PR to feature branch.

⚠️ Tests for the new field and backend validation will be added in subsequent PR to feature branch.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [X] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [X] The changes are tested
* [X] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
