### PR TITLE
Drop fallback for company address

### DIFF
--- a/saleor/graphql/product/tests/test_product_channel_listings_queries.py
+++ b/saleor/graphql/product/tests/test_product_channel_listings_queries.py
@@ -1,46 +1,49 @@
+from unittest import mock
+
 import graphene
 
+from ....warehouse.models import Warehouse
 from ...tests.utils import get_graphql_content
 
 QUERY_PRICING_ON_PRODUCT_CHANNEL_LISTING = """
+fragment Pricing on ProductPricingInfo {
+  priceRangeUndiscounted {
+    start {
+      net {
+        amount
+        currency
+      }
+      gross {
+        amount
+        currency
+      }
+    }
+    stop {
+      gross {
+        amount
+        currency
+      }
+    }
+  }
+}
 query FetchProduct($id: ID, $channel: String, $address: AddressInput) {
   product(id: $id, channel: $channel) {
     id
     pricing(address: $address) {
-      priceRangeUndiscounted {
-        start {
-          gross {
-            amount
-            currency
-          }
-        }
-        stop {
-          gross {
-            amount
-            currency
-          }
-        }
-      }
+      ...Pricing
+    }
+    pricingNoAddress: pricing {
+      ...Pricing
     }
     channelListings {
       channel {
         slug
       }
       pricing(address: $address) {
-        priceRangeUndiscounted {
-          start {
-            gross {
-              amount
-              currency
-            }
-          }
-          stop {
-            gross {
-              amount
-              currency
-            }
-          }
-        }
+        ...Pricing
+      }
+      pricingNoAddress: pricing {
+        ...Pricing
       }
     }
   }
@@ -48,14 +51,27 @@ query FetchProduct($id: ID, $channel: String, $address: AddressInput) {
 """
 
 
+@mock.patch("saleor.graphql.product.types.channels.WarehouseCountryCodeByChannelLoader")
 def test_product_channel_listing_pricing_field(
-    staff_api_client, permission_manage_products, channel_USD, product
+    warehouse_country_code_loader,
+    address_usa,
+    staff_api_client,
+    permission_manage_products,
+    channel_USD,
+    product,
 ):
     # given
+
+    # Changing the address of a warehouse used by the product to address_usa, so that
+    # we can query pricing in two countries: US and PL.
+    warehouse = Warehouse.objects.first()
+    warehouse.address = address_usa
+    warehouse.save()
+
     variables = {
         "id": graphene.Node.to_global_id("Product", product.pk),
         "channel": channel_USD.slug,
-        "address": {"country": "US"},
+        "address": {"country": "PL"},
     }
     product.channel_listings.exclude(channel__slug=channel_USD.slug).delete()
 
@@ -72,3 +88,4 @@ def test_product_channel_listing_pricing_field(
     product_data = content["data"]["product"]
     product_channel_listing_data = product_data["channelListings"][0]
     assert product_data["pricing"] == product_channel_listing_data["pricing"]
+    assert warehouse_country_code_loader.called

--- a/saleor/graphql/product/tests/test_variant_pricing.py
+++ b/saleor/graphql/product/tests/test_variant_pricing.py
@@ -122,6 +122,7 @@ def test_variant_pricing(
         discounts=[],
         channel=channel_USD,
         plugins=manager,
+        country=Country("US"),
     )
     assert pricing.price == taxed_price
     assert pricing.price_local_currency is None
@@ -131,7 +132,6 @@ def test_variant_pricing(
         lambda c: {"PLN": Mock(rate=2)},
     )
 
-    settings.DEFAULT_COUNTRY = "PL"
     settings.OPENEXCHANGERATES_API_KEY = "fake-key"
 
     pricing = get_variant_availability(
@@ -157,6 +157,7 @@ def test_variant_pricing(
         discounts=[],
         channel=channel_USD,
         plugins=manager,
+        country=Country("PL"),
     )
     assert pricing.price.tax.amount
     assert pricing.price_undiscounted.tax.amount

--- a/saleor/graphql/product/tests/test_variant_pricing.py
+++ b/saleor/graphql/product/tests/test_variant_pricing.py
@@ -1,3 +1,4 @@
+from unittest import mock
 from unittest.mock import Mock
 
 from django_countries.fields import Country
@@ -9,31 +10,37 @@ from ....product.utils.availability import get_variant_availability
 from ...tests.utils import get_graphql_content
 
 QUERY_GET_VARIANT_PRICING = """
+fragment VariantPricingInfo on VariantPricingInfo {
+  onSale
+  discount {
+    currency
+    net {
+      amount
+    }
+  }
+  priceUndiscounted {
+    currency
+    net {
+      amount
+    }
+  }
+  price {
+    currency
+    net {
+      amount
+    }
+  }
+}
 query ($channel: String, $address: AddressInput) {
   products(first: 1, channel: $channel) {
     edges {
       node {
         variants {
           pricing(address: $address) {
-            onSale
-            discount {
-              currency
-              net {
-                amount
-              }
-            }
-            priceUndiscounted {
-              currency
-              net {
-                amount
-              }
-            }
-            price {
-              currency
-              net {
-                amount
-              }
-            }
+            ...VariantPricingInfo
+          }
+          pricingNoAddress: pricing {
+            ...VariantPricingInfo
           }
         }
       }
@@ -73,7 +80,10 @@ def test_get_variant_pricing_on_sale(api_client, sale, product, channel_USD):
     assert pricing["price"]["net"]["amount"] == discounted_price
 
 
-def test_get_variant_pricing_not_on_sale(api_client, product, channel_USD):
+@mock.patch("saleor.graphql.product.types.products.WarehouseCountryCodeByChannelLoader")
+def test_get_variant_pricing_not_on_sale(
+    warehouse_country_code_loader, api_client, product, channel_USD
+):
     price = product.variants.first().channel_listings.get().price
 
     variables = {"channel": channel_USD.slug, "address": {"country": "US"}}
@@ -98,6 +108,9 @@ def test_get_variant_pricing_not_on_sale(api_client, product, channel_USD):
     # check the discounted price
     assert pricing["price"]["currency"] == price.currency
     assert pricing["price"]["net"]["amount"] == price.amount
+
+    # check that country_code loader was called for pricing without address
+    assert warehouse_country_code_loader.called
 
 
 def test_variant_pricing(

--- a/saleor/graphql/tests/test_utils.py
+++ b/saleor/graphql/tests/test_utils.py
@@ -1,52 +1,8 @@
 import re
 
-import graphene
-from django.conf import settings
 from graphql.utils import schema_printer
 
-from ..account.types import AddressInput
-from ..utils import get_user_country_context
 from .utils import get_graphql_content
-
-
-def test_get_user_country_context_from_address_instance(address, address_other_country):
-    destination_address = address
-    company_address = address_other_country
-
-    country = get_user_country_context(destination_address=destination_address)
-    assert country == destination_address.country.code
-
-    country = get_user_country_context(company_address=company_address)
-    assert country == company_address.country.code
-
-    country = get_user_country_context(
-        destination_address=destination_address, company_address=company_address
-    )
-    assert country == destination_address.country.code
-
-    country = get_user_country_context()
-    assert country == settings.DEFAULT_COUNTRY
-
-
-def test_get_user_country_from_address_input():
-    class Query(graphene.ObjectType):
-        field = graphene.Field(graphene.String, address=graphene.Argument(AddressInput))
-
-        @staticmethod
-        def resolve_field(_root, _info, address):
-            return get_user_country_context(destination_address=address)
-
-    schema = graphene.Schema(query=Query)
-    result = schema.execute(
-        """
-        query {
-            field(address: {country: US})
-        }
-        """
-    )
-
-    assert not result.errors
-    assert result.data == {"field": "US"}
 
 
 def test_multiple_interface_separator_in_schema(api_client):

--- a/saleor/graphql/utils/__init__.py
+++ b/saleor/graphql/utils/__init__.py
@@ -1,20 +1,14 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Union
 
 import graphene
-from django.conf import settings
 from django.db.models import Value
 from django.db.models.functions import Concat
 from graphene_django.registry import get_global_registry
 from graphql.error import GraphQLError
 from graphql_relay import from_global_id
 
-from ...account import models as account_models
 from ..core.enums import PermissionEnum
 from ..core.types import Permission
-
-if TYPE_CHECKING:
-    from ..account import types as account_types
-
 
 ERROR_COULD_NO_RESOLVE_GLOBAL_ID = (
     "Could not resolve to a node with the global id list of '%s'."
@@ -136,26 +130,3 @@ def get_user_or_app_from_context(context):
 def requestor_is_superuser(requestor):
     """Return True if requestor is superuser."""
     return getattr(requestor, "is_superuser", False)
-
-
-def get_user_country_context(
-    destination_address: Optional[
-        Union["account_types.AddressInput", "account_models.Address"]
-    ] = None,
-    company_address: Optional["account_models.Address"] = None,
-) -> str:
-    """Get country of the current user to use for tax and stock related calculations.
-
-    User's country context is determined from the provided `destination_address` (which
-    may represent user's current location determined by the client or a shipping
-    address provided in the checkout). If `destination_address` is not given, the
-    default company address from the shop settings is assumed. If this address is not
-    set, fallback to the `DEFAULT_COUNTRY` setting.
-    """
-    if destination_address and destination_address.country:
-        if isinstance(destination_address, account_models.Address):
-            return destination_address.country.code
-        return destination_address.country
-    elif company_address and company_address.country:
-        return company_address.country.code
-    return settings.DEFAULT_COUNTRY

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -5,14 +5,16 @@ from uuid import UUID
 from django.conf import settings
 
 from ...warehouse.models import Stock, Warehouse
+from ..account.dataloaders import AddressByIdLoader
+from ..channel.dataloaders import ChannelBySlugLoader
 from ..core.dataloaders import DataLoader
 
 CountryCode = Optional[str]
-VariantIdAndCountryCode = Tuple[int, CountryCode]
+VariantIdCountryCodeChannelSlug = Tuple[int, CountryCode, str]
 
 
 class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
-    DataLoader[VariantIdAndCountryCode, int]
+    DataLoader[VariantIdCountryCodeChannelSlug, int]
 ):
     """Calculates available variant quantity based on variant ID and country code.
 
@@ -37,11 +39,11 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
 
         # For each country code execute a single query for all product variants.
         quantity_by_variant_and_country: DefaultDict[
-            VariantIdAndCountryCode, int
+            VariantIdCountryCodeChannelSlug, int
         ] = defaultdict(int)
         for key, variant_ids in variants_by_country_and_channel.items():
             country_code, channel_slug = key
-            quantities = self.batch_load_country(
+            quantities = self.batch_load_quantities_by_country(
                 country_code, channel_slug, variant_ids
             )
             for variant_id, quantity in quantities:
@@ -51,25 +53,25 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
 
         return [quantity_by_variant_and_country[key] for key in keys]
 
-    def batch_load_country(
+    def batch_load_quantities_by_country(
         self,
-        country_code: CountryCode,
+        country_code: Optional[CountryCode],
         channel_slug: Optional[str],
         variant_ids: Iterable[int],
     ) -> Iterable[Tuple[int, int]]:
         # get stocks only for warehouses assigned to the shipping zones
         # that are available in the given channel
-        results = Stock.objects.filter(product_variant_id__in=variant_ids)
+        stocks = Stock.objects.filter(product_variant_id__in=variant_ids)
         if country_code:
-            results = results.filter(
+            stocks = stocks.filter(
                 warehouse__shipping_zones__countries__contains=country_code
             )
         if channel_slug:
-            results = results.filter(
+            stocks = stocks.filter(
                 warehouse__shipping_zones__channels__slug=channel_slug
             )
-        results = results.annotate_available_quantity()
-        results = results.values_list(
+        stocks = stocks.annotate_available_quantity()
+        stocks = stocks.values_list(
             "product_variant_id", "warehouse__shipping_zones", "available_quantity"
         )
 
@@ -79,7 +81,7 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
         quantity_by_shipping_zone_by_product_variant: DefaultDict[
             int, DefaultDict[int, int]
         ] = defaultdict(lambda: defaultdict(int))
-        for variant_id, shipping_zone_id, quantity in results:
+        for variant_id, shipping_zone_id, quantity in stocks:
             quantity_by_shipping_zone_by_product_variant[variant_id][
                 shipping_zone_id
             ] += quantity
@@ -108,8 +110,8 @@ class AvailableQuantityByProductVariantIdCountryCodeAndChannelSlugLoader(
         ]
 
 
-class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChanneLoader(
-    DataLoader[VariantIdAndCountryCode, Iterable[Stock]]
+class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChannelLoader(
+    DataLoader[VariantIdCountryCodeChannelSlug, Iterable[Stock]]
 ):
     """Return stocks with available quantity based on variant ID, country code, channel.
 
@@ -123,17 +125,21 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChanneLoader(
         # Split the list of keys by country first. A typical query will only touch
         # a handful of unique countries but may access thousands of product variants
         # so it's cheaper to execute one query per country.
-        variants_by_country: DefaultDict[CountryCode, List[int]] = defaultdict(list)
+        variants_by_country_and_channel: DefaultDict[
+            CountryCode, List[int]
+        ] = defaultdict(list)
         for variant_id, country_code, channel_slug in keys:
-            variants_by_country[(country_code, channel_slug)].append(variant_id)
+            variants_by_country_and_channel[(country_code, channel_slug)].append(
+                variant_id
+            )
 
         # For each country code execute a single query for all product variants.
         stocks_by_variant_and_country: DefaultDict[
-            VariantIdAndCountryCode, Iterable[Stock]
+            VariantIdCountryCodeChannelSlug, Iterable[Stock]
         ] = defaultdict(list)
-        for key, variant_ids in variants_by_country.items():
+        for key, variant_ids in variants_by_country_and_channel.items():
             country_code, channel_slug = key
-            variant_ids_stocks = self.batch_load_country(
+            variant_ids_stocks = self.batch_load_stocks_by_country(
                 country_code, channel_slug, variant_ids
             )
             for variant_id, stocks in variant_ids_stocks:
@@ -143,9 +149,9 @@ class StocksWithAvailableQuantityByProductVariantIdCountryCodeAndChanneLoader(
 
         return [stocks_by_variant_and_country[key] for key in keys]
 
-    def batch_load_country(
+    def batch_load_stocks_by_country(
         self,
-        country_code: CountryCode,
+        country_code: Optional[CountryCode],
         channel_slug: Optional[str],
         variant_ids: Iterable[int],
     ) -> Iterable[Tuple[int, List[Stock]]]:
@@ -179,3 +185,47 @@ class WarehouseByIdLoader(DataLoader):
     def batch_load(self, keys):
         warehouses = Warehouse.objects.in_bulk(keys)
         return [warehouses.get(UUID(warehouse_uuid)) for warehouse_uuid in keys]
+
+
+class WarehouseCountryCodeByChannelLoader(DataLoader):
+    """Loads country code of a first available warehouse that is found for a channel."""
+
+    context_key = "warehouses_by_channel"
+
+    def batch_load(self, keys):
+        def with_channels(channels):
+            address_id_by_channel_slug = dict()
+            for channel in channels:
+                warehouses = Warehouse.objects.filter(
+                    shipping_zones__channels=channel.id
+                )
+                first_warehouse = warehouses[0] if warehouses else None
+                address_pk = first_warehouse.address_id if first_warehouse else None
+                address_id_by_channel_slug[channel.slug] = address_pk
+
+            def with_addresses(addresses):
+                address_by_id = {address.pk: address for address in addresses}
+                country_codes = []
+                for key in keys:
+                    address_id = address_id_by_channel_slug[key]
+                    address = address_by_id.get(address_id)
+                    if address and address.country:
+                        country_code = address.country.code
+                    else:
+                        # Fallback when warehouse address has no country set. API has
+                        # validation to prevent from adding such addresses, so this is
+                        # added only to handle an edge-case if a warehouse would be
+                        # added with bypassing the API (for instance with a migration).
+                        country_code = settings.DEFAULT_COUNTRY
+                    country_codes.append(country_code)
+                return country_codes
+
+            address_ids = address_id_by_channel_slug.values()
+            # FIXME: Handle loading addresses when first warehouse is null
+            return (
+                AddressByIdLoader(self.context)
+                .load_many(address_ids)
+                .then(with_addresses)
+            )
+
+        return ChannelBySlugLoader(self.context).load_many(keys).then(with_channels)

--- a/saleor/graphql/warehouse/dataloaders.py
+++ b/saleor/graphql/warehouse/dataloaders.py
@@ -190,7 +190,7 @@ class WarehouseByIdLoader(DataLoader):
 class WarehouseCountryCodeByChannelLoader(DataLoader):
     """Loads country code of a first available warehouse that is found for a channel."""
 
-    context_key = "warehouses_by_channel"
+    context_key = "warehouse_country_code_by_channel"
 
     def batch_load(self, keys):
         def with_channels(channels):

--- a/saleor/graphql/warehouse/tests/test_dataloaders.py
+++ b/saleor/graphql/warehouse/tests/test_dataloaders.py
@@ -1,0 +1,31 @@
+from unittest.mock import Mock
+
+from ..dataloaders import WarehouseCountryCodeByChannelLoader
+
+
+def test_warehouse_country_code_loader(channel_USD, shipping_zone):
+    warehouse = channel_USD.shipping_zones.first().warehouses.first()
+    request = Mock(dataloaders={})
+
+    def with_country_code(country_code):
+        assert country_code == warehouse.address.country.code
+
+    WarehouseCountryCodeByChannelLoader(request).load(channel_USD.slug).then(
+        with_country_code
+    )
+
+
+def test_warehouse_country_code_loader_fallback_to_settings_country_no_warehouse(
+    channel_USD, settings
+):
+    # Change the DEFAULT_COUNTRY for test purpose to a country that is different than
+    # fixtures' addresses.
+    settings.DEFAULT_COUNTRY = "TH"
+    request = Mock(dataloaders={})
+
+    def with_country_code(country_code):
+        assert country_code == "TH"
+
+    WarehouseCountryCodeByChannelLoader(request).load(channel_USD.slug).then(
+        with_country_code
+    )

--- a/saleor/graphql/warehouse/tests/test_stock.py
+++ b/saleor/graphql/warehouse/tests/test_stock.py
@@ -204,6 +204,7 @@ def test_stock_quantities_in_different_warehouses(
         productVariant(id: $id, channel: $channel) {
             quantityPL: quantityAvailable(address: { country: $country1 })
             quantityUS: quantityAvailable(address: { country: $country2 })
+            quantityNoAddress: quantityAvailable
         }
     }
     """
@@ -228,6 +229,12 @@ def test_stock_quantities_in_different_warehouses(
 
     assert content["data"]["productVariant"]["quantityPL"] == stock_map["PL"]
     assert content["data"]["productVariant"]["quantityUS"] == stock_map["US"]
+
+    # when country is not provided, should return max value of all available stock
+    # quantities
+    assert content["data"]["productVariant"]["quantityNoAddress"] == max(
+        stock_map.values()
+    )
 
 
 def test_stock_quantity_is_max_from_all_warehouses_without_provided_country(

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -147,10 +147,9 @@ def get_product_availability(
     discounts: Iterable[DiscountInfo],
     channel: Channel,
     manager: "PluginsManager",
-    country: Optional[Country] = None,
+    country: Country,
     local_currency: Optional[str] = None,
 ) -> ProductAvailability:
-    country = country or Country(settings.DEFAULT_COUNTRY)
     with opentracing.global_tracer().start_active_span("get_product_availability"):
         channel_slug = channel.slug
 
@@ -237,10 +236,9 @@ def get_variant_availability(
     discounts: Iterable[DiscountInfo],
     channel: Channel,
     plugins: "PluginsManager",
-    country: Optional[Country] = None,
+    country: Country,
     local_currency: Optional[str] = None,
 ) -> VariantAvailability:
-    country = country or Country(settings.DEFAULT_COUNTRY)
     with opentracing.global_tracer().start_active_span("get_variant_availability"):
         channel_slug = channel.slug
         discounted = plugins.apply_taxes_to_product(

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -4012,18 +4012,18 @@ def warehouse(address, shipping_zone):
 
 
 @pytest.fixture
-def warehouses(address):
+def warehouses(address, address_usa):
     return Warehouse.objects.bulk_create(
         [
             Warehouse(
                 address=address.get_copy(),
-                name="Warehouse1",
+                name="Warehouse PL",
                 slug="warehouse1",
                 email="warehouse1@example.com",
             ),
             Warehouse(
-                address=address.get_copy(),
-                name="Warehouse2",
+                address=address_usa.get_copy(),
+                name="Warehouse USA",
                 slug="warehouse2",
                 email="warehouse2@example.com",
             ),

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -8,7 +8,7 @@ from ..core.exceptions import InsufficientStock, InsufficientStockData
 from .models import Stock, StockQuerySet
 
 if TYPE_CHECKING:
-    from ..product.models import Product, ProductVariant
+    from ..product.models import ProductVariant
 
 
 def _get_available_quantity(stocks: StockQuerySet) -> int:
@@ -84,13 +84,3 @@ def check_stock_quantity_bulk(
 
     if insufficient_stocks:
         raise InsufficientStock(insufficient_stocks)
-
-
-def is_product_in_stock(
-    product: "Product", country_code: str, channel_slug: str
-) -> bool:
-    """Check if there is any variant of given product available in given country."""
-    stocks = Stock.objects.get_product_stocks_for_country_and_channel(
-        country_code, channel_slug, product
-    ).annotate_available_quantity()
-    return any(stocks.values_list("available_quantity", flat=True))

--- a/saleor/warehouse/models.py
+++ b/saleor/warehouse/models.py
@@ -25,6 +25,9 @@ class WarehouseQueryset(models.QuerySet):
             .order_by("pk")
         )
 
+    def get_first_warehouse_for_channel(self, channel_pk: int):
+        return self.filter(shipping_zones__channels=channel_pk).first()
+
 
 class Warehouse(ModelWithMetadata):
     id = models.UUIDField(default=uuid.uuid4, primary_key=True)

--- a/saleor/warehouse/tests/test_warehouse.py
+++ b/saleor/warehouse/tests/test_warehouse.py
@@ -1,0 +1,23 @@
+from ...shipping.models import ShippingZone
+from ..models import Warehouse
+
+
+def test_get_first_warehouse_for_channel_no_shipping_zone(
+    warehouses_with_different_shipping_zone, channel_USD
+):
+    for shipping_zone in ShippingZone.objects.all():
+        shipping_zone.channels.all().delete()
+    # At this point warehouse has no shipping zones; getting the first warehouse for
+    # channel should return None.
+    warehouse = Warehouse.objects.get_first_warehouse_for_channel(channel_USD.pk)
+    assert warehouse is None
+
+
+def test_get_first_warehouse_for_channel(warehouses, channel_USD):
+    warehouse_usa = warehouses[1]
+    shipping_zone = ShippingZone.objects.create(name="USA", countries=["US"])
+    shipping_zone.channels.add(channel_USD)
+    warehouse_usa.shipping_zones.add(shipping_zone)
+
+    first_warehouse = Warehouse.objects.get_first_warehouse_for_channel(channel_USD.pk)
+    assert first_warehouse == warehouse_usa


### PR DESCRIPTION
Drop fallback to company address in queries and mutations. Instead, rely on address provided as parameter or input. If not provided, try to get the address of the first warehouse available in the channel. If no warehouse is assigned to channel (which should be considered an improper or unfinished configuration of the shop) fallback to `settings.DEFAULT_COUNTRY`.

Affected queries or mutations:

- `checkoutCreate`
- `checkoutShippingMethodUpdate`
- `ProductChannelListing.pricing`
- `ProductVariant.stocks`
- `ProductVariant.quantityAvailable`
- `ProductVariant.pricing`
- `Product.isAvailable`
- `Product.pricing`

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
