### PR TITLE
Fulfillments refund

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -642,6 +642,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
                 cleaned_input,
                 whitelisted_statuses=[
                     FulfillmentStatus.FULFILLED,
+                    FulfillmentStatus.WAITING_FOR_APPROVAL,
                     FulfillmentStatus.RETURNED,
                 ],
             )


### PR DESCRIPTION
I want to merge this change because it enables fulfillments which are in WAITING_FOR_APPROVAL state to be refunded.
⚠️ PR is a WIP and the codewise concept might even change. For now it works for single waiting for approval fulfillment.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
