### PR TITLE
fix: typo grammar spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -365,7 +365,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Fix filtering products by multiple attributes - #6215 by @GrzegorzDerdak
 - Add attributes validation while creating/updating a product's variant - #6269 by @GrzegorzDerdak
 - Add metadata to page model - #6292 by @dominik-zeglen
-- Fix for unnecesary attributes validation while updating simple product - #6300 by @GrzegorzDerdak
+- Fix for unnecessary attributes validation while updating simple product - #6300 by @GrzegorzDerdak
 - Include order line total price to webhook payload - #6354 by @korycins
 - Fix for fulfilling an order when product quantity equals allocated quantity - #6333 by @GrzegorzDerdak
 - Fix for the ability to filter products on collection - #6363 by @GrzegorzDerdak

--- a/saleor/app/management/commands/utils.py
+++ b/saleor/app/management/commands/utils.py
@@ -10,8 +10,8 @@ def clean_permissions(required_permissions: List[str]):
     for perm in required_permissions:
         if not all_permissions.get(perm):
             raise CommandError(
-                f"Permisssion: {perm} doesn't exist in Saleor."
-                f" Avaiable permissions: {all_permissions}"
+                f"Permission: {perm} doesn't exist in Saleor."
+                f" Available permissions: {all_permissions}"
             )
     permissions = get_permissions(
         [all_permissions[perm] for perm in required_permissions]

--- a/saleor/core/weight.py
+++ b/saleor/core/weight.py
@@ -23,7 +23,7 @@ def zero_weight():
 
 def convert_weight(weight: Weight, unit: str) -> Weight:
     """Covert weight to given unit and round it to 3 digits after decimal point."""
-    # Weight amount from the Weight instance can be retrived in several units
+    # Weight amount from the Weight instance can be retrieved in several units
     # via its properties. eg. Weight(lb=10).kg
     converted_weight = getattr(weight, unit)
     weight = Weight(**{unit: converted_weight})

--- a/saleor/demo/settings.py
+++ b/saleor/demo/settings.py
@@ -45,7 +45,7 @@ PWA_DASHBOARD_URL_RE = re.compile("^https?://[^/]+/dashboard/.*")
 ROOT_EMAIL = os.environ.get("ROOT_EMAIL")
 
 # Remove "saleor.core" and add it after adding "saleor.demo", to have "populatedb"
-# command overriden when using demo settings
+# command overridden when using demo settings
 # (see saleor.demo.management.commands.populatedb).
 INSTALLED_APPS.remove("saleor.core")
 INSTALLED_APPS += ["saleor.demo", "saleor.core"]

--- a/saleor/graphql/account/filters.py
+++ b/saleor/graphql/account/filters.py
@@ -87,7 +87,7 @@ class StaffUserFilter(django_filters.FilterSet):
     status = EnumFilter(input_class=StaffMemberStatus, method=filter_staff_status)
     search = django_filters.CharFilter(method=filter_user_search)
 
-    # TODO - Figure out after permision types
+    # TODO - Figure out after permission types
     # department = ObjectTypeFilter
 
     class Meta:

--- a/saleor/graphql/account/tests/benchmark/fixtures.py
+++ b/saleor/graphql/account/tests/benchmark/fixtures.py
@@ -50,7 +50,7 @@ def _create_permission_groups(user):
 def users_for_customers_benchmarks(channel_USD, address, shipping_method):
     users = [
         User(
-            email=f"jane.doe.{i}@exmaple.com",
+            email=f"jane.doe.{i}@example.com",
             is_active=True,
             default_billing_address=address.get_copy(),
             default_shipping_address=address.get_copy(),

--- a/saleor/graphql/account/tests/mutations/test_external_authentication.py
+++ b/saleor/graphql/account/tests/mutations/test_external_authentication.py
@@ -19,7 +19,7 @@ MUTATION_EXTERNAL_AUTHENTICATION = """
 def test_external_authentication_url_plugin_not_active(api_client, customer_user):
     variables = {
         "pluginId": "pluginID1",
-        "input": json.dumps({"redirectUrl": "http://locahost:3000/"}),
+        "input": json.dumps({"redirectUrl": "http://localhost:3000/"}),
     }
     response = api_client.post_graphql(MUTATION_EXTERNAL_AUTHENTICATION, variables)
     content = get_graphql_content(response)
@@ -37,7 +37,7 @@ def test_external_authentication_url(api_client, customer_user, monkeypatch, rf)
     )
     variables = {
         "pluginId": "pluginID1",
-        "input": json.dumps({"redirectUrl": "http://locahost:3000/"}),
+        "input": json.dumps({"redirectUrl": "http://localhost:3000/"}),
     }
     response = api_client.post_graphql(MUTATION_EXTERNAL_AUTHENTICATION, variables)
     content = get_graphql_content(response)

--- a/saleor/graphql/account/tests/test_account_utils.py
+++ b/saleor/graphql/account/tests/test_account_utils.py
@@ -574,7 +574,7 @@ def test_get_not_manageable_perms_removing_users_from_group_user_from_group_can_
 def test_get_notmanageable_perms_removing_users_from_group_user_out_of_group_can_manage(
     staff_users, permission_manage_users, permission_manage_staff
 ):
-    """Ensure not returning permission for group, when managable of all permissions are
+    """Ensure not returning permission for group, when manageable of all permissions are
     ensure by other groups.
     """
     groups = Group.objects.bulk_create(
@@ -602,7 +602,7 @@ def test_get_not_manageable_perms_removing_users_from_group_some_cannot_be_manag
     permission_manage_staff,
     permission_manage_orders,
 ):
-    """Ensure returning permission for group, when managable of all permissions are not
+    """Ensure returning permission for group, when manageable of all permissions are not
     ensure by other groups.
     """
     groups = Group.objects.bulk_create(
@@ -636,7 +636,7 @@ def test_get_not_manageable_permissions_when_deactivate_or_remove_user_no_permis
     permission_manage_staff,
     permission_manage_orders,
 ):
-    """Ensure user can be deactivated or removed when managable of all permissions are
+    """Ensure user can be deactivated or removed when manageable of all permissions are
     ensure by other users."""
     groups = Group.objects.bulk_create(
         [
@@ -669,7 +669,7 @@ def test_get_not_manageable_permissions_when_deactivate_or_remove_users_some_per
     permission_manage_staff,
     permission_manage_orders,
 ):
-    """Ensure user cannot be deactivated or removed when managable of all permissions
+    """Ensure user cannot be deactivated or removed when manageable of all permissions
     are not ensure by other users."""
     groups = Group.objects.bulk_create(
         [

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -236,7 +236,7 @@ class BaseMutation(graphene.Mutation):
 
     @staticmethod
     def remap_error_fields(validation_error, field_map):
-        """Rename validation_error fields accoring to provided field_map.
+        """Rename validation_error fields according to provided field_map.
 
         Skips renaming fields from field_map that are not on validation_error.
         """

--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -50,7 +50,7 @@ class OrderLineCreateInput(OrderLineInput):
 class DraftOrderInput(InputObjectType):
     billing_address = AddressInput(description="Billing address of the customer.")
     user = graphene.ID(
-        descripton="Customer associated with the draft order.", name="user"
+        description="Customer associated with the draft order.", name="user"
     )
     user_email = graphene.String(description="Email address of the customer.")
     discount = PositiveDecimal(description="Discount amount for the order.")

--- a/saleor/graphql/order/tests/benchmark/fixtures.py
+++ b/saleor/graphql/order/tests/benchmark/fixtures.py
@@ -69,7 +69,7 @@ def _prepare_lines_for_order(order, variant_with_image):
 def users_for_order_benchmarks(address):
     users = [
         User(
-            email=f"john.doe.{i}@exmaple.com",
+            email=f"john.doe.{i}@example.com",
             is_active=True,
             default_billing_address=address.get_copy(),
             default_shipping_address=address.get_copy(),

--- a/saleor/graphql/page/tests/test_attributes.py
+++ b/saleor/graphql/page/tests/test_attributes.py
@@ -296,7 +296,7 @@ def test_assign_attributes_to_page_type_multiple_error_returned(
     author_page_attribute,
     color_attribute,
 ):
-    """Ensure that when multiple errors ocurred all will br returned."""
+    """Ensure that when multiple errors occurred all will br returned."""
     # given
     staff_user = staff_api_client.user
     staff_user.user_permissions.add(permission_manage_page_types_and_attributes)

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -242,7 +242,7 @@ class GraphQLView(View):
                 if selection_name == "__schema":
                     query_with_schema = True
                     if selection_count > 1:
-                        msg = "`__schema` must be fetched in separete query"
+                        msg = "`__schema` must be fetched in separate query"
                         raise GraphQLError(msg)
         return query_with_schema
 

--- a/saleor/payment/gateways/braintree/plugin.py
+++ b/saleor/payment/gateways/braintree/plugin.py
@@ -67,7 +67,7 @@ class BraintreeGatewayPlugin(BasePlugin):
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "Require 3D secure": {

--- a/saleor/payment/gateways/dummy/plugin.py
+++ b/saleor/payment/gateways/dummy/plugin.py
@@ -37,7 +37,7 @@ class DummyGatewayPlugin(BasePlugin):
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "Supported currencies": {

--- a/saleor/payment/gateways/dummy_credit_card/plugin.py
+++ b/saleor/payment/gateways/dummy_credit_card/plugin.py
@@ -37,7 +37,7 @@ class DummyCreditCardGatewayPlugin(BasePlugin):
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "Supported currencies": {

--- a/saleor/payment/gateways/razorpay/plugin.py
+++ b/saleor/payment/gateways/razorpay/plugin.py
@@ -41,7 +41,7 @@ class RazorpayGatewayPlugin(BasePlugin):
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "Supported currencies": {

--- a/saleor/payment/gateways/stripe/deprecated/plugin.py
+++ b/saleor/payment/gateways/stripe/deprecated/plugin.py
@@ -56,7 +56,7 @@ class DeprecatedStripeGatewayPlugin(BasePlugin):
         },
         "Automatic payment capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "Supported currencies": {

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -78,7 +78,7 @@ class StripeGatewayPlugin(BasePlugin):
         },
         "automatic_payment_capture": {
             "type": ConfigurationTypeField.BOOLEAN,
-            "help_text": "Determines if Saleor should automaticaly capture payments.",
+            "help_text": "Determines if Saleor should automatically capture payments.",
             "label": "Automatic payment capture",
         },
         "supported_currencies": {

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -173,7 +173,7 @@ def create_transaction(
 ) -> Transaction:
     """Create a transaction based on transaction kind and gateway response."""
     # Default values for token, amount, currency are only used in cases where
-    # response from gateway was invalid or an exception occured
+    # response from gateway was invalid or an exception occurred
     if not gateway_response:
         gateway_response = GatewayResponse(
             kind=kind,

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -389,7 +389,7 @@ class VatlayerPlugin(BasePlugin):
         if not taxes or not tax_rate:
             return previous_value
         tax = taxes.get(tax_rate) or taxes.get(DEFAULT_TAX_RATE_NAME)
-        # tax value is given in precentage so it need be be converted into decimal value
+        # tax value is given in percentage so it need be be converted into decimal value
         return Decimal(tax["value"] / 100)
 
     def get_checkout_shipping_tax_rate(
@@ -416,7 +416,7 @@ class VatlayerPlugin(BasePlugin):
         if not taxes:
             return previous_value
         tax = taxes.get(DEFAULT_TAX_RATE_NAME)
-        # tax value is given in precentage so it need be be converted into decimal value
+        # tax value is given in percentage so it need be be converted into decimal value
         return Decimal(tax["value"]) / 100
 
     def get_tax_rate_type_choices(

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -644,7 +644,7 @@ JWT_TTL_REQUEST_EMAIL_CHANGE = timedelta(
 
 # Support multiple interface notation in schema for Apollo tooling.
 
-# In `graphql-core` V2 separator for interaces is `,`.
+# In `graphql-core` V2 separator for interface is `,`.
 # Apollo tooling to generate TypeScript types using `&` as interfaces separator.
 # https://github.com/graphql-python/graphql-core-legacy/pull/258
 # https://github.com/graphql-python/graphql-core-legacy/issues/176


### PR DESCRIPTION
I want to merge this change because... fixing typo codespelling grammar on ```saleor```

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
