### PR TITLE
Create gift cards when fulfilling order

### DIFF
--- a/saleor/giftcard/events.py
+++ b/saleor/giftcard/events.py
@@ -44,6 +44,24 @@ def gift_card_sent(
     )
 
 
+def gift_cards_sent(
+    gift_cards: Iterable[GiftCard], user: UserType, app: AppType, email: str
+):
+    if not user_is_valid(user):
+        user = None
+    gift_cards_events = [
+        GiftCardEvent(
+            gift_card=gift_card,
+            user=user,
+            app=app,
+            type=GiftCardEvents.SENT_TO_CUSTOMER,
+            parameters={"email": email},
+        )
+        for gift_card in gift_cards
+    ]
+    return GiftCardEvent.objects.bulk_create(gift_cards_events)
+
+
 def gift_card_resent(
     gift_card_id: int, user_id: Optional[int], app_id: Optional[int], email: str
 ):
@@ -234,5 +252,23 @@ def gift_cards_used_in_order(
             },
         )
         for gift_card, previous_balance in balance_data
+    ]
+    return GiftCardEvent.objects.bulk_create(events)
+
+
+def gift_cards_bought(
+    gift_cards: Iterable[GiftCard], order_id: int, user: UserType, app: AppType
+):
+    if not user_is_valid(user):
+        user = None
+    events = [
+        GiftCardEvent(
+            gift_card=gift_card,
+            user=user,
+            app=app,
+            type=GiftCardEvents.BOUGHT,
+            parameters={"order_id": order_id},
+        )
+        for gift_card in gift_cards
     ]
     return GiftCardEvent.objects.bulk_create(events)

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -1,12 +1,21 @@
 from datetime import date
+from typing import TYPE_CHECKING, Iterable, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
 
 from ..checkout.models import Checkout
-from ..core.utils.promo_code import InvalidPromoCode
-from . import GiftCardExpiryType
+from ..core.utils.promo_code import InvalidPromoCode, generate_promo_code
+from . import GiftCardExpiryType, events
 from .models import GiftCard
+from .notifications import send_gift_card_notification
+
+if TYPE_CHECKING:
+    from ..account.models import User
+    from ..app.models import App
+    from ..order.models import Order, OrderLine
+    from ..plugins.manager import PluginsManager
+    from ..site.models import SiteSettings
 
 
 def add_gift_card_code_to_checkout(
@@ -66,3 +75,59 @@ def calculate_expiry_date(gift_card: GiftCard):
         time_delta = {f"{gift_card.expiry_period_type}s": gift_card.expiry_period}
         expiry_date = today + relativedelta(**time_delta)  # type: ignore
     return expiry_date
+
+
+def gift_cards_create(
+    order: "Order",
+    gift_card_lines: Iterable["OrderLine"],
+    settings: "SiteSettings",
+    requestor_user: Optional["User"],
+    app: Optional["App"],
+    manager: "PluginsManager",
+):
+    """Create purchased gift cards."""
+    customer_user = order.user
+    user_email = order.user_email
+    gift_cards = []
+    non_shippable_gift_cards = []
+    for order_line in gift_card_lines:
+        price = order_line.total_price_gross
+        line_gift_cards = [
+            GiftCard(  # type: ignore
+                code=generate_promo_code(),
+                initial_balance=price,
+                current_balance=price,
+                created_by=customer_user,
+                created_by_email=user_email,
+                product=order_line.variant.product if order_line.variant else None,
+                expiry_type=settings.gift_card_expiry_type,
+                expiry_period_type=settings.gift_card_expiry_period_type,
+                expiry_period=settings.gift_card_expiry_period,
+            )
+            for _ in range(order_line.quantity)
+        ]
+        gift_cards.extend(line_gift_cards)
+        if not order_line.is_shipping_required:
+            non_shippable_gift_cards.extend(line_gift_cards)
+
+    gift_cards = GiftCard.objects.bulk_create(gift_cards)
+    events.gift_cards_bought(gift_cards, order.id, requestor_user, app)
+
+    # send to customer all non-shippable gift cards
+    send_gift_cards_to_customer(
+        non_shippable_gift_cards, user_email, requestor_user, app, manager
+    )
+    return gift_cards
+
+
+def send_gift_cards_to_customer(
+    gift_cards: Iterable[GiftCard],
+    user_email: str,
+    requestor_user: Optional["User"],
+    app: Optional["App"],
+    manager: "PluginsManager",
+):
+    for gift_card in gift_cards:
+        send_gift_card_notification(requestor_user, app, user_email, gift_card, manager)
+
+    events.gift_cards_sent(gift_cards, requestor_user, app, user_email)

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -1,5 +1,5 @@
 from datetime import date
-from typing import TYPE_CHECKING, Iterable, Optional
+from typing import TYPE_CHECKING, Dict, Iterable, Optional
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -80,6 +80,7 @@ def calculate_expiry_date(gift_card: GiftCard):
 def gift_cards_create(
     order: "Order",
     gift_card_lines: Iterable["OrderLine"],
+    quantities: Dict[int, int],
     settings: "SiteSettings",
     requestor_user: Optional["User"],
     app: Optional["App"],
@@ -91,7 +92,7 @@ def gift_cards_create(
     gift_cards = []
     non_shippable_gift_cards = []
     for order_line in gift_card_lines:
-        price = order_line.total_price_gross
+        price = order_line.unit_price_gross
         line_gift_cards = [
             GiftCard(  # type: ignore
                 code=generate_promo_code(),
@@ -104,7 +105,7 @@ def gift_cards_create(
                 expiry_period_type=settings.gift_card_expiry_period_type,
                 expiry_period=settings.gift_card_expiry_period,
             )
-            for _ in range(order_line.quantity)
+            for _ in range(quantities[order_line.pk])
         ]
         gift_cards.extend(line_gift_cards)
         if not order_line.is_shipping_required:

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -101,10 +101,11 @@ class OrderFulfill(BaseMutation):
 
     @classmethod
     def clean_lines(cls, order_lines, quantities):
-        for order_line, line_quantities in zip(order_lines, quantities):
+        for order_line in order_lines:
             line_quantity_unfulfilled = order_line.quantity_unfulfilled
+            line_total_quantity = quantities[order_line.pk]
 
-            if sum(line_quantities) > line_quantity_unfulfilled:
+            if line_total_quantity > line_quantity_unfulfilled:
                 msg = (
                     "Only %(quantity)d item%(item_pluralize)s remaining "
                     "to fulfill: %(order_line)s."
@@ -186,8 +187,12 @@ class OrderFulfill(BaseMutation):
         order_lines = cls.get_nodes_or_error(
             lines_ids, field="lines", only_type=OrderLine
         )
+        order_line_id_to_total_quantity = {
+            order_line.pk: sum(line_quantities)
+            for order_line, line_quantities in zip(order_lines, quantities_for_lines)
+        }
 
-        cls.clean_lines(order_lines, quantities_for_lines)
+        cls.clean_lines(order_lines, order_line_id_to_total_quantity)
 
         cls.check_total_quantity_of_items(quantities_for_lines)
 
@@ -204,7 +209,7 @@ class OrderFulfill(BaseMutation):
 
         data["order_lines"] = order_lines
         data["gift_card_lines"] = cls.get_gift_card_lines(lines_ids)
-        data["quantities"] = quantities_for_lines
+        data["quantities"] = order_line_id_to_total_quantity
         data["lines_for_warehouses"] = lines_for_warehouses
         return data
 
@@ -243,10 +248,12 @@ class OrderFulfill(BaseMutation):
         lines_for_warehouses = cleaned_input["lines_for_warehouses"]
         notify_customer = cleaned_input.get("notify_customer", True)
         gift_card_lines = cleaned_input["gift_card_lines"]
+        quantities = cleaned_input["quantities"]
 
         gift_cards_create(
             order,
             gift_card_lines,
+            quantities,
             context.site.settings,
             user,
             app,

--- a/saleor/graphql/order/tests/benchmark/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/benchmark/test_order_fulfill.py
@@ -86,6 +86,10 @@ def test_order_fulfill_with_gift_cards(
         gift_card_non_shippable_order_line,
         gift_card_shippable_order_line,
     )
+
+    order_line2.quantity = 10
+    order_line2.save(update_fields=["quantity"])
+
     order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
     order_line2_id = graphene.Node.to_global_id("OrderLine", order_line2.id)
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
@@ -100,7 +104,7 @@ def test_order_fulfill_with_gift_cards(
                 },
                 {
                     "orderLineId": order_line2_id,
-                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                    "stocks": [{"quantity": 10, "warehouse": warehouse_id}],
                 },
             ],
         },

--- a/saleor/graphql/order/tests/benchmark/test_order_fulfill.py
+++ b/saleor/graphql/order/tests/benchmark/test_order_fulfill.py
@@ -1,0 +1,114 @@
+from unittest.mock import patch
+
+import graphene
+import pytest
+
+from ....tests.utils import get_graphql_content
+
+ORDER_FULFILL_QUERY = """
+    mutation fulfillOrder(
+        $order: ID, $input: OrderFulfillInput!
+    ) {
+        orderFulfill(
+            order: $order,
+            input: $input
+        ) {
+            errors {
+                field
+                code
+                message
+                warehouse
+                orderLines
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")
+def test_order_fulfill(
+    mock_create_fulfillments,
+    staff_api_client,
+    order_with_lines,
+    permission_manage_orders,
+    warehouse,
+    count_queries,
+):
+    order = order_with_lines
+    query = ORDER_FULFILL_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line, order_line2 = order.lines.all()
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    order_line2_id = graphene.Node.to_global_id("OrderLine", order_line2.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [{"quantity": 3, "warehouse": warehouse_id}],
+                },
+                {
+                    "orderLineId": order_line2_id,
+                    "stocks": [{"quantity": 2, "warehouse": warehouse_id}],
+                },
+            ],
+        },
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfill"]
+    assert not data["errors"]
+
+
+@pytest.mark.count_queries(autouse=False)
+@patch("saleor.giftcard.utils.send_gift_card_notification")
+@patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")
+def test_order_fulfill_with_gift_cards(
+    mock_create_fulfillments,
+    mock_send_notification,
+    staff_api_client,
+    order,
+    gift_card_non_shippable_order_line,
+    gift_card_shippable_order_line,
+    permission_manage_orders,
+    warehouse,
+    count_queries,
+):
+    query = ORDER_FULFILL_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line, order_line2 = (
+        gift_card_non_shippable_order_line,
+        gift_card_shippable_order_line,
+    )
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    order_line2_id = graphene.Node.to_global_id("OrderLine", order_line2.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                },
+                {
+                    "orderLineId": order_line2_id,
+                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                },
+            ],
+        },
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfill"]
+    assert not data["errors"]

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -1,9 +1,10 @@
 from unittest.mock import ANY, patch
 
 import graphene
-from django.contrib.auth.models import AnonymousUser
 
 from ....core.exceptions import InsufficientStock, InsufficientStockData
+from ....giftcard import GiftCardEvents
+from ....giftcard.models import GiftCard, GiftCardEvent
 from ....order import OrderStatus
 from ....order.error_codes import OrderErrorCode
 from ....order.events import OrderEvents
@@ -85,7 +86,6 @@ def test_order_fulfill(
 def test_order_fulfill_as_app(
     mock_create_fulfillments,
     app_api_client,
-    staff_user,
     order_with_lines,
     permission_manage_orders,
     warehouse,
@@ -127,7 +127,7 @@ def test_order_fulfill_as_app(
         ]
     }
     mock_create_fulfillments.assert_called_once_with(
-        AnonymousUser(),
+        None,
         app_api_client.app,
         order,
         fulfillment_lines_for_warehouses,
@@ -193,6 +193,158 @@ def test_order_fulfill_many_warehouses(
     mock_create_fulfillments.assert_called_once_with(
         staff_user, None, order, fulfillment_lines_for_warehouses, ANY, True
     )
+
+
+@patch("saleor.giftcard.utils.send_gift_card_notification")
+@patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")
+def test_order_fulfill_with_gift_cards(
+    mock_create_fulfillments,
+    mock_send_notification,
+    staff_api_client,
+    staff_user,
+    order,
+    gift_card_non_shippable_order_line,
+    gift_card_shippable_order_line,
+    permission_manage_orders,
+    warehouse,
+):
+    query = ORDER_FULFILL_QUERY
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line, order_line2 = (
+        gift_card_non_shippable_order_line,
+        gift_card_shippable_order_line,
+    )
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    order_line2_id = graphene.Node.to_global_id("OrderLine", order_line2.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                },
+                {
+                    "orderLineId": order_line2_id,
+                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                },
+            ],
+        },
+    }
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfill"]
+    assert not data["errors"]
+    gift_cards = GiftCard.objects.all()
+    assert gift_cards.count() == 2
+    non_shippable_gift_card = gift_cards.get(
+        product_id=gift_card_non_shippable_order_line.variant.product_id
+    )
+    shippable_gift_card = gift_cards.get(
+        product_id=gift_card_shippable_order_line.variant.product_id
+    )
+    assert non_shippable_gift_card.initial_balance.amount == round(
+        gift_card_non_shippable_order_line.total_price_gross.amount, 2
+    )
+    assert non_shippable_gift_card.current_balance.amount == round(
+        gift_card_non_shippable_order_line.total_price_gross.amount, 2
+    )
+    assert shippable_gift_card.initial_balance.amount == round(
+        gift_card_shippable_order_line.total_price_gross.amount, 2
+    )
+    assert shippable_gift_card.current_balance.amount == round(
+        gift_card_shippable_order_line.total_price_gross.amount, 2
+    )
+
+    assert GiftCardEvent.objects.filter(
+        gift_card=shippable_gift_card, type=GiftCardEvents.BOUGHT
+    )
+    assert GiftCardEvent.objects.filter(
+        gift_card=non_shippable_gift_card, type=GiftCardEvents.BOUGHT
+    )
+    assert GiftCardEvent.objects.filter(
+        gift_card=non_shippable_gift_card, type=GiftCardEvents.SENT_TO_CUSTOMER
+    )
+
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line, "quantity": 1},
+            {"order_line": order_line2, "quantity": 1},
+        ]
+    }
+    mock_create_fulfillments.assert_called_once_with(
+        staff_user, None, order, fulfillment_lines_for_warehouses, ANY, True
+    )
+
+    mock_send_notification.assert_called_once_with(
+        staff_user, None, order.user_email, non_shippable_gift_card, ANY
+    )
+
+
+@patch("saleor.giftcard.utils.send_gift_card_notification")
+@patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")
+def test_order_fulfill_with_gift_cards_by_app(
+    mock_create_fulfillments,
+    mock_send_notification,
+    app_api_client,
+    order,
+    gift_card_shippable_order_line,
+    permission_manage_orders,
+    warehouse,
+):
+    query = ORDER_FULFILL_QUERY
+    app = app_api_client.app
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line = gift_card_shippable_order_line
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                },
+            ],
+        },
+    }
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfill"]
+    assert not data["errors"]
+    shippable_gift_card = GiftCard.objects.get()
+    assert shippable_gift_card.initial_balance.amount == round(
+        gift_card_shippable_order_line.total_price_gross.amount, 2
+    )
+    assert shippable_gift_card.current_balance.amount == round(
+        gift_card_shippable_order_line.total_price_gross.amount, 2
+    )
+
+    assert GiftCardEvent.objects.filter(
+        gift_card=shippable_gift_card,
+        type=GiftCardEvents.BOUGHT,
+        user=None,
+        app=app_api_client.app,
+    )
+
+    fulfillment_lines_for_warehouses = {
+        str(warehouse.pk): [
+            {"order_line": order_line, "quantity": 1},
+        ]
+    }
+    mock_create_fulfillments.assert_called_once_with(
+        None, app, order, fulfillment_lines_for_warehouses, ANY, True
+    )
+
+    mock_send_notification.assert_not_called
 
 
 @patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -248,16 +248,16 @@ def test_order_fulfill_with_gift_cards(
         product_id=gift_card_shippable_order_line.variant.product_id
     )
     assert non_shippable_gift_card.initial_balance.amount == round(
-        gift_card_non_shippable_order_line.total_price_gross.amount, 2
+        gift_card_non_shippable_order_line.unit_price_gross.amount, 2
     )
     assert non_shippable_gift_card.current_balance.amount == round(
-        gift_card_non_shippable_order_line.total_price_gross.amount, 2
+        gift_card_non_shippable_order_line.unit_price_gross.amount, 2
     )
     assert shippable_gift_card.initial_balance.amount == round(
-        gift_card_shippable_order_line.total_price_gross.amount, 2
+        gift_card_shippable_order_line.unit_price_gross.amount, 2
     )
     assert shippable_gift_card.current_balance.amount == round(
-        gift_card_shippable_order_line.total_price_gross.amount, 2
+        gift_card_shippable_order_line.unit_price_gross.amount, 2
     )
 
     assert GiftCardEvent.objects.filter(
@@ -302,6 +302,7 @@ def test_order_fulfill_with_gift_cards_by_app(
     order_line = gift_card_shippable_order_line
     order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
     warehouse_id = graphene.Node.to_global_id("Warehouse", warehouse.pk)
+    quantity = 2
     variables = {
         "order": order_id,
         "input": {
@@ -309,7 +310,7 @@ def test_order_fulfill_with_gift_cards_by_app(
             "lines": [
                 {
                     "orderLineId": order_line_id,
-                    "stocks": [{"quantity": 1, "warehouse": warehouse_id}],
+                    "stocks": [{"quantity": quantity, "warehouse": warehouse_id}],
                 },
             ],
         },
@@ -320,25 +321,101 @@ def test_order_fulfill_with_gift_cards_by_app(
     content = get_graphql_content(response)
     data = content["data"]["orderFulfill"]
     assert not data["errors"]
-    shippable_gift_card = GiftCard.objects.get()
-    assert shippable_gift_card.initial_balance.amount == round(
-        gift_card_shippable_order_line.total_price_gross.amount, 2
-    )
-    assert shippable_gift_card.current_balance.amount == round(
-        gift_card_shippable_order_line.total_price_gross.amount, 2
-    )
+    gift_cards = GiftCard.objects.all()
+    assert gift_cards.count() == quantity
+    for card in gift_cards:
+        assert card.initial_balance.amount == round(
+            gift_card_shippable_order_line.unit_price_gross.amount, 2
+        )
+        assert card.current_balance.amount == round(
+            gift_card_shippable_order_line.unit_price_gross.amount, 2
+        )
 
-    assert GiftCardEvent.objects.filter(
-        gift_card=shippable_gift_card,
-        type=GiftCardEvents.BOUGHT,
-        user=None,
-        app=app_api_client.app,
-    )
+        assert GiftCardEvent.objects.filter(
+            gift_card=card,
+            type=GiftCardEvents.BOUGHT,
+            user=None,
+            app=app_api_client.app,
+        )
 
     fulfillment_lines_for_warehouses = {
         str(warehouse.pk): [
-            {"order_line": order_line, "quantity": 1},
+            {"order_line": order_line, "quantity": 2},
         ]
+    }
+    mock_create_fulfillments.assert_called_once_with(
+        None, app, order, fulfillment_lines_for_warehouses, ANY, True
+    )
+
+    mock_send_notification.assert_not_called
+
+
+@patch("saleor.giftcard.utils.send_gift_card_notification")
+@patch("saleor.graphql.order.mutations.fulfillments.create_fulfillments")
+def test_order_fulfill_with_gift_cards_multiple_warehouses(
+    mock_create_fulfillments,
+    mock_send_notification,
+    app_api_client,
+    order,
+    gift_card_shippable_order_line,
+    permission_manage_orders,
+    warehouses,
+):
+    query = ORDER_FULFILL_QUERY
+    app = app_api_client.app
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    order_line = gift_card_shippable_order_line
+    order_line_id = graphene.Node.to_global_id("OrderLine", order_line.id)
+    warehouse1, warehouse2 = warehouses
+    warehouse1_id = graphene.Node.to_global_id("Warehouse", warehouse1.pk)
+    warehouse2_id = graphene.Node.to_global_id("Warehouse", warehouse2.pk)
+    quantity_1 = 2
+    quantity_2 = 1
+    variables = {
+        "order": order_id,
+        "input": {
+            "notifyCustomer": True,
+            "lines": [
+                {
+                    "orderLineId": order_line_id,
+                    "stocks": [
+                        {"quantity": quantity_1, "warehouse": warehouse1_id},
+                        {"quantity": quantity_2, "warehouse": warehouse2_id},
+                    ],
+                },
+            ],
+        },
+    }
+    response = app_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfill"]
+    assert not data["errors"]
+    gift_cards = GiftCard.objects.all()
+    assert gift_cards.count() == quantity_1 + quantity_2
+    for card in gift_cards:
+        assert card.initial_balance.amount == round(
+            gift_card_shippable_order_line.unit_price_gross.amount, 2
+        )
+        assert card.current_balance.amount == round(
+            gift_card_shippable_order_line.unit_price_gross.amount, 2
+        )
+
+        assert GiftCardEvent.objects.filter(
+            gift_card=card,
+            type=GiftCardEvents.BOUGHT,
+            user=None,
+            app=app_api_client.app,
+        )
+
+    fulfillment_lines_for_warehouses = {
+        str(warehouse1.pk): [
+            {"order_line": order_line, "quantity": quantity_1},
+        ],
+        str(warehouse2.pk): [
+            {"order_line": order_line, "quantity": quantity_2},
+        ],
     }
     mock_create_fulfillments.assert_called_once_with(
         None, app, order, fulfillment_lines_for_warehouses, ANY, True

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2014,7 +2014,9 @@ def variant_with_many_stocks_different_shipping_zones(
 @pytest.fixture
 def gift_card_shippable_variant(shippable_gift_card_product, channel_USD):
     product = shippable_gift_card_product
-    product_variant = ProductVariant.objects.create(product=product, sku="SKU_CARD_A")
+    product_variant = ProductVariant.objects.create(
+        product=product, sku="SKU_CARD_A", track_inventory=False
+    )
     ProductVariantChannelListing.objects.create(
         variant=product_variant,
         channel=channel_USD,
@@ -2028,7 +2030,9 @@ def gift_card_shippable_variant(shippable_gift_card_product, channel_USD):
 @pytest.fixture
 def gift_card_non_shippable_variant(non_shippable_gift_card_product, channel_USD):
     product = non_shippable_gift_card_product
-    product_variant = ProductVariant.objects.create(product=product, sku="SKU_CARD_B")
+    product_variant = ProductVariant.objects.create(
+        product=product, sku="SKU_CARD_B", track_inventory=False
+    )
     ProductVariantChannelListing.objects.create(
         variant=product_variant,
         channel=channel_USD,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2012,7 +2012,7 @@ def variant_with_many_stocks_different_shipping_zones(
 
 
 @pytest.fixture
-def gift_card_shippable_variant(shippable_gift_card_product, channel_USD):
+def gift_card_shippable_variant(shippable_gift_card_product, channel_USD, warehouse):
     product = shippable_gift_card_product
     product_variant = ProductVariant.objects.create(
         product=product, sku="SKU_CARD_A", track_inventory=False
@@ -2024,11 +2024,16 @@ def gift_card_shippable_variant(shippable_gift_card_product, channel_USD):
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
     )
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=product_variant, quantity=1
+    )
     return product_variant
 
 
 @pytest.fixture
-def gift_card_non_shippable_variant(non_shippable_gift_card_product, channel_USD):
+def gift_card_non_shippable_variant(
+    non_shippable_gift_card_product, channel_USD, warehouse
+):
     product = non_shippable_gift_card_product
     product_variant = ProductVariant.objects.create(
         product=product, sku="SKU_CARD_B", track_inventory=False
@@ -2039,6 +2044,9 @@ def gift_card_non_shippable_variant(non_shippable_gift_card_product, channel_USD
         price_amount=Decimal(10),
         cost_price_amount=Decimal(1),
         currency=channel_USD.currency_code,
+    )
+    Stock.objects.create(
+        warehouse=warehouse, product_variant=product_variant, quantity=1
     )
     return product_variant
 
@@ -2634,7 +2642,7 @@ def gift_card_shippable_order_line(order, gift_card_shippable_variant):
     net = variant.get_price(product, [], channel, channel_listing)
     currency = net.currency
     gross = Money(amount=net.amount * Decimal(1.23), currency=currency)
-    quantity = 1
+    quantity = 3
     unit_price = TaxedMoney(net=net, gross=gross)
     return order.lines.create(
         product_name=str(product),


### PR DESCRIPTION
Create gift cards when fulfilling order with gift card products, create `BOUGHT` events.
Send non-shippable gift cards to the customer, create `SENT_TO_CUSTOMER` events.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
