### PR TITLE
Allow updating gift card balance with 0 amount

### DIFF
--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -256,7 +256,7 @@ class GiftCardUpdate(GiftCardCreate):
     def clean_balance(cleaned_input, instance):
         amount = cleaned_input.pop("balance_amount", None)
 
-        if not amount:
+        if amount is None:
             return
 
         currency = instance.currency

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -1,6 +1,7 @@
 from datetime import date, timedelta
 
 import graphene
+import pytest
 
 from .....giftcard import GiftCardEvents
 from .....giftcard.error_codes import GiftCardErrorCode
@@ -341,7 +342,9 @@ def test_update_gift_card_by_customer(api_client, customer_user, gift_card):
     assert_no_permission(response)
 
 
+@pytest.mark.parametrize("initial_balance", [100.0, 0.0])
 def test_update_gift_card_balance(
+    initial_balance,
     staff_api_client,
     gift_card,
     permission_manage_gift_card,
@@ -352,7 +355,6 @@ def test_update_gift_card_balance(
     old_initial_balance = float(gift_card.initial_balance.amount)
     old_current_balance = float(gift_card.current_balance.amount)
 
-    initial_balance = 100.0
     currency = gift_card.currency
     variables = {
         "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),


### PR DESCRIPTION
Allow updating `gift_card` with 0 balance amount.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
