### PR TITLE
Fix bug with Index out of range in ProductTranslatableContent

### DIFF
--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -46,8 +46,7 @@ def get_translatable_attribute_values(attributes: list) -> List[AttributeValue]:
     for assignment in attributes:
         attr = assignment["attribute"]
         if attr.input_type in AttributeInputType.TRANSLATABLE_ATTRIBUTES:
-            value = assignment["values"][0]
-            translatable_values.append(value)
+            translatable_values.extend(assignment["values"])
     return translatable_values
 
 


### PR DESCRIPTION
I want to merge this change because it fix bug with ProductTranslatable Content list out of range.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
