### PR TITLE
Add access token to AppExtension type

### DIFF
--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -208,7 +208,7 @@ def _create_access_token_for_third_party_actions(
 def create_access_token_for_app(app: "App", user: "User"):
     """Create access token for app.
 
-    App can use user jwt token to proceed given operation on the Saleor side.
+    App can use user's JWT token to proceed given operation in Saleor.
     The token which can be used by App has additional field defining the permissions
     assigned to it. The permissions set is the intersection of user permissions and
     app permissions.

--- a/saleor/core/tests/test_jwt.py
+++ b/saleor/core/tests/test_jwt.py
@@ -1,0 +1,65 @@
+import graphene
+
+from ..jwt import create_access_token_for_app_extension, jwt_decode
+
+
+def test_create_access_token_for_app_extension_staff_user_with_more_permissions(
+    app_with_extensions,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_channels,
+):
+    # given
+    staff_user.user_permissions.set(
+        [permission_manage_channels, permission_manage_apps, permission_manage_products]
+    )
+    app, extensions = app_with_extensions
+    extension = extensions[0]
+    extension.permissions.set([permission_manage_products])
+
+    # when
+    access_token = create_access_token_for_app_extension(
+        app_extension=extension,
+        permissions=extension.permissions.all(),
+        user=staff_user,
+    )
+
+    # then
+    decoded_token = jwt_decode(access_token, verify_expiration=False)
+    assert decoded_token["permissions"] == ["MANAGE_PRODUCTS"]
+    _, decode_extension_id = graphene.Node.from_global_id(
+        decoded_token["app_extension"]
+    )
+    assert int(decode_extension_id) == extension.id
+
+
+def test_create_access_token_for_app_extension_with_more_permissions(
+    app_with_extensions,
+    staff_user,
+    permission_manage_apps,
+    permission_manage_products,
+    permission_manage_channels,
+):
+    # given
+    staff_user.user_permissions.set([permission_manage_products])
+    app, extensions = app_with_extensions
+    extension = extensions[0]
+    extension.permissions.set(
+        [permission_manage_channels, permission_manage_apps, permission_manage_products]
+    )
+
+    # when
+    access_token = create_access_token_for_app_extension(
+        app_extension=extension,
+        permissions=extension.permissions.all(),
+        user=staff_user,
+    )
+
+    # then
+    decoded_token = jwt_decode(access_token, verify_expiration=False)
+    assert decoded_token["permissions"] == ["MANAGE_PRODUCTS"]
+    _, decode_extension_id = graphene.Node.from_global_id(
+        decoded_token["app_extension"]
+    )
+    assert int(decode_extension_id) == extension.id

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -1,5 +1,8 @@
 from ...app import models
-from ...core.jwt import create_access_token_for_app
+from ...core.jwt import (
+    create_access_token_for_app,
+    create_access_token_for_app_extension,
+)
 from ...core.permissions import AppPermission
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
@@ -14,7 +17,7 @@ def resolve_apps(info, **_kwargs):
     return models.App.objects.all()
 
 
-def resolve_access_token(info, root, **_kwargs):
+def resolve_access_token_for_app(info, root, **_kwargs):
     if root.type != AppTypeEnum.THIRDPARTY.value:
         return None
 
@@ -22,6 +25,19 @@ def resolve_access_token(info, root, **_kwargs):
     if user.is_anonymous:
         return None
     return create_access_token_for_app(root, user)
+
+
+def resolve_access_token_for_app_extension(info, root, **_kwargs):
+    user = info.context.user
+    if user.is_anonymous:
+        return None
+    extension_permissions = root.permissions.all()
+    user_permissions = user.effective_permissions
+    if set(extension_permissions).issubset(user_permissions):
+        return create_access_token_for_app_extension(
+            app_extension=root, permissions=extension_permissions, user=user
+        )
+    return None
 
 
 @permission_required(AppPermission.MANAGE_APPS)

--- a/saleor/graphql/app/resolvers.py
+++ b/saleor/graphql/app/resolvers.py
@@ -4,6 +4,7 @@ from ...core.jwt import (
     create_access_token_for_app_extension,
 )
 from ...core.permissions import AppPermission
+from ...core.utils.validators import user_is_valid
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .enums import AppTypeEnum
@@ -29,7 +30,7 @@ def resolve_access_token_for_app(info, root, **_kwargs):
 
 def resolve_access_token_for_app_extension(info, root, **_kwargs):
     user = info.context.user
-    if user.is_anonymous:
+    if not user_is_valid(user):
         return None
     extension_permissions = root.permissions.all()
     user_permissions = user.effective_permissions

--- a/saleor/graphql/app/tests/benchmarks/test_app_extensions.py
+++ b/saleor/graphql/app/tests/benchmarks/test_app_extensions.py
@@ -25,6 +25,7 @@ def test_app_extensions(
             target
             id
             type
+            accessToken
             permissions{
               code
             }
@@ -67,7 +68,7 @@ def test_app_extensions(
 
     # when
     response = staff_api_client.post_graphql(
-        query,
+        query, permissions=[permission_manage_products], check_no_permissions=False
     )
 
     # then
@@ -119,6 +120,7 @@ def test_app_extensions_with_filter(
             target
             id
             type
+            accessToken
             permissions{
               code
             }
@@ -162,6 +164,8 @@ def test_app_extensions_with_filter(
     response = staff_api_client.post_graphql(
         query,
         variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
     )
 
     # then

--- a/saleor/graphql/app/tests/queries/test_app_extension.py
+++ b/saleor/graphql/app/tests/queries/test_app_extension.py
@@ -1,9 +1,9 @@
 import graphene
 
-from saleor.app.models import AppExtension
-from saleor.app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
-from saleor.core.jwt import jwt_decode
-from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+from .....app.models import AppExtension
+from .....app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from .....core.jwt import jwt_decode
+from ....tests.utils import assert_no_permission, get_graphql_content
 
 QUERY_APP_EXTENSION = """
 query ($id: ID!){

--- a/saleor/graphql/app/tests/queries/test_app_extensions.py
+++ b/saleor/graphql/app/tests/queries/test_app_extensions.py
@@ -1,14 +1,10 @@
 import pytest
 
-from saleor.app.models import AppExtension
-from saleor.app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
-from saleor.core.jwt import jwt_decode
-from saleor.graphql.app.enums import (
-    AppExtensionTargetEnum,
-    AppExtensionTypeEnum,
-    AppExtensionViewEnum,
-)
-from saleor.graphql.tests.utils import assert_no_permission, get_graphql_content
+from .....app.models import AppExtension
+from .....app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from .....core.jwt import jwt_decode
+from ....tests.utils import assert_no_permission, get_graphql_content
+from ...enums import AppExtensionTargetEnum, AppExtensionTypeEnum, AppExtensionViewEnum
 
 QUERY_APP_EXTENSIONS = """
 query ($filter: AppExtensionFilterInput){

--- a/saleor/graphql/app/tests/queries/test_app_extensions.py
+++ b/saleor/graphql/app/tests/queries/test_app_extensions.py
@@ -2,6 +2,7 @@ import pytest
 
 from saleor.app.models import AppExtension
 from saleor.app.types import AppExtensionTarget, AppExtensionType, AppExtensionView
+from saleor.core.jwt import jwt_decode
 from saleor.graphql.app.enums import (
     AppExtensionTargetEnum,
     AppExtensionTypeEnum,
@@ -20,6 +21,7 @@ query ($filter: AppExtensionFilterInput){
         target
         id
         type
+        accessToken
         permissions{
           code
         }
@@ -47,6 +49,8 @@ def test_app_extensions(staff_api_client, app, permission_manage_products):
     response = staff_api_client.post_graphql(
         QUERY_APP_EXTENSIONS,
         variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
     )
 
     # then
@@ -66,6 +70,10 @@ def test_app_extensions(staff_api_client, app, permission_manage_products):
     assert len(extension_data["permissions"]) == 1
     permission_code = extension_data["permissions"][0]["code"].lower()
     assert app_extension.permissions.first().codename == permission_code
+
+    assert extension_data["accessToken"]
+    decode_token = jwt_decode(extension_data["accessToken"])
+    decode_token["permissions"] = ["MANAGE_PRODUCTS"]
 
 
 def test_app_extensions_app_not_active(

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -17,7 +17,10 @@ from .enums import (
     AppExtensionViewEnum,
     AppTypeEnum,
 )
-from .resolvers import resolve_access_token
+from .resolvers import (
+    resolve_access_token_for_app,
+    resolve_access_token_for_app_extension,
+)
 
 
 class AppManifestExtension(graphene.ObjectType):
@@ -46,6 +49,12 @@ class AppManifestExtension(graphene.ObjectType):
 
 class AppExtension(AppManifestExtension, CountableDjangoObjectType):
     app = graphene.Field("saleor.graphql.app.types.App", required=True)
+    access_token = graphene.String(
+        description="JWT token used to authenticate by thridparty app extension."
+    )
+    can_be_used_by_user = graphene.Boolean(
+        description="Determine if user has enough permission to use this extension"
+    )
 
     class Meta:
         description = "Represents app data."
@@ -73,6 +82,10 @@ class AppExtension(AppManifestExtension, CountableDjangoObjectType):
             "codename"
         )
         return format_permissions_for_display(permissions)
+
+    @staticmethod
+    def resolve_access_token(root: models.App, info):
+        return resolve_access_token_for_app_extension(info, root)
 
 
 class Manifest(graphene.ObjectType):
@@ -188,7 +201,7 @@ class App(CountableDjangoObjectType):
 
     @staticmethod
     def resolve_access_token(root: models.App, info):
-        return resolve_access_token(info, root)
+        return resolve_access_token_for_app(info, root)
 
     @staticmethod
     def resolve_extensions(root: models.App, info):

--- a/saleor/graphql/app/types.py
+++ b/saleor/graphql/app/types.py
@@ -52,9 +52,6 @@ class AppExtension(AppManifestExtension, CountableDjangoObjectType):
     access_token = graphene.String(
         description="JWT token used to authenticate by thridparty app extension."
     )
-    can_be_used_by_user = graphene.Boolean(
-        description="Determine if user has enough permission to use this extension"
-    )
 
     class Meta:
         description = "Represents app data."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -300,7 +300,6 @@ type AppExtension implements Node {
   target: AppExtensionTargetEnum!
   permissions: [Permission!]!
   accessToken: String
-  canBeUsedByUser: Boolean
 }
 
 type AppExtensionCountableConnection {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -299,6 +299,8 @@ type AppExtension implements Node {
   type: AppExtensionTypeEnum!
   target: AppExtensionTargetEnum!
   permissions: [Permission!]!
+  accessToken: String
+  canBeUsedByUser: Boolean
 }
 
 type AppExtensionCountableConnection {


### PR DESCRIPTION
I want to merge this change because it adds accessToken to AppExtension type.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
