### PR TITLE
Revert channel sorting param

### DIFF
--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -8,7 +8,7 @@ from ...product import models
 from ..attribute.enums import AttributeTypeEnum
 from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.filters import EnumFilter, MetadataFilterBase
-from ..core.types import FilterInputObjectType
+from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.utils import from_global_id_or_error
 from ..utils import get_user_or_app_from_context
 from ..utils.filters import filter_fields_containing_value
@@ -107,7 +107,7 @@ class AttributeFilter(MetadataFilterBase):
         )
 
 
-class AttributeFilterInput(FilterInputObjectType):
+class AttributeFilterInput(ChannelFilterInputObjectType):
     class Meta:
         filterset_class = AttributeFilter
 

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filtering_with_channels.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filtering_with_channels.py
@@ -192,7 +192,7 @@ def test_attributes_with_filtering_without_channel(
     "tested_field, attribute_count",
     [("inCategory", 5), ("inCollection", 5)],
 )
-def test_products_with_filtering_with_as_staff_user(
+def test_products_with_filtering_with_channel_as_staff_user(
     tested_field,
     attribute_count,
     staff_api_client,
@@ -225,6 +225,34 @@ def test_products_with_filtering_with_as_staff_user(
     content = get_graphql_content(response)
     attribute_nodes = content["data"]["attributes"]["edges"]
     assert len(attribute_nodes) == attribute_count
+
+
+def test_products_with_alternative_filtering_with_channel_as_staff_user(
+    staff_api_client,
+    permission_manage_products,
+    attributes_for_filtering_with_channels,
+    category,
+    channel_USD,
+):
+    # given
+    filtered_by_node_id = graphene.Node.to_global_id("Category", category.pk)
+    filter_by = {"inCategory": filtered_by_node_id}
+    filter_by["channel"] = channel_USD.slug
+
+    variables = {"filter": filter_by}
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_ATTRIBUTES_FILTERING,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+
+    # then
+    content = get_graphql_content(response)
+    attribute_nodes = content["data"]["attributes"]["edges"]
+    assert len(attribute_nodes) == 5
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/channel/filters.py
+++ b/saleor/graphql/channel/filters.py
@@ -2,5 +2,5 @@ from typing import Dict
 
 
 def get_channel_slug_from_filter_data(filter_data: Dict):
-    channel_slug = str(filter_data["channel"])
-    return channel_slug
+    channel = filter_data.get("channel")
+    return str(channel) if channel else None

--- a/saleor/graphql/core/types/__init__.py
+++ b/saleor/graphql/core/types/__init__.py
@@ -10,7 +10,7 @@ from .common import (
     TaxType,
     Weight,
 )
-from .filter_input import FilterInputObjectType
+from .filter_input import ChannelFilterInputObjectType, FilterInputObjectType
 from .money import VAT, Money, MoneyRange, ReducedRate, TaxedMoney, TaxedMoneyRange
-from .sort_input import SortInputObjectType
+from .sort_input import ChannelSortInputObjectType, SortInputObjectType
 from .upload import Upload

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -1,4 +1,4 @@
-from graphene import InputField, InputObjectType
+from graphene import Argument, InputField, InputObjectType, String
 from graphene.types.inputobjecttype import InputObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
 from graphene_django.filter.utils import get_filterset_class
@@ -62,3 +62,17 @@ class FilterInputObjectType(InputObjectType):
             field_type.kwargs = kwargs
             args[name] = field_type
         return args
+
+
+class ChannelFilterInputObjectType(FilterInputObjectType):
+    channel = Argument(
+        String,
+        description=(
+            "Specifies the channel by which the data should be filtered."
+            "DEPRECATED: Will be removed in Saleor 4.0."
+            "Use root-level channel argument instead."
+        ),
+    )
+
+    class Meta:
+        abstract = True

--- a/saleor/graphql/core/types/sort_input.py
+++ b/saleor/graphql/core/types/sort_input.py
@@ -35,3 +35,17 @@ class SortInputObjectType(graphene.InputObjectType):
                 description=f"Sort {type_name} by the selected field.",
             )
             cls._meta.fields.update({"field": field})
+
+
+class ChannelSortInputObjectType(SortInputObjectType):
+    channel = graphene.Argument(
+        graphene.String,
+        description=(
+            "Specifies the channel in which to sort the data."
+            "DEPRECATED: Will be removed in Saleor 4.0."
+            "Use root-level channel argument instead."
+        ),
+    )
+
+    class Meta:
+        abstract = True

--- a/saleor/graphql/discount/sorters.py
+++ b/saleor/graphql/discount/sorters.py
@@ -1,7 +1,7 @@
 import graphene
 from django.db.models import Min, Q, QuerySet
 
-from ..core.types import SortInputObjectType
+from ..core.types import ChannelSortInputObjectType
 
 
 class SaleSortField(graphene.Enum):
@@ -28,7 +28,7 @@ class SaleSortField(graphene.Enum):
         )
 
 
-class SaleSortingInput(SortInputObjectType):
+class SaleSortingInput(ChannelSortInputObjectType):
     class Meta:
         sort_enum = SaleSortField
         type_name = "sales"
@@ -69,7 +69,7 @@ class VoucherSortField(graphene.Enum):
         )
 
 
-class VoucherSortingInput(SortInputObjectType):
+class VoucherSortingInput(ChannelSortInputObjectType):
     class Meta:
         sort_enum = VoucherSortField
         type_name = "vouchers"

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -38,7 +38,7 @@ from ..core.filters import (
     MetadataFilterBase,
     ObjectTypeFilter,
 )
-from ..core.types import FilterInputObjectType
+from ..core.types import ChannelFilterInputObjectType, FilterInputObjectType
 from ..core.types.common import IntRangeInput, PriceRangeInput
 from ..utils import resolve_global_ids_to_primary_keys
 from ..utils.filters import filter_fields_containing_value, filter_range_field
@@ -662,7 +662,7 @@ class ProductTypeFilter(MetadataFilterBase):
         fields = ["search", "configurable", "product_type"]
 
 
-class ProductFilterInput(FilterInputObjectType):
+class ProductFilterInput(ChannelFilterInputObjectType):
     class Meta:
         filterset_class = ProductFilter
 
@@ -672,7 +672,7 @@ class ProductVariantFilterInput(FilterInputObjectType):
         filterset_class = ProductVariantFilter
 
 
-class CollectionFilterInput(FilterInputObjectType):
+class CollectionFilterInput(ChannelFilterInputObjectType):
     class Meta:
         filterset_class = CollectionFilter
 

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -22,7 +22,7 @@ from ...product.models import (
     Product,
     ProductChannelListing,
 )
-from ..core.types import SortInputObjectType
+from ..core.types import ChannelSortInputObjectType, SortInputObjectType
 
 
 class CategorySortField(graphene.Enum):
@@ -63,7 +63,7 @@ class CategorySortField(graphene.Enum):
         return queryset.annotate(subcategory_count=Count("children__id"))
 
 
-class CategorySortingInput(SortInputObjectType):
+class CategorySortingInput(ChannelSortInputObjectType):
     class Meta:
         sort_enum = CategorySortField
         type_name = "categories"
@@ -115,7 +115,7 @@ class CollectionSortField(graphene.Enum):
         )
 
 
-class CollectionSortingInput(SortInputObjectType):
+class CollectionSortingInput(ChannelSortInputObjectType):
     class Meta:
         sort_enum = CollectionSortField
         type_name = "collections"
@@ -219,7 +219,7 @@ class ProductOrderField(graphene.Enum):
         raise GraphQLError("Sorting by Rank is available only with searching.")
 
 
-class ProductOrder(SortInputObjectType):
+class ProductOrder(ChannelSortInputObjectType):
     attribute_id = graphene.Argument(
         graphene.ID,
         description=(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -513,6 +513,7 @@ input AttributeFilterInput {
   type: AttributeTypeEnum
   inCollection: ID
   inCategory: ID
+  channel: String
 }
 
 input AttributeInput {
@@ -808,6 +809,7 @@ enum CategorySortField {
 
 input CategorySortingInput {
   direction: OrderDirection!
+  channel: String
   field: CategorySortField!
 }
 
@@ -1241,6 +1243,7 @@ input CollectionFilterInput {
   search: String
   metadata: [MetadataFilter]
   ids: [ID]
+  channel: String
 }
 
 input CollectionInput {
@@ -1280,6 +1283,7 @@ enum CollectionSortField {
 
 input CollectionSortingInput {
   direction: OrderDirection!
+  channel: String
   field: CollectionSortField!
 }
 
@@ -4305,6 +4309,7 @@ input ProductFilterInput {
   minimalPrice: PriceRangeInput
   productTypes: [ID]
   ids: [ID]
+  channel: String
 }
 
 type ProductImage {
@@ -4389,6 +4394,7 @@ input ProductMediaUpdateInput {
 
 input ProductOrder {
   direction: OrderDirection!
+  channel: String
   attributeId: ID
   field: ProductOrderField
 }
@@ -4956,6 +4962,7 @@ enum SaleSortField {
 
 input SaleSortingInput {
   direction: OrderDirection!
+  channel: String
   field: SaleSortField!
 }
 
@@ -5905,6 +5912,7 @@ enum VoucherSortField {
 
 input VoucherSortingInput {
   direction: OrderDirection!
+  channel: String
   field: VoucherSortField!
 }
 


### PR DESCRIPTION
I want to merge this change because it partially reversed changes from #7374 to keep backwards compability.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
