### PR TITLE
Fix fulfillment cancel when warehouse provided

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -331,6 +331,8 @@ class FulfillmentCancel(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         fulfillment = cls.get_node_or_error(info, data.get("id"), only_type=Fulfillment)
+
+        warehouse = None
         if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
             warehouse = None
         elif warehouse_id := data.get("input", {}).get("warehouse_id"):

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -330,12 +330,13 @@ class FulfillmentCancel(BaseMutation):
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
-        warehouse = None
-        if warehouse_id := data.get("input", {}).get("warehouse_id"):
+        fulfillment = cls.get_node_or_error(info, data.get("id"), only_type=Fulfillment)
+        if fulfillment.status == FulfillmentStatus.WAITING_FOR_APPROVAL:
+            warehouse = None
+        elif warehouse_id := data.get("input", {}).get("warehouse_id"):
             warehouse = cls.get_node_or_error(
                 info, warehouse_id, only_type="Warehouse", field="warehouse_id"
             )
-        fulfillment = cls.get_node_or_error(info, data.get("id"), only_type=Fulfillment)
 
         cls.validate_fulfillment(fulfillment, warehouse)
 


### PR DESCRIPTION
I want to merge this change because it fixes a bug with fulfillment cancellation - items were restocked if `warehouseId` was provided. Warehouse parameter should be ignored when fulfillment is in `WAITING_FOR_APPROVAL` state.

⚠️ This is a PR to feature branch.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
