### PR TITLE
Allow cancelling fulfillments waiting for approval

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -79,7 +79,7 @@ class OrderFulfill(BaseMutation):
             description="ID of the order to be fulfilled.", name="order"
         )
         input = OrderFulfillInput(
-            required=True, description="Fields required to create an fulfillment."
+            required=True, description="Fields required to create a fulfillment."
         )
 
     class Meta:
@@ -246,9 +246,9 @@ class FulfillmentUpdateTracking(BaseMutation):
     )
 
     class Arguments:
-        id = graphene.ID(required=True, description="ID of an fulfillment to update.")
+        id = graphene.ID(required=True, description="ID of a fulfillment to update.")
         input = FulfillmentUpdateTrackingInput(
-            required=True, description="Fields required to update an fulfillment."
+            required=True, description="Fields required to update a fulfillment."
         )
 
     class Meta:
@@ -289,9 +289,9 @@ class FulfillmentCancel(BaseMutation):
     order = graphene.Field(Order, description="Order which fulfillment was cancelled.")
 
     class Arguments:
-        id = graphene.ID(required=True, description="ID of an fulfillment to cancel.")
+        id = graphene.ID(required=True, description="ID of a fulfillment to cancel.")
         input = FulfillmentCancelInput(
-            required=False, description="Fields required to cancel an fulfillment."
+            required=False, description="Fields required to cancel a fulfillment."
         )
 
     class Meta:
@@ -354,7 +354,7 @@ class FulfillmentApprove(BaseMutation):
     order = graphene.Field(Order, description="Order which fulfillment was approved.")
 
     class Arguments:
-        id = graphene.ID(required=True, description="ID of an fulfillment to approve.")
+        id = graphene.ID(required=True, description="ID of a fulfillment to approve.")
         notify_customer = graphene.Boolean(
             required=True, description="True if confirmation email should be send."
         )

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -159,9 +159,9 @@ class OrderFulfill(BaseMutation):
 
     @classmethod
     def clean_input(cls, info, order, data):
-        if (
-            not info.context.site.settings.fulfillment_allow_unpaid
-            and not order.is_fully_paid()
+        if not order.is_fully_paid() and (
+            info.context.site.settings.fulfillment_auto_approve
+            and not info.context.site.settings.fulfillment_allow_unpaid
         ):
             raise ValidationError(
                 {

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -758,7 +758,22 @@ def test_cancel_fulfillment(
 def test_cancel_fulfillment_no_warehouse_id(
     staff_api_client, fulfillment, permission_manage_orders
 ):
-    query = CANCEL_FULFILLMENT_MUTATION
+    query = """
+        mutation cancelFulfillment($id: ID!) {
+            orderFulfillmentCancel(id: $id) {
+                fulfillment {
+                    status
+                }
+                order {
+                    status
+                }
+                errors {
+                    code
+                    field
+                }
+            }
+        }
+    """
     fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
     variables = {"id": fulfillment_id}
     response = staff_api_client.post_graphql(

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -711,13 +711,17 @@ def test_fulfillment_update_tracking_send_notification_false(
 
 
 CANCEL_FULFILLMENT_MUTATION = """
-    mutation cancelFulfillment($id: ID!, $warehouseId: ID!) {
+    mutation cancelFulfillment($id: ID!, $warehouseId: ID) {
         orderFulfillmentCancel(id: $id, input: {warehouseId: $warehouseId}) {
             fulfillment {
                 status
             }
             order {
                 status
+            }
+            errors {
+                code
+                field
             }
         }
     }
@@ -749,6 +753,63 @@ def test_cancel_fulfillment(
         "warehouse": str(warehouse.pk),
     }
     assert event_restocked_items.user == staff_user
+
+
+def test_cancel_fulfillment_no_warehouse_id(
+    staff_api_client, fulfillment, permission_manage_orders
+):
+    query = CANCEL_FULFILLMENT_MUTATION
+    fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
+    variables = {"id": fulfillment_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["orderFulfillmentCancel"]["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "warehouseId"
+    assert error["code"] == OrderErrorCode.REQUIRED.name
+
+
+def test_cancel_fulfillment_awaiting_approval(
+    staff_api_client, fulfillment, permission_manage_orders
+):
+    fulfillment.status = FulfillmentStatus.WAITING_FOR_APPROVAL
+    fulfillment.save(update_fields=["status"])
+    query = CANCEL_FULFILLMENT_MUTATION
+    fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
+    variables = {"id": fulfillment_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentCancel"]
+    assert data["fulfillment"]["status"] == FulfillmentStatus.CANCELED.upper()
+    event_cancelled = fulfillment.order.events.get()
+    assert event_cancelled.type == (OrderEvents.FULFILLMENT_CANCELED)
+    assert event_cancelled.parameters == {"composed_id": fulfillment.composed_id}
+    assert event_cancelled.user == staff_api_client.user
+
+
+def test_cancel_fulfillment_cancelled_state(
+    staff_api_client, fulfillment, permission_manage_orders, warehouse
+):
+    query = CANCEL_FULFILLMENT_MUTATION
+    fulfillment.status = FulfillmentStatus.CANCELED
+    fulfillment.save(update_fields=["status"])
+    fulfillment_id = graphene.Node.to_global_id("Fulfillment", fulfillment.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.id)
+    variables = {"id": fulfillment_id, "warehouseId": warehouse_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    errors = content["data"]["orderFulfillmentCancel"]["errors"]
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "fulfillment"
+    assert error["code"] == OrderErrorCode.CANNOT_CANCEL_FULFILLMENT.name
 
 
 def test_cancel_fulfillment_warehouse_without_stock(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2106,7 +2106,7 @@ type FulfillmentCancel {
 }
 
 input FulfillmentCancelInput {
-  warehouseId: ID!
+  warehouseId: ID
 }
 
 type FulfillmentLine implements Node {
@@ -2835,7 +2835,7 @@ type Mutation {
   orderCapture(amount: PositiveDecimal!, id: ID!): OrderCapture
   orderConfirm(id: ID!): OrderConfirm
   orderFulfill(input: OrderFulfillInput!, order: ID): OrderFulfill
-  orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput!): FulfillmentCancel
+  orderFulfillmentCancel(id: ID!, input: FulfillmentCancelInput): FulfillmentCancel
   orderFulfillmentApprove(id: ID!, notifyCustomer: Boolean!): FulfillmentApprove
   orderFulfillmentUpdateTracking(id: ID!, input: FulfillmentUpdateTrackingInput!): FulfillmentUpdateTracking
   orderFulfillmentRefundProducts(input: OrderRefundProductsInput!, order: ID!): FulfillmentRefundProducts

--- a/saleor/order/actions.py
+++ b/saleor/order/actions.py
@@ -319,6 +319,9 @@ def cancel_fulfillment(
     Return products to corresponding stocks if warehouse was defined.
     """
     fulfillment = Fulfillment.objects.select_for_update().get(pk=fulfillment.pk)
+    events.fulfillment_canceled_event(
+        order=fulfillment.order, user=user, app=app, fulfillment=fulfillment
+    )
     if warehouse:
         restock_fulfillment_lines(fulfillment, warehouse)
         events.fulfillment_restocked_items_event(
@@ -328,9 +331,6 @@ def cancel_fulfillment(
             fulfillment=fulfillment,
             warehouse_pk=warehouse.pk,
         )
-    events.fulfillment_canceled_event(
-        order=fulfillment.order, user=user, app=app, fulfillment=fulfillment
-    )
     fulfillment.status = FulfillmentStatus.CANCELED
     fulfillment.save(update_fields=["status"])
     update_order_status(fulfillment.order)


### PR DESCRIPTION
I want to merge this change because it allows to cancel fulfillments which are in `waiting for approval` state.

Also resolves a case where order couldn't be fulfilled with `fulfillOrder` mutation based on order settings.

⚠️ This is a PR to feature branch.

Related tickets:
[SALEOR-4154](https://app.clickup.com/t/rp3dfv)
[SALEOR-4156](https://app.clickup.com/t/rp3ktf)

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
