### PR TITLE
Add `page_type_id` to `AttribteValue` translated webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ All notable, unreleased changes to this project will be documented in this file.
 - Add `product_id`, `product_variant_id`, `attribute_id` and `page_id` when it's possible for `AttributeValue` translations webhook. - #7783 by @fowczarek
 - Deprecate `query` argument in `sales` and `vouchers` queries - #7806 by @maarcingebala
 - Allow translating objects by translatable content ID - #7803 by @maarcingebala
+- Add `page_type_id` when it's possible for `AttributeValue` translations webhook. - #7825 by @fowczarek
+
 
 ### Breaking
 - Multichannel MVP: Multicurrency - #6242 by @fowczarek @d-wysocki

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -278,6 +278,8 @@ class AttributeValueTranslation(Translation):
                 if assigned_page_attribute_value := (
                     attribute_value.pagevalueassignment.first()
                 ):
-                    if page_id := assigned_page_attribute_value.assignment.page_id:
-                        context["page_id"] = page_id
+                    if page := assigned_page_attribute_value.assignment.page:
+                        context["page_id"] = page.id
+                        if page_type_id := page.page_type_id:
+                            context["page_type_id"] = page_type_id
         return context

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -619,6 +619,7 @@ def process_translation_context(context):
         ("product_variant_id", "ProductVariant"),
         ("attribute_id", "Attribute"),
         ("page_id", "Page"),
+        ("page_type_id", "PageType"),
     ]
     result = {}
     for key, type_name in additional_id_fields:

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -445,6 +445,7 @@ def test_generate_unique_product_attribute_value_translation_payload(
         "Attribute", rich_text_attribute.id
     )
     assert data["page_id"] is None
+    assert data["page_type_id"] is None
     translation_keys = {i["key"]: i["value"] for i in data["keys"]}
     assert translation_keys["rich_text"] == translated_attribute_value.rich_text
 
@@ -469,6 +470,7 @@ def test_generate_unique_variant_attribute_value_translation_payload(
         "Attribute", rich_text_attribute.id
     )
     assert data["page_id"] is None
+    assert data["page_type_id"] is None
     translation_keys = {i["key"]: i["value"] for i in data["keys"]}
     assert translation_keys["rich_text"] == translated_attribute_value.rich_text
 
@@ -491,6 +493,9 @@ def test_generate_unique_page_attribute_value_translation_payload(
         "Attribute", rich_text_attribute_page_type.id
     )
     assert data["page_id"] == graphene.Node.to_global_id("Page", page.id)
+    assert data["page_type_id"] == graphene.Node.to_global_id(
+        "PageType", page.page_type_id
+    )
     translation_keys = {i["key"]: i["value"] for i in data["keys"]}
     assert translation_keys["rich_text"] == translated_attribute_value.rich_text
 


### PR DESCRIPTION
I want to merge this change because adding `page_type_id` to `AttribteValue` translated webhook

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
