### PR TITLE
Fix for failing voucher recalculation

### DIFF
--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -349,7 +349,7 @@ def get_prices_of_discounted_specific_product(
             lines=lines,
             checkout_line_info=line_info,
             discounts=discounts,
-        ).gross
+        )
         line_unit_price = manager.calculate_checkout_line_unit_price(
             line_total,
             line.quantity,
@@ -358,7 +358,7 @@ def get_prices_of_discounted_specific_product(
             line_info,
             address,
             discounts,
-        )
+        ).gross
         line_prices.extend([line_unit_price] * line.quantity)
 
     return line_prices


### PR DESCRIPTION
I want to merge this change because it fixes a failing recalculation of vouchers for specific products 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
