### PR TITLE
Drop assigning cheapest shipping method in checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add app support for events - #7622 by @IKarbowiak
 - Add date & date time attributes - #7500 by @piotrgrundas
 - Add `withChoices` flag for Attribute type - #7733 by @dexon44
+- Drop assigning cheapest shipping method in checkout - #7767 by @maarcingebala
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -78,7 +78,7 @@ def test_update_checkout_shipping_method_if_invalid(
     other_shipping_method,
     shipping_zone_without_countries,
 ):
-    """If the shipping method is invalid, it should replace it."""
+    # If the shipping method is invalid, it should be removed.
 
     checkout = checkout_with_single_item
     checkout.shipping_address = address
@@ -92,18 +92,13 @@ def test_update_checkout_shipping_method_if_invalid(
     checkout_info = fetch_checkout_info(checkout, lines, [], manager)
     update_checkout_shipping_method_if_invalid(checkout_info, lines)
 
-    assert checkout.shipping_method == other_shipping_method
-    assert checkout_info.shipping_method == other_shipping_method
-    assert (
-        checkout_info.shipping_method_channel_listings
-        == shipping_models.ShippingMethodChannelListing.objects.filter(
-            shipping_method=other_shipping_method, channel=checkout_info.channel
-        ).first()
-    )
+    assert checkout.shipping_method is None
+    assert checkout_info.shipping_method is None
+    assert checkout_info.shipping_method_channel_listings is None
 
     # Ensure the checkout's shipping method was saved
     checkout.refresh_from_db(fields=["shipping_method"])
-    assert checkout.shipping_method == other_shipping_method
+    assert checkout.shipping_method is None
 
 
 MUTATION_CHECKOUT_CREATE = """

--- a/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
+++ b/saleor/graphql/checkout/tests/test_checkout_promo_codes.py
@@ -712,7 +712,7 @@ def test_checkout_add_promo_code_invalidate_shipping_method(
     shipping_method_id = graphene.Node.to_global_id(
         "ShippingMethod", shipping_method.pk
     )
-    assert shipping_method_id != data["checkout"]["shippingMethod"]["id"]
+    assert data["checkout"]["shippingMethod"] is None
     assert shipping_method_id not in data["checkout"]["availableShippingMethods"]
 
 


### PR DESCRIPTION
If a shipping method becomes invalid in checkout, we should clear it and let the user pick a different one. This PR changes checkout behavior to clear the shipping method in this case.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
