### PR TITLE
Add preorder filtering to API

### DIFF
--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -740,7 +740,9 @@ def create_fake_order(discounts, max_order_lines=5, create_preorder_lines=False)
     customer = random.choice([None, customers.first()])
 
     # 20% chance to be unconfirmed order.
-    will_be_unconfirmed = random.choice([0, 0, 0, 0, 1])
+    will_be_unconfirmed = (
+        random.choice([0, 0, 0, 0, 1]) if not create_preorder_lines else True
+    )
 
     if customer:
         address = customer.default_shipping_address
@@ -795,7 +797,7 @@ def create_fake_order(discounts, max_order_lines=5, create_preorder_lines=False)
 
     create_fake_payment(order=order)
 
-    if not (will_be_unconfirmed and create_preorder_lines):
+    if not will_be_unconfirmed:
         create_fulfillments(order)
 
     return order

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -434,6 +434,10 @@ def filter_sku_list(qs, _, value):
     return qs.filter(sku__in=value)
 
 
+def filter_is_preorder(qs, _, value):
+    return qs.filter(is_preorder=value)
+
+
 def filter_quantity(qs, quantity_value, warehouses=None):
     """Filter products queryset by product variants quantity.
 
@@ -533,6 +537,7 @@ class ProductVariantFilter(MetadataFilterBase):
         method=filter_fields_containing_value("name", "product__name", "sku")
     )
     sku = ListObjectTypeFilter(input_class=graphene.String, method=filter_sku_list)
+    is_preorder = django_filters.BooleanFilter(method=filter_is_preorder)
 
     class Meta:
         model = ProductVariant

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -316,7 +316,11 @@ def filter_has_category(qs, _, value):
 
 
 def filter_has_preordered_variants(qs, _, value):
-    return qs.filter(variants__is_preorder=value)
+    variants = ProductVariant.objects.filter(is_preorder=True).values("product_id")
+    if value:
+        return qs.filter(Exists(variants.filter(product_id=OuterRef("pk"))))
+    else:
+        return qs.filter(~Exists(variants.filter(product_id=OuterRef("pk"))))
 
 
 def filter_collections(qs, _, value):

--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -315,6 +315,10 @@ def filter_has_category(qs, _, value):
     return qs.filter(category__isnull=not value)
 
 
+def filter_has_preordered_variants(qs, _, value):
+    return qs.filter(variants__is_preorder=value)
+
+
 def filter_collections(qs, _, value):
     if value:
         _, collection_pks = resolve_global_ids_to_primary_keys(
@@ -493,6 +497,9 @@ class ProductFilter(MetadataFilterBase):
     stocks = ObjectTypeFilter(input_class=ProductStockFilterInput, method=filter_stocks)
     search = django_filters.CharFilter(method=filter_search)
     ids = GlobalIDMultipleChoiceFilter(method=filter_product_ids)
+    has_preordered_variants = django_filters.BooleanFilter(
+        method=filter_has_preordered_variants
+    )
 
     class Meta:
         model = Product

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -2421,6 +2421,40 @@ def test_query_products_with_filter_ids(
     assert [node["node"]["id"] for node in products_data] == product_ids
 
 
+def test_products_query_with_filter_has_preordered_variants_false(
+    query_products_with_filter, staff_api_client, product, permission_manage_products
+):
+    variables = {"filter": {"hasPreorderedVariants": False}}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+    content = get_graphql_content(response)
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    products = content["data"]["products"]["edges"]
+
+    assert len(products) == 1
+    assert products[0]["node"]["id"] == product_id
+    assert products[0]["node"]["name"] == product.name
+
+
+def test_products_query_with_filter_has_preordered_variants_true(
+    query_products_with_filter,
+    staff_api_client,
+    preorder_variant_global_threshold,
+    permission_manage_products,
+):
+    product = preorder_variant_global_threshold.product
+    variables = {"filter": {"hasPreorderedVariants": True}}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+    content = get_graphql_content(response)
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    products = content["data"]["products"]["edges"]
+
+    assert len(products) == 1
+    assert products[0]["node"]["id"] == product_id
+    assert products[0]["node"]["name"] == product.name
+
+
 QUERY_PRODUCT_MEDIA_BY_ID = """
     query productMediaById($mediaId: ID!, $productId: ID!, $channel: String) {
         product(id: $productId, channel: $channel) {

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -2422,8 +2422,13 @@ def test_query_products_with_filter_ids(
 
 
 def test_products_query_with_filter_has_preordered_variants_false(
-    query_products_with_filter, staff_api_client, product, permission_manage_products
+    query_products_with_filter,
+    staff_api_client,
+    preorder_variant_global_threshold,
+    product_without_shipping,
+    permission_manage_products,
 ):
+    product = product_without_shipping
     variables = {"filter": {"hasPreorderedVariants": False}}
     staff_api_client.user.user_permissions.add(permission_manage_products)
     response = staff_api_client.post_graphql(query_products_with_filter, variables)
@@ -2440,6 +2445,7 @@ def test_products_query_with_filter_has_preordered_variants_true(
     query_products_with_filter,
     staff_api_client,
     preorder_variant_global_threshold,
+    product_without_shipping,
     permission_manage_products,
 ):
     product = preorder_variant_global_threshold.product

--- a/saleor/graphql/product/tests/test_variant_with_filtering.py
+++ b/saleor/graphql/product/tests/test_variant_with_filtering.py
@@ -51,6 +51,12 @@ def products_for_variant_filtering(product_type, category):
                 category=category,
                 product_type=product_type,
             ),
+            Product(
+                name="ProductWithPreorder",
+                slug="prod4",
+                category=category,
+                product_type=product_type,
+            ),
         ]
     )
     ProductVariant.objects.bulk_create(
@@ -73,6 +79,11 @@ def products_for_variant_filtering(product_type, category):
                 product=products[4],
                 sku="P3-V1",
             ),
+            ProductVariant(
+                product=products[5],
+                sku="Preorder-V1",
+                is_preorder=True,
+            ),
         ]
     )
     return products
@@ -92,6 +103,11 @@ def products_for_variant_filtering(product_type, category):
         ({"sku": ["P1-V1", "P1-V2", "PP1-V1"]}, ["P1-V1", "P1-V2", "PP1-V1"]),
         ({"sku": ["PP1-V1", "PP2-V1"]}, ["PP1-V1", "PP2-V1"]),
         ({"sku": ["invalid"]}, []),
+        ({"isPreorder": True}, ["Preorder-V1"]),
+        (
+            {"isPreorder": False},
+            ["P1-V1", "P1-V2", "P2-V1", "P3-V1", "PP1-V1", "PP2-V1"],
+        ),
     ],
 )
 def test_products_pagination_with_filtering(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4307,6 +4307,7 @@ input ProductFilterInput {
   minimalPrice: PriceRangeInput
   productTypes: [ID]
   ids: [ID]
+  hasPreorderedVariants: Boolean
 }
 
 type ProductImage {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4666,6 +4666,7 @@ input ProductVariantFilterInput {
   search: String
   sku: [String]
   metadata: [MetadataFilter]
+  isPreorder: Boolean
 }
 
 input ProductVariantInput {


### PR DESCRIPTION
I want to merge this change because it adds new filtering for preorder in API. It also fixes an issue introduced in #7766 .

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [x] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
