### PR TITLE
Draft order shipping method doesn't update after removed all products.

### DIFF
--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -34,14 +34,14 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
             )
 
 
-class DeprecatedDraftOrderLinesBulkDelete(ModelBulkDeleteMutation):
+class DraftOrderLinesBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = graphene.List(
             graphene.ID, required=True, description="List of order lines IDs to delete."
         )
 
     class Meta:
-        description = "DEPRECATED: Will be removed in Saleor 4.0."
+        description = "Deletes order lines."
         model = models.OrderLine
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError

--- a/saleor/graphql/order/bulk_mutations/draft_orders.py
+++ b/saleor/graphql/order/bulk_mutations/draft_orders.py
@@ -34,14 +34,14 @@ class DraftOrderBulkDelete(ModelBulkDeleteMutation):
             )
 
 
-class DraftOrderLinesBulkDelete(ModelBulkDeleteMutation):
+class DeprecatedDraftOrderLinesBulkDelete(ModelBulkDeleteMutation):
     class Arguments:
         ids = graphene.List(
             graphene.ID, required=True, description="List of order lines IDs to delete."
         )
 
     class Meta:
-        description = "Deletes order lines."
+        description = "DEPRECATED: Will be removed in Saleor 4.0."
         model = models.OrderLine
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError

--- a/saleor/graphql/order/mutations/orders.py
+++ b/saleor/graphql/order/mutations/orders.py
@@ -220,7 +220,9 @@ class OrderUpdate(DraftOrderCreate):
 
 class OrderUpdateShippingInput(graphene.InputObjectType):
     shipping_method = graphene.ID(
-        description="ID of the selected shipping method.", name="shippingMethod"
+        description="ID of the selected shipping method,"
+        " pass null to remove currently assigned shippingMethod.",
+        name="shippingMethod",
     )
 
 
@@ -251,11 +253,16 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
             description="ID of the order to update a shipping method.",
         )
         input = OrderUpdateShippingInput(
-            description="Fields required to change shipping method of the order."
+            description="Fields required to change shipping method of the order.",
+            required=True,
         )
 
     class Meta:
-        description = "Updates a shipping method of the order."
+        description = (
+            "Updates a shipping method of the order."
+            " Requires shipping Id to update, when null is passed "
+            "then currently assigned shipping method is removed."
+        )
         permissions = (OrderPermissions.MANAGE_ORDERS,)
         error_type_class = OrderError
         error_type_field = "order_errors"
@@ -269,14 +276,34 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
             qs=models.Order.objects.prefetch_related("lines"),
         )
         cls.validate_order(order)
+
         data = data.get("input")
 
-        if not data["shipping_method"]:
+        if "shipping_method" not in data:
+            raise ValidationError(
+                {
+                    "shipping_method": ValidationError(
+                        "Shipping method must be provided to perform mutation.",
+                        code=OrderErrorCode.SHIPPING_METHOD_REQUIRED,
+                    )
+                }
+            )
+
+        if not data.get("shipping_method"):
             if not order.is_draft() and order.is_shipping_required():
                 raise ValidationError(
                     {
                         "shipping_method": ValidationError(
                             "Shipping method is required for this order.",
+                            code=OrderErrorCode.SHIPPING_METHOD_REQUIRED,
+                        )
+                    }
+                )
+            if data["shipping_method"] == "":
+                raise ValidationError(
+                    {
+                        "shipping_method": ValidationError(
+                            "Shipping method cannot be empty.",
                             code=OrderErrorCode.SHIPPING_METHOD_REQUIRED,
                         )
                     }
@@ -294,6 +321,7 @@ class OrderUpdateShipping(EditableOrderValidationMixin, BaseMutation):
                     "shipping_method_name",
                 ]
             )
+            recalculate_order(order)
             return OrderUpdateShipping(order=order)
 
         method = cls.get_node_or_error(
@@ -824,6 +852,28 @@ class OrderLineDelete(EditableOrderValidationMixin, BaseMutation):
         delete_order_line(line_info)
         line.id = db_id
 
+        if order.is_shipping_required():
+            events.order_removed_products_event(
+                order=order,
+                user=info.context.user,
+                app=info.context.app,
+                order_lines=[(line.quantity, line)],
+            )
+            recalculate_order(order)
+            return OrderLineDelete(order=order, order_line=line)
+
+        order.shipping_method = None
+        order.shipping_price = zero_taxed_money(order.currency)
+        order.shipping_method_name = None
+        order.save(
+            update_fields=[
+                "currency",
+                "shipping_method",
+                "shipping_price_net_amount",
+                "shipping_price_gross_amount",
+                "shipping_method_name",
+            ]
+        )
         # Create the removal event
         events.order_removed_products_event(
             order=order,

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,10 +7,7 @@ from ..core.scalars import UUID
 from ..core.types import FilterInputObjectType, TaxedMoney
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
-from .bulk_mutations.draft_orders import (
-    DeprecatedDraftOrderLinesBulkDelete,
-    DraftOrderBulkDelete,
-)
+from .bulk_mutations.draft_orders import DraftOrderBulkDelete, DraftOrderLinesBulkDelete
 from .bulk_mutations.orders import OrderBulkCancel
 from .filters import DraftOrderFilter, OrderFilter
 from .mutations.discount_order import (
@@ -142,7 +139,9 @@ class OrderMutations(graphene.ObjectType):
     draft_order_create = DraftOrderCreate.Field()
     draft_order_delete = DraftOrderDelete.Field()
     draft_order_bulk_delete = DraftOrderBulkDelete.Field()
-    draft_order_lines_bulk_delete = DeprecatedDraftOrderLinesBulkDelete.Field()
+    draft_order_lines_bulk_delete = DraftOrderLinesBulkDelete.Field(
+        deprecation_reason="DEPRECATED: Will be removed in Saleor 4.0."
+    )
     draft_order_update = DraftOrderUpdate.Field()
 
     order_add_note = OrderAddNote.Field()

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -7,7 +7,10 @@ from ..core.scalars import UUID
 from ..core.types import FilterInputObjectType, TaxedMoney
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
-from .bulk_mutations.draft_orders import DraftOrderBulkDelete, DraftOrderLinesBulkDelete
+from .bulk_mutations.draft_orders import (
+    DeprecatedDraftOrderLinesBulkDelete,
+    DraftOrderBulkDelete,
+)
 from .bulk_mutations.orders import OrderBulkCancel
 from .filters import DraftOrderFilter, OrderFilter
 from .mutations.discount_order import (
@@ -139,7 +142,7 @@ class OrderMutations(graphene.ObjectType):
     draft_order_create = DraftOrderCreate.Field()
     draft_order_delete = DraftOrderDelete.Field()
     draft_order_bulk_delete = DraftOrderBulkDelete.Field()
-    draft_order_lines_bulk_delete = DraftOrderLinesBulkDelete.Field()
+    draft_order_lines_bulk_delete = DeprecatedDraftOrderLinesBulkDelete.Field()
     draft_order_update = DraftOrderUpdate.Field()
 
     order_add_note = OrderAddNote.Field()

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -6541,6 +6541,7 @@ mutation OrderUpdateShipping(
     "input, response_msg",
     [
         ({"shippingMethod": ""}, "Shipping method cannot be empty."),
+        ({}, "Shipping method must be provided to perform mutation."),
     ],
 )
 def test_order_shipping_update_mutation_return_error_for_empty_value(
@@ -6579,7 +6580,4 @@ def test_order_shipping_update_mutation_properly_recalculate_total(
     )
     content = get_graphql_content(response)
     data = content["data"]["orderUpdateShipping"]
-    if data["order"]["shippingMethod"] is None:
-        assert True
-    else:
-        assert False
+    assert data["order"]["shippingMethod"] is None

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -3701,6 +3701,12 @@ ORDER_LINE_DELETE_MUTATION = """
             }
             order {
                 id
+                total{
+                    gross{
+                        currency
+                        amount
+                    }
+                }
             }
         }
     }
@@ -6483,3 +6489,97 @@ def test_get_variant_from_order_line_variant_not_exists_as_staff(
     content = get_graphql_content(response)
     orders = content["data"]["me"]["orders"]["edges"]
     assert orders[0]["node"]["lines"][0]["variant"] is None
+
+
+def test_draft_order_properly_recalculate_total_after_shipping_product_removed(
+    staff_api_client,
+    draft_order,
+    permission_manage_orders,
+):
+    order = draft_order
+    line = order.lines.get(product_sku="SKU_AA")
+    line.is_shipping_required = True
+    line.save()
+
+    query = ORDER_LINE_DELETE_MUTATION
+    line = order.lines.get(product_sku="SKU_B")
+    line_id = graphene.Node.to_global_id("OrderLine", line.id)
+    variables = {"id": line_id}
+
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderLineDelete"]
+
+    assert data["order"]["total"]["gross"]["amount"] == float(
+        order.total_gross_amount
+    ) - float(line.total_price_gross_amount)
+
+
+ORDER_UPDATE_SHIPPING_QUERY_WITH_TOTAL = """
+mutation OrderUpdateShipping(
+    $orderId: ID!
+    $shippingMethod: OrderUpdateShippingInput!
+) {
+    orderUpdateShipping(order: $orderId, input: $shippingMethod) {
+        order {
+            shippingMethod {
+                id
+            }
+        }
+        errors {
+            field
+            message
+        }
+    }
+}
+"""
+
+
+@pytest.mark.parametrize(
+    "input, response_msg",
+    [
+        ({"shippingMethod": ""}, "Shipping method cannot be empty."),
+    ],
+)
+def test_order_shipping_update_mutation_return_error_for_empty_value(
+    draft_order, permission_manage_orders, staff_api_client, input, response_msg
+):
+    query = ORDER_UPDATE_SHIPPING_QUERY_WITH_TOTAL
+
+    order = draft_order
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"orderId": order_id, "shippingMethod": input}
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=(permission_manage_orders,),
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderUpdateShipping"]
+
+    assert data["errors"][0]["message"] == response_msg
+
+
+def test_order_shipping_update_mutation_properly_recalculate_total(
+    draft_order,
+    permission_manage_orders,
+    staff_api_client,
+):
+    query = ORDER_UPDATE_SHIPPING_QUERY_WITH_TOTAL
+
+    order = draft_order
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"orderId": order_id, "shippingMethod": {"shippingMethod": None}}
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=(permission_manage_orders,),
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderUpdateShipping"]
+    if data["order"]["shippingMethod"] is None:
+        assert True
+    else:
+        assert False

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1733,12 +1733,6 @@ type DeletePrivateMetadata {
   item: ObjectWithMetadata
 }
 
-type DeprecatedDraftOrderLinesBulkDelete {
-  count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
-  errors: [OrderError!]!
-}
-
 type DigitalContent implements Node & ObjectWithMetadata {
   useDefaultSettings: Boolean!
   automaticFulfillment: Boolean!
@@ -1911,6 +1905,12 @@ input DraftOrderInput {
   customerNote: String
   channelId: ID
   redirectUrl: String
+}
+
+type DraftOrderLinesBulkDelete {
+  count: Int!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
@@ -2820,7 +2820,7 @@ type Mutation {
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
   draftOrderBulkDelete(ids: [ID]!): DraftOrderBulkDelete
-  draftOrderLinesBulkDelete(ids: [ID]!): DeprecatedDraftOrderLinesBulkDelete
+  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "DEPRECATED: Will be removed in Saleor 4.0.")
   draftOrderUpdate(id: ID!, input: DraftOrderInput!): DraftOrderUpdate
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2842,7 +2842,7 @@ type Mutation {
   orderMarkAsPaid(id: ID!, transactionReference: String): OrderMarkAsPaid
   orderRefund(amount: PositiveDecimal!, id: ID!): OrderRefund
   orderUpdate(id: ID!, input: OrderUpdateInput!): OrderUpdate
-  orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput): OrderUpdateShipping
+  orderUpdateShipping(order: ID!, input: OrderUpdateShippingInput!): OrderUpdateShipping
   orderVoid(id: ID!): OrderVoid
   orderBulkCancel(ids: [ID]!): OrderBulkCancel
   deleteMetadata(id: ID!, keys: [String!]!): DeleteMetadata

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1733,6 +1733,12 @@ type DeletePrivateMetadata {
   item: ObjectWithMetadata
 }
 
+type DeprecatedDraftOrderLinesBulkDelete {
+  count: Int!
+  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  errors: [OrderError!]!
+}
+
 type DigitalContent implements Node & ObjectWithMetadata {
   useDefaultSettings: Boolean!
   automaticFulfillment: Boolean!
@@ -1905,12 +1911,6 @@ input DraftOrderInput {
   customerNote: String
   channelId: ID
   redirectUrl: String
-}
-
-type DraftOrderLinesBulkDelete {
-  count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
-  errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
@@ -2820,7 +2820,7 @@ type Mutation {
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
   draftOrderBulkDelete(ids: [ID]!): DraftOrderBulkDelete
-  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete
+  draftOrderLinesBulkDelete(ids: [ID]!): DeprecatedDraftOrderLinesBulkDelete
   draftOrderUpdate(id: ID!, input: DraftOrderInput!): DraftOrderUpdate
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel


### PR DESCRIPTION
I want to merge this change because it fix bug with OrderLineDelete mutation doesn't remove shipping method and recalculate total.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
