### PR TITLE
Deprecate query args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `withChoices` flag for Attribute type - #7733 by @dexon44
 - Drop assigning cheapest shipping method in checkout - #7767 by @maarcingebala
 - Add `product_id`, `product_variant_id`, `attribute_id` and `page_id` when it's possible for `AttributeValue` translations webhook. - #7783 by @fowczarek
+- Deprecate `query` argument in `sales` and `vouchers` queries - #7806 by @maarcingebala
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -68,7 +68,7 @@ class ChannelFilterInputObjectType(FilterInputObjectType):
     channel = Argument(
         String,
         description=(
-            "Specifies the channel by which the data should be filtered."
+            "Specifies the channel by which the data should be filtered. "
             "DEPRECATED: Will be removed in Saleor 4.0."
             "Use root-level channel argument instead."
         ),

--- a/saleor/graphql/core/types/sort_input.py
+++ b/saleor/graphql/core/types/sort_input.py
@@ -41,7 +41,7 @@ class ChannelSortInputObjectType(SortInputObjectType):
     channel = graphene.Argument(
         graphene.String,
         description=(
-            "Specifies the channel in which to sort the data."
+            "Specifies the channel in which to sort the data. "
             "DEPRECATED: Will be removed in Saleor 4.0."
             "Use root-level channel argument instead."
         ),

--- a/saleor/graphql/discount/resolvers.py
+++ b/saleor/graphql/discount/resolvers.py
@@ -1,8 +1,6 @@
 from ...discount import models
 from ..channel import ChannelContext, ChannelQsContext
-
-VOUCHER_SEARCH_FIELDS = ("name", "code")
-SALE_SEARCH_FIELDS = ("name", "value", "type")
+from .filters import filter_sale_search, filter_voucher_search
 
 
 def resolve_voucher(id, channel):
@@ -10,10 +8,15 @@ def resolve_voucher(id, channel):
     return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
-def resolve_vouchers(info, channel_slug, **_kwargs) -> ChannelQsContext:
+def resolve_vouchers(info, channel_slug, **kwargs) -> ChannelQsContext:
     qs = models.Voucher.objects.all()
     if channel_slug:
         qs = qs.filter(channel_listings__channel__slug=channel_slug)
+
+    # DEPRECATED: remove filtering by `query` argument when it's removed from the schema
+    if query := kwargs.get("query"):
+        qs = filter_voucher_search(qs, None, query)
+
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)
 
 
@@ -22,8 +25,13 @@ def resolve_sale(id, channel):
     return ChannelContext(node=sale, channel_slug=channel) if sale else None
 
 
-def resolve_sales(info, channel_slug, **_kwargs) -> ChannelQsContext:
+def resolve_sales(info, channel_slug, **kwargs) -> ChannelQsContext:
     qs = models.Sale.objects.all()
     if channel_slug:
         qs = qs.filter(channel_listings__channel__slug=channel_slug)
+
+    # DEPRECATED: remove filtering by `query` argument when it's removed from the schema
+    if query := kwargs.get("query"):
+        qs = filter_sale_search(qs, None, query)
+
     return ChannelQsContext(qs=qs, channel_slug=channel_slug)

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -50,7 +50,12 @@ class DiscountQueries(graphene.ObjectType):
         Sale,
         filter=SaleFilterInput(description="Filtering options for sales."),
         sort_by=SaleSortingInput(description="Sort sales."),
-        query=graphene.String(description="Search sales by name, value or type."),
+        query=graphene.String(
+            description=(
+                "Search sales by name, value or type. DEPRECATED: Will be removed in "
+                "Saleor 4.0. Use `filter.search` input instead."
+            )
+        ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),
@@ -70,7 +75,12 @@ class DiscountQueries(graphene.ObjectType):
         Voucher,
         filter=VoucherFilterInput(description="Filtering options for vouchers."),
         sort_by=VoucherSortingInput(description="Sort voucher."),
-        query=graphene.String(description="Search vouchers by name or code."),
+        query=graphene.String(
+            description=(
+                "Search vouchers by name or code. DEPRECATED: Will be removed in "
+                "Saleor 4.0. Use `filter.search` input instead."
+            )
+        ),
         channel=graphene.String(
             description="Slug of a channel for which the data should be returned."
         ),

--- a/saleor/graphql/product/bulk_mutations/products.py
+++ b/saleor/graphql/product/bulk_mutations/products.py
@@ -182,7 +182,7 @@ class BulkAttributeValueInput(InputObjectType):
     boolean = graphene.Boolean(
         required=False,
         description=(
-            "The boolean value of an attribute to resolve."
+            "The boolean value of an attribute to resolve. "
             "If the passed value is non-existent, it will be created."
         ),
     )


### PR DESCRIPTION
- Deprecated unused query args.
- Fix descriptions grammar. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [x] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [x] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
