### PR TITLE
Add object type to translation webhook payload

### DIFF
--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -621,6 +621,7 @@ def generate_translation_payload(translation: "Translation"):
 
     translation_data = {
         "id": graphene.Node.to_global_id(object_type, object_id),
+        "type": object_type,
         "language_code": translation.language_code,
         "keys": translated_keys,
     }


### PR DESCRIPTION
Adds object type name to translation payload, so decoding ID is no longer necessary:

```json
{
  "id": "UHJvZHVjdDoxMTU=",
  "type": "ProductVariant",
  "language_code": "pl",
  "keys": [
    {"key": "seo_title", "value": null},
    {"key": "seo_description", "value": null},
    {"key": "name", "value": "Bluza z kapturem czarna"},
    {"key": "description", "value": {"time": 1627493627745, "blocks": [{"type": "paragraph", "data": {"text": "Oferta specjalna. Kup bluz\u0119 i otrzymaj za darmo czarny sweter. Woho! Lorem ipsum 125"}}], "version": "2.20.0"}}
  ]
}
```

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
