### PR TITLE
Extend GiftCardCreateInput with isActive field

### DIFF
--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -47,6 +47,9 @@ class GiftCardCreateInput(GiftCardInput):
         required=False,
         description="Email of the customer to whom gift card will be sent.",
     )
+    is_active = graphene.Boolean(
+        required=True, description="Determine if gift card is active."
+    )
     code = graphene.String(
         required=False,
         description=(

--- a/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
@@ -9,11 +9,11 @@ from ....tests.utils import get_graphql_content
 CREATE_GIFT_CARD_MUTATION = """
     mutation giftCardCreate(
         $balance: PriceInput!, $userEmail: String, $tag: String,
-        $note: String, $expiryDate: Date
+        $note: String, $expiryDate: Date, $isActive: Boolean!
     ){
         giftCardCreate(input: {
                 balance: $balance, userEmail: $userEmail, tag: $tag,
-                expiryDate: $expiryDate, note: $note }) {
+                expiryDate: $expiryDate, note: $note, isActive: $isActive }) {
             giftCard {
                 id
                 code
@@ -106,6 +106,7 @@ def test_create_never_expiry_gift_card(
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiry_date": None,
+        "isActive": True,
     }
 
     # when

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
@@ -5,13 +5,13 @@ from ....tests.utils import get_graphql_content
 CREATE_GIFT_CARD_MUTATION = """
     mutation giftCardCreate(
         $startDate: Date, $endDate: Date, $expiryDate: Date
-        $balance: PriceInput!, $userEmail: String
+        $balance: PriceInput!, $userEmail: String, $isActive: Boolean!
     ){
         giftCardCreate(input: {
                 startDate: $startDate,
                 endDate: $endDate,
                 balance: $balance, userEmail: $userEmail,
-                expiryDate: $expiryDate
+                expiryDate: $expiryDate, isActive: $isActive
             }) {
             giftCard {
                 id
@@ -69,6 +69,7 @@ def test_create_never_expiry_gift_card(
         "note": "This is gift card note that will be save in gift card event.",
         "startDate": start_date.isoformat(),
         "endDate": end_date.isoformat(),
+        "isActive": True,
     }
     response = staff_api_client.post_graphql(
         CREATE_GIFT_CARD_MUTATION,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -7,11 +7,13 @@ from ....tests.utils import assert_no_permission, get_graphql_content
 CREATE_GIFT_CARD_MUTATION = """
     mutation giftCardCreate(
         $balance: PriceInput!, $userEmail: String, $tag: String,
-        $expiryDate: Date, $note: String
+        $expiryDate: Date, $note: String, $isActive: Boolean!
     ){
         giftCardCreate(input: {
                 balance: $balance, userEmail: $userEmail, tag: $tag,
-                expiryDate: $expiryDate, note: $note }) {
+                expiryDate: $expiryDate, note: $note,
+                isActive: $isActive
+            }) {
             giftCard {
                 id
                 code
@@ -100,6 +102,7 @@ def test_create_never_expiry_gift_card(
         "userEmail": customer_user.email,
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
+        "isActive": True,
     }
 
     # when
@@ -170,6 +173,7 @@ def test_create_gift_card_by_app(
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiryDate": None,
+        "isActive": False,
     }
 
     # when
@@ -195,7 +199,7 @@ def test_create_gift_card_by_app(
     assert not data["usedByEmail"]
     assert data["app"]["name"] == app_api_client.app.name
     assert not data["lastUsedOn"]
-    assert data["isActive"]
+    assert data["isActive"] is False
     assert data["initialBalance"]["amount"] == initial_balance
     assert data["currentBalance"]["amount"] == initial_balance
 
@@ -231,6 +235,7 @@ def test_create_gift_card_by_customer(api_client, customer_user):
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiryDate": None,
+        "isActive": True,
     }
 
     # when
@@ -256,6 +261,7 @@ def test_create_gift_card_no_premissions(staff_api_client):
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiryDate": None,
+        "isActive": True,
     }
 
     # when
@@ -287,6 +293,7 @@ def test_create_gift_card_with_too_many_decimal_places_in_balance_amount(
         "userEmail": customer_user.email,
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
+        "isActive": True,
     }
 
     # when
@@ -329,6 +336,7 @@ def test_create_gift_card_with_malformed_email(
         "userEmail": "malformed",
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
+        "isActive": True,
     }
 
     # when
@@ -372,6 +380,7 @@ def test_create_gift_card_with_zero_balance_amount(
         "userEmail": customer_user.email,
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
+        "isActive": True,
     }
 
     # when
@@ -417,6 +426,7 @@ def test_create_gift_card_with_expiry_date(
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiryDate": date_value,
+        "isActive": True,
     }
 
     # when
@@ -479,6 +489,7 @@ def test_create_gift_card_with_expiry_date_type_date_in_past(
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiryDate": date_value,
+        "isActive": True,
     }
 
     # when

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2232,6 +2232,7 @@ input GiftCardCreateInput {
   endDate: Date
   balance: PriceInput!
   userEmail: String
+  isActive: Boolean!
   code: String
   note: String
 }


### PR DESCRIPTION
Require defining if gift card should be activated or not during creation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
