### PR TITLE
Gift cards - block zero amount

### DIFF
--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -188,6 +188,15 @@ class GiftCardCreate(ModelMutation):
                             )
                         }
                     )
+            if not amount > 0:
+                raise ValidationError(
+                    {
+                        "balance": ValidationError(
+                            "Balance amount have to be greater than 0.",
+                            code=GiftCardErrorCode.INVALID.value,
+                        )
+                    }
+                )
             cleaned_input["currency"] = currency
             cleaned_input["current_balance_amount"] = amount
             cleaned_input["initial_balance_amount"] = amount

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -332,6 +332,52 @@ def test_create_gift_card_with_to_many_decimal_places_in_balance_amount(
     assert errors[0]["code"] == GiftCardErrorCode.INVALID.name
 
 
+def test_create_gift_card_with_zero_balance_amount(
+    staff_api_client,
+    customer_user,
+    permission_manage_gift_card,
+    permission_manage_users,
+    permission_manage_apps,
+):
+    # given
+    currency = "USD"
+    expiry_type = GiftCardExpiryTypeEnum.NEVER_EXPIRE.name
+    tag = "gift-card-tag"
+    variables = {
+        "balance": {
+            "amount": 0,
+            "currency": currency,
+        },
+        "userEmail": customer_user.email,
+        "tag": tag,
+        "note": "This is gift card note that will be save in gift card event.",
+        "expirySettings": {
+            "expiryType": expiry_type,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_users,
+            permission_manage_apps,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardCreate"]["errors"]
+    data = content["data"]["giftCardCreate"]["giftCard"]
+
+    assert not data
+    assert len(errors) == 1
+    assert errors[0]["field"] == "balance"
+    assert errors[0]["code"] == GiftCardErrorCode.INVALID.name
+
+
 def test_create_gift_card_with_expiry_date(
     staff_api_client,
     customer_user,


### PR DESCRIPTION
I want to merge this change because it raises an error when zero is passed as gift card amount argument.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
