### PR TITLE
Add support for afterpay and clearpay

### DIFF
--- a/saleor/payment/gateways/adyen/tests/utils/test_common.py
+++ b/saleor/payment/gateways/adyen/tests/utils/test_common.py
@@ -8,7 +8,7 @@ from prices import Money, TaxedMoney
 from saleor.core.prices import quantize_price
 from saleor.payment import PaymentError
 from saleor.payment.gateways.adyen.utils.common import (
-    append_klarna_data,
+    append_checkout_details,
     get_payment_method_info,
     get_shopper_locale_value,
     request_data_for_gateway_config,
@@ -32,7 +32,7 @@ def test_get_shopper_locale_value(country_code, shopper_locale, settings):
     assert result == shopper_locale
 
 
-def test_append_klarna_data(
+def test_append_checkout_details(
     dummy_payment_data, payment_dummy, checkout_ready_to_complete
 ):
     # given
@@ -45,7 +45,7 @@ def test_append_klarna_data(
     country_code = checkout_ready_to_complete.get_country()
 
     # when
-    result = append_klarna_data(dummy_payment_data, payment_data)
+    result = append_checkout_details(dummy_payment_data, payment_data)
 
     # then
     variant_channel_listing = line.variant.channel_listings.get(channel_id=channel_id)
@@ -56,7 +56,6 @@ def test_append_klarna_data(
     assert result == {
         "reference": "test",
         "shopperLocale": get_shopper_locale_value(country_code),
-        "shopperReference": dummy_payment_data.customer_email,
         "countryCode": country_code,
         "lineItems": [
             {
@@ -83,7 +82,7 @@ def test_append_klarna_data(
 
 @mock.patch("saleor.payment.gateways.adyen.utils.common.get_plugins_manager")
 @mock.patch("saleor.payment.gateways.adyen.utils.common.checkout_line_total")
-def test_append_klarna_data_tax_included(
+def test_append_checkout_details_tax_included(
     mocked_checkout_line_total,
     mocked_plugins_manager,
     dummy_payment_data,
@@ -111,14 +110,13 @@ def test_append_klarna_data_tax_included(
     }
 
     # when
-    result = append_klarna_data(dummy_payment_data, payment_data)
+    result = append_checkout_details(dummy_payment_data, payment_data)
 
     # then
 
     expected_result = {
         "reference": "test",
         "shopperLocale": get_shopper_locale_value(country_code),
-        "shopperReference": dummy_payment_data.customer_email,
         "countryCode": country_code,
         "lineItems": [
             {
@@ -144,12 +142,15 @@ def test_append_klarna_data_tax_included(
     assert result == expected_result
 
 
-def test_request_data_for_payment_payment_not_valid(dummy_payment_data):
+def test_request_data_for_payment_payment_not_valid(
+    dummy_payment_data, dummy_address_data
+):
     # given
     dummy_payment_data.data = {
         "originUrl": "https://www.example.com",
         "is_valid": False,
     }
+    dummy_payment_data.billing = dummy_address_data
     native_3d_secure = False
 
     # when
@@ -165,7 +166,7 @@ def test_request_data_for_payment_payment_not_valid(dummy_payment_data):
     assert str(e._excinfo[1]) == "Payment data are not valid."
 
 
-def test_request_data_for_payment(dummy_payment_data):
+def test_request_data_for_payment(dummy_payment_data, dummy_address_data):
     # given
     return_url = "https://www.example.com"
     merchant_account = "MerchantTestAccount"
@@ -175,11 +176,12 @@ def test_request_data_for_payment(dummy_payment_data):
         "riskData": {"clientData": "test_client_data"},
         "paymentMethod": {"type": "scheme"},
         "browserInfo": {"acceptHeader": "*/*", "colorDepth": 30, "language": "pl"},
-        "billingAddress": {"address": "test_address"},
         "shopperIP": "123",
         "originUrl": origin_url,
     }
     dummy_payment_data.data = data
+    dummy_payment_data.billing = dummy_address_data
+    dummy_payment_data.shipping = dummy_address_data
     native_3d_secure = False
 
     # when
@@ -201,14 +203,36 @@ def test_request_data_for_payment(dummy_payment_data):
         "merchantAccount": merchant_account,
         "origin": return_url,
         "shopperIP": data["shopperIP"],
-        "billingAddress": data["billingAddress"],
         "browserInfo": data["browserInfo"],
         "channel": "web",
         "shopperEmail": "example@test.com",
+        "shopperName": {
+            "firstName": dummy_payment_data.billing.first_name,
+            "lastName": dummy_payment_data.billing.last_name,
+        },
+        "shopperReference": "example@test.com",
+        "deliveryAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
+        "billingAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
     }
 
 
-def test_request_data_for_payment_native_3d_secure(dummy_payment_data):
+def test_request_data_for_payment_without_shipping(
+    dummy_payment_data, dummy_address_data
+):
     # given
     return_url = "https://www.example.com"
     merchant_account = "MerchantTestAccount"
@@ -218,11 +242,70 @@ def test_request_data_for_payment_native_3d_secure(dummy_payment_data):
         "riskData": {"clientData": "test_client_data"},
         "paymentMethod": {"type": "scheme"},
         "browserInfo": {"acceptHeader": "*/*", "colorDepth": 30, "language": "pl"},
-        "billingAddress": {"address": "test_address"},
         "shopperIP": "123",
         "originUrl": origin_url,
     }
     dummy_payment_data.data = data
+    dummy_payment_data.billing = dummy_address_data
+    dummy_payment_data.shipping = None
+    native_3d_secure = False
+
+    # when
+    result = request_data_for_payment(
+        dummy_payment_data, return_url, merchant_account, native_3d_secure
+    )
+
+    # then
+    assert result == {
+        "amount": {
+            "value": price_to_minor_unit(
+                dummy_payment_data.amount, dummy_payment_data.currency
+            ),
+            "currency": dummy_payment_data.currency,
+        },
+        "reference": dummy_payment_data.graphql_payment_id,
+        "paymentMethod": {"type": "scheme"},
+        "returnUrl": return_url,
+        "merchantAccount": merchant_account,
+        "origin": return_url,
+        "shopperIP": data["shopperIP"],
+        "browserInfo": data["browserInfo"],
+        "channel": "web",
+        "shopperEmail": "example@test.com",
+        "shopperName": {
+            "firstName": dummy_payment_data.billing.first_name,
+            "lastName": dummy_payment_data.billing.last_name,
+        },
+        "shopperReference": "example@test.com",
+        "billingAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
+    }
+
+
+def test_request_data_for_payment_native_3d_secure(
+    dummy_payment_data, dummy_address_data
+):
+    # given
+    return_url = "https://www.example.com"
+    merchant_account = "MerchantTestAccount"
+    origin_url = "https://www.example.com"
+    data = {
+        "is_valid": True,
+        "riskData": {"clientData": "test_client_data"},
+        "paymentMethod": {"type": "scheme"},
+        "browserInfo": {"acceptHeader": "*/*", "colorDepth": 30, "language": "pl"},
+        "shopperIP": "123",
+        "originUrl": origin_url,
+    }
+    dummy_payment_data.data = data
+    dummy_payment_data.shipping = dummy_address_data
+    dummy_payment_data.billing = dummy_address_data
     native_3d_secure = True
 
     # when
@@ -242,22 +325,46 @@ def test_request_data_for_payment_native_3d_secure(dummy_payment_data):
         "paymentMethod": {"type": "scheme"},
         "returnUrl": return_url,
         "merchantAccount": merchant_account,
-        "origin": origin_url,
+        "origin": return_url,
         "shopperIP": data["shopperIP"],
-        "billingAddress": data["billingAddress"],
         "browserInfo": data["browserInfo"],
         "channel": "web",
         "additionalData": {"allow3DS2": "true"},
         "shopperEmail": "example@test.com",
+        "shopperName": {
+            "firstName": dummy_payment_data.billing.first_name,
+            "lastName": dummy_payment_data.billing.last_name,
+        },
+        "shopperReference": "example@test.com",
+        "deliveryAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
+        "billingAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
     }
 
 
-def test_request_data_for_payment_channel_different_than_web(dummy_payment_data):
+def test_request_data_for_payment_channel_different_than_web(
+    dummy_payment_data, dummy_address_data
+):
     # given
     return_url = "https://www.example.com"
     merchant_account = "MerchantTestAccount"
     data = {"is_valid": True, "paymentMethod": {"type": "scheme"}, "channel": "iOS"}
     dummy_payment_data.data = data
+    dummy_payment_data.billing = dummy_address_data
+    dummy_payment_data.shipping = dummy_address_data
     native_3d_secure = True
 
     # when
@@ -280,12 +387,34 @@ def test_request_data_for_payment_channel_different_than_web(dummy_payment_data)
         "channel": "iOS",
         "additionalData": {"allow3DS2": "true"},
         "shopperEmail": "example@test.com",
+        "shopperName": {
+            "firstName": dummy_payment_data.billing.first_name,
+            "lastName": dummy_payment_data.billing.last_name,
+        },
+        "shopperReference": "example@test.com",
+        "deliveryAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
+        "billingAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
     }
 
 
-@mock.patch("saleor.payment.gateways.adyen.utils.common.append_klarna_data")
-def test_request_data_for_payment_append_klarna_data(
-    append_klarna_data_mock, dummy_payment_data
+@pytest.mark.parametrize("method_type", ["klarna", "clearpay", "afterpaytouch"])
+@mock.patch("saleor.payment.gateways.adyen.utils.common.append_checkout_details")
+def test_request_data_for_payment_append_checkout_details(
+    append_checkout_details_mock, method_type, dummy_payment_data, dummy_address_data
 ):
     # given
     return_url = "https://www.example.com"
@@ -294,14 +423,16 @@ def test_request_data_for_payment_append_klarna_data(
     data = {
         "is_valid": True,
         "riskData": {"clientData": "test_client_data"},
-        "paymentMethod": {"type": "klarna"},
+        "paymentMethod": {"type": method_type},
         "browserInfo": {"acceptHeader": "*/*", "colorDepth": 30, "language": "pl"},
-        "billingAddress": {"address": "test_address"},
         "shopperIP": "123",
         "originUrl": origin_url,
     }
     dummy_payment_data.data = data
-    klarna_result = {
+    dummy_payment_data.billing = dummy_address_data
+    dummy_payment_data.shipping = dummy_address_data
+
+    checkout_details_result = {
         "amount": {
             "value": price_to_minor_unit(
                 dummy_payment_data.amount, dummy_payment_data.currency
@@ -314,11 +445,31 @@ def test_request_data_for_payment_append_klarna_data(
         "merchantAccount": merchant_account,
         "origin": return_url,
         "shopperIP": data["shopperIP"],
-        "billingAddress": data["billingAddress"],
         "browserInfo": data["browserInfo"],
         "shopperLocale": "test_shopper",
+        "shopperName": {
+            "firstName": dummy_payment_data.billing.first_name,
+            "lastName": dummy_payment_data.billing.last_name,
+        },
+        "shopperReference": "example@test.com",
+        "deliveryAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
+        "billingAddress": {
+            "city": "WROCŁAW",
+            "country": "PL",
+            "houseNumberOrName": "Mirumee Software",
+            "postalCode": "53-601",
+            "stateOrProvince": "",
+            "street": "Tęczowa 7",
+        },
     }
-    append_klarna_data_mock.return_value = klarna_result
+    append_checkout_details_mock.return_value = checkout_details_result
     native_3d_secure = False
     # when
     result = request_data_for_payment(
@@ -326,7 +477,7 @@ def test_request_data_for_payment_append_klarna_data(
     )
 
     # then
-    assert result == klarna_result
+    assert result == checkout_details_result
 
 
 @pytest.mark.parametrize(

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -25,7 +25,7 @@ from ....interface import PaymentMethodInfo
 from ....utils import price_to_minor_unit
 
 if TYPE_CHECKING:
-    from ....interface import PaymentData
+    from ....interface import AddressData, PaymentData
 
 logger = logging.getLogger(__name__)
 
@@ -55,6 +55,45 @@ def api_call(request_data: Optional[Dict[str, Any]], method: Callable) -> Adyen.
         raise PaymentError("Unable to process the payment request.")
 
 
+def prepare_address_request_data(address: Optional["AddressData"]) -> Optional[dict]:
+    """Create address structure for Adyen request.
+
+    The sample recieved from Adyen team:
+
+    Customer enters only address 1: 2500 Valley Creek Way
+    Ideal: houseNumberOrName: "2500", street: "Valley Creek Way"
+    If above not possible: houseNumberOrName: "", street: "2500 Valley Creek Way"
+
+    ***Note the blank string above
+
+    Customer enters address 1 and address 2: 30 Granger Circle, 160 Bath Street
+    Ideal: houseNumberOrName: "30 Granger Circle", street: "160 Bath Street"
+    """
+    house_number_or_name = ""
+    if not address:
+        return None
+
+    if address.company_name:
+        house_number_or_name = address.company_name
+        street = address.street_address_1
+        if address.street_address_2:
+            street += f" {address.street_address_2}"
+    elif address.street_address_2:
+        street = address.street_address_2
+        house_number_or_name = address.street_address_1
+    else:
+        street = address.street_address_1
+
+    return {
+        "city": address.city,
+        "country": str(address.country),
+        "houseNumberOrName": house_number_or_name,
+        "postalCode": address.postal_code,
+        "stateOrProvince": address.country_area,
+        "street": street,
+    }
+
+
 def request_data_for_payment(
     payment_information: "PaymentData",
     return_url: str,
@@ -77,9 +116,13 @@ def request_data_for_payment(
     billing_address = payment_data.get("billingAddress")
     if billing_address:
         extra_request_params["billingAddress"] = billing_address
+    elif billing_address := prepare_address_request_data(payment_information.billing):
+        extra_request_params["billingAddress"] = billing_address
 
     delivery_address = payment_data.get("deliveryAddress")
     if delivery_address:
+        extra_request_params["deliveryAddress"] = delivery_address
+    elif delivery_address := prepare_address_request_data(payment_information.shipping):
         extra_request_params["deliveryAddress"] = delivery_address
 
     shopper_ip = payment_data.get("shopperIP")
@@ -108,6 +151,12 @@ def request_data_for_payment(
         extra_request_params["additionalData"] = {"allow3DS2": "true"}
 
     extra_request_params["shopperEmail"] = payment_information.customer_email
+
+    if payment_information.billing:
+        extra_request_params["shopperName"] = {
+            "firstName": payment_information.billing.first_name,
+            "lastName": payment_information.billing.last_name,
+        }
     request_data = {
         "amount": {
             "value": price_to_minor_unit(
@@ -119,11 +168,16 @@ def request_data_for_payment(
         "paymentMethod": payment_method,
         "returnUrl": return_url,
         "merchantAccount": merchant_account,
+        "shopperEmail": payment_information.customer_email,
+        "shopperReference": payment_information.customer_email,
         **extra_request_params,
     }
 
-    if "klarna" in method:
-        request_data = append_klarna_data(payment_information, request_data)
+    methods_that_require_checkout_details = ["afterpaytouch", "clearpay"]
+    # klarna in method - because there is a lot of variable klarna methods - like pay
+    # later with klarna or pay with klarna etc
+    if "klarna" in method or method in methods_that_require_checkout_details:
+        request_data = append_checkout_details(payment_information, request_data)
     return request_data
 
 
@@ -154,7 +208,7 @@ def get_shipping_data(manager, checkout_info, lines, discounts):
     }
 
 
-def append_klarna_data(payment_information: "PaymentData", payment_data: dict):
+def append_checkout_details(payment_information: "PaymentData", payment_data: dict):
     checkout = (
         Checkout.objects.prefetch_related(
             "shipping_method",
@@ -174,8 +228,8 @@ def append_klarna_data(payment_information: "PaymentData", payment_data: dict):
     country_code = checkout.get_country()
 
     payment_data["shopperLocale"] = get_shopper_locale_value(country_code)
-    payment_data["shopperReference"] = payment_information.customer_email
     payment_data["countryCode"] = country_code
+
     line_items = []
     for line_info in lines:
         total = checkout_line_total(

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -68,7 +68,7 @@ from ..order.models import FulfillmentStatus, Order, OrderEvent, OrderLine
 from ..order.utils import recalculate_order
 from ..page.models import Page, PageTranslation, PageType
 from ..payment import ChargeStatus, TransactionKind
-from ..payment.interface import GatewayConfig, PaymentData
+from ..payment.interface import AddressData, GatewayConfig, PaymentData
 from ..payment.models import Payment
 from ..plugins.manager import get_plugins_manager
 from ..plugins.models import PluginConfiguration
@@ -3220,6 +3220,23 @@ def dummy_payment_data(payment_dummy):
         order_id=None,
         customer_ip_address=None,
         customer_email="example@test.com",
+    )
+
+
+@pytest.fixture
+def dummy_address_data(address):
+    return AddressData(
+        first_name=address.first_name,
+        last_name=address.last_name,
+        company_name=address.company_name,
+        street_address_1=address.street_address_1,
+        street_address_2=address.street_address_2,
+        city=address.city,
+        city_area=address.city_area,
+        postal_code=address.postal_code,
+        country=address.country,
+        country_area=address.country_area,
+        phone=address.phone,
     )
 
 


### PR DESCRIPTION
I want to merge this change because it allows a customer to use afterpay or clearpay as a payment method.

clearpay: https://docs.adyen.com/payment-methods/clearpay/web-drop-in

Country | countryCode | amount.currency
-- | -- | --
United Kingdom | GB | GBP


----
afterpay: https://docs.adyen.com/payment-methods/afterpaytouch/web-drop-in

Country | countryCode | amount.currency
-- | -- | --
Australia | AU | AUD
New Zealand | NZ | NZD
United States | US | USD
Canada | CA | CAD

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
