### PR TITLE
Do not allow defining balance currency in GiftCardUpdate mutation

### DIFF
--- a/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
@@ -239,17 +239,13 @@ def test_update_gift_card(
 ):
     # given
     initial_balance = 100.0
-    currency = gift_card.currency
     expiry_type = GiftCardExpiryTypeEnum.EXPIRY_DATE.name
     date_value = date.today() + timedelta(days=365)
     tag = "new-gift-card-tag"
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
         "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
+            "balanceAmount": initial_balance,
             "tag": tag,
             "expirySettings": {
                 "expiryType": expiry_type,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -285,7 +285,7 @@ def test_create_gift_card_no_premissions(staff_api_client):
     assert_no_permission(response)
 
 
-def test_create_gift_card_with_to_many_decimal_places_in_balance_amount(
+def test_create_gift_card_with_too_many_decimal_places_in_balance_amount(
     staff_api_client,
     customer_user,
     permission_manage_gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -121,10 +121,7 @@ def test_update_gift_card(
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
         "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
+            "balanceAmount": initial_balance,
             "tag": tag,
             "expirySettings": {
                 "expiryType": expiry_type,
@@ -235,10 +232,7 @@ def test_update_gift_card_by_app(
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
         "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
+            "balanceAmount": initial_balance,
             "tag": tag,
             "expirySettings": {
                 "expiryType": expiry_type,
@@ -328,15 +322,11 @@ def test_update_gift_card_by_app(
 def test_update_gift_card_by_customer(api_client, customer_user, gift_card):
     # given
     initial_balance = 100.0
-    currency = gift_card.currency
     tag = "new-gift-card-tag"
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
         "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
+            "balanceAmount": initial_balance,
             "tag": tag,
         },
     }
@@ -367,10 +357,7 @@ def test_update_gift_card_balance(
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
         "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
+            "balanceAmount": initial_balance,
         },
     }
 
@@ -755,54 +742,4 @@ def test_update_gift_card_date_in_past(
     assert not data
     assert len(errors) == 1
     assert errors[0]["field"] == "expiryDate"
-    assert errors[0]["code"] == GiftCardErrorCode.INVALID.name
-
-
-def test_update_gift_card_currency_raised_error(
-    staff_api_client,
-    gift_card,
-    permission_manage_gift_card,
-    permission_manage_users,
-    permission_manage_apps,
-):
-    # given
-    initial_balance = 100.0
-    currency = "PLN"
-    expiry_type = GiftCardExpiryTypeEnum.EXPIRY_DATE.name
-    date_value = date.today() + timedelta(days=365)
-    tag = "new-gift-card-tag"
-    variables = {
-        "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
-        "input": {
-            "balance": {
-                "amount": initial_balance,
-                "currency": currency,
-            },
-            "tag": tag,
-            "expirySettings": {
-                "expiryType": expiry_type,
-                "expiryDate": date_value,
-            },
-        },
-    }
-
-    # when
-    response = staff_api_client.post_graphql(
-        UPDATE_GIFT_CARD_MUTATION,
-        variables,
-        permissions=[
-            permission_manage_gift_card,
-            permission_manage_users,
-            permission_manage_apps,
-        ],
-    )
-
-    # then
-    content = get_graphql_content(response)
-    errors = content["data"]["giftCardUpdate"]["errors"]
-    data = content["data"]["giftCardUpdate"]["giftCard"]
-
-    assert not data
-    assert len(errors) == 1
-    assert errors[0]["field"] == "balance"
     assert errors[0]["code"] == GiftCardErrorCode.INVALID.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2296,7 +2296,7 @@ input GiftCardUpdateInput {
   tag: String
   startDate: Date
   endDate: Date
-  balance: PriceInput
+  balanceAmount: PositiveDecimal
   expirySettings: GiftCardExpirySettingsInput
 }
 


### PR DESCRIPTION
Update `GiftCardUpdateInput`

```
input GiftCardUpdateInput {
  tag: String
  startDate: Date
  endDate: Date
  balanceAmount: PositiveDecimal
  expirySettings: GiftCardExpirySettingsInput
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
