### PR TITLE
SALEOR-3825 Implement new order payment status logic

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -616,6 +616,21 @@ def test_order_query_in_pln_channel(
             ChargeStatus.PENDING,
             PaymentChargeStatusEnum.PARTIALLY_CHARGED,
         ],
+        [
+            ChargeStatus.FULLY_CHARGED,
+            ChargeStatus.PARTIALLY_REFUNDED,
+            PaymentChargeStatusEnum.PARTIALLY_REFUNDED,
+        ],
+        [
+            ChargeStatus.FULLY_CHARGED,
+            ChargeStatus.FULLY_REFUNDED,
+            PaymentChargeStatusEnum.PARTIALLY_REFUNDED,
+        ],
+        [
+            ChargeStatus.FULLY_REFUNDED,
+            ChargeStatus.FULLY_REFUNDED,
+            PaymentChargeStatusEnum.FULLY_REFUNDED,
+        ],
     ],
 )
 def test_order_query_payment_status_depending_on_charge_statuses(
@@ -642,6 +657,7 @@ def test_order_query_payment_status_depending_on_charge_statuses(
 @pytest.mark.parametrize(
     "total_paid_amount,total_gross_amount,expected",
     [
+        # TODO: change to overpaid
         [Decimal("200"), Decimal("100"), PaymentChargeStatusEnum.FULLY_CHARGED],
         [Decimal("100"), Decimal("100"), PaymentChargeStatusEnum.FULLY_CHARGED],
     ],

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -644,6 +644,8 @@ def test_order_query_payment_status_depending_on_charge_statuses(
     Payment.objects.create(
         **{**payment_kwargs, **{"order": order, "charge_status": p2}}
     )
+    choices = dict(ChargeStatus.CHOICES)
+    expected_display = choices.get(getattr(ChargeStatus, expected.name))
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY)
@@ -652,6 +654,7 @@ def test_order_query_payment_status_depending_on_charge_statuses(
 
     # then
     assert order_data["paymentStatus"] == expected.name
+    assert order_data["paymentStatusDisplay"] == expected_display
 
 
 @pytest.mark.parametrize(
@@ -675,6 +678,8 @@ def test_order_query_payment_status_depending_on_balance(
     order.total_paid_amount = total_paid_amount
     order.total_paid_amount = total_gross_amount
     order.save()
+    choices = dict(ChargeStatus.CHOICES)
+    expected_display = choices.get(getattr(ChargeStatus, expected.name))
 
     # when
     response = staff_api_client.post_graphql(ORDERS_QUERY)
@@ -683,6 +688,7 @@ def test_order_query_payment_status_depending_on_balance(
 
     # then
     assert order_data["paymentStatus"] == expected.name
+    assert order_data["paymentStatusDisplay"] == expected_display
 
 
 ORDERS_QUERY_SHIPPING_METHODS = """

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -949,7 +949,12 @@ class Order(CountableDjangoObjectType):
             if root.total_paid_amount == root.total_gross_amount:
                 return ChargeStatus.FULLY_CHARGED
 
-            if any(_map(payments, [ChargeStatus.FULLY_REFUNDED])):
+            if any(
+                _map(
+                    payments,
+                    [ChargeStatus.FULLY_REFUNDED, ChargeStatus.PARTIALLY_REFUNDED],
+                )
+            ):
                 if all(_map(payments, [ChargeStatus.FULLY_REFUNDED])):
                     return ChargeStatus.FULLY_REFUNDED
                 return ChargeStatus.PARTIALLY_REFUNDED

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -938,9 +938,30 @@ class Order(CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_payment_status(root: models.Order, info):
+        def _map(payments, status_list):
+            return map(lambda p: p.charge_status in status_list, payments)
+
         def _resolve_payment_status(payments):
-            if last_payment := max(payments, default=None, key=attrgetter("pk")):
-                return last_payment.charge_status
+            # TODO: change to overpaid
+            if root.total_paid_amount > root.total_gross_amount:
+                return ChargeStatus.FULLY_CHARGED
+
+            if root.total_paid_amount == root.total_gross_amount:
+                return ChargeStatus.FULLY_CHARGED
+
+            if any(_map(payments, [ChargeStatus.FULLY_REFUNDED])):
+                if all(_map(payments, [ChargeStatus.FULLY_REFUNDED])):
+                    return ChargeStatus.FULLY_REFUNDED
+                return ChargeStatus.PARTIALLY_REFUNDED
+
+            if any(
+                _map(
+                    payments,
+                    [ChargeStatus.FULLY_CHARGED, ChargeStatus.PARTIALLY_CHARGED],
+                )
+            ):
+                return ChargeStatus.PARTIALLY_CHARGED
+
             return ChargeStatus.NOT_CHARGED
 
         return (

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from operator import attrgetter
 from typing import Optional
 
 import graphene
@@ -77,6 +76,7 @@ from .dataloaders import (
     OrderLinesByOrderIdLoader,
 )
 from .enums import OrderEventsEmailsEnum, OrderEventsEnum, OrderOriginEnum
+from .resolvers import resolve_order_payment_status
 from .utils import validate_draft_order
 
 
@@ -938,54 +938,19 @@ class Order(CountableDjangoObjectType):
     @staticmethod
     @traced_resolver
     def resolve_payment_status(root: models.Order, info):
-        def _map(payments, status_list):
-            return map(lambda p: p.charge_status in status_list, payments)
-
-        def _resolve_payment_status(payments):
-            # TODO: change to overpaid
-            if root.total_paid_amount > root.total_gross_amount:
-                return ChargeStatus.FULLY_CHARGED
-
-            if root.total_paid_amount == root.total_gross_amount:
-                return ChargeStatus.FULLY_CHARGED
-
-            if any(
-                _map(
-                    payments,
-                    [ChargeStatus.FULLY_REFUNDED, ChargeStatus.PARTIALLY_REFUNDED],
-                )
-            ):
-                if all(_map(payments, [ChargeStatus.FULLY_REFUNDED])):
-                    return ChargeStatus.FULLY_REFUNDED
-                return ChargeStatus.PARTIALLY_REFUNDED
-
-            if any(
-                _map(
-                    payments,
-                    [ChargeStatus.FULLY_CHARGED, ChargeStatus.PARTIALLY_CHARGED],
-                )
-            ):
-                return ChargeStatus.PARTIALLY_CHARGED
-
-            return ChargeStatus.NOT_CHARGED
-
         return (
             PaymentsByOrderIdLoader(info.context)
             .load(root.id)
-            .then(_resolve_payment_status)
+            .then(lambda p: resolve_order_payment_status(root, p))
         )
 
     @staticmethod
     def resolve_payment_status_display(root: models.Order, info):
-        def _resolve_payment_status(payments):
-            if last_payment := max(payments, default=None, key=attrgetter("pk")):
-                return last_payment.get_charge_status_display()
-            return dict(ChargeStatus.CHOICES).get(ChargeStatus.NOT_CHARGED)
-
+        choices = dict(ChargeStatus.CHOICES)
         return (
             PaymentsByOrderIdLoader(info.context)
             .load(root.id)
-            .then(_resolve_payment_status)
+            .then(lambda p: choices.get(resolve_order_payment_status(root, p)))
         )
 
     @staticmethod

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3655,8 +3655,8 @@ def menu_item_translation_fr(menu_item):
 
 
 @pytest.fixture
-def payment_dummy(db, order_with_lines):
-    return Payment.objects.create(
+def payment_kwargs(db, order_with_lines):
+    return dict(
         gateway="mirumee.payments.dummy",
         order=order_with_lines,
         is_active=True,
@@ -3678,6 +3678,11 @@ def payment_dummy(db, order_with_lines):
         billing_country_area=order_with_lines.billing_address.country_area,
         billing_email=order_with_lines.user_email,
     )
+
+
+@pytest.fixture
+def payment_dummy(payment_kwargs):
+    return Payment.objects.create(**payment_kwargs)
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR implements SALEOR-3825.

A resolver function has been extracted to be reused in both `resolve_payment_status` and `resolve_payment_status_display`.

TODOs are left since this is the spot where changes will be done further in the epic

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
