### PR TITLE
Add validation of the requested AppExtension configuration

### DIFF
--- a/saleor/app/tests/test_manifest_validation.py
+++ b/saleor/app/tests/test_manifest_validation.py
@@ -1,0 +1,51 @@
+from collections import defaultdict
+
+import pytest
+
+from ..manifest_validations import _validate_configuration
+from ..types import AppExtensionTarget, AppExtensionType, AppExtensionView
+
+
+@pytest.mark.parametrize(
+    "view, type, target",
+    [
+        (
+            AppExtensionView.PRODUCT,
+            AppExtensionType.OVERVIEW,
+            AppExtensionTarget.CREATE,
+        ),
+        (
+            AppExtensionView.PRODUCT,
+            AppExtensionType.OVERVIEW,
+            AppExtensionTarget.MORE_ACTIONS,
+        ),
+        (AppExtensionView.PRODUCT, AppExtensionType.DETAILS, AppExtensionTarget.CREATE),
+        (
+            AppExtensionView.PRODUCT,
+            AppExtensionType.DETAILS,
+            AppExtensionTarget.MORE_ACTIONS,
+        ),
+    ],
+)
+def test_validate_configuration_accepts_correct_configuration(view, type, target):
+    errors = []
+    extension = {
+        "view": view,
+        "type": type,
+        "target": target,
+    }
+    _validate_configuration(extension, errors)
+
+    assert not errors
+
+
+def test_incorrect_configuration():
+    errors = defaultdict(list)
+    extension = {
+        "view": AppExtensionView.PRODUCT,
+        "type": AppExtensionType.DETAILS,
+        "target": "incorrect",
+    }
+    _validate_configuration(extension, errors)
+
+    assert len(errors["extensions"]) == 1

--- a/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
+++ b/saleor/graphql/app/tests/mutations/test_app_fetch_manifest.py
@@ -358,12 +358,25 @@ def test_app_fetch_manifest_extensions_incorrect_enum_values(
     content = get_graphql_content(response)
     errors = content["data"]["appFetchManifest"]["errors"]
 
-    assert len(errors) == 1
-    assert errors[0] == {
-        "code": "INVALID",
-        "field": "extensions",
-        "message": f"Incorrect value for field: {incorrect_field}",
-    }
+    assert len(errors) == 2
+    expected_errors = [
+        {
+            "code": "INVALID",
+            "field": "extensions",
+            "message": f"Incorrect value for field: {incorrect_field}",
+        },
+        {
+            "field": "extensions",
+            "message": (
+                "Incorrect configuration of app extension for fields: view, type and "
+                "target."
+            ),
+            "code": "INVALID",
+        },
+    ]
+
+    assert errors[0] in expected_errors
+    assert errors[1] in expected_errors
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I want to merge this change because it adds a map to validate available app extension configuration

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
