### PR TITLE
Fix bug with swapped shipping and billing address in webhook payloads

### DIFF
--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -532,6 +532,24 @@ def customer_user(address):  # pylint: disable=W0613
 
 
 @pytest.fixture
+def customer_user_different_billing_and_shipping_address(
+    address, address_other_country
+):
+    billing_address = address.get_copy()
+    shipping_address = address_other_country.get_copy()
+    user = User.objects.create_user(
+        "test@example.com",
+        "password",
+        default_billing_address=billing_address,
+        default_shipping_address=shipping_address,
+        first_name="Leslie",
+        last_name="Wade",
+    )
+    user._password = "password"
+    return user
+
+
+@pytest.fixture
 def user_checkout(customer_user, channel_USD):
     checkout = Checkout.objects.create(
         user=customer_user,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -532,24 +532,6 @@ def customer_user(address):  # pylint: disable=W0613
 
 
 @pytest.fixture
-def customer_user_different_billing_and_shipping_address(
-    address, address_other_country
-):
-    billing_address = address.get_copy()
-    shipping_address = address_other_country.get_copy()
-    user = User.objects.create_user(
-        "test@example.com",
-        "password",
-        default_billing_address=billing_address,
-        default_shipping_address=shipping_address,
-        first_name="Leslie",
-        last_name="Wade",
-    )
-    user._password = "password"
-    return user
-
-
-@pytest.fixture
 def user_checkout(customer_user, channel_USD):
     checkout = Checkout.objects.create(
         user=customer_user,

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -261,11 +261,11 @@ def generate_customer_payload(customer: "User"):
         ],
         additional_fields={
             "default_shipping_address": (
-                lambda c: c.default_billing_address,
+                lambda c: c.default_shipping_address,
                 ADDRESS_FIELDS,
             ),
             "default_billing_address": (
-                lambda c: c.default_shipping_address,
+                lambda c: c.default_billing_address,
                 ADDRESS_FIELDS,
             ),
             "addresses": (

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -375,7 +375,8 @@ def test_generate_payment_payload(dummy_webhook_app_payment_data):
     ).name
     assert payload == json.dumps(expected_payload, cls=CustomJsonEncoder)
 
-    def test_generate_product_translation_payload(product_translation_fr):
+
+def test_generate_product_translation_payload(product_translation_fr):
     payload = generate_translation_payload(product_translation_fr)
     data = json.loads(payload)
     assert data["id"] == graphene.Node.to_global_id(
@@ -472,4 +473,3 @@ def test_generate_customer_payload(customer_user, address_other_country, address
     }
 
     assert payload == expected_payload
-

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -18,6 +18,7 @@ from ..payloads import (
     ORDER_FIELDS,
     PRODUCT_VARIANT_FIELDS,
     generate_checkout_payload,
+    generate_customer_payload,
     generate_fulfillment_lines_payload,
     generate_invoice_payload,
     generate_list_gateways_payload,
@@ -372,3 +373,21 @@ def test_generate_payment_payload(dummy_webhook_app_payment_data):
         dummy_webhook_app_payment_data.gateway
     ).name
     assert payload == json.dumps(expected_payload, cls=CustomJsonEncoder)
+
+
+def test_generate_customer_payload_with_proper_shipping_and_billing_address(
+    customer_user_different_billing_and_shipping_address,
+):
+    customer = customer_user_different_billing_and_shipping_address
+    payload = json.loads(generate_customer_payload(customer))[0]
+    keys_to_remove = ["id", "type"]
+    for key in keys_to_remove:
+        del payload["default_shipping_address"][key]
+        del payload["default_billing_address"][key]
+    assert (
+        payload["default_shipping_address"]
+        == customer.default_shipping_address.as_data()
+    )
+    assert (
+        payload["default_billing_address"] == customer.default_billing_address.as_data()
+    )


### PR DESCRIPTION
I want to merge this change because it fix bug with swapped shipping and billing address

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
