### PR TITLE
Email plugin does not choose proper channel configuration

### DIFF
--- a/saleor/plugins/admin_email/notify_events.py
+++ b/saleor/plugins/admin_email/notify_events.py
@@ -5,37 +5,107 @@ from .tasks import (
     send_staff_order_confirmation_email_task,
     send_staff_password_reset_email_task,
 )
+from ..email_common import (
+    get_email_subject,
+    get_email_template_or_default,
+)
+from . import constants
 
 
-def send_set_staff_password_email(payload: dict, config: dict):
+def send_set_staff_password_email(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.SET_STAFF_PASSWORD_TEMPLATE_FIELD,
+        constants.SET_STAFF_PASSWORD_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.SET_STAFF_PASSWORD_SUBJECT_FIELD,
+        constants.SET_STAFF_PASSWORD_DEFAULT_SUBJECT,
+    )
     send_set_staff_password_email_task.delay(
-        recipient_email,
-        payload,
-        config,
+        recipient_email, payload, config, subject, template
     )
 
 
-def send_csv_product_export_success(payload: dict, config: dict):
+def send_csv_product_export_success(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload.get("recipient_email")
     if recipient_email:
+        template = get_email_template_or_default(
+            plugin_configuration,
+            constants.CSV_PRODUCT_EXPORT_SUCCESS_TEMPLATE_FIELD,
+            constants.CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_TEMPLATE,
+            constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+        )
+        subject = get_email_subject(
+            plugin_configuration,
+            constants.CSV_PRODUCT_EXPORT_SUCCESS_SUBJECT_FIELD,
+            constants.CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_SUBJECT,
+        )
         send_email_with_link_to_download_file_task.delay(
-            recipient_email, payload, config
+            recipient_email, payload, config, subject, template
         )
 
 
-def send_staff_order_confirmation(payload: dict, config: dict):
+def send_staff_order_confirmation(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_list = payload.get("recipient_list")
-    send_staff_order_confirmation_email_task.delay(recipient_list, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
+        constants.STAFF_ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,
+        constants.STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_staff_order_confirmation_email_task.delay(
+        recipient_list, payload, config, subject, template
+    )
 
 
-def send_csv_export_failed(payload: dict, config: dict):
+def send_csv_export_failed(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload.get("recipient_email")
     if recipient_email:
-        send_export_failed_email_task.delay(recipient_email, payload, config)
+        template = get_email_template_or_default(
+            plugin_configuration,
+            constants.CSV_EXPORT_FAILED_TEMPLATE_FIELD,
+            constants.CSV_EXPORT_FAILED_TEMPLATE_DEFAULT_TEMPLATE,
+            constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+        )
+        subject = get_email_subject(
+            plugin_configuration,
+            constants.CSV_EXPORT_FAILED_SUBJECT_FIELD,
+            constants.CSV_EXPORT_FAILED_DEFAULT_SUBJECT,
+        )
+        send_export_failed_email_task.delay(
+            recipient_email, payload, config, subject, template
+        )
 
 
-def send_staff_reset_password(payload: dict, config: dict):
+def send_staff_reset_password(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload.get("recipient_email")
     if recipient_email:
-        send_staff_password_reset_email_task.delay(recipient_email, payload, config)
+        template = get_email_template_or_default(
+            plugin_configuration,
+            constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
+            constants.STAFF_PASSWORD_RESET_DEFAULT_TEMPLATE,
+            constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+        )
+        subject = get_email_subject(
+            plugin_configuration,
+            constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD,
+            constants.STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
+        )
+        send_staff_password_reset_email_task.delay(
+            recipient_email, payload, config, subject, template
+        )

--- a/saleor/plugins/admin_email/plugin.py
+++ b/saleor/plugins/admin_email/plugin.py
@@ -229,7 +229,7 @@ class AdminEmailPlugin(BasePlugin):
         template_map = get_admin_template_map(self.templates)
         if not template_map.get(event):
             return previous_value
-        event_map[event](payload, asdict(self.config))  # type: ignore
+        event_map[event](payload, asdict(self.config), self.configuration)  # type: ignore
 
     @classmethod
     def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):

--- a/saleor/plugins/admin_email/tasks.py
+++ b/saleor/plugins/admin_email/tasks.py
@@ -4,64 +4,34 @@ from ...celeryconf import app
 from ...csv.events import export_failed_info_sent_event, export_file_sent_event
 from ..email_common import (
     EmailConfig,
-    get_email_subject,
-    get_email_template_or_default,
     send_email,
 )
-from ..models import PluginConfiguration
-from . import constants
-
-
-def get_plugin_configuration() -> Optional[PluginConfiguration]:
-    return PluginConfiguration.objects.filter(identifier=constants.PLUGIN_ID).first()
 
 
 @app.task(compression="zlib")
-def send_set_staff_password_email_task(recipient_email, payload, config: dict):
+def send_set_staff_password_email_task(
+    recipient_email, payload, config: dict, subject, template
+):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.SET_STAFF_PASSWORD_TEMPLATE_FIELD,
-        constants.SET_STAFF_PASSWORD_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.SET_STAFF_PASSWORD_SUBJECT_FIELD,
-        constants.SET_STAFF_PASSWORD_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
 
 
 @app.task(compression="zlib")
 def send_email_with_link_to_download_file_task(
-    recipient_email: str, payload, config: dict
+    recipient_email: str, payload, config: dict, subject, template
 ):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.CSV_PRODUCT_EXPORT_SUCCESS_TEMPLATE_FIELD,
-        constants.CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.CSV_PRODUCT_EXPORT_SUCCESS_SUBJECT_FIELD,
-        constants.CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
         context=payload,
     )
     export_file_sent_event(
@@ -70,25 +40,15 @@ def send_email_with_link_to_download_file_task(
 
 
 @app.task(compression="zlib")
-def send_export_failed_email_task(recipient_email: str, payload: dict, config: dict):
+def send_export_failed_email_task(
+    recipient_email: str, payload: dict, config: dict, subject, template
+):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.CSV_EXPORT_FAILED_TEMPLATE_FIELD,
-        constants.CSV_EXPORT_FAILED_TEMPLATE_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.CSV_EXPORT_FAILED_SUBJECT_FIELD,
-        constants.CSV_EXPORT_FAILED_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
         context=payload,
     )
     export_failed_info_sent_event(
@@ -98,50 +58,27 @@ def send_export_failed_email_task(recipient_email: str, payload: dict, config: d
 
 @app.task(compression="zlib")
 def send_staff_order_confirmation_email_task(
-    recipient_list: str, payload: dict, config: dict
+    recipient_list: str, payload: dict, config: dict, subject, template
 ):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.STAFF_ORDER_CONFIRMATION_TEMPLATE_FIELD,
-        constants.STAFF_ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.STAFF_ORDER_CONFIRMATION_SUBJECT_FIELD,
-        constants.STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=recipient_list,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
         context=payload,
     )
 
 
 @app.task(compression="zlib")
-def send_staff_password_reset_email_task(recipient_email, payload, config):
+def send_staff_password_reset_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.STAFF_PASSWORD_RESET_TEMPLATE_FIELD,
-        constants.STAFF_PASSWORD_RESET_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.STAFF_PASSWORD_RESET_SUBJECT_FIELD,
-        constants.STAFF_PASSWORD_RESET_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )

--- a/saleor/plugins/admin_email/tests/test_notify_events.py
+++ b/saleor/plugins/admin_email/tests/test_notify_events.py
@@ -26,11 +26,10 @@ def test_send_account_password_reset_event(mocked_email_task, customer_user):
         "site_name": "Saleor",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_staff_reset_password(
-        payload=payload,
-        config=config,
+    send_staff_reset_password(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -44,10 +43,11 @@ def test_send_set_staff_password_email(mocked_email_task):
     }
     config = {"host": "localhost", "port": "1025"}
     send_set_staff_password_email(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -61,10 +61,11 @@ def test_send_csv_product_export_success(mocked_email_task):
     }
     config = {"host": "localhost", "port": "1025"}
     send_csv_product_export_success(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -79,10 +80,11 @@ def test_send_staff_order_confirmation(mocked_email_task, order):
     }
     config = {"host": "localhost", "port": "1025"}
     send_staff_order_confirmation(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_list"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_list"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -93,8 +95,7 @@ def test_send_csv_export_failed(mocked_email_task):
         "recipient_email": "admin@example.com",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_csv_export_failed(
-        payload=payload,
-        config=config,
+    send_csv_export_failed(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)

--- a/saleor/plugins/admin_email/tests/test_plugin.py
+++ b/saleor/plugins/admin_email/tests/test_plugin.py
@@ -56,7 +56,9 @@ def test_notify(mocked_get_event_map, event_type, admin_email_plugin):
     plugin = admin_email_plugin()
     plugin.notify(event_type, payload, previous_value=None)
 
-    mocked_event.assert_called_with(payload, asdict(plugin.config))
+    mocked_event.assert_called_with(
+        payload, asdict(plugin.config), plugin.configuration
+    )
 
 
 @patch("saleor.plugins.admin_email.plugin.get_admin_event_map")

--- a/saleor/plugins/admin_email/tests/test_tasks.py
+++ b/saleor/plugins/admin_email/tests/test_tasks.py
@@ -30,7 +30,13 @@ def test_send_staff_password_reset_email_task_default_template(
         "site_name": "Saleor",
     }
 
-    send_staff_password_reset_email_task(recipient_email, payload, email_dict_config)
+    send_staff_password_reset_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        "subject",
+        "template",
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -57,7 +63,13 @@ def test_send_staff_password_reset_email_task_custom_template(
         "site_name": "Saleor",
     }
 
-    send_staff_password_reset_email_task(recipient_email, payload, email_dict_config)
+    send_staff_password_reset_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**email_dict_config)
     mocked_send_email.assert_called_with(
@@ -84,7 +96,13 @@ def test_send_set_staff_password_email_task_default_template(
         "domain": "localhost:8000",
     }
 
-    send_set_staff_password_email_task(recipient_email, payload, email_dict_config)
+    send_set_staff_password_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        "subject",
+        "template",
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -111,7 +129,13 @@ def test_send_set_staff_password_email_task_custom_template(
         "domain": "localhost:8000",
     }
 
-    send_set_staff_password_email_task(recipient_email, payload, email_dict_config)
+    send_set_staff_password_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**email_dict_config)
     mocked_send_email.assert_called_with(
@@ -138,7 +162,11 @@ def test_send_email_with_link_to_download_file_task_default_template(
         "domain": "localhost:8000",
     }
     send_email_with_link_to_download_file_task(
-        recipient_email, payload, email_dict_config
+        recipient_email,
+        payload,
+        email_dict_config,
+        "subject",
+        "template",
     )
 
     # confirm that mail has correct structure and email was sent
@@ -172,7 +200,11 @@ def test_send_email_with_link_to_download_file_task_custom_template(
     }
 
     send_email_with_link_to_download_file_task(
-        recipient_email, payload, email_dict_config
+        recipient_email,
+        payload,
+        email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**email_dict_config)
@@ -202,7 +234,13 @@ def test_send_export_failed_email_task_default_template(
         "domain": "localhost:8000",
     }
 
-    send_export_failed_email_task(recipient_email, payload, email_dict_config)
+    send_export_failed_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        "subject",
+        "template",
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -231,7 +269,13 @@ def test_send_export_failed_email_task_custom_template(
         "domain": "localhost:8000",
     }
 
-    send_export_failed_email_task(recipient_email, payload, email_dict_config)
+    send_export_failed_email_task(
+        recipient_email,
+        payload,
+        email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**email_dict_config)
     mocked_send_email.assert_called_with(
@@ -263,7 +307,11 @@ def test_send_staff_order_confirmation_email_task_default_template(
     }
 
     send_staff_order_confirmation_email_task(
-        [recipient_email], payload, email_dict_config
+        [recipient_email],
+        payload,
+        email_dict_config,
+        "subject",
+        "template",
     )
 
     # confirm that mail has correct structure and email was sent
@@ -291,7 +339,11 @@ def test_send_staff_order_confirmation_email_task_custom_template(
     }
 
     send_staff_order_confirmation_email_task(
-        [recipient_email], payload, email_dict_config
+        [recipient_email],
+        payload,
+        email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**email_dict_config)

--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -325,18 +325,17 @@ def validate_format_of_provided_templates(
 
 
 def get_email_template(
-    plugin_configuration: PluginConfiguration, template_field_name: str, default: str
+    plugin_configuration: list, template_field_name: str, default: str
 ) -> str:
     """Get email template from plugin configuration."""
-    configuration = plugin_configuration.configuration
-    for config_field in configuration:
+    for config_field in plugin_configuration:
         if config_field["name"] == template_field_name:
             return config_field["value"] or default
     return default
 
 
 def get_email_template_or_default(
-    plugin_configuration: Optional[PluginConfiguration],
+    plugin_configuration: Optional[list],
     template_field_name: str,
     default_template_file_name: str,
     default_template_path: str,
@@ -356,15 +355,14 @@ def get_email_template_or_default(
 
 
 def get_email_subject(
-    plugin_configuration: Optional["PluginConfiguration"],
+    plugin_configuration: Optional[list],
     subject_field_name: str,
     default: str,
 ) -> str:
     """Get email subject from plugin configuration."""
     if not plugin_configuration:
         return default
-    configuration = plugin_configuration.configuration
-    for config_field in configuration:
+    for config_field in plugin_configuration:
         if config_field["name"] == subject_field_name:
             return config_field["value"] or default
     return default

--- a/saleor/plugins/user_email/notify_events.py
+++ b/saleor/plugins/user_email/notify_events.py
@@ -14,85 +14,272 @@ from .tasks import (
     send_set_user_password_email_task,
     send_user_change_email_notification_task,
 )
+from ..email_common import (
+    get_email_subject,
+    get_email_template_or_default,
+)
+from . import constants
 
 
-def send_account_password_reset_event(payload: dict, config: dict):
+def send_account_password_reset_event(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_PASSWORD_RESET_TEMPLATE_FIELD,
+        constants.ACCOUNT_PASSWORD_RESET_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_PASSWORD_RESET_SUBJECT_FIELD,
+        constants.ACCOUNT_PASSWORD_RESET_DEFAULT_SUBJECT,
+    )
     send_password_reset_email_task.delay(
         recipient_email,
         payload,
         config,
+        subject,
+        template,
     )
 
 
-def send_account_confirmation(payload: dict, config: dict):
+def send_account_confirmation(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_account_confirmation_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_CONFIRMATION_TEMPLATE_FIELD,
+        constants.ACCOUNT_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_CONFIRMATION_SUBJECT_FIELD,
+        constants.ACCOUNT_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_account_confirmation_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_account_change_email_request(payload: dict, config: dict):
+def send_account_change_email_request(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_TEMPLATE_FIELD,
+        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_SUBJECT_FIELD,
+        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_SUBJECT,
+    )
     send_request_email_change_email_task.delay(
-        recipient_email,
-        payload,
-        config,
+        recipient_email, payload, config, subject, template
     )
 
 
-def send_account_change_email_confirm(payload: dict, config: dict):
+def send_account_change_email_confirm(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
-    send_user_change_email_notification_task.delay(recipient_email, payload, config)
-
-
-def send_account_delete(payload: dict, config: dict):
-    recipient_email = payload["recipient_email"]
-    send_account_delete_confirmation_email_task.delay(recipient_email, payload, config)
-
-
-def send_account_set_customer_password(payload: dict, config: dict):
-    recipient_email = payload["recipient_email"]
-    send_set_user_password_email_task.delay(recipient_email, payload, config)
-
-
-def send_invoice(payload: dict, config: dict):
-    recipient_email = payload["recipient_email"]
-    send_invoice_email_task.delay(
-        recipient_email,
-        payload,
-        config,
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_TEMPLATE_FIELD,
+        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_SUBJECT_FIELD,
+        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_SUBJECT,
+    )
+    send_user_change_email_notification_task.delay(
+        recipient_email, payload, config, subject, template
     )
 
 
-def send_order_confirmation(payload: dict, config: dict):
+def send_account_delete(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_order_confirmation_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_DELETE_TEMPLATE_FIELD,
+        constants.ACCOUNT_DELETE_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_DELETE_SUBJECT_FIELD,
+        constants.ACCOUNT_DELETE_DEFAULT_SUBJECT,
+    )
+    send_account_delete_confirmation_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_fulfillment_confirmation(payload: dict, config: dict):
+def send_account_set_customer_password(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
-    send_fulfillment_confirmation_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_TEMPLATE_FIELD,
+        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_SUBJECT_FIELD,
+        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_DEFAULT_SUBJECT,
+    )
+    send_set_user_password_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_fulfillment_update(payload: dict, config: dict):
+def send_invoice(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_fulfillment_update_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.INVOICE_READY_TEMPLATE_FIELD,
+        constants.INVOICE_READY_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.INVOICE_READY_SUBJECT_FIELD,
+        constants.INVOICE_READY_DEFAULT_SUBJECT,
+    )
+    send_invoice_email_task.delay(recipient_email, payload, config, subject, template)
 
 
-def send_payment_confirmation(payload: dict, config: dict):
+def send_order_confirmation(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_payment_confirmation_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_CONFIRMATION_TEMPLATE_FIELD,
+        constants.ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_CONFIRMATION_SUBJECT_FIELD,
+        constants.ORDER_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_order_confirmation_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_order_canceled(payload: dict, config: dict):
+def send_fulfillment_confirmation(
+    payload: dict, config: dict, plugin_configuration: list
+):
     recipient_email = payload["recipient_email"]
-    send_order_canceled_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_FULFILLMENT_CONFIRMATION_TEMPLATE_FIELD,
+        constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_FULFILLMENT_CONFIRMATION_SUBJECT_FIELD,
+        constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_fulfillment_confirmation_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_order_refund(payload: dict, config: dict):
+def send_fulfillment_update(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_order_refund_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_FULFILLMENT_UPDATE_TEMPLATE_FIELD,
+        constants.ORDER_FULFILLMENT_UPDATE_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_FULFILLMENT_UPDATE_SUBJECT_FIELD,
+        constants.ORDER_FULFILLMENT_UPDATE_DEFAULT_SUBJECT,
+    )
+    send_fulfillment_update_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
 
 
-def send_order_confirmed(payload: dict, config: dict):
+def send_payment_confirmation(payload: dict, config: dict, plugin_configuration: list):
     recipient_email = payload["recipient_email"]
-    send_order_confirmed_email_task.delay(recipient_email, payload, config)
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_PAYMENT_CONFIRMATION_TEMPLATE_FIELD,
+        constants.ORDER_PAYMENT_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_PAYMENT_CONFIRMATION_SUBJECT_FIELD,
+        constants.ORDER_PAYMENT_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_payment_confirmation_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
+
+
+def send_order_canceled(payload: dict, config: dict, plugin_configuration: list):
+    recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_CANCELED_TEMPLATE_FIELD,
+        constants.ORDER_CANCELED_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_CANCELED_SUBJECT_FIELD,
+        constants.ORDER_CANCELED_DEFAULT_SUBJECT,
+    )
+    send_order_canceled_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
+
+
+def send_order_refund(payload: dict, config: dict, plugin_configuration: list):
+    recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_REFUND_CONFIRMATION_TEMPLATE_FIELD,
+        constants.ORDER_REFUND_CONFIRMATION_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_REFUND_CONFIRMATION_SUBJECT_FIELD,
+        constants.ORDER_REFUND_CONFIRMATION_DEFAULT_SUBJECT,
+    )
+    send_order_refund_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )
+
+
+def send_order_confirmed(payload: dict, config: dict, plugin_configuration: list):
+    recipient_email = payload["recipient_email"]
+    template = get_email_template_or_default(
+        plugin_configuration,
+        constants.ORDER_CONFIRMED_TEMPLATE_FIELD,
+        constants.ORDER_CONFIRMED_DEFAULT_TEMPLATE,
+        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
+    )
+    subject = get_email_subject(
+        plugin_configuration,
+        constants.ORDER_CONFIRMED_SUBJECT_FIELD,
+        constants.ORDER_CONFIRMED_DEFAULT_SUBJECT,
+    )
+    send_order_confirmed_email_task.delay(
+        recipient_email, payload, config, subject, template
+    )

--- a/saleor/plugins/user_email/plugin.py
+++ b/saleor/plugins/user_email/plugin.py
@@ -422,7 +422,7 @@ class UserEmailPlugin(BasePlugin):
         template_map = get_user_template_map(self.templates)
         if not template_map.get(event):
             return previous_value
-        event_map[event](payload, asdict(self.config))  # type: ignore
+        event_map[event](payload, asdict(self.config), self.configuration)  # type: ignore
 
     @classmethod
     def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):

--- a/saleor/plugins/user_email/tasks.py
+++ b/saleor/plugins/user_email/tasks.py
@@ -1,102 +1,56 @@
-from typing import Optional
-
 from ...account import events as account_events
 from ...celeryconf import app
 from ...invoice import events as invoice_events
 from ...order import events as order_events
 from ..email_common import (
     EmailConfig,
-    get_email_subject,
-    get_email_template_or_default,
     send_email,
 )
-from ..models import PluginConfiguration
-from . import constants
-
-
-def get_plugin_configuration() -> Optional[PluginConfiguration]:
-    return PluginConfiguration.objects.filter(identifier=constants.PLUGIN_ID).first()
 
 
 @app.task(compression="zlib")
-def send_account_confirmation_email_task(recipient_email, payload, config):
+def send_account_confirmation_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_CONFIRMATION_TEMPLATE_FIELD,
-        constants.ACCOUNT_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_CONFIRMATION_SUBJECT_FIELD,
-        constants.ACCOUNT_CONFIRMATION_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
 
 
 @app.task(compression="zlib")
-def send_password_reset_email_task(recipient_email, payload, config):
+def send_password_reset_email_task(recipient_email, payload, config, subject, template):
     user_id = payload.get("user", {}).get("id")
     email_config = EmailConfig(**config)
 
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_PASSWORD_RESET_TEMPLATE_FIELD,
-        constants.ACCOUNT_PASSWORD_RESET_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_PASSWORD_RESET_SUBJECT_FIELD,
-        constants.ACCOUNT_PASSWORD_RESET_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     account_events.customer_password_reset_link_sent_event(user_id=user_id)
 
 
 @app.task(compression="zlib")
-def send_request_email_change_email_task(recipient_email, payload, config):
+def send_request_email_change_email_task(
+    recipient_email, payload, config, subject, template
+):
     user_id = payload.get("user", {}).get("id")
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_TEMPLATE_FIELD,
-        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_SUBJECT_FIELD,
-        constants.ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     account_events.customer_email_change_request_event(
         user_id=user_id,
@@ -108,30 +62,18 @@ def send_request_email_change_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_user_change_email_notification_task(recipient_email, payload, config):
+def send_user_change_email_notification_task(
+    recipient_email, payload, config, subject, template
+):
     user_id = payload.get("user", {}).get("id")
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_TEMPLATE_FIELD,
-        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_SUBJECT_FIELD,
-        constants.ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     event_parameters = {
         "old_email": payload["old_email"],
@@ -144,84 +86,46 @@ def send_user_change_email_notification_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_account_delete_confirmation_email_task(recipient_email, payload, config):
+def send_account_delete_confirmation_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_DELETE_TEMPLATE_FIELD,
-        constants.ACCOUNT_DELETE_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_DELETE_SUBJECT_FIELD,
-        constants.ACCOUNT_DELETE_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
 
 
 @app.task(compression="zlib")
-def send_set_user_password_email_task(recipient_email, payload, config):
+def send_set_user_password_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_TEMPLATE_FIELD,
-        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_SUBJECT_FIELD,
-        constants.ACCOUNT_SET_CUSTOMER_PASSWORD_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
 
 
 @app.task(compression="zlib")
-def send_invoice_email_task(recipient_email, payload, config):
+def send_invoice_email_task(recipient_email, payload, config, subject, template):
     """Send an invoice to user of related order with URL to download it."""
     email_config = EmailConfig(**config)
 
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.INVOICE_READY_TEMPLATE_FIELD,
-        constants.INVOICE_READY_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.INVOICE_READY_SUBJECT_FIELD,
-        constants.INVOICE_READY_DEFAULT_SUBJECT,
-    )
-
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     invoice_events.notification_invoice_sent_event(
         user_id=payload["requester_user_id"],
@@ -238,30 +142,18 @@ def send_invoice_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_order_confirmation_email_task(recipient_email, payload, config):
+def send_order_confirmation_email_task(
+    recipient_email, payload, config, subject, template
+):
     """Send order confirmation email."""
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_CONFIRMATION_TEMPLATE_FIELD,
-        constants.ORDER_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_CONFIRMATION_SUBJECT_FIELD,
-        constants.ORDER_CONFIRMATION_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_order_confirmation_notification(
         order_id=payload["order"]["id"],
@@ -271,29 +163,17 @@ def send_order_confirmation_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_fulfillment_confirmation_email_task(recipient_email, payload, config):
+def send_fulfillment_confirmation_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_FULFILLMENT_CONFIRMATION_TEMPLATE_FIELD,
-        constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_FULFILLMENT_CONFIRMATION_SUBJECT_FIELD,
-        constants.ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_fulfillment_confirmed_notification(
         order_id=payload["order"]["id"],
@@ -312,54 +192,32 @@ def send_fulfillment_confirmation_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_fulfillment_update_email_task(recipient_email, payload, config):
+def send_fulfillment_update_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_FULFILLMENT_UPDATE_TEMPLATE_FIELD,
-        constants.ORDER_FULFILLMENT_UPDATE_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
 
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_FULFILLMENT_UPDATE_SUBJECT_FIELD,
-        constants.ORDER_FULFILLMENT_UPDATE_DEFAULT_SUBJECT,
-    )
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
 
 
 @app.task(compression="zlib")
-def send_payment_confirmation_email_task(recipient_email, payload, config):
+def send_payment_confirmation_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_PAYMENT_CONFIRMATION_TEMPLATE_FIELD,
-        constants.ORDER_PAYMENT_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_PAYMENT_CONFIRMATION_SUBJECT_FIELD,
-        constants.ORDER_PAYMENT_CONFIRMATION_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_payment_confirmed_notification(
         order_id=payload["order"]["id"],
@@ -369,29 +227,15 @@ def send_payment_confirmation_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_order_canceled_email_task(recipient_email, payload, config):
+def send_order_canceled_email_task(recipient_email, payload, config, subject, template):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_CANCELED_TEMPLATE_FIELD,
-        constants.ORDER_CANCELED_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_CANCELED_SUBJECT_FIELD,
-        constants.ORDER_CANCELED_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_order_cancelled_notification(
         order_id=payload["order"]["id"],
@@ -402,29 +246,15 @@ def send_order_canceled_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_order_refund_email_task(recipient_email, payload, config):
+def send_order_refund_email_task(recipient_email, payload, config, subject, template):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_REFUND_CONFIRMATION_TEMPLATE_FIELD,
-        constants.ORDER_REFUND_CONFIRMATION_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_REFUND_CONFIRMATION_SUBJECT_FIELD,
-        constants.ORDER_REFUND_CONFIRMATION_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_order_refunded_notification(
         order_id=payload["order"]["id"],
@@ -435,29 +265,17 @@ def send_order_refund_email_task(recipient_email, payload, config):
 
 
 @app.task(compression="zlib")
-def send_order_confirmed_email_task(recipient_email, payload, config):
+def send_order_confirmed_email_task(
+    recipient_email, payload, config, subject, template
+):
     email_config = EmailConfig(**config)
-
-    plugin_configuration = get_plugin_configuration()
-    email_template_str = get_email_template_or_default(
-        plugin_configuration,
-        constants.ORDER_CONFIRMED_TEMPLATE_FIELD,
-        constants.ORDER_CONFIRMED_DEFAULT_TEMPLATE,
-        constants.DEFAULT_EMAIL_TEMPLATES_PATH,
-    )
-
-    subject = get_email_subject(
-        plugin_configuration,
-        constants.ORDER_CONFIRMED_SUBJECT_FIELD,
-        constants.ORDER_CONFIRMED_DEFAULT_SUBJECT,
-    )
 
     send_email(
         config=email_config,
         recipient_list=[recipient_email],
         context=payload,
         subject=subject,
-        template_str=email_template_str,
+        template_str=template,
     )
     order_events.event_order_confirmed_notification(
         order_id=payload.get("order", {}).get("id"),

--- a/saleor/plugins/user_email/tests/test_notify_events.py
+++ b/saleor/plugins/user_email/tests/test_notify_events.py
@@ -38,10 +38,11 @@ def test_send_account_password_reset_event(mocked_email_task, customer_user):
     }
     config = {"host": "localhost", "port": "1025"}
     send_account_password_reset_event(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -58,11 +59,10 @@ def test_send_account_confirmation(mocked_email_task, customer_user):
         "site_name": "Saleor",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_account_confirmation(
-        payload=payload,
-        config=config,
+    send_account_confirmation(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -82,10 +82,11 @@ def test_send_account_change_email_request(mocked_email_task, customer_user):
     }
     config = {"host": "localhost", "port": "1025"}
     send_account_change_email_request(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -101,10 +102,11 @@ def test_send_account_change_email_confirm(mocked_email_task, customer_user):
     }
     config = {"host": "localhost", "port": "1025"}
     send_account_change_email_confirm(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -122,11 +124,10 @@ def test_send_account_delete(mocked_email_task, customer_user):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_account_delete(
-        payload=payload,
-        config=config,
+    send_account_delete(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -144,10 +145,11 @@ def test_send_account_set_customer_password(mocked_email_task, customer_user):
     }
     config = {"host": "localhost", "port": "1025"}
     send_account_set_customer_password(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch("saleor.plugins.user_email.notify_events.send_invoice_email_task.delay")
@@ -165,11 +167,10 @@ def test_send_invoice(
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_invoice(
-        payload=payload,
-        config=config,
+    send_invoice(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -183,11 +184,10 @@ def test_send_order_confirmation(mocked_email_task, order):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_order_confirmation(
-        payload=payload,
-        config=config,
+    send_order_confirmation(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -198,10 +198,11 @@ def test_send_fulfillment_confirmation(mocked_email_task, order, fulfillment):
     payload = get_default_fulfillment_payload(order, fulfillment)
     config = {"host": "localhost", "port": "1025"}
     send_fulfillment_confirmation(
-        payload=payload,
-        config=config,
+        payload=payload, config=config, plugin_configuration=[]
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
+    )
 
 
 @mock.patch(
@@ -210,11 +211,10 @@ def test_send_fulfillment_confirmation(mocked_email_task, order, fulfillment):
 def test_send_fulfillment_update(mocked_email_task, order, fulfillment):
     payload = get_default_fulfillment_payload(order, fulfillment)
     config = {"host": "localhost", "port": "1025"}
-    send_fulfillment_update(
-        payload=payload,
-        config=config,
+    send_fulfillment_update(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -236,11 +236,10 @@ def test_send_payment_confirmation(mocked_email_task, order, payment_dummy):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_payment_confirmation(
-        payload=payload,
-        config=config,
+    send_payment_confirmation(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -254,11 +253,10 @@ def test_send_order_canceled(mocked_email_task, order):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_order_canceled(
-        payload=payload,
-        config=config,
+    send_order_canceled(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -274,11 +272,10 @@ def test_send_order_refund(mocked_email_task, order):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_order_refund(
-        payload=payload,
-        config=config,
+    send_order_refund(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)
 
 
 @mock.patch(
@@ -292,8 +289,7 @@ def test_send_order_confirmed(mocked_email_task, order):
         "domain": "localhost:8000",
     }
     config = {"host": "localhost", "port": "1025"}
-    send_order_confirmed(
-        payload=payload,
-        config=config,
+    send_order_confirmed(payload=payload, config=config, plugin_configuration=[])
+    mocked_email_task.assert_called_with(
+        payload["recipient_email"], payload, config, mock.ANY, mock.ANY
     )
-    mocked_email_task.assert_called_with(payload["recipient_email"], payload, config)

--- a/saleor/plugins/user_email/tests/test_plugin.py
+++ b/saleor/plugins/user_email/tests/test_plugin.py
@@ -82,7 +82,9 @@ def test_notify(mocked_get_event_map, event_type, user_email_plugin):
     plugin = user_email_plugin()
     plugin.notify(event_type, payload, previous_value=None)
 
-    mocked_event.assert_called_with(payload, asdict(plugin.config))
+    mocked_event.assert_called_with(
+        payload, asdict(plugin.config), plugin.configuration
+    )
 
 
 @patch("saleor.plugins.user_email.plugin.get_user_event_map")

--- a/saleor/plugins/user_email/tests/test_tasks.py
+++ b/saleor/plugins/user_email/tests/test_tasks.py
@@ -43,7 +43,7 @@ def test_send_account_confirmation_email_task_default_template(
     }
 
     send_account_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email, payload, user_email_dict_config, "subject", "template"
     )
 
     # confirm that mail has correct structure and email was sent
@@ -52,14 +52,10 @@ def test_send_account_confirmation_email_task_default_template(
 
 @mock.patch("saleor.plugins.user_email.tasks.send_email")
 def test_send_account_confirmation_email_task_custom_template(
-    mocked_send_email, user_email_dict_config, user_email_plugin, customer_user
+    mocked_send_email, user_email_dict_config, customer_user
 ):
     expected_template_str = "<html><body>Template body</body></html>"
     expected_subject = "Test Email Subject"
-    user_email_plugin(
-        account_confirmation_template=expected_template_str,
-        account_confirmation_subject=expected_subject,
-    )
     recipient_email = "admin@example.com"
     token = "token123"
     payload = {
@@ -72,7 +68,11 @@ def test_send_account_confirmation_email_task_custom_template(
     }
 
     send_account_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -100,7 +100,13 @@ def test_send_password_reset_email_task_default_template(
         "site_name": "Saleor",
     }
 
-    send_password_reset_email_task(recipient_email, payload, user_email_dict_config)
+    send_password_reset_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        "subject",
+        "template",
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -127,7 +133,13 @@ def test_send_password_reset_email_task_custom_template(
         "site_name": "Saleor",
     }
 
-    send_password_reset_email_task(recipient_email, payload, user_email_dict_config)
+    send_password_reset_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -157,7 +169,7 @@ def test_send_request_email_change_email_task_default_template(
     }
 
     send_request_email_change_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email, payload, user_email_dict_config, "subject", "template"
     )
 
     # confirm that mail has correct structure and email was sent
@@ -188,7 +200,11 @@ def test_send_request_email_change_email_task_custom_template(
     }
 
     send_request_email_change_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -216,7 +232,7 @@ def test_send_user_change_email_notification_task_default_template(
     }
 
     send_user_change_email_notification_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email, payload, user_email_dict_config, "subject", "template"
     )
 
     # confirm that mail has correct structure and email was sent
@@ -244,7 +260,11 @@ def test_send_user_change_email_notification_task_custom_template(
     }
 
     send_user_change_email_notification_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -273,7 +293,7 @@ def test_send_account_delete_confirmation_email_task_default_template(
     }
 
     send_account_delete_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email, payload, user_email_dict_config, "subject", "template"
     )
 
     # confirm that mail has correct structure and email was sent
@@ -302,7 +322,11 @@ def test_send_account_delete_confirmation_email_task_custom_template(
     }
 
     send_account_delete_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -330,7 +354,9 @@ def test_send_set_user_password_email_task_default_template(
         "domain": "localhost:8000",
     }
 
-    send_set_user_password_email_task(recipient_email, payload, user_email_dict_config)
+    send_set_user_password_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -357,7 +383,13 @@ def test_send_set_user_password_email_task_custom_template(
         "domain": "localhost:8000",
     }
 
-    send_set_user_password_email_task(recipient_email, payload, user_email_dict_config)
+    send_set_user_password_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -392,7 +424,9 @@ def test_send_invoice_email_task_default_template_by_user(
         "requester_app_id": None,
     }
 
-    send_invoice_email_task(recipient_email, payload, user_email_dict_config)
+    send_invoice_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -433,7 +467,9 @@ def test_send_invoice_email_task_default_template_by_app(
         "requester_app_id": app.pk,
     }
 
-    send_invoice_email_task(recipient_email, payload, user_email_dict_config)
+    send_invoice_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -477,7 +513,13 @@ def test_send_invoice_email_task_custom_template(
         "requester_app_id": None,
     }
 
-    send_invoice_email_task(recipient_email, payload, user_email_dict_config)
+    send_invoice_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -513,7 +555,9 @@ def test_send_order_confirmation_email_task_default_template(
         "domain": "localhost:8000",
     }
 
-    send_order_confirmation_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_confirmation_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -537,7 +581,13 @@ def test_send_order_confirmation_email_task_custom_template(
         "domain": "localhost:8000",
     }
 
-    send_order_confirmation_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_confirmation_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -558,7 +608,11 @@ def test_send_fulfillment_confirmation_email_task_default_template(
     payload["requester_app_id"] = None
 
     send_fulfillment_confirmation_email_task(
-        payload["recipient_email"], payload, user_email_dict_config
+        payload["recipient_email"],
+        payload,
+        user_email_dict_config,
+        "subject",
+        "template",
     )
 
     # confirm that mail has correct structure and email was sent
@@ -594,7 +648,11 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_user(
     recipient_email = payload["recipient_email"]
 
     send_fulfillment_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -643,7 +701,11 @@ def test_send_fulfillment_confirmation_email_task_custom_template_by_app(
     recipient_email = payload["recipient_email"]
 
     send_fulfillment_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -677,7 +739,11 @@ def test_send_fulfillment_update_email_task_default_template(
     payload = get_default_fulfillment_payload(order, fulfillment)
 
     send_fulfillment_update_email_task(
-        payload["recipient_email"], payload, user_email_dict_config
+        payload["recipient_email"],
+        payload,
+        user_email_dict_config,
+        "subject",
+        "template",
     )
 
     # confirm that mail has correct structure and email was sent
@@ -701,7 +767,13 @@ def test_send_fulfillment_update_email_task_custom_template(
     )
     payload = get_default_fulfillment_payload(order, fulfillment)
     recipient_email = payload["recipient_email"]
-    send_fulfillment_update_email_task(recipient_email, payload, user_email_dict_config)
+    send_fulfillment_update_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -734,7 +806,7 @@ def test_send_payment_confirmation_email_task_default_template(
     }
 
     send_payment_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email, payload, user_email_dict_config, "subject", "template"
     )
 
     # confirm that mail has correct structure and email was sent
@@ -773,7 +845,11 @@ def test_send_payment_confirmation_email_task_custom_template(
         "domain": "localhost:8000",
     }
     send_payment_confirmation_email_task(
-        recipient_email, payload, user_email_dict_config
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
     )
 
     email_config = EmailConfig(**user_email_dict_config)
@@ -800,7 +876,9 @@ def test_send_order_canceled_email_task_default_template_by_user(
         "requester_app_id": None,
     }
 
-    send_order_canceled_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_canceled_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -820,7 +898,9 @@ def test_send_order_canceled_email_task_default_template_by_app(
         "requester_app_id": app.pk,
     }
 
-    send_order_canceled_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_canceled_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -845,7 +925,13 @@ def test_send_order_canceled_email_task_custom_template(
         "requester_user_id": staff_user.pk,
         "requester_app_id": None,
     }
-    send_order_canceled_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_canceled_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -873,7 +959,9 @@ def test_send_order_refund_email_task_default_template_by_user(
         "requester_app_id": None,
     }
 
-    send_order_refund_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_refund_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -901,7 +989,9 @@ def test_send_order_refund_email_task_default_template_by_app(
         "requester_app_id": app.pk,
     }
 
-    send_order_refund_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_refund_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -934,7 +1024,13 @@ def test_send_order_refund_email_task_custom_template(
         "requester_user_id": staff_user.pk,
         "requester_app_id": None,
     }
-    send_order_refund_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_refund_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(
@@ -965,7 +1061,9 @@ def test_send_order_confirmed_email_task_default_template_by_user(
         "domain": "localhost:8000",
     }
 
-    send_order_confirmed_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_confirmed_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -993,7 +1091,9 @@ def test_send_order_confirmed_email_task_default_template_by_app(
         "domain": "localhost:8000",
     }
 
-    send_order_confirmed_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_confirmed_email_task(
+        recipient_email, payload, user_email_dict_config, "subject", "template"
+    )
 
     # confirm that mail has correct structure and email was sent
     assert mocked_send_mail.called
@@ -1027,7 +1127,13 @@ def test_send_order_confirmed_email_task_custom_template(
         "domain": "localhost:8000",
     }
 
-    send_order_confirmed_email_task(recipient_email, payload, user_email_dict_config)
+    send_order_confirmed_email_task(
+        recipient_email,
+        payload,
+        user_email_dict_config,
+        expected_subject,
+        expected_template_str,
+    )
 
     email_config = EmailConfig(**user_email_dict_config)
     mocked_send_email.assert_called_with(


### PR DESCRIPTION
I want to merge this change because email plugins were not using the proper plugin configuration. This change passes the template and the subject to the celery tasks.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
