### PR TITLE
Move shipping validation after voucher

### DIFF
--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -147,6 +147,7 @@ def get_valid_shipping_method_list_for_checkout_info(
     subtotal = manager.calculate_checkout_subtotal(
         checkout_info, lines, checkout_info.shipping_address, discounts
     )
+    subtotal -= checkout_info.checkout.discount
     valid_shipping_method = get_valid_shipping_methods_for_checkout(
         checkout_info, lines, subtotal, country_code=country_code
     )

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -1205,10 +1205,9 @@ class CheckoutAddPromoCode(BaseMutation):
             )
 
         manager = info.context.plugins
+        discounts = info.context.discounts
         lines = fetch_checkout_lines(checkout)
-        checkout_info = fetch_checkout_info(
-            checkout, lines, info.context.discounts, manager
-        )
+        checkout_info = fetch_checkout_info(checkout, lines, discounts, manager)
 
         if info.context.user and checkout.user == info.context.user:
             # reassign user from request to make sure that we will take into account
@@ -1221,8 +1220,16 @@ class CheckoutAddPromoCode(BaseMutation):
             checkout_info,
             lines,
             promo_code,
-            info.context.discounts,
+            discounts,
         )
+
+        checkout_info.valid_shipping_methods = (
+            get_valid_shipping_method_list_for_checkout_info(
+                checkout_info, checkout_info.shipping_address, lines, discounts, manager
+            )
+        )
+
+        update_checkout_shipping_method_if_invalid(checkout_info, lines)
         manager.checkout_updated(checkout)
         return CheckoutAddPromoCode(checkout=checkout)
 

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -712,7 +712,7 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
-    assert shipping_method_id not in data["checkout"]["shippingMethod"]
+    assert shipping_method_id != data["checkout"]["shippingMethod"]["id"]
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
 
 

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -8,10 +8,11 @@ from prices import Money
 from ....checkout import calculations
 from ....checkout.error_codes import CheckoutErrorCode
 from ....checkout.fetch import fetch_checkout_info, fetch_checkout_lines
-from ....checkout.utils import add_voucher_to_checkout
+from ....checkout.utils import add_variant_to_checkout, add_voucher_to_checkout
 from ....core.taxes import TaxedMoney
 from ....discount import DiscountInfo, VoucherType
 from ....plugins.manager import get_plugins_manager
+from ....warehouse.models import Stock
 from ...tests.utils import get_graphql_content
 from .test_checkout import MUTATION_CHECKOUT_SHIPPING_ADDRESS_UPDATE
 from .test_checkout_lines import MUTATION_CHECKOUT_LINES_DELETE
@@ -242,6 +243,12 @@ MUTATION_CHECKOUT_ADD_PROMO_CODE = """
                     gross {
                         amount
                     }
+                }
+                availableShippingMethods {
+                    id
+                }
+                shippingMethod {
+                    id
                 }
             }
         }
@@ -668,6 +675,45 @@ def test_checkout_add_promo_code_invalid_promo_code(api_client, checkout_with_it
 
     assert data["errors"]
     assert data["errors"][0]["field"] == "promoCode"
+
+
+def test_checkout_add_promo_code_invalidate_shipping_method(
+    api_client,
+    checkout,
+    variant_with_many_stocks_different_shipping_zones,
+    gift_card_created_by_staff,
+    address_usa,
+    shipping_method,
+    channel_USD,
+    voucher,
+):
+    Stock.objects.update(quantity=5)
+
+    # Free shipping for 50 USD
+    shipping_channel_listing = shipping_method.channel_listings.first()
+    shipping_channel_listing.minimum_order_price = Money(50, "USD")
+    shipping_channel_listing.price = Money(0, "USD")
+    shipping_channel_listing.save()
+
+    # Setup checkout with items worth $50
+    checkout.shipping_address = address_usa
+    checkout.shipping_method = shipping_method
+    checkout.billing_address = address_usa
+    checkout.save()
+
+    checkout_info = fetch_checkout_info(checkout, [], [], get_plugins_manager())
+    variant = variant_with_many_stocks_different_shipping_zones
+    add_variant_to_checkout(checkout_info, variant, 5)
+
+    # Apply voucher
+    variables = {"token": checkout.token, "promoCode": voucher.code}
+    data = _mutate_checkout_add_promo_code(api_client, variables)
+
+    shipping_method_id = graphene.Node.to_global_id(
+        "ShippingMethod", shipping_method.pk
+    )
+    assert shipping_method_id not in data["checkout"]["shippingMethod"]
+    assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
 
 
 MUTATION_CHECKOUT_REMOVE_PROMO_CODE = """


### PR DESCRIPTION
Makes shipping validation account for order's subtotal - discount instead of just `shipping validation`

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
