### PR TITLE
Unify deprecation messages

### DIFF
--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -16,6 +16,7 @@ from ..app.types import App
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import PrefetchingConnectionField
 from ..core.scalars import UUID
@@ -212,7 +213,7 @@ class User(CountableDjangoObjectType):
         Checkout,
         description="Returns the last open checkout of this user.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. "
+            f"{DEPRECATED_IN_3X} "
             "Use the `checkout_tokens` field to fetch the user checkouts."
         ),
     )

--- a/saleor/graphql/account/types.py
+++ b/saleor/graphql/account/types.py
@@ -16,7 +16,7 @@ from ..app.types import App
 from ..checkout.dataloaders import CheckoutByUserAndChannelLoader, CheckoutByUserLoader
 from ..checkout.types import Checkout
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.fields import PrefetchingConnectionField
 from ..core.scalars import UUID
@@ -213,7 +213,7 @@ class User(CountableDjangoObjectType):
         Checkout,
         description="Returns the last open checkout of this user.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} "
+            f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `checkout_tokens` field to fetch the user checkouts."
         ),
     )

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -41,6 +41,7 @@ from ...warehouse.models import Warehouse
 from ..account.i18n import I18nMixin
 from ..account.types import AddressInput
 from ..channel.utils import clean_channel
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import BaseMutation, ModelMutation
 from ..core.scalars import UUID
@@ -248,8 +249,8 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         description=(
             "Whether the checkout was created or the current active one was returned. "
             "Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart "
-            "with an active checkout."
-            "DEPRECATED: Will be removed in Saleor 4.0. Always returns True."
+            "with an active checkout. "
+            f"{DEPRECATED_IN_3X} Always returns True."
         ),
     )
 
@@ -416,8 +417,7 @@ class CheckoutLinesAdd(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "The ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -553,8 +553,7 @@ class CheckoutLineDelete(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "The ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -608,8 +607,7 @@ class CheckoutCustomerAttach(BaseMutation):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                "ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -659,8 +657,7 @@ class CheckoutCustomerDetach(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -708,8 +705,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                "ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -817,8 +813,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                "ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -868,8 +863,7 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                "ID of the checkout."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -909,8 +903,7 @@ class CheckoutEmailUpdate(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -950,8 +943,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -1049,8 +1041,7 @@ class CheckoutComplete(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -1171,8 +1162,7 @@ class CheckoutAddPromoCode(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID. "
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )
@@ -1239,8 +1229,7 @@ class CheckoutRemovePromoCode(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -41,7 +41,7 @@ from ...warehouse.models import Warehouse
 from ..account.i18n import I18nMixin
 from ..account.types import AddressInput
 from ..channel.utils import clean_channel
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD, DEPRECATED_IN_3X_INPUT
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import BaseMutation, ModelMutation
 from ..core.scalars import UUID
@@ -249,9 +249,9 @@ class CheckoutCreate(ModelMutation, I18nMixin):
         description=(
             "Whether the checkout was created or the current active one was returned. "
             "Refer to checkoutLinesAdd and checkoutLinesUpdate to merge a cart "
-            "with an active checkout. "
-            f"{DEPRECATED_IN_3X} Always returns True."
+            "with an active checkout."
         ),
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Always returns `True`.",
     )
 
     class Arguments:
@@ -417,7 +417,7 @@ class CheckoutLinesAdd(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -553,7 +553,7 @@ class CheckoutLineDelete(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -607,7 +607,7 @@ class CheckoutCustomerAttach(BaseMutation):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -657,7 +657,7 @@ class CheckoutCustomerDetach(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -705,7 +705,7 @@ class CheckoutShippingAddressUpdate(BaseMutation, I18nMixin):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -813,7 +813,7 @@ class CheckoutBillingAddressUpdate(CheckoutShippingAddressUpdate):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -863,7 +863,7 @@ class CheckoutLanguageCodeUpdate(BaseMutation):
         checkout_id = graphene.ID(
             required=False,
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
         )
         token = UUID(description="Checkout token.", required=False)
@@ -903,7 +903,7 @@ class CheckoutEmailUpdate(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -943,7 +943,7 @@ class CheckoutShippingMethodUpdate(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -1041,7 +1041,7 @@ class CheckoutComplete(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -1162,7 +1162,7 @@ class CheckoutAddPromoCode(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )
@@ -1229,7 +1229,7 @@ class CheckoutRemovePromoCode(BaseMutation):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -1,1 +1,1 @@
-DEPRECATED_IN_3X = "DEPRECATED: this field will be removed in Saleor 4.0."
+DEPRECATED_IN_3X = "\nDEPRECATED: this field will be removed in Saleor 4.0."

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -1,0 +1,1 @@
+DEPRECATED_IN_3X = "DEPRECATED: this field will be removed in Saleor 4.0."

--- a/saleor/graphql/core/descriptions.py
+++ b/saleor/graphql/core/descriptions.py
@@ -1,1 +1,7 @@
-DEPRECATED_IN_3X = "\nDEPRECATED: this field will be removed in Saleor 4.0."
+# Deprecation message for queries, object fields and mutations. Use it, when
+# `deprecation_reason` argument is supported.
+DEPRECATED_IN_3X_FIELD = "This field will be removed in Saleor 4.0."
+
+# Deprecation message for input fields and query arguments. Use it, when
+# deprecation message needs to be included in the field description.
+DEPRECATED_IN_3X_INPUT = "\n\nDEPRECATED: this field will be removed in Saleor 4.0."

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -20,6 +20,7 @@ from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions
 from ..decorators import staff_member_or_app_required
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
+from .descriptions import DEPRECATED_IN_3X
 from .types import File, Upload
 from .types.common import UploadError
 from .utils import from_global_id_or_error, snake_to_camel_case
@@ -134,9 +135,7 @@ class BaseMutation(graphene.Mutation):
             description=description, _meta=_meta, **options
         )
         if error_type_field:
-            deprecated_msg = (
-                "Use errors field instead. This field will be removed in Saleor 4.0."
-            )
+            deprecated_msg = f"{DEPRECATED_IN_3X} Use `errors` field instead."
             cls._meta.fields.update(
                 get_error_fields(
                     error_type_class,

--- a/saleor/graphql/core/mutations.py
+++ b/saleor/graphql/core/mutations.py
@@ -20,7 +20,7 @@ from ...core.exceptions import PermissionDenied
 from ...core.permissions import AccountPermissions
 from ..decorators import staff_member_or_app_required
 from ..utils import get_nodes, resolve_global_ids_to_primary_keys
-from .descriptions import DEPRECATED_IN_3X
+from .descriptions import DEPRECATED_IN_3X_FIELD
 from .types import File, Upload
 from .types.common import UploadError
 from .utils import from_global_id_or_error, snake_to_camel_case
@@ -135,7 +135,7 @@ class BaseMutation(graphene.Mutation):
             description=description, _meta=_meta, **options
         )
         if error_type_field:
-            deprecated_msg = f"{DEPRECATED_IN_3X} Use `errors` field instead."
+            deprecated_msg = f"{DEPRECATED_IN_3X_FIELD} Use `errors` field instead."
             cls._meta.fields.update(
                 get_error_fields(
                     error_type_class,

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -3,7 +3,7 @@ from graphene.types.inputobjecttype import InputObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
 from graphene_django.filter.utils import get_filterset_class
 
-from ..descriptions import DEPRECATED_IN_3X
+from ..descriptions import DEPRECATED_IN_3X_INPUT
 from .converter import convert_form_field
 
 
@@ -70,7 +70,7 @@ class ChannelFilterInputObjectType(FilterInputObjectType):
         String,
         description=(
             "Specifies the channel by which the data should be filtered. "
-            f"{DEPRECATED_IN_3X} Use root-level channel argument instead."
+            f"{DEPRECATED_IN_3X_INPUT} Use root-level channel argument instead."
         ),
     )
 

--- a/saleor/graphql/core/types/filter_input.py
+++ b/saleor/graphql/core/types/filter_input.py
@@ -3,6 +3,7 @@ from graphene.types.inputobjecttype import InputObjectTypeOptions
 from graphene.types.utils import yank_fields_from_attrs
 from graphene_django.filter.utils import get_filterset_class
 
+from ..descriptions import DEPRECATED_IN_3X
 from .converter import convert_form_field
 
 
@@ -69,8 +70,7 @@ class ChannelFilterInputObjectType(FilterInputObjectType):
         String,
         description=(
             "Specifies the channel by which the data should be filtered. "
-            "DEPRECATED: Will be removed in Saleor 4.0."
-            "Use root-level channel argument instead."
+            f"{DEPRECATED_IN_3X} Use root-level channel argument instead."
         ),
     )
 

--- a/saleor/graphql/core/types/sort_input.py
+++ b/saleor/graphql/core/types/sort_input.py
@@ -1,6 +1,7 @@
 import graphene
 from graphene.types.objecttype import ObjectTypeOptions
 
+from ..descriptions import DEPRECATED_IN_3X
 from ..enums import OrderDirection
 
 
@@ -42,8 +43,7 @@ class ChannelSortInputObjectType(SortInputObjectType):
         graphene.String,
         description=(
             "Specifies the channel in which to sort the data. "
-            "DEPRECATED: Will be removed in Saleor 4.0."
-            "Use root-level channel argument instead."
+            f"{DEPRECATED_IN_3X} Use root-level channel argument instead."
         ),
     )
 

--- a/saleor/graphql/core/types/sort_input.py
+++ b/saleor/graphql/core/types/sort_input.py
@@ -1,7 +1,7 @@
 import graphene
 from graphene.types.objecttype import ObjectTypeOptions
 
-from ..descriptions import DEPRECATED_IN_3X
+from ..descriptions import DEPRECATED_IN_3X_INPUT
 from ..enums import OrderDirection
 
 
@@ -43,7 +43,7 @@ class ChannelSortInputObjectType(SortInputObjectType):
         graphene.String,
         description=(
             "Specifies the channel in which to sort the data. "
-            f"{DEPRECATED_IN_3X} Use root-level channel argument instead."
+            f"{DEPRECATED_IN_3X_INPUT} Use root-level channel argument instead."
         ),
     )
 

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.permissions import DiscountPermissions
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.fields import ChannelContextFilterConnectionField
 from ..core.types import FilterInputObjectType
 from ..core.utils import from_global_id_or_error
@@ -52,8 +53,8 @@ class DiscountQueries(graphene.ObjectType):
         sort_by=SaleSortingInput(description="Sort sales."),
         query=graphene.String(
             description=(
-                "Search sales by name, value or type. DEPRECATED: Will be removed in "
-                "Saleor 4.0. Use `filter.search` input instead."
+                "Search sales by name, value or type. "
+                f"{DEPRECATED_IN_3X} Use `filter.search` input instead."
             )
         ),
         channel=graphene.String(
@@ -77,8 +78,8 @@ class DiscountQueries(graphene.ObjectType):
         sort_by=VoucherSortingInput(description="Sort voucher."),
         query=graphene.String(
             description=(
-                "Search vouchers by name or code. DEPRECATED: Will be removed in "
-                "Saleor 4.0. Use `filter.search` input instead."
+                "Search vouchers by name or code. "
+                f"{DEPRECATED_IN_3X} Use `filter.search` input instead."
             )
         ),
         channel=graphene.String(

--- a/saleor/graphql/discount/schema.py
+++ b/saleor/graphql/discount/schema.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...core.permissions import DiscountPermissions
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.fields import ChannelContextFilterConnectionField
 from ..core.types import FilterInputObjectType
 from ..core.utils import from_global_id_or_error
@@ -54,7 +54,7 @@ class DiscountQueries(graphene.ObjectType):
         query=graphene.String(
             description=(
                 "Search sales by name, value or type. "
-                f"{DEPRECATED_IN_3X} Use `filter.search` input instead."
+                f"{DEPRECATED_IN_3X_INPUT} Use `filter.search` input instead."
             )
         ),
         channel=graphene.String(
@@ -79,7 +79,7 @@ class DiscountQueries(graphene.ObjectType):
         query=graphene.String(
             description=(
                 "Search vouchers by name or code. "
-                f"{DEPRECATED_IN_3X} Use `filter.search` input instead."
+                f"{DEPRECATED_IN_3X_INPUT} Use `filter.search` input instead."
             )
         ),
         channel=graphene.String(

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -9,7 +9,7 @@ from ...core.utils.validators import date_passed, user_is_valid
 from ...giftcard import GiftCardExpiryType, events, models
 from ...giftcard.error_codes import GiftCardErrorCode
 from ...giftcard.utils import activate_gift_card, deactivate_gift_card
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types.common import GiftCardError, PriceInput, TimePeriodInputType
@@ -32,13 +32,13 @@ class GiftCardInput(graphene.InputObjectType):
     # DEPRECATED
     start_date = graphene.types.datetime.Date(
         description=(
-            f"Start date of the gift card in ISO 8601 format. {DEPRECATED_IN_3X}"
+            f"Start date of the gift card in ISO 8601 format. {DEPRECATED_IN_3X_INPUT}"
         )
     )
     end_date = graphene.types.datetime.Date(
         description=(
             "End date of the gift card in ISO 8601 format. "
-            f"{DEPRECATED_IN_3X} Use `expiryDate` from `expirySettings` instead."
+            f"{DEPRECATED_IN_3X_INPUT} Use `expiryDate` from `expirySettings` instead."
         )
     )
 
@@ -58,7 +58,7 @@ class GiftCardCreateInput(GiftCardInput):
         required=False,
         description=(
             "Code to use the gift card. "
-            f"{DEPRECATED_IN_3X} The code is now auto generated."
+            f"{DEPRECATED_IN_3X_INPUT} The code is now auto generated."
         ),
     )
     note = graphene.String(description="The gift card note from the staff member.")

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -9,6 +9,7 @@ from ...core.utils.validators import date_passed, user_is_valid
 from ...giftcard import GiftCardExpiryType, events, models
 from ...giftcard.error_codes import GiftCardErrorCode
 from ...giftcard.utils import activate_gift_card, deactivate_gift_card
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
 from ..core.types.common import GiftCardError, PriceInput, TimePeriodInputType
@@ -31,15 +32,13 @@ class GiftCardInput(graphene.InputObjectType):
     # DEPRECATED
     start_date = graphene.types.datetime.Date(
         description=(
-            "Start date of the gift card in ISO 8601 format. "
-            "DEPRECATED: Will be removed in Saleor 4.0."
+            f"Start date of the gift card in ISO 8601 format. {DEPRECATED_IN_3X}"
         )
     )
     end_date = graphene.types.datetime.Date(
         description=(
-            "End date of the gift card in ISO 8601 format."
-            "DEPRECATED: Will be removed in Saleor 4.0. "
-            "Use expiryDate from expirySettings instead."
+            "End date of the gift card in ISO 8601 format. "
+            f"{DEPRECATED_IN_3X} Use `expiryDate` from `expirySettings` instead."
         )
     )
 
@@ -59,8 +58,7 @@ class GiftCardCreateInput(GiftCardInput):
         required=False,
         description=(
             "Code to use the gift card. "
-            "DEPRECATED: The code is auto generated. "
-            "The field will be removed in Saleor 4.0"
+            f"{DEPRECATED_IN_3X} The code is now auto generated."
         ),
     )
     note = graphene.String(description="The gift card note from the staff member.")

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -15,6 +15,7 @@ from ..account.utils import requestor_has_access
 from ..app.dataloaders import AppByIdLoader
 from ..app.types import App
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.types.common import TimePeriod
 from ..core.types.money import Money
 from ..decorators import permission_required
@@ -256,19 +257,15 @@ class GiftCard(CountableDjangoObjectType):
     user = graphene.Field(
         "saleor.graphql.account.types.User",
         description="The customer who bought a gift card.",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use created_by field instead"
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use `createdBy` field instead.",
     )
     end_date = graphene.types.datetime.DateTime(
         description="End date of gift card.",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use expiry_date field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use `expiryDate` field instead.",
     )
     start_date = graphene.types.datetime.DateTime(
         description="Start date of gift card.",
-        deprecation_reason=("Will be removed in Saleor 4.0."),
+        deprecation_reason=f"{DEPRECATED_IN_3X}",
     )
 
     class Meta:

--- a/saleor/graphql/giftcard/types.py
+++ b/saleor/graphql/giftcard/types.py
@@ -15,7 +15,7 @@ from ..account.utils import requestor_has_access
 from ..app.dataloaders import AppByIdLoader
 from ..app.types import App
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.types.common import TimePeriod
 from ..core.types.money import Money
 from ..decorators import permission_required
@@ -257,15 +257,15 @@ class GiftCard(CountableDjangoObjectType):
     user = graphene.Field(
         "saleor.graphql.account.types.User",
         description="The customer who bought a gift card.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use `createdBy` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `createdBy` field instead.",
     )
     end_date = graphene.types.datetime.DateTime(
         description="End date of gift card.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use `expiryDate` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use `expiryDate` field instead.",
     )
     start_date = graphene.types.datetime.DateTime(
         description="Start date of gift card.",
-        deprecation_reason=f"{DEPRECATED_IN_3X}",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD}",
     )
 
     class Meta:

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ...core.permissions import OrderPermissions
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
@@ -141,7 +142,7 @@ class OrderMutations(graphene.ObjectType):
     draft_order_delete = DraftOrderDelete.Field()
     draft_order_bulk_delete = DraftOrderBulkDelete.Field()
     draft_order_lines_bulk_delete = DraftOrderLinesBulkDelete.Field(
-        deprecation_reason="DEPRECATED: Will be removed in Saleor 4.0."
+        deprecation_reason=DEPRECATED_IN_3X
     )
     draft_order_update = DraftOrderUpdate.Field()
 

--- a/saleor/graphql/order/schema.py
+++ b/saleor/graphql/order/schema.py
@@ -1,7 +1,7 @@
 import graphene
 
 from ...core.permissions import OrderPermissions
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.enums import ReportingPeriod
 from ..core.fields import FilterInputConnectionField, PrefetchingConnectionField
 from ..core.scalars import UUID
@@ -142,7 +142,7 @@ class OrderMutations(graphene.ObjectType):
     draft_order_delete = DraftOrderDelete.Field()
     draft_order_bulk_delete = DraftOrderBulkDelete.Field()
     draft_order_lines_bulk_delete = DraftOrderLinesBulkDelete.Field(
-        deprecation_reason=DEPRECATED_IN_3X
+        deprecation_reason=DEPRECATED_IN_3X_FIELD
     )
     draft_order_update = DraftOrderUpdate.Field()
 

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -43,7 +43,7 @@ from ..app.types import App
 from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader, ChannelByOrderLineIdLoader
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import validation_error_to_error_type
 from ..core.scalars import PositiveDecimal
@@ -676,7 +676,7 @@ class Order(CountableDjangoObjectType):
     )
     language_code = graphene.String(
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} "
+            f"{DEPRECATED_IN_3X_FIELD} "
             "Use the `languageCodeEnum` field to fetch the language code. "
         ),
         required=True,
@@ -687,16 +687,16 @@ class Order(CountableDjangoObjectType):
     discount = graphene.Field(
         Money,
         description="Returns applied discount.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use discounts field.",
     )
     discount_name = graphene.String(
         description="Discount name.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use discounts field.",
     )
 
     translated_discount_name = graphene.String(
         description="Translated discount name.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field. ",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use discounts field. ",
     )
 
     discounts = graphene.List(

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -43,6 +43,7 @@ from ..app.types import App
 from ..channel import ChannelContext
 from ..channel.dataloaders import ChannelByIdLoader, ChannelByOrderLineIdLoader
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import LanguageCodeEnum
 from ..core.mutations import validation_error_to_error_type
 from ..core.scalars import PositiveDecimal
@@ -675,8 +676,8 @@ class Order(CountableDjangoObjectType):
     )
     language_code = graphene.String(
         deprecation_reason=(
+            f"{DEPRECATED_IN_3X} "
             "Use the `languageCodeEnum` field to fetch the language code. "
-            "This field will be removed in Saleor 4.0."
         ),
         required=True,
     )
@@ -686,22 +687,16 @@ class Order(CountableDjangoObjectType):
     discount = graphene.Field(
         Money,
         description="Returns applied discount.",
-        deprecation_reason=(
-            "Use discounts field. This field will be removed in Saleor 4.0."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field.",
     )
     discount_name = graphene.String(
         description="Discount name.",
-        deprecation_reason=(
-            "Use discounts field. This field will be removed in Saleor 4.0."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field.",
     )
 
     translated_discount_name = graphene.String(
         description="Translated discount name.",
-        deprecation_reason=(
-            "Use discounts field. This field will be removed in Saleor 4.0."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use discounts field. ",
     )
 
     discounts = graphene.List(

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -7,6 +7,7 @@ from ...page import models
 from ..attribute.filters import AttributeFilterInput
 from ..attribute.types import Attribute, SelectedAttribute
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.fields import FilterInputConnectionField
 from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
@@ -23,9 +24,7 @@ from .dataloaders import (
 class Page(CountableDjangoObjectType):
     content_json = graphene.JSONString(
         description="Content of the page (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `content` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/page/types.py
+++ b/saleor/graphql/page/types.py
@@ -7,7 +7,7 @@ from ...page import models
 from ..attribute.filters import AttributeFilterInput
 from ..attribute.types import Attribute, SelectedAttribute
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.fields import FilterInputConnectionField
 from ..decorators import permission_required
 from ..meta.types import ObjectWithMetadata
@@ -24,7 +24,7 @@ from .dataloaders import (
 class Page(CountableDjangoObjectType):
     content_json = graphene.JSONString(
         description="Content of the page (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use the `content` field instead.",
         required=True,
     )
     translation = TranslationField(PageTranslation, type_name="page")

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -15,6 +15,7 @@ from ...payment.utils import create_payment, is_currency_supported
 from ..account.i18n import I18nMixin
 from ..checkout.mutations import get_checkout_by_token
 from ..checkout.types import Checkout
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.mutations import BaseMutation
 from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
@@ -60,8 +61,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                "Checkout ID."
-                "DEPRECATED: Will be removed in Saleor 4.0. Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
             ),
             required=False,
         )

--- a/saleor/graphql/payment/mutations.py
+++ b/saleor/graphql/payment/mutations.py
@@ -15,7 +15,7 @@ from ...payment.utils import create_payment, is_currency_supported
 from ..account.i18n import I18nMixin
 from ..checkout.mutations import get_checkout_by_token
 from ..checkout.types import Checkout
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.mutations import BaseMutation
 from ..core.scalars import UUID, PositiveDecimal
 from ..core.types import common as common_types
@@ -61,7 +61,7 @@ class CheckoutPaymentCreate(BaseMutation, I18nMixin):
     class Arguments:
         checkout_id = graphene.ID(
             description=(
-                f"The ID of the checkout. {DEPRECATED_IN_3X} Use token instead."
+                f"The ID of the checkout. {DEPRECATED_IN_3X_INPUT} Use token instead."
             ),
             required=False,
         )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -31,7 +31,7 @@ from ...channel.dataloaders import ChannelBySlugLoader
 from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import CountableDjangoObjectType
-from ...core.descriptions import DEPRECATED_IN_3X
+from ...core.descriptions import DEPRECATED_IN_3X_FIELD, DEPRECATED_IN_3X_INPUT
 from ...core.enums import ReportingPeriod
 from ...core.fields import (
     ChannelContextFilterConnectionField,
@@ -206,7 +206,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     images = graphene.List(
         lambda: ProductImage,
         description="List of images for the product variant.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `media` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use the `media` field instead.",
     )
     media = graphene.List(
         graphene.NonNull(lambda: ProductMedia),
@@ -228,7 +228,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             CountryCodeEnum,
             description=(
                 "Two-letter ISO 3166-1 country code. "
-                f"{DEPRECATED_IN_3X} Use `address` argument instead."
+                f"{DEPRECATED_IN_3X_INPUT} Use `address` argument instead."
             ),
         ),
     )
@@ -243,7 +243,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                 "from a warehouse operating in shipping zones that contain this "
                 "country will be returned. Otherwise, it will return the maximum "
                 "quantity from all shipping zones. "
-                f"{DEPRECATED_IN_3X} Use `address` argument instead."
+                f"{DEPRECATED_IN_3X_INPUT} Use `address` argument instead."
             ),
         ),
     )
@@ -504,7 +504,9 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the product (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     thumbnail = graphene.Field(
         Image,
@@ -544,7 +546,9 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         lambda: ProductImage,
         id=graphene.Argument(graphene.ID, description="ID of a product image."),
         description="Get a single product image by ID.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `mediaById` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `mediaById` field instead."
+        ),
     )
     variants = graphene.List(
         ProductVariant, description="List of variants for the product."
@@ -556,7 +560,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     images = graphene.List(
         lambda: ProductImage,
         description="List of images for the product.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `media` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use the `media` field instead.",
     )
     collections = graphene.List(
         lambda: Collection, description="List of collections for the product."
@@ -953,7 +957,7 @@ class ProductType(CountableDjangoObjectType):
         ),
         description="List of products of this type.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} "
+            f"{DEPRECATED_IN_3X_FIELD} "
             "Use the top-level `products` query with the `productTypes` filter."
         ),
     )
@@ -1052,7 +1056,9 @@ class ProductType(CountableDjangoObjectType):
 class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the collection (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     products = ChannelContextFilterConnectionField(
         Product,
@@ -1130,7 +1136,9 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 class Category(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the category (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     ancestors = PrefetchingConnectionField(
         lambda: Category, description="List of ancestors of the category."

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -31,6 +31,7 @@ from ...channel.dataloaders import ChannelBySlugLoader
 from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import CountableDjangoObjectType
+from ...core.descriptions import DEPRECATED_IN_3X
 from ...core.enums import ReportingPeriod
 from ...core.fields import (
     ChannelContextFilterConnectionField,
@@ -205,7 +206,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     images = graphene.List(
         lambda: ProductImage,
         description="List of images for the product variant.",
-        deprecation_reason="Will be removed in Saleor 4.0. Use the `media` instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `media` field instead.",
     )
     media = graphene.List(
         graphene.NonNull(lambda: ProductMedia),
@@ -226,8 +227,8 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         country_code=graphene.Argument(
             CountryCodeEnum,
             description=(
-                "DEPRECATED: use `address` argument instead. This argument will be "
-                "removed in Saleor 4.0. Two-letter ISO 3166-1 country code."
+                "Two-letter ISO 3166-1 country code. "
+                f"{DEPRECATED_IN_3X} Use `address` argument instead."
             ),
         ),
     )
@@ -238,12 +239,11 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         country_code=graphene.Argument(
             CountryCodeEnum,
             description=(
-                "DEPRECATED: use `address` argument instead. This argument will be "
-                "removed in Saleor 4.0."
                 "Two-letter ISO 3166-1 country code. When provided, the exact quantity "
                 "from a warehouse operating in shipping zones that contain this "
                 "country will be returned. Otherwise, it will return the maximum "
-                "quantity from all shipping zones."
+                "quantity from all shipping zones. "
+                f"{DEPRECATED_IN_3X} Use `address` argument instead."
             ),
         ),
     )
@@ -504,9 +504,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the product (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     thumbnail = graphene.Field(
         Image,
@@ -546,9 +544,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         lambda: ProductImage,
         id=graphene.Argument(graphene.ID, description="ID of a product image."),
         description="Get a single product image by ID.",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `mediaById` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `mediaById` field instead.",
     )
     variants = graphene.List(
         ProductVariant, description="List of variants for the product."
@@ -560,9 +556,7 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     images = graphene.List(
         lambda: ProductImage,
         description="List of images for the product.",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `media` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `media` field instead.",
     )
     collections = graphene.List(
         lambda: Collection, description="List of collections for the product."
@@ -959,7 +953,7 @@ class ProductType(CountableDjangoObjectType):
         ),
         description="List of products of this type.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. "
+            f"{DEPRECATED_IN_3X} "
             "Use the top-level `products` query with the `productTypes` filter."
         ),
     )
@@ -1058,9 +1052,7 @@ class ProductType(CountableDjangoObjectType):
 class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the collection (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     products = ChannelContextFilterConnectionField(
         Product,
@@ -1138,9 +1130,7 @@ class Collection(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
 class Category(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the category (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     ancestors = PrefetchingConnectionField(
         lambda: Category, description="List of ancestors of the category."

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5,27 +5,27 @@ schema {
 
 type AccountAddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -82,7 +82,7 @@ input AccountInput {
 
 type AccountRegister {
   requiresConfirmation: Boolean
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -97,18 +97,18 @@ input AccountRegisterInput {
 }
 
 type AccountRequestDeletion {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -132,14 +132,14 @@ type Address implements Node {
 
 type AddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -160,7 +160,7 @@ input AddressInput {
 
 type AddressSetDefault {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -171,7 +171,7 @@ enum AddressTypeEnum {
 
 type AddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -226,7 +226,7 @@ type App implements Node & ObjectWithMetadata {
 }
 
 type AppActivate {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -244,25 +244,25 @@ type AppCountableEdge {
 
 type AppCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeactivate {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDelete {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeleteFailedInstallation {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -335,7 +335,7 @@ enum AppExtensionViewEnum {
 
 type AppFetchManifest {
   manifest: Manifest
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -351,7 +351,7 @@ input AppInput {
 }
 
 type AppInstall {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -383,7 +383,7 @@ type AppManifestExtension {
 }
 
 type AppRetryInstall {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -406,13 +406,13 @@ type AppToken implements Node {
 
 type AppTokenCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
 
 type AppTokenDelete {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
@@ -424,7 +424,7 @@ input AppTokenInput {
 
 type AppTokenVerify {
   valid: Boolean!
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -434,7 +434,7 @@ enum AppTypeEnum {
 }
 
 type AppUpdate {
-  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -450,7 +450,7 @@ enum AreaUnitsEnum {
 
 type AssignNavigation {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -479,7 +479,7 @@ type Attribute implements Node & ObjectWithMetadata {
 
 type AttributeBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -506,7 +506,7 @@ type AttributeCountableEdge {
 
 type AttributeCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -528,7 +528,7 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attribute: Attribute
 }
@@ -592,7 +592,7 @@ enum AttributeInputTypeEnum {
 
 type AttributeReorderValues {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -617,11 +617,11 @@ type AttributeTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
-  attribute: Attribute @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  attribute: Attribute @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attribute: Attribute
 }
@@ -639,7 +639,7 @@ enum AttributeTypeEnum {
 
 type AttributeUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -675,7 +675,7 @@ type AttributeValue implements Node {
 
 type AttributeValueBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -692,7 +692,7 @@ type AttributeValueCountableEdge {
 
 type AttributeValueCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -705,7 +705,7 @@ input AttributeValueCreateInput {
 
 type AttributeValueDelete {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -731,11 +731,11 @@ type AttributeValueTranslatableContent implements Node {
   name: String!
   richText: JSONString
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
-  attributeValue: AttributeValue @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  attributeValue: AttributeValue @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeValueTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attributeValue: AttributeValue
 }
@@ -754,7 +754,7 @@ input AttributeValueTranslationInput {
 
 type AttributeValueUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -802,7 +802,7 @@ type Category implements Node & ObjectWithMetadata {
   level: Int!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
@@ -812,7 +812,7 @@ type Category implements Node & ObjectWithMetadata {
 
 type CategoryBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -828,13 +828,13 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -872,13 +872,13 @@ type CategoryTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
-  category: Category @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  category: Category @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CategoryTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   category: Category
 }
@@ -890,11 +890,11 @@ type CategoryTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CategoryUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -910,12 +910,12 @@ type Channel implements Node {
 
 type ChannelActivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelCreate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -930,12 +930,12 @@ input ChannelCreateInput {
 
 type ChannelDeactivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelDelete {
-  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -964,7 +964,7 @@ enum ChannelErrorCode {
 }
 
 type ChannelUpdate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -1009,13 +1009,13 @@ type Checkout implements Node & ObjectWithMetadata {
 
 type CheckoutAddPromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1023,7 +1023,7 @@ type CheckoutComplete {
   order: Order
   confirmationNeeded: Boolean!
   confirmationData: JSONString
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1040,7 +1040,7 @@ type CheckoutCountableEdge {
 
 type CheckoutCreate {
   created: Boolean
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
   checkout: Checkout
 }
@@ -1056,19 +1056,19 @@ input CheckoutCreateInput {
 
 type CheckoutCustomerAttach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1108,7 +1108,7 @@ enum CheckoutErrorCode {
 
 type CheckoutLanguageCodeUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1133,7 +1133,7 @@ type CheckoutLineCountableEdge {
 
 type CheckoutLineDelete {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1144,38 +1144,38 @@ input CheckoutLineInput {
 
 type CheckoutLinesAdd {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
   checkout: Checkout
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1193,7 +1193,7 @@ type Collection implements Node & ObjectWithMetadata {
   slug: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
@@ -1202,13 +1202,13 @@ type Collection implements Node & ObjectWithMetadata {
 
 type CollectionAddProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionBulkDelete {
   count: Int!
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1230,7 +1230,7 @@ type CollectionChannelListingError {
 
 type CollectionChannelListingUpdate {
   collection: Collection
-  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionChannelListingError!]!
 }
 
@@ -1251,7 +1251,7 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1269,7 +1269,7 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1317,13 +1317,13 @@ enum CollectionPublished {
 
 type CollectionRemoveProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionReorderProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1346,13 +1346,13 @@ type CollectionTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
-  collection: Collection @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  collection: Collection @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CollectionTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   collection: Collection
 }
@@ -1364,11 +1364,11 @@ type CollectionTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CollectionUpdate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1398,13 +1398,13 @@ enum ConfigurationTypeFieldEnum {
 
 type ConfirmAccount {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ConfirmEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1672,7 +1672,7 @@ type CreateToken {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1686,18 +1686,18 @@ type CreditCard {
 
 type CustomerBulkDelete {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type CustomerCreate {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1750,7 +1750,7 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1770,18 +1770,18 @@ input DateTimeRangeInput {
 }
 
 type DeactivateAllUserTokens {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type DeleteMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -1813,13 +1813,13 @@ type DigitalContentCountableEdge {
 type DigitalContentCreate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type DigitalContentDelete {
   variant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1833,7 +1833,7 @@ input DigitalContentInput {
 type DigitalContentUpdate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1855,7 +1855,7 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
@@ -1911,18 +1911,18 @@ type Domain {
 
 type DraftOrderBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderComplete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1942,7 +1942,7 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1962,12 +1962,12 @@ input DraftOrderInput {
 
 type DraftOrderLinesBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -2054,7 +2054,7 @@ input ExportInfoInput {
 
 type ExportProducts {
   exportFile: ExportFile
-  exportErrors: [ExportError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  exportErrors: [ExportError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ExportError!]!
 }
 
@@ -2079,13 +2079,13 @@ type ExternalAuthentication {
 
 type ExternalAuthenticationUrl {
   authenticationData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ExternalLogout {
   logoutData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2094,7 +2094,7 @@ type ExternalObtainAccessTokens {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2103,7 +2103,7 @@ type ExternalRefresh {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2111,7 +2111,7 @@ type ExternalVerify {
   user: User
   isValid: Boolean!
   verifyData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2127,7 +2127,7 @@ enum FileTypesEnum {
 
 type FileUpload {
   uploadedFile: File
-  uploadErrors: [UploadError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  uploadErrors: [UploadError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [UploadError!]!
 }
 
@@ -2147,14 +2147,14 @@ type Fulfillment implements Node & ObjectWithMetadata {
 type FulfillmentApprove {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type FulfillmentCancel {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2171,7 +2171,7 @@ type FulfillmentLine implements Node {
 type FulfillmentRefundProducts {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2180,7 +2180,7 @@ type FulfillmentReturnProducts {
   replaceFulfillment: Fulfillment
   order: Order
   replaceOrder: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2197,7 +2197,7 @@ enum FulfillmentStatus {
 type FulfillmentUpdateTracking {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2235,14 +2235,14 @@ type GiftCard implements Node & ObjectWithMetadata {
   expiryPeriod: TimePeriod
   product: Product
   events: [GiftCardEvent!]!
-  user: User @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `createdBy` field instead.")
-  endDate: DateTime @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` field instead.")
-  startDate: DateTime @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0.")
+  user: User @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `createdBy` field instead.")
+  endDate: DateTime @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` field instead.")
+  startDate: DateTime @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0.")
 }
 
 type GiftCardActivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
@@ -2258,7 +2258,7 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2276,12 +2276,12 @@ input GiftCardCreateInput {
 
 type GiftCardDeactivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
 type GiftCardDelete {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2362,7 +2362,7 @@ input GiftCardFilterInput {
 }
 
 type GiftCardUpdate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2418,7 +2418,7 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 }
 
 type InvoiceCreate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2429,7 +2429,7 @@ input InvoiceCreateInput {
 }
 
 type InvoiceDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2452,25 +2452,25 @@ enum InvoiceErrorCode {
 
 type InvoiceRequest {
   order: Order
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceRequestDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceSendNotification {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceUpdate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -3356,7 +3356,7 @@ type Menu implements Node & ObjectWithMetadata {
 
 type MenuBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3372,7 +3372,7 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3384,7 +3384,7 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3436,7 +3436,7 @@ type MenuItem implements Node & ObjectWithMetadata {
 
 type MenuItemBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3452,7 +3452,7 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3468,7 +3468,7 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3488,7 +3488,7 @@ input MenuItemInput {
 
 type MenuItemMove {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3507,11 +3507,11 @@ type MenuItemTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
-  menuItem: MenuItem @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  menuItem: MenuItem @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type MenuItemTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   menuItem: MenuItem
 }
@@ -3523,7 +3523,7 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3543,7 +3543,7 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3695,7 +3695,7 @@ type Mutation {
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
   draftOrderBulkDelete(ids: [ID]!): DraftOrderBulkDelete
-  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0.")
+  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0.")
   draftOrderUpdate(id: ID!, input: DraftOrderInput!): DraftOrderUpdate
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel
@@ -3915,11 +3915,11 @@ type Order implements Node & ObjectWithMetadata {
   totalBalance: Money!
   userEmail: String
   isShippingRequired: Boolean!
-  languageCode: String! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
+  languageCode: String! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
   languageCodeEnum: LanguageCodeEnum!
-  discount: Money @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
-  discountName: String @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
-  translatedDiscountName: String @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field. ")
+  discount: Money @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
+  discountName: String @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
+  translatedDiscountName: String @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field. ")
   discounts: [OrderDiscount!]
   errors: [OrderError!]!
 }
@@ -3934,7 +3934,7 @@ enum OrderAction {
 type OrderAddNote {
   order: Order
   event: OrderEvent
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3944,25 +3944,25 @@ input OrderAddNoteInput {
 
 type OrderBulkCancel {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCancel {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCapture {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderConfirm {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3995,7 +3995,7 @@ type OrderDiscount implements Node {
 
 type OrderDiscountAdd {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4007,7 +4007,7 @@ input OrderDiscountCommonInput {
 
 type OrderDiscountDelete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4018,7 +4018,7 @@ enum OrderDiscountType {
 
 type OrderDiscountUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4197,7 +4197,7 @@ input OrderFilterInput {
 type OrderFulfill {
   fulfillments: [Fulfillment]
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4249,21 +4249,21 @@ input OrderLineCreateInput {
 type OrderLineDelete {
   order: Order
   orderLine: OrderLine
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountRemove {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountUpdate {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4273,7 +4273,7 @@ input OrderLineInput {
 
 type OrderLineUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   orderLine: OrderLine
 }
@@ -4281,13 +4281,13 @@ type OrderLineUpdate {
 type OrderLinesCreate {
   order: Order
   orderLines: [OrderLine!]
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderMarkAsPaid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4299,7 +4299,7 @@ enum OrderOriginEnum {
 
 type OrderRefund {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4356,7 +4356,7 @@ enum OrderSettingsErrorCode {
 
 type OrderSettingsUpdate {
   orderSettings: OrderSettings
-  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderSettingsError!]!
 }
 
@@ -4399,7 +4399,7 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -4412,7 +4412,7 @@ input OrderUpdateInput {
 
 type OrderUpdateShipping {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4422,7 +4422,7 @@ input OrderUpdateShippingInput {
 
 type OrderVoid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4439,32 +4439,32 @@ type Page implements Node & ObjectWithMetadata {
   created: DateTime!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  contentJson: JSONString! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   attributes: [SelectedAttribute!]!
 }
 
 type PageAttributeAssign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageAttributeUnassign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkPublish {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4480,7 +4480,7 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4497,7 +4497,7 @@ input PageCreateInput {
 }
 
 type PageDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4546,7 +4546,7 @@ input PageInput {
 
 type PageReorderAttributeValues {
   page: Page
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4569,14 +4569,14 @@ type PageTranslatableContent implements Node {
   seoDescription: String
   title: String!
   content: JSONString
-  contentJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
-  page: Page @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  page: Page @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type PageTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   page: PageTranslatableContent
 }
@@ -4588,7 +4588,7 @@ type PageTranslation implements Node {
   title: String
   content: JSONString
   language: LanguageDisplay!
-  contentJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
 }
 
 input PageTranslationInput {
@@ -4611,7 +4611,7 @@ type PageType implements Node & ObjectWithMetadata {
 
 type PageTypeBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4627,7 +4627,7 @@ type PageTypeCountableEdge {
 }
 
 type PageTypeCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4639,7 +4639,7 @@ input PageTypeCreateInput {
 }
 
 type PageTypeDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4650,7 +4650,7 @@ input PageTypeFilterInput {
 
 type PageTypeReorderAttributes {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4665,7 +4665,7 @@ input PageTypeSortingInput {
 }
 
 type PageTypeUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4678,14 +4678,14 @@ input PageTypeUpdateInput {
 }
 
 type PageUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -4712,7 +4712,7 @@ type Payment implements Node {
 
 type PaymentCapture {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4773,7 +4773,7 @@ type PaymentGateway {
 
 type PaymentInitialize {
   initializedPayment: PaymentInitialized
-  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4792,7 +4792,7 @@ input PaymentInput {
 
 type PaymentRefund {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4804,7 +4804,7 @@ type PaymentSource {
 
 type PaymentVoid {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4835,7 +4835,7 @@ enum PermissionEnum {
 }
 
 type PermissionGroupCreate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4847,7 +4847,7 @@ input PermissionGroupCreateInput {
 }
 
 type PermissionGroupDelete {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4885,7 +4885,7 @@ input PermissionGroupSortingInput {
 }
 
 type PermissionGroupUpdate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4966,7 +4966,7 @@ input PluginStatusInChannelsInput {
 
 type PluginUpdate {
   plugin: Plugin
-  pluginsErrors: [PluginError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pluginsErrors: [PluginError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PluginError!]!
 }
 
@@ -5008,7 +5008,7 @@ type Product implements Node & ObjectWithMetadata {
   rating: Float
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   thumbnail(size: Int): Image
   pricing(address: AddressInput): ProductPricingInfo
   isAvailable(address: AddressInput): Boolean
@@ -5016,10 +5016,10 @@ type Product implements Node & ObjectWithMetadata {
   attributes: [SelectedAttribute!]!
   channelListings: [ProductChannelListing!]
   mediaById(id: ID): ProductMedia
-  imageById(id: ID): ProductImage @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
+  imageById(id: ID): ProductImage @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
   variants: [ProductVariant]
   media: [ProductMedia!]
-  images: [ProductImage] @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
+  images: [ProductImage] @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
   collections: [Collection]
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   availableForPurchase: Date
@@ -5028,7 +5028,7 @@ type Product implements Node & ObjectWithMetadata {
 
 type ProductAttributeAssign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5044,13 +5044,13 @@ enum ProductAttributeType {
 
 type ProductAttributeUnassign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5091,7 +5091,7 @@ type ProductChannelListingError {
 
 type ProductChannelListingUpdate {
   product: Product
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5112,7 +5112,7 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5133,7 +5133,7 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5229,14 +5229,14 @@ type ProductMedia implements Node {
 
 type ProductMediaBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaCreate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5250,14 +5250,14 @@ input ProductMediaCreateInput {
 type ProductMediaDelete {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaReorder {
   product: Product
   media: [ProductMedia!]
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5269,7 +5269,7 @@ enum ProductMediaType {
 type ProductMediaUpdate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5308,7 +5308,7 @@ type ProductPricingInfo {
 
 type ProductReorderAttributeValues {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5323,14 +5323,14 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
-  product: Product @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  product: Product @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   product: Product
 }
@@ -5342,7 +5342,7 @@ type ProductTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {
@@ -5355,7 +5355,7 @@ type ProductType implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
   taxType: TaxType
   variantAttributes(variantSelection: VariantAttributeScope): [Attribute]
   productAttributes: [Attribute]
@@ -5364,7 +5364,7 @@ type ProductType implements Node & ObjectWithMetadata {
 
 type ProductTypeBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5385,13 +5385,13 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
@@ -5423,7 +5423,7 @@ input ProductTypeInput {
 
 type ProductTypeReorderAttributes {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5439,13 +5439,13 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5465,7 +5465,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   margin: Int
   quantityOrdered: Int
   revenue(period: ReportingPeriod): TaxedMoney
-  images: [ProductImage] @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
+  images: [ProductImage] @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
   media: [ProductMedia!]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
@@ -5476,7 +5476,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
 type ProductVariantBulkCreate {
   count: Int!
   productVariants: [ProductVariant!]!
-  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkProductError!]!
 }
 
@@ -5491,7 +5491,7 @@ input ProductVariantBulkCreateInput {
 
 type ProductVariantBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5511,7 +5511,7 @@ input ProductVariantChannelListingAddInput {
 
 type ProductVariantChannelListingUpdate {
   variant: ProductVariant
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5527,7 +5527,7 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5542,7 +5542,7 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5562,37 +5562,37 @@ input ProductVariantInput {
 
 type ProductVariantReorder {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantReorderAttributeValues {
   productVariant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantSetDefault {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantStocksCreate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
 type ProductVariantStocksDelete {
   productVariant: ProductVariant
-  stockErrors: [StockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  stockErrors: [StockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StockError!]!
 }
 
 type ProductVariantStocksUpdate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
@@ -5600,12 +5600,12 @@ type ProductVariantTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
-  productVariant: ProductVariant @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  productVariant: ProductVariant @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductVariantTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   productVariant: ProductVariant
 }
@@ -5617,7 +5617,7 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5714,7 +5714,7 @@ type ReducedRate {
 type RefreshToken {
   token: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5730,12 +5730,12 @@ enum ReportingPeriod {
 
 type RequestEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5758,13 +5758,13 @@ type Sale implements Node & ObjectWithMetadata {
 
 type SaleAddCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type SaleBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5787,7 +5787,7 @@ input SaleChannelListingInput {
 
 type SaleChannelListingUpdate {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5803,13 +5803,13 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
 
 type SaleDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5835,7 +5835,7 @@ input SaleInput {
 
 type SaleRemoveCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5857,11 +5857,11 @@ type SaleTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
-  sale: Sale @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  sale: Sale @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type SaleTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   sale: Sale
 }
@@ -5878,7 +5878,7 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5898,7 +5898,7 @@ type SetPassword {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5963,7 +5963,7 @@ input ShippingMethodChannelListingInput {
 
 type ShippingMethodChannelListingUpdate {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -5979,7 +5979,7 @@ type ShippingMethodTranslatableContent implements Node {
   name: String!
   description: JSONString
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
-  shippingMethod: ShippingMethod @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  shippingMethod: ShippingMethod @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type ShippingMethodTranslation implements Node {
@@ -6001,27 +6001,27 @@ input ShippingPostalCodeRulesCreateInputRange {
 
 type ShippingPriceBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceDelete {
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceExcludeProducts {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6045,12 +6045,12 @@ input ShippingPriceInput {
 
 type ShippingPriceRemoveProductFromExclude {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   shippingMethod: ShippingMethod
 }
@@ -6063,7 +6063,7 @@ input ShippingPriceTranslationInput {
 type ShippingPriceUpdate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6083,7 +6083,7 @@ type ShippingZone implements Node & ObjectWithMetadata {
 
 type ShippingZoneBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6099,7 +6099,7 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6114,7 +6114,7 @@ input ShippingZoneCreateInput {
 }
 
 type ShippingZoneDelete {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6125,7 +6125,7 @@ input ShippingZoneFilterInput {
 }
 
 type ShippingZoneUpdate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6177,13 +6177,13 @@ type Shop {
 
 type ShopAddressUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6205,7 +6205,7 @@ enum ShopErrorCode {
 
 type ShopFetchTaxRates {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6229,7 +6229,7 @@ input ShopSettingsInput {
 
 type ShopSettingsTranslate {
   shop: Shop
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
 }
 
@@ -6240,7 +6240,7 @@ input ShopSettingsTranslationInput {
 
 type ShopSettingsUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6258,12 +6258,12 @@ input SiteDomainInput {
 
 type StaffBulkDelete {
   count: Int!
-  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
 }
 
 type StaffCreate {
-  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6279,7 +6279,7 @@ input StaffCreateInput {
 }
 
 type StaffDelete {
-  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6307,13 +6307,13 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
@@ -6325,13 +6325,13 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6512,13 +6512,13 @@ input UpdateInvoiceInput {
 }
 
 type UpdateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -6550,7 +6550,7 @@ type User implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   addresses: [Address]
-  checkout: Checkout @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
+  checkout: Checkout @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
   checkoutTokens(channel: String): [UUID!]
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
@@ -6565,19 +6565,19 @@ type User implements Node & ObjectWithMetadata {
 
 type UserAvatarDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserBulkSetActive {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6638,14 +6638,14 @@ enum VariantAttributeScope {
 type VariantMediaAssign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type VariantMediaUnassign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -6662,7 +6662,7 @@ type VerifyToken {
   user: User
   isValid: Boolean!
   payload: GenericScalar
-  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6711,13 +6711,13 @@ type Voucher implements Node & ObjectWithMetadata {
 
 type VoucherAddCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type VoucherBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6742,7 +6742,7 @@ input VoucherChannelListingInput {
 
 type VoucherChannelListingUpdate {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6758,13 +6758,13 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6804,7 +6804,7 @@ input VoucherInput {
 
 type VoucherRemoveCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6828,11 +6828,11 @@ type VoucherTranslatableContent implements Node {
   id: ID!
   name: String
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  voucher: Voucher @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  voucher: Voucher @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type VoucherTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   voucher: Voucher
 }
@@ -6850,7 +6850,7 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6864,7 +6864,7 @@ type Warehouse implements Node & ObjectWithMetadata {
   email: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  companyName: String! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
+  companyName: String! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
 }
 
 type WarehouseCountableConnection {
@@ -6879,7 +6879,7 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6893,7 +6893,7 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6919,13 +6919,13 @@ input WarehouseFilterInput {
 }
 
 type WarehouseShippingZoneAssign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
 type WarehouseShippingZoneUnassign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6940,7 +6940,7 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6963,7 +6963,7 @@ type Webhook implements Node {
 }
 
 type WebhookCreate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -6978,7 +6978,7 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -7078,7 +7078,7 @@ enum WebhookSampleEventTypeEnum {
 }
 
 type WebhookUpdate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5,27 +5,27 @@ schema {
 
 type AccountAddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -82,7 +82,7 @@ input AccountInput {
 
 type AccountRegister {
   requiresConfirmation: Boolean
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -97,18 +97,18 @@ input AccountRegisterInput {
 }
 
 type AccountRequestDeletion {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -132,14 +132,14 @@ type Address implements Node {
 
 type AddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -160,7 +160,7 @@ input AddressInput {
 
 type AddressSetDefault {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -171,7 +171,7 @@ enum AddressTypeEnum {
 
 type AddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -226,7 +226,7 @@ type App implements Node & ObjectWithMetadata {
 }
 
 type AppActivate {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -244,25 +244,25 @@ type AppCountableEdge {
 
 type AppCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeactivate {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDelete {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeleteFailedInstallation {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -335,7 +335,7 @@ enum AppExtensionViewEnum {
 
 type AppFetchManifest {
   manifest: Manifest
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -351,7 +351,7 @@ input AppInput {
 }
 
 type AppInstall {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -383,7 +383,7 @@ type AppManifestExtension {
 }
 
 type AppRetryInstall {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -406,13 +406,13 @@ type AppToken implements Node {
 
 type AppTokenCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
 
 type AppTokenDelete {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
@@ -424,7 +424,7 @@ input AppTokenInput {
 
 type AppTokenVerify {
   valid: Boolean!
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -434,7 +434,7 @@ enum AppTypeEnum {
 }
 
 type AppUpdate {
-  appErrors: [AppError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  appErrors: [AppError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -450,7 +450,7 @@ enum AreaUnitsEnum {
 
 type AssignNavigation {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -479,7 +479,7 @@ type Attribute implements Node & ObjectWithMetadata {
 
 type AttributeBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -506,7 +506,7 @@ type AttributeCountableEdge {
 
 type AttributeCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -528,7 +528,7 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attribute: Attribute
 }
@@ -592,7 +592,7 @@ enum AttributeInputTypeEnum {
 
 type AttributeReorderValues {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -617,11 +617,11 @@ type AttributeTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
-  attribute: Attribute @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  attribute: Attribute @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attribute: Attribute
 }
@@ -639,7 +639,7 @@ enum AttributeTypeEnum {
 
 type AttributeUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -675,7 +675,7 @@ type AttributeValue implements Node {
 
 type AttributeValueBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -692,7 +692,7 @@ type AttributeValueCountableEdge {
 
 type AttributeValueCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -705,7 +705,7 @@ input AttributeValueCreateInput {
 
 type AttributeValueDelete {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -731,11 +731,11 @@ type AttributeValueTranslatableContent implements Node {
   name: String!
   richText: JSONString
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
-  attributeValue: AttributeValue @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  attributeValue: AttributeValue @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeValueTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attributeValue: AttributeValue
 }
@@ -754,7 +754,7 @@ input AttributeValueTranslationInput {
 
 type AttributeValueUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -802,7 +802,7 @@ type Category implements Node & ObjectWithMetadata {
   level: Int!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
@@ -812,7 +812,7 @@ type Category implements Node & ObjectWithMetadata {
 
 type CategoryBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -828,13 +828,13 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -872,13 +872,13 @@ type CategoryTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
-  category: Category @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  category: Category @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CategoryTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   category: Category
 }
@@ -890,11 +890,11 @@ type CategoryTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CategoryUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -910,12 +910,12 @@ type Channel implements Node {
 
 type ChannelActivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelCreate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -930,12 +930,12 @@ input ChannelCreateInput {
 
 type ChannelDeactivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelDelete {
-  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -964,7 +964,7 @@ enum ChannelErrorCode {
 }
 
 type ChannelUpdate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -1009,13 +1009,13 @@ type Checkout implements Node & ObjectWithMetadata {
 
 type CheckoutAddPromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1023,7 +1023,7 @@ type CheckoutComplete {
   order: Order
   confirmationNeeded: Boolean!
   confirmationData: JSONString
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1039,8 +1039,8 @@ type CheckoutCountableEdge {
 }
 
 type CheckoutCreate {
-  created: Boolean
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  created: Boolean @deprecated(reason: "This field will be removed in Saleor 4.0. Always returns `True`.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
   checkout: Checkout
 }
@@ -1056,19 +1056,19 @@ input CheckoutCreateInput {
 
 type CheckoutCustomerAttach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1108,7 +1108,7 @@ enum CheckoutErrorCode {
 
 type CheckoutLanguageCodeUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1133,7 +1133,7 @@ type CheckoutLineCountableEdge {
 
 type CheckoutLineDelete {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1144,38 +1144,38 @@ input CheckoutLineInput {
 
 type CheckoutLinesAdd {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
   checkout: Checkout
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1193,7 +1193,7 @@ type Collection implements Node & ObjectWithMetadata {
   slug: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
@@ -1202,13 +1202,13 @@ type Collection implements Node & ObjectWithMetadata {
 
 type CollectionAddProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionBulkDelete {
   count: Int!
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1230,7 +1230,7 @@ type CollectionChannelListingError {
 
 type CollectionChannelListingUpdate {
   collection: Collection
-  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionChannelListingError!]!
 }
 
@@ -1251,7 +1251,7 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1269,7 +1269,7 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1317,13 +1317,13 @@ enum CollectionPublished {
 
 type CollectionRemoveProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionReorderProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1346,13 +1346,13 @@ type CollectionTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
-  collection: Collection @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  collection: Collection @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CollectionTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   collection: Collection
 }
@@ -1364,11 +1364,11 @@ type CollectionTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CollectionUpdate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1398,13 +1398,13 @@ enum ConfigurationTypeFieldEnum {
 
 type ConfirmAccount {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ConfirmEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1672,7 +1672,7 @@ type CreateToken {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1686,18 +1686,18 @@ type CreditCard {
 
 type CustomerBulkDelete {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type CustomerCreate {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1750,7 +1750,7 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1770,18 +1770,18 @@ input DateTimeRangeInput {
 }
 
 type DeactivateAllUserTokens {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type DeleteMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -1813,13 +1813,13 @@ type DigitalContentCountableEdge {
 type DigitalContentCreate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type DigitalContentDelete {
   variant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1833,7 +1833,7 @@ input DigitalContentInput {
 type DigitalContentUpdate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1855,7 +1855,7 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
@@ -1911,18 +1911,18 @@ type Domain {
 
 type DraftOrderBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderComplete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1942,7 +1942,7 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1962,12 +1962,12 @@ input DraftOrderInput {
 
 type DraftOrderLinesBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -2054,7 +2054,7 @@ input ExportInfoInput {
 
 type ExportProducts {
   exportFile: ExportFile
-  exportErrors: [ExportError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  exportErrors: [ExportError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ExportError!]!
 }
 
@@ -2079,13 +2079,13 @@ type ExternalAuthentication {
 
 type ExternalAuthenticationUrl {
   authenticationData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ExternalLogout {
   logoutData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2094,7 +2094,7 @@ type ExternalObtainAccessTokens {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2103,7 +2103,7 @@ type ExternalRefresh {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2111,7 +2111,7 @@ type ExternalVerify {
   user: User
   isValid: Boolean!
   verifyData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2127,7 +2127,7 @@ enum FileTypesEnum {
 
 type FileUpload {
   uploadedFile: File
-  uploadErrors: [UploadError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  uploadErrors: [UploadError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [UploadError!]!
 }
 
@@ -2147,14 +2147,14 @@ type Fulfillment implements Node & ObjectWithMetadata {
 type FulfillmentApprove {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type FulfillmentCancel {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2171,7 +2171,7 @@ type FulfillmentLine implements Node {
 type FulfillmentRefundProducts {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2180,7 +2180,7 @@ type FulfillmentReturnProducts {
   replaceFulfillment: Fulfillment
   order: Order
   replaceOrder: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2197,7 +2197,7 @@ enum FulfillmentStatus {
 type FulfillmentUpdateTracking {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2235,14 +2235,14 @@ type GiftCard implements Node & ObjectWithMetadata {
   expiryPeriod: TimePeriod
   product: Product
   events: [GiftCardEvent!]!
-  user: User @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `createdBy` field instead.")
-  endDate: DateTime @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` field instead.")
-  startDate: DateTime @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0.")
+  user: User @deprecated(reason: "This field will be removed in Saleor 4.0. Use `createdBy` field instead.")
+  endDate: DateTime @deprecated(reason: "This field will be removed in Saleor 4.0. Use `expiryDate` field instead.")
+  startDate: DateTime @deprecated(reason: "This field will be removed in Saleor 4.0.")
 }
 
 type GiftCardActivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
@@ -2258,7 +2258,7 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2276,12 +2276,12 @@ input GiftCardCreateInput {
 
 type GiftCardDeactivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
 type GiftCardDelete {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2362,7 +2362,7 @@ input GiftCardFilterInput {
 }
 
 type GiftCardUpdate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2418,7 +2418,7 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 }
 
 type InvoiceCreate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2429,7 +2429,7 @@ input InvoiceCreateInput {
 }
 
 type InvoiceDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2452,25 +2452,25 @@ enum InvoiceErrorCode {
 
 type InvoiceRequest {
   order: Order
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceRequestDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceSendNotification {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceUpdate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -3356,7 +3356,7 @@ type Menu implements Node & ObjectWithMetadata {
 
 type MenuBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3372,7 +3372,7 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3384,7 +3384,7 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3436,7 +3436,7 @@ type MenuItem implements Node & ObjectWithMetadata {
 
 type MenuItemBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3452,7 +3452,7 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3468,7 +3468,7 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3488,7 +3488,7 @@ input MenuItemInput {
 
 type MenuItemMove {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3507,11 +3507,11 @@ type MenuItemTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
-  menuItem: MenuItem @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  menuItem: MenuItem @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type MenuItemTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   menuItem: MenuItem
 }
@@ -3523,7 +3523,7 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3543,7 +3543,7 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  menuErrors: [MenuError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3695,7 +3695,7 @@ type Mutation {
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
   draftOrderBulkDelete(ids: [ID]!): DraftOrderBulkDelete
-  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0.")
+  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "This field will be removed in Saleor 4.0.")
   draftOrderUpdate(id: ID!, input: DraftOrderInput!): DraftOrderUpdate
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel
@@ -3915,11 +3915,11 @@ type Order implements Node & ObjectWithMetadata {
   totalBalance: Money!
   userEmail: String
   isShippingRequired: Boolean!
-  languageCode: String! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
+  languageCode: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
   languageCodeEnum: LanguageCodeEnum!
-  discount: Money @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
-  discountName: String @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
-  translatedDiscountName: String @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use discounts field. ")
+  discount: Money @deprecated(reason: "This field will be removed in Saleor 4.0. Use discounts field.")
+  discountName: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use discounts field.")
+  translatedDiscountName: String @deprecated(reason: "This field will be removed in Saleor 4.0. Use discounts field. ")
   discounts: [OrderDiscount!]
   errors: [OrderError!]!
 }
@@ -3934,7 +3934,7 @@ enum OrderAction {
 type OrderAddNote {
   order: Order
   event: OrderEvent
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3944,25 +3944,25 @@ input OrderAddNoteInput {
 
 type OrderBulkCancel {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCancel {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCapture {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderConfirm {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3995,7 +3995,7 @@ type OrderDiscount implements Node {
 
 type OrderDiscountAdd {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4007,7 +4007,7 @@ input OrderDiscountCommonInput {
 
 type OrderDiscountDelete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4018,7 +4018,7 @@ enum OrderDiscountType {
 
 type OrderDiscountUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4197,7 +4197,7 @@ input OrderFilterInput {
 type OrderFulfill {
   fulfillments: [Fulfillment]
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4249,21 +4249,21 @@ input OrderLineCreateInput {
 type OrderLineDelete {
   order: Order
   orderLine: OrderLine
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountRemove {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountUpdate {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4273,7 +4273,7 @@ input OrderLineInput {
 
 type OrderLineUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   orderLine: OrderLine
 }
@@ -4281,13 +4281,13 @@ type OrderLineUpdate {
 type OrderLinesCreate {
   order: Order
   orderLines: [OrderLine!]
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderMarkAsPaid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4299,7 +4299,7 @@ enum OrderOriginEnum {
 
 type OrderRefund {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4356,7 +4356,7 @@ enum OrderSettingsErrorCode {
 
 type OrderSettingsUpdate {
   orderSettings: OrderSettings
-  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderSettingsError!]!
 }
 
@@ -4399,7 +4399,7 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -4412,7 +4412,7 @@ input OrderUpdateInput {
 
 type OrderUpdateShipping {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4422,7 +4422,7 @@ input OrderUpdateShippingInput {
 
 type OrderVoid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  orderErrors: [OrderError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4439,32 +4439,32 @@ type Page implements Node & ObjectWithMetadata {
   created: DateTime!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  contentJson: JSONString! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString! @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   attributes: [SelectedAttribute!]!
 }
 
 type PageAttributeAssign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageAttributeUnassign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkPublish {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4480,7 +4480,7 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4497,7 +4497,7 @@ input PageCreateInput {
 }
 
 type PageDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4546,7 +4546,7 @@ input PageInput {
 
 type PageReorderAttributeValues {
   page: Page
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4569,14 +4569,14 @@ type PageTranslatableContent implements Node {
   seoDescription: String
   title: String!
   content: JSONString
-  contentJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
-  page: Page @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  page: Page @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type PageTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   page: PageTranslatableContent
 }
@@ -4588,7 +4588,7 @@ type PageTranslation implements Node {
   title: String
   content: JSONString
   language: LanguageDisplay!
-  contentJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `content` field instead.")
 }
 
 input PageTranslationInput {
@@ -4611,7 +4611,7 @@ type PageType implements Node & ObjectWithMetadata {
 
 type PageTypeBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4627,7 +4627,7 @@ type PageTypeCountableEdge {
 }
 
 type PageTypeCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4639,7 +4639,7 @@ input PageTypeCreateInput {
 }
 
 type PageTypeDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4650,7 +4650,7 @@ input PageTypeFilterInput {
 
 type PageTypeReorderAttributes {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4665,7 +4665,7 @@ input PageTypeSortingInput {
 }
 
 type PageTypeUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4678,14 +4678,14 @@ input PageTypeUpdateInput {
 }
 
 type PageUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pageErrors: [PageError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -4712,7 +4712,7 @@ type Payment implements Node {
 
 type PaymentCapture {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4773,7 +4773,7 @@ type PaymentGateway {
 
 type PaymentInitialize {
   initializedPayment: PaymentInitialized
-  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4792,7 +4792,7 @@ input PaymentInput {
 
 type PaymentRefund {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4804,7 +4804,7 @@ type PaymentSource {
 
 type PaymentVoid {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4835,7 +4835,7 @@ enum PermissionEnum {
 }
 
 type PermissionGroupCreate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4847,7 +4847,7 @@ input PermissionGroupCreateInput {
 }
 
 type PermissionGroupDelete {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4885,7 +4885,7 @@ input PermissionGroupSortingInput {
 }
 
 type PermissionGroupUpdate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4966,7 +4966,7 @@ input PluginStatusInChannelsInput {
 
 type PluginUpdate {
   plugin: Plugin
-  pluginsErrors: [PluginError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  pluginsErrors: [PluginError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PluginError!]!
 }
 
@@ -5008,7 +5008,7 @@ type Product implements Node & ObjectWithMetadata {
   rating: Float
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   thumbnail(size: Int): Image
   pricing(address: AddressInput): ProductPricingInfo
   isAvailable(address: AddressInput): Boolean
@@ -5016,10 +5016,10 @@ type Product implements Node & ObjectWithMetadata {
   attributes: [SelectedAttribute!]!
   channelListings: [ProductChannelListing!]
   mediaById(id: ID): ProductMedia
-  imageById(id: ID): ProductImage @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
+  imageById(id: ID): ProductImage @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
   variants: [ProductVariant]
   media: [ProductMedia!]
-  images: [ProductImage] @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
+  images: [ProductImage] @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `media` field instead.")
   collections: [Collection]
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   availableForPurchase: Date
@@ -5028,7 +5028,7 @@ type Product implements Node & ObjectWithMetadata {
 
 type ProductAttributeAssign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5044,13 +5044,13 @@ enum ProductAttributeType {
 
 type ProductAttributeUnassign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5091,7 +5091,7 @@ type ProductChannelListingError {
 
 type ProductChannelListingUpdate {
   product: Product
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5112,7 +5112,7 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5133,7 +5133,7 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5229,14 +5229,14 @@ type ProductMedia implements Node {
 
 type ProductMediaBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaCreate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5250,14 +5250,14 @@ input ProductMediaCreateInput {
 type ProductMediaDelete {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaReorder {
   product: Product
   media: [ProductMedia!]
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5269,7 +5269,7 @@ enum ProductMediaType {
 type ProductMediaUpdate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5308,7 +5308,7 @@ type ProductPricingInfo {
 
 type ProductReorderAttributeValues {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5323,14 +5323,14 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
-  product: Product @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  product: Product @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   product: Product
 }
@@ -5342,7 +5342,7 @@ type ProductTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {
@@ -5355,7 +5355,7 @@ type ProductType implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "This field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
   taxType: TaxType
   variantAttributes(variantSelection: VariantAttributeScope): [Attribute]
   productAttributes: [Attribute]
@@ -5364,7 +5364,7 @@ type ProductType implements Node & ObjectWithMetadata {
 
 type ProductTypeBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5385,13 +5385,13 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
@@ -5423,7 +5423,7 @@ input ProductTypeInput {
 
 type ProductTypeReorderAttributes {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5439,13 +5439,13 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5465,7 +5465,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   margin: Int
   quantityOrdered: Int
   revenue(period: ReportingPeriod): TaxedMoney
-  images: [ProductImage] @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
+  images: [ProductImage] @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `media` field instead.")
   media: [ProductMedia!]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
@@ -5476,7 +5476,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
 type ProductVariantBulkCreate {
   count: Int!
   productVariants: [ProductVariant!]!
-  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkProductError!]!
 }
 
@@ -5491,7 +5491,7 @@ input ProductVariantBulkCreateInput {
 
 type ProductVariantBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5511,7 +5511,7 @@ input ProductVariantChannelListingAddInput {
 
 type ProductVariantChannelListingUpdate {
   variant: ProductVariant
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5527,7 +5527,7 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5542,7 +5542,7 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5562,37 +5562,37 @@ input ProductVariantInput {
 
 type ProductVariantReorder {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantReorderAttributeValues {
   productVariant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantSetDefault {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantStocksCreate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
 type ProductVariantStocksDelete {
   productVariant: ProductVariant
-  stockErrors: [StockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  stockErrors: [StockError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StockError!]!
 }
 
 type ProductVariantStocksUpdate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
@@ -5600,12 +5600,12 @@ type ProductVariantTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
-  productVariant: ProductVariant @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  productVariant: ProductVariant @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductVariantTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   productVariant: ProductVariant
 }
@@ -5617,7 +5617,7 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5714,7 +5714,7 @@ type ReducedRate {
 type RefreshToken {
   token: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5730,12 +5730,12 @@ enum ReportingPeriod {
 
 type RequestEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5758,13 +5758,13 @@ type Sale implements Node & ObjectWithMetadata {
 
 type SaleAddCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type SaleBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5787,7 +5787,7 @@ input SaleChannelListingInput {
 
 type SaleChannelListingUpdate {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5803,13 +5803,13 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
 
 type SaleDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5835,7 +5835,7 @@ input SaleInput {
 
 type SaleRemoveCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5857,11 +5857,11 @@ type SaleTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
-  sale: Sale @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  sale: Sale @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type SaleTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   sale: Sale
 }
@@ -5878,7 +5878,7 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5898,7 +5898,7 @@ type SetPassword {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5963,7 +5963,7 @@ input ShippingMethodChannelListingInput {
 
 type ShippingMethodChannelListingUpdate {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -5979,7 +5979,7 @@ type ShippingMethodTranslatableContent implements Node {
   name: String!
   description: JSONString
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
-  shippingMethod: ShippingMethod @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  shippingMethod: ShippingMethod @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type ShippingMethodTranslation implements Node {
@@ -6001,27 +6001,27 @@ input ShippingPostalCodeRulesCreateInputRange {
 
 type ShippingPriceBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceDelete {
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceExcludeProducts {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6045,12 +6045,12 @@ input ShippingPriceInput {
 
 type ShippingPriceRemoveProductFromExclude {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   shippingMethod: ShippingMethod
 }
@@ -6063,7 +6063,7 @@ input ShippingPriceTranslationInput {
 type ShippingPriceUpdate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6083,7 +6083,7 @@ type ShippingZone implements Node & ObjectWithMetadata {
 
 type ShippingZoneBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6099,7 +6099,7 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6114,7 +6114,7 @@ input ShippingZoneCreateInput {
 }
 
 type ShippingZoneDelete {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6125,7 +6125,7 @@ input ShippingZoneFilterInput {
 }
 
 type ShippingZoneUpdate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6177,13 +6177,13 @@ type Shop {
 
 type ShopAddressUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6205,7 +6205,7 @@ enum ShopErrorCode {
 
 type ShopFetchTaxRates {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6229,7 +6229,7 @@ input ShopSettingsInput {
 
 type ShopSettingsTranslate {
   shop: Shop
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
 }
 
@@ -6240,7 +6240,7 @@ input ShopSettingsTranslationInput {
 
 type ShopSettingsUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6258,12 +6258,12 @@ input SiteDomainInput {
 
 type StaffBulkDelete {
   count: Int!
-  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
 }
 
 type StaffCreate {
-  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6279,7 +6279,7 @@ input StaffCreateInput {
 }
 
 type StaffDelete {
-  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6307,13 +6307,13 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
@@ -6325,13 +6325,13 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  shopErrors: [ShopError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  shopErrors: [ShopError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  staffErrors: [StaffError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  staffErrors: [StaffError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6512,13 +6512,13 @@ input UpdateInvoiceInput {
 }
 
 type UpdateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -6550,7 +6550,7 @@ type User implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   addresses: [Address]
-  checkout: Checkout @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
+  checkout: Checkout @deprecated(reason: "This field will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
   checkoutTokens(channel: String): [UUID!]
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
@@ -6565,19 +6565,19 @@ type User implements Node & ObjectWithMetadata {
 
 type UserAvatarDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserBulkSetActive {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6638,14 +6638,14 @@ enum VariantAttributeScope {
 type VariantMediaAssign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type VariantMediaUnassign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  productErrors: [ProductError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -6662,7 +6662,7 @@ type VerifyToken {
   user: User
   isValid: Boolean!
   payload: GenericScalar
-  accountErrors: [AccountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  accountErrors: [AccountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6711,13 +6711,13 @@ type Voucher implements Node & ObjectWithMetadata {
 
 type VoucherAddCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type VoucherBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6742,7 +6742,7 @@ input VoucherChannelListingInput {
 
 type VoucherChannelListingUpdate {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6758,13 +6758,13 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6804,7 +6804,7 @@ input VoucherInput {
 
 type VoucherRemoveCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6828,11 +6828,11 @@ type VoucherTranslatableContent implements Node {
   id: ID!
   name: String
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  voucher: Voucher @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
+  voucher: Voucher @deprecated(reason: "This field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type VoucherTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   voucher: Voucher
 }
@@ -6850,7 +6850,7 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6864,7 +6864,7 @@ type Warehouse implements Node & ObjectWithMetadata {
   email: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  companyName: String! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
+  companyName: String! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
 }
 
 type WarehouseCountableConnection {
@@ -6879,7 +6879,7 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6893,7 +6893,7 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6919,13 +6919,13 @@ input WarehouseFilterInput {
 }
 
 type WarehouseShippingZoneAssign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
 type WarehouseShippingZoneUnassign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6940,7 +6940,7 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6963,7 +6963,7 @@ type Webhook implements Node {
 }
 
 type WebhookCreate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -6978,7 +6978,7 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -7078,7 +7078,7 @@ enum WebhookSampleEventTypeEnum {
 }
 
 type WebhookUpdate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "\\nDEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5,27 +5,27 @@ schema {
 
 type AccountAddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountAddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AccountDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -82,7 +82,7 @@ input AccountInput {
 
 type AccountRegister {
   requiresConfirmation: Boolean
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -97,18 +97,18 @@ input AccountRegisterInput {
 }
 
 type AccountRequestDeletion {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountSetDefaultAddress {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type AccountUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -132,14 +132,14 @@ type Address implements Node {
 
 type AddressCreate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
 
 type AddressDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -160,7 +160,7 @@ input AddressInput {
 
 type AddressSetDefault {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -171,7 +171,7 @@ enum AddressTypeEnum {
 
 type AddressUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   address: Address
 }
@@ -226,7 +226,7 @@ type App implements Node & ObjectWithMetadata {
 }
 
 type AppActivate {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -244,25 +244,25 @@ type AppCountableEdge {
 
 type AppCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeactivate {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDelete {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
 
 type AppDeleteFailedInstallation {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -335,7 +335,7 @@ enum AppExtensionViewEnum {
 
 type AppFetchManifest {
   manifest: Manifest
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -351,7 +351,7 @@ input AppInput {
 }
 
 type AppInstall {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -383,7 +383,7 @@ type AppManifestExtension {
 }
 
 type AppRetryInstall {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appInstallation: AppInstallation
 }
@@ -406,13 +406,13 @@ type AppToken implements Node {
 
 type AppTokenCreate {
   authToken: String
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
 
 type AppTokenDelete {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   appToken: AppToken
 }
@@ -424,7 +424,7 @@ input AppTokenInput {
 
 type AppTokenVerify {
   valid: Boolean!
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
 }
 
@@ -434,7 +434,7 @@ enum AppTypeEnum {
 }
 
 type AppUpdate {
-  appErrors: [AppError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  appErrors: [AppError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AppError!]!
   app: App
 }
@@ -450,7 +450,7 @@ enum AreaUnitsEnum {
 
 type AssignNavigation {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -479,7 +479,7 @@ type Attribute implements Node & ObjectWithMetadata {
 
 type AttributeBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -506,7 +506,7 @@ type AttributeCountableEdge {
 
 type AttributeCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -528,7 +528,7 @@ input AttributeCreateInput {
 }
 
 type AttributeDelete {
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attribute: Attribute
 }
@@ -592,7 +592,7 @@ enum AttributeInputTypeEnum {
 
 type AttributeReorderValues {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -617,11 +617,11 @@ type AttributeTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): AttributeTranslation
-  attribute: Attribute @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attribute: Attribute @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attribute: Attribute
 }
@@ -639,7 +639,7 @@ enum AttributeTypeEnum {
 
 type AttributeUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -675,7 +675,7 @@ type AttributeValue implements Node {
 
 type AttributeValueBulkDelete {
   count: Int!
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
 }
 
@@ -692,7 +692,7 @@ type AttributeValueCountableEdge {
 
 type AttributeValueCreate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -705,7 +705,7 @@ input AttributeValueCreateInput {
 
 type AttributeValueDelete {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -731,11 +731,11 @@ type AttributeValueTranslatableContent implements Node {
   name: String!
   richText: JSONString
   translation(languageCode: LanguageCodeEnum!): AttributeValueTranslation
-  attributeValue: AttributeValue @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  attributeValue: AttributeValue @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type AttributeValueTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   attributeValue: AttributeValue
 }
@@ -754,7 +754,7 @@ input AttributeValueTranslationInput {
 
 type AttributeValueUpdate {
   attribute: Attribute
-  attributeErrors: [AttributeError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  attributeErrors: [AttributeError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AttributeError!]!
   attributeValue: AttributeValue
 }
@@ -802,7 +802,7 @@ type Category implements Node & ObjectWithMetadata {
   level: Int!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   ancestors(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
   products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   children(before: String, after: String, first: Int, last: Int): CategoryCountableConnection
@@ -812,7 +812,7 @@ type Category implements Node & ObjectWithMetadata {
 
 type CategoryBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -828,13 +828,13 @@ type CategoryCountableEdge {
 }
 
 type CategoryCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
 
 type CategoryDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -872,13 +872,13 @@ type CategoryTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CategoryTranslation
-  category: Category @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  category: Category @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CategoryTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   category: Category
 }
@@ -890,11 +890,11 @@ type CategoryTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CategoryUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   category: Category
 }
@@ -910,12 +910,12 @@ type Channel implements Node {
 
 type ChannelActivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelCreate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -930,12 +930,12 @@ input ChannelCreateInput {
 
 type ChannelDeactivate {
   channel: Channel
-  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
 }
 
 type ChannelDelete {
-  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -964,7 +964,7 @@ enum ChannelErrorCode {
 }
 
 type ChannelUpdate {
-  channelErrors: [ChannelError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  channelErrors: [ChannelError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ChannelError!]!
   channel: Channel
 }
@@ -1009,13 +1009,13 @@ type Checkout implements Node & ObjectWithMetadata {
 
 type CheckoutAddPromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutBillingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1023,7 +1023,7 @@ type CheckoutComplete {
   order: Order
   confirmationNeeded: Boolean!
   confirmationData: JSONString
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1040,7 +1040,7 @@ type CheckoutCountableEdge {
 
 type CheckoutCreate {
   created: Boolean
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
   checkout: Checkout
 }
@@ -1056,19 +1056,19 @@ input CheckoutCreateInput {
 
 type CheckoutCustomerAttach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutCustomerDetach {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutEmailUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1108,7 +1108,7 @@ enum CheckoutErrorCode {
 
 type CheckoutLanguageCodeUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1133,7 +1133,7 @@ type CheckoutLineCountableEdge {
 
 type CheckoutLineDelete {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1144,38 +1144,38 @@ input CheckoutLineInput {
 
 type CheckoutLinesAdd {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutLinesUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutPaymentCreate {
   checkout: Checkout
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
 type CheckoutRemovePromoCode {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingAddressUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
 type CheckoutShippingMethodUpdate {
   checkout: Checkout
-  checkoutErrors: [CheckoutError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  checkoutErrors: [CheckoutError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CheckoutError!]!
 }
 
@@ -1193,7 +1193,7 @@ type Collection implements Node & ObjectWithMetadata {
   slug: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   products(filter: ProductFilterInput, sortBy: ProductOrder, before: String, after: String, first: Int, last: Int): ProductCountableConnection
   backgroundImage(size: Int): Image
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
@@ -1202,13 +1202,13 @@ type Collection implements Node & ObjectWithMetadata {
 
 type CollectionAddProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionBulkDelete {
   count: Int!
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1230,7 +1230,7 @@ type CollectionChannelListingError {
 
 type CollectionChannelListingUpdate {
   collection: Collection
-  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionChannelListingErrors: [CollectionChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionChannelListingError!]!
 }
 
@@ -1251,7 +1251,7 @@ type CollectionCountableEdge {
 }
 
 type CollectionCreate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1269,7 +1269,7 @@ input CollectionCreateInput {
 }
 
 type CollectionDelete {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1317,13 +1317,13 @@ enum CollectionPublished {
 
 type CollectionRemoveProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
 type CollectionReorderProducts {
   collection: Collection
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
 }
 
@@ -1346,13 +1346,13 @@ type CollectionTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): CollectionTranslation
-  collection: Collection @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  collection: Collection @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type CollectionTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   collection: Collection
 }
@@ -1364,11 +1364,11 @@ type CollectionTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type CollectionUpdate {
-  collectionErrors: [CollectionError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  collectionErrors: [CollectionError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [CollectionError!]!
   collection: Collection
 }
@@ -1398,13 +1398,13 @@ enum ConfigurationTypeFieldEnum {
 
 type ConfirmAccount {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ConfirmEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1672,7 +1672,7 @@ type CreateToken {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -1686,18 +1686,18 @@ type CreditCard {
 
 type CustomerBulkDelete {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type CustomerCreate {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
 
 type CustomerDelete {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1750,7 +1750,7 @@ input CustomerInput {
 }
 
 type CustomerUpdate {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
   user: User
 }
@@ -1770,18 +1770,18 @@ input DateTimeRangeInput {
 }
 
 type DeactivateAllUserTokens {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type DeleteMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type DeletePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -1813,13 +1813,13 @@ type DigitalContentCountableEdge {
 type DigitalContentCreate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type DigitalContentDelete {
   variant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1833,7 +1833,7 @@ input DigitalContentInput {
 type DigitalContentUpdate {
   variant: ProductVariant
   content: DigitalContent
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -1855,7 +1855,7 @@ type DigitalContentUrl implements Node {
 }
 
 type DigitalContentUrlCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   digitalContentUrl: DigitalContentUrl
 }
@@ -1911,18 +1911,18 @@ type Domain {
 
 type DraftOrderBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderComplete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderCreate {
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1942,7 +1942,7 @@ input DraftOrderCreateInput {
 }
 
 type DraftOrderDelete {
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -1962,12 +1962,12 @@ input DraftOrderInput {
 
 type DraftOrderLinesBulkDelete {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type DraftOrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -2054,7 +2054,7 @@ input ExportInfoInput {
 
 type ExportProducts {
   exportFile: ExportFile
-  exportErrors: [ExportError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  exportErrors: [ExportError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ExportError!]!
 }
 
@@ -2079,13 +2079,13 @@ type ExternalAuthentication {
 
 type ExternalAuthenticationUrl {
   authenticationData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type ExternalLogout {
   logoutData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2094,7 +2094,7 @@ type ExternalObtainAccessTokens {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2103,7 +2103,7 @@ type ExternalRefresh {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2111,7 +2111,7 @@ type ExternalVerify {
   user: User
   isValid: Boolean!
   verifyData: JSONString
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -2127,7 +2127,7 @@ enum FileTypesEnum {
 
 type FileUpload {
   uploadedFile: File
-  uploadErrors: [UploadError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  uploadErrors: [UploadError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [UploadError!]!
 }
 
@@ -2147,14 +2147,14 @@ type Fulfillment implements Node & ObjectWithMetadata {
 type FulfillmentApprove {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type FulfillmentCancel {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2171,7 +2171,7 @@ type FulfillmentLine implements Node {
 type FulfillmentRefundProducts {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2180,7 +2180,7 @@ type FulfillmentReturnProducts {
   replaceFulfillment: Fulfillment
   order: Order
   replaceOrder: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2197,7 +2197,7 @@ enum FulfillmentStatus {
 type FulfillmentUpdateTracking {
   fulfillment: Fulfillment
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -2235,14 +2235,14 @@ type GiftCard implements Node & ObjectWithMetadata {
   expiryPeriod: TimePeriod
   product: Product
   events: [GiftCardEvent!]!
-  user: User @deprecated(reason: "Will be removed in Saleor 4.0. Use created_by field instead")
-  endDate: DateTime @deprecated(reason: "Will be removed in Saleor 4.0. Use expiry_date field instead.")
-  startDate: DateTime @deprecated(reason: "Will be removed in Saleor 4.0.")
+  user: User @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `createdBy` field instead.")
+  endDate: DateTime @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `expiryDate` field instead.")
+  startDate: DateTime @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0.")
 }
 
 type GiftCardActivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
@@ -2258,7 +2258,7 @@ type GiftCardCountableEdge {
 }
 
 type GiftCardCreate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2276,12 +2276,12 @@ input GiftCardCreateInput {
 
 type GiftCardDeactivate {
   giftCard: GiftCard
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
 }
 
 type GiftCardDelete {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2362,7 +2362,7 @@ input GiftCardFilterInput {
 }
 
 type GiftCardUpdate {
-  giftCardErrors: [GiftCardError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  giftCardErrors: [GiftCardError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [GiftCardError!]!
   giftCard: GiftCard
 }
@@ -2418,7 +2418,7 @@ type Invoice implements ObjectWithMetadata & Job & Node {
 }
 
 type InvoiceCreate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2429,7 +2429,7 @@ input InvoiceCreateInput {
 }
 
 type InvoiceDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -2452,25 +2452,25 @@ enum InvoiceErrorCode {
 
 type InvoiceRequest {
   order: Order
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceRequestDelete {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceSendNotification {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
 
 type InvoiceUpdate {
-  invoiceErrors: [InvoiceError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  invoiceErrors: [InvoiceError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [InvoiceError!]!
   invoice: Invoice
 }
@@ -3356,7 +3356,7 @@ type Menu implements Node & ObjectWithMetadata {
 
 type MenuBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3372,7 +3372,7 @@ type MenuCountableEdge {
 }
 
 type MenuCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3384,7 +3384,7 @@ input MenuCreateInput {
 }
 
 type MenuDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3436,7 +3436,7 @@ type MenuItem implements Node & ObjectWithMetadata {
 
 type MenuItemBulkDelete {
   count: Int!
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3452,7 +3452,7 @@ type MenuItemCountableEdge {
 }
 
 type MenuItemCreate {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3468,7 +3468,7 @@ input MenuItemCreateInput {
 }
 
 type MenuItemDelete {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3488,7 +3488,7 @@ input MenuItemInput {
 
 type MenuItemMove {
   menu: Menu
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
 }
 
@@ -3507,11 +3507,11 @@ type MenuItemTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): MenuItemTranslation
-  menuItem: MenuItem @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  menuItem: MenuItem @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type MenuItemTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   menuItem: MenuItem
 }
@@ -3523,7 +3523,7 @@ type MenuItemTranslation implements Node {
 }
 
 type MenuItemUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menuItem: MenuItem
 }
@@ -3543,7 +3543,7 @@ input MenuSortingInput {
 }
 
 type MenuUpdate {
-  menuErrors: [MenuError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  menuErrors: [MenuError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MenuError!]!
   menu: Menu
 }
@@ -3695,7 +3695,7 @@ type Mutation {
   draftOrderCreate(input: DraftOrderCreateInput!): DraftOrderCreate
   draftOrderDelete(id: ID!): DraftOrderDelete
   draftOrderBulkDelete(ids: [ID]!): DraftOrderBulkDelete
-  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "DEPRECATED: Will be removed in Saleor 4.0.")
+  draftOrderLinesBulkDelete(ids: [ID]!): DraftOrderLinesBulkDelete @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0.")
   draftOrderUpdate(id: ID!, input: DraftOrderInput!): DraftOrderUpdate
   orderAddNote(order: ID!, input: OrderAddNoteInput!): OrderAddNote
   orderCancel(id: ID!): OrderCancel
@@ -3915,11 +3915,11 @@ type Order implements Node & ObjectWithMetadata {
   totalBalance: Money!
   userEmail: String
   isShippingRequired: Boolean!
-  languageCode: String! @deprecated(reason: "Use the `languageCodeEnum` field to fetch the language code. This field will be removed in Saleor 4.0.")
+  languageCode: String! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `languageCodeEnum` field to fetch the language code. ")
   languageCodeEnum: LanguageCodeEnum!
-  discount: Money @deprecated(reason: "Use discounts field. This field will be removed in Saleor 4.0.")
-  discountName: String @deprecated(reason: "Use discounts field. This field will be removed in Saleor 4.0.")
-  translatedDiscountName: String @deprecated(reason: "Use discounts field. This field will be removed in Saleor 4.0.")
+  discount: Money @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
+  discountName: String @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field.")
+  translatedDiscountName: String @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use discounts field. ")
   discounts: [OrderDiscount!]
   errors: [OrderError!]!
 }
@@ -3934,7 +3934,7 @@ enum OrderAction {
 type OrderAddNote {
   order: Order
   event: OrderEvent
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3944,25 +3944,25 @@ input OrderAddNoteInput {
 
 type OrderBulkCancel {
   count: Int!
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCancel {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderCapture {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderConfirm {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -3995,7 +3995,7 @@ type OrderDiscount implements Node {
 
 type OrderDiscountAdd {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4007,7 +4007,7 @@ input OrderDiscountCommonInput {
 
 type OrderDiscountDelete {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4018,7 +4018,7 @@ enum OrderDiscountType {
 
 type OrderDiscountUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4197,7 +4197,7 @@ input OrderFilterInput {
 type OrderFulfill {
   fulfillments: [Fulfillment]
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4249,21 +4249,21 @@ input OrderLineCreateInput {
 type OrderLineDelete {
   order: Order
   orderLine: OrderLine
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountRemove {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderLineDiscountUpdate {
   orderLine: OrderLine
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4273,7 +4273,7 @@ input OrderLineInput {
 
 type OrderLineUpdate {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   orderLine: OrderLine
 }
@@ -4281,13 +4281,13 @@ type OrderLineUpdate {
 type OrderLinesCreate {
   order: Order
   orderLines: [OrderLine!]
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
 type OrderMarkAsPaid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4299,7 +4299,7 @@ enum OrderOriginEnum {
 
 type OrderRefund {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4356,7 +4356,7 @@ enum OrderSettingsErrorCode {
 
 type OrderSettingsUpdate {
   orderSettings: OrderSettings
-  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderSettingsErrors: [OrderSettingsError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderSettingsError!]!
 }
 
@@ -4399,7 +4399,7 @@ enum OrderStatusFilter {
 }
 
 type OrderUpdate {
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
   order: Order
 }
@@ -4412,7 +4412,7 @@ input OrderUpdateInput {
 
 type OrderUpdateShipping {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4422,7 +4422,7 @@ input OrderUpdateShippingInput {
 
 type OrderVoid {
   order: Order
-  orderErrors: [OrderError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  orderErrors: [OrderError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [OrderError!]!
 }
 
@@ -4439,32 +4439,32 @@ type Page implements Node & ObjectWithMetadata {
   created: DateTime!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  contentJson: JSONString! @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
   attributes: [SelectedAttribute!]!
 }
 
 type PageAttributeAssign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageAttributeUnassign {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
 type PageBulkPublish {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4480,7 +4480,7 @@ type PageCountableEdge {
 }
 
 type PageCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4497,7 +4497,7 @@ input PageCreateInput {
 }
 
 type PageDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
@@ -4546,7 +4546,7 @@ input PageInput {
 
 type PageReorderAttributeValues {
   page: Page
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4569,14 +4569,14 @@ type PageTranslatableContent implements Node {
   seoDescription: String
   title: String!
   content: JSONString
-  contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
   translation(languageCode: LanguageCodeEnum!): PageTranslation
-  page: Page @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  page: Page @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type PageTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   page: PageTranslatableContent
 }
@@ -4588,7 +4588,7 @@ type PageTranslation implements Node {
   title: String
   content: JSONString
   language: LanguageDisplay!
-  contentJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `content` field instead.")
+  contentJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `content` field instead.")
 }
 
 input PageTranslationInput {
@@ -4611,7 +4611,7 @@ type PageType implements Node & ObjectWithMetadata {
 
 type PageTypeBulkDelete {
   count: Int!
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4627,7 +4627,7 @@ type PageTypeCountableEdge {
 }
 
 type PageTypeCreate {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4639,7 +4639,7 @@ input PageTypeCreateInput {
 }
 
 type PageTypeDelete {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4650,7 +4650,7 @@ input PageTypeFilterInput {
 
 type PageTypeReorderAttributes {
   pageType: PageType
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
 }
 
@@ -4665,7 +4665,7 @@ input PageTypeSortingInput {
 }
 
 type PageTypeUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   pageType: PageType
 }
@@ -4678,14 +4678,14 @@ input PageTypeUpdateInput {
 }
 
 type PageUpdate {
-  pageErrors: [PageError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pageErrors: [PageError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PageError!]!
   page: Page
 }
 
 type PasswordChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -4712,7 +4712,7 @@ type Payment implements Node {
 
 type PaymentCapture {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4773,7 +4773,7 @@ type PaymentGateway {
 
 type PaymentInitialize {
   initializedPayment: PaymentInitialized
-  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4792,7 +4792,7 @@ input PaymentInput {
 
 type PaymentRefund {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4804,7 +4804,7 @@ type PaymentSource {
 
 type PaymentVoid {
   payment: Payment
-  paymentErrors: [PaymentError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  paymentErrors: [PaymentError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PaymentError!]!
 }
 
@@ -4835,7 +4835,7 @@ enum PermissionEnum {
 }
 
 type PermissionGroupCreate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4847,7 +4847,7 @@ input PermissionGroupCreateInput {
 }
 
 type PermissionGroupDelete {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4885,7 +4885,7 @@ input PermissionGroupSortingInput {
 }
 
 type PermissionGroupUpdate {
-  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  permissionGroupErrors: [PermissionGroupError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PermissionGroupError!]!
   group: Group
 }
@@ -4966,7 +4966,7 @@ input PluginStatusInChannelsInput {
 
 type PluginUpdate {
   plugin: Plugin
-  pluginsErrors: [PluginError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  pluginsErrors: [PluginError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [PluginError!]!
 }
 
@@ -5008,7 +5008,7 @@ type Product implements Node & ObjectWithMetadata {
   rating: Float
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   thumbnail(size: Int): Image
   pricing(address: AddressInput): ProductPricingInfo
   isAvailable(address: AddressInput): Boolean
@@ -5016,10 +5016,10 @@ type Product implements Node & ObjectWithMetadata {
   attributes: [SelectedAttribute!]!
   channelListings: [ProductChannelListing!]
   mediaById(id: ID): ProductMedia
-  imageById(id: ID): ProductImage @deprecated(reason: "Will be removed in Saleor 4.0. Use the `mediaById` field instead.")
+  imageById(id: ID): ProductImage @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `mediaById` field instead.")
   variants: [ProductVariant]
   media: [ProductMedia!]
-  images: [ProductImage] @deprecated(reason: "Will be removed in Saleor 4.0. Use the `media` field instead.")
+  images: [ProductImage] @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
   collections: [Collection]
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
   availableForPurchase: Date
@@ -5028,7 +5028,7 @@ type Product implements Node & ObjectWithMetadata {
 
 type ProductAttributeAssign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5044,13 +5044,13 @@ enum ProductAttributeType {
 
 type ProductAttributeUnassign {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5091,7 +5091,7 @@ type ProductChannelListingError {
 
 type ProductChannelListingUpdate {
   product: Product
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5112,7 +5112,7 @@ type ProductCountableEdge {
 }
 
 type ProductCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5133,7 +5133,7 @@ input ProductCreateInput {
 }
 
 type ProductDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5229,14 +5229,14 @@ type ProductMedia implements Node {
 
 type ProductMediaBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaCreate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5250,14 +5250,14 @@ input ProductMediaCreateInput {
 type ProductMediaDelete {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductMediaReorder {
   product: Product
   media: [ProductMedia!]
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5269,7 +5269,7 @@ enum ProductMediaType {
 type ProductMediaUpdate {
   product: Product
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5308,7 +5308,7 @@ type ProductPricingInfo {
 
 type ProductReorderAttributeValues {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5323,14 +5323,14 @@ type ProductTranslatableContent implements Node {
   seoDescription: String
   name: String!
   description: JSONString
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
   translation(languageCode: LanguageCodeEnum!): ProductTranslation
-  product: Product @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  product: Product @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   product: Product
 }
@@ -5342,7 +5342,7 @@ type ProductTranslation implements Node {
   name: String
   description: JSONString
   language: LanguageDisplay!
-  descriptionJson: JSONString @deprecated(reason: "Will be removed in Saleor 4.0. Use the `description` field instead.")
+  descriptionJson: JSONString @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `description` field instead.")
 }
 
 type ProductType implements Node & ObjectWithMetadata {
@@ -5355,7 +5355,7 @@ type ProductType implements Node & ObjectWithMetadata {
   weight: Weight
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "Will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
+  products(channel: String, before: String, after: String, first: Int, last: Int): ProductCountableConnection @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the top-level `products` query with the `productTypes` filter.")
   taxType: TaxType
   variantAttributes(variantSelection: VariantAttributeScope): [Attribute]
   productAttributes: [Attribute]
@@ -5364,7 +5364,7 @@ type ProductType implements Node & ObjectWithMetadata {
 
 type ProductTypeBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5385,13 +5385,13 @@ type ProductTypeCountableEdge {
 }
 
 type ProductTypeCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductTypeDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
@@ -5423,7 +5423,7 @@ input ProductTypeInput {
 
 type ProductTypeReorderAttributes {
   productType: ProductType
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5439,13 +5439,13 @@ input ProductTypeSortingInput {
 }
 
 type ProductTypeUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productType: ProductType
 }
 
 type ProductUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   product: Product
 }
@@ -5465,7 +5465,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
   margin: Int
   quantityOrdered: Int
   revenue(period: ReportingPeriod): TaxedMoney
-  images: [ProductImage] @deprecated(reason: "Will be removed in Saleor 4.0. Use the `media` instead.")
+  images: [ProductImage] @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `media` field instead.")
   media: [ProductMedia!]
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
   digitalContent: DigitalContent
@@ -5476,7 +5476,7 @@ type ProductVariant implements Node & ObjectWithMetadata {
 type ProductVariantBulkCreate {
   count: Int!
   productVariants: [ProductVariant!]!
-  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  bulkProductErrors: [BulkProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkProductError!]!
 }
 
@@ -5491,7 +5491,7 @@ input ProductVariantBulkCreateInput {
 
 type ProductVariantBulkDelete {
   count: Int!
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -5511,7 +5511,7 @@ input ProductVariantChannelListingAddInput {
 
 type ProductVariantChannelListingUpdate {
   variant: ProductVariant
-  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productChannelListingErrors: [ProductChannelListingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductChannelListingError!]!
 }
 
@@ -5527,7 +5527,7 @@ type ProductVariantCountableEdge {
 }
 
 type ProductVariantCreate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5542,7 +5542,7 @@ input ProductVariantCreateInput {
 }
 
 type ProductVariantDelete {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5562,37 +5562,37 @@ input ProductVariantInput {
 
 type ProductVariantReorder {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantReorderAttributeValues {
   productVariant: ProductVariant
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantSetDefault {
   product: Product
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type ProductVariantStocksCreate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
 type ProductVariantStocksDelete {
   productVariant: ProductVariant
-  stockErrors: [StockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  stockErrors: [StockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StockError!]!
 }
 
 type ProductVariantStocksUpdate {
   productVariant: ProductVariant
-  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  bulkStockErrors: [BulkStockError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [BulkStockError!]!
 }
 
@@ -5600,12 +5600,12 @@ type ProductVariantTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): ProductVariantTranslation
-  productVariant: ProductVariant @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  productVariant: ProductVariant @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
   attributeValues: [AttributeValueTranslatableContent!]!
 }
 
 type ProductVariantTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   productVariant: ProductVariant
 }
@@ -5617,7 +5617,7 @@ type ProductVariantTranslation implements Node {
 }
 
 type ProductVariantUpdate {
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
   productVariant: ProductVariant
 }
@@ -5714,7 +5714,7 @@ type ReducedRate {
 type RefreshToken {
   token: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5730,12 +5730,12 @@ enum ReportingPeriod {
 
 type RequestEmailChange {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type RequestPasswordReset {
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5758,13 +5758,13 @@ type Sale implements Node & ObjectWithMetadata {
 
 type SaleAddCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type SaleBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5787,7 +5787,7 @@ input SaleChannelListingInput {
 
 type SaleChannelListingUpdate {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5803,13 +5803,13 @@ type SaleCountableEdge {
 }
 
 type SaleCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
 
 type SaleDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5835,7 +5835,7 @@ input SaleInput {
 
 type SaleRemoveCatalogues {
   sale: Sale
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -5857,11 +5857,11 @@ type SaleTranslatableContent implements Node {
   id: ID!
   name: String!
   translation(languageCode: LanguageCodeEnum!): SaleTranslation
-  sale: Sale @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  sale: Sale @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type SaleTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   sale: Sale
 }
@@ -5878,7 +5878,7 @@ enum SaleType {
 }
 
 type SaleUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   sale: Sale
 }
@@ -5898,7 +5898,7 @@ type SetPassword {
   refreshToken: String
   csrfToken: String
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -5963,7 +5963,7 @@ input ShippingMethodChannelListingInput {
 
 type ShippingMethodChannelListingUpdate {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -5979,7 +5979,7 @@ type ShippingMethodTranslatableContent implements Node {
   name: String!
   description: JSONString
   translation(languageCode: LanguageCodeEnum!): ShippingMethodTranslation
-  shippingMethod: ShippingMethod @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  shippingMethod: ShippingMethod @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type ShippingMethodTranslation implements Node {
@@ -6001,27 +6001,27 @@ input ShippingPostalCodeRulesCreateInputRange {
 
 type ShippingPriceBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceCreate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceDelete {
   shippingMethod: ShippingMethod
   shippingZone: ShippingZone
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceExcludeProducts {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6045,12 +6045,12 @@ input ShippingPriceInput {
 
 type ShippingPriceRemoveProductFromExclude {
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
 type ShippingPriceTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   shippingMethod: ShippingMethod
 }
@@ -6063,7 +6063,7 @@ input ShippingPriceTranslationInput {
 type ShippingPriceUpdate {
   shippingZone: ShippingZone
   shippingMethod: ShippingMethod
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6083,7 +6083,7 @@ type ShippingZone implements Node & ObjectWithMetadata {
 
 type ShippingZoneBulkDelete {
   count: Int!
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
 }
 
@@ -6099,7 +6099,7 @@ type ShippingZoneCountableEdge {
 }
 
 type ShippingZoneCreate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6114,7 +6114,7 @@ input ShippingZoneCreateInput {
 }
 
 type ShippingZoneDelete {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6125,7 +6125,7 @@ input ShippingZoneFilterInput {
 }
 
 type ShippingZoneUpdate {
-  shippingErrors: [ShippingError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shippingErrors: [ShippingError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShippingError!]!
   shippingZone: ShippingZone
 }
@@ -6177,13 +6177,13 @@ type Shop {
 
 type ShopAddressUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
 type ShopDomainUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6205,7 +6205,7 @@ enum ShopErrorCode {
 
 type ShopFetchTaxRates {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6229,7 +6229,7 @@ input ShopSettingsInput {
 
 type ShopSettingsTranslate {
   shop: Shop
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
 }
 
@@ -6240,7 +6240,7 @@ input ShopSettingsTranslationInput {
 
 type ShopSettingsUpdate {
   shop: Shop
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
 }
 
@@ -6258,12 +6258,12 @@ input SiteDomainInput {
 
 type StaffBulkDelete {
   count: Int!
-  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
 }
 
 type StaffCreate {
-  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6279,7 +6279,7 @@ input StaffCreateInput {
 }
 
 type StaffDelete {
-  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6307,13 +6307,13 @@ type StaffNotificationRecipient implements Node {
 }
 
 type StaffNotificationRecipientCreate {
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffNotificationRecipientDelete {
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
@@ -6325,13 +6325,13 @@ input StaffNotificationRecipientInput {
 }
 
 type StaffNotificationRecipientUpdate {
-  shopErrors: [ShopError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  shopErrors: [ShopError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ShopError!]!
   staffNotificationRecipient: StaffNotificationRecipient
 }
 
 type StaffUpdate {
-  staffErrors: [StaffError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  staffErrors: [StaffError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [StaffError!]!
   user: User
 }
@@ -6512,13 +6512,13 @@ input UpdateInvoiceInput {
 }
 
 type UpdateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
 
 type UpdatePrivateMetadata {
-  metadataErrors: [MetadataError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  metadataErrors: [MetadataError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [MetadataError!]!
   item: ObjectWithMetadata
 }
@@ -6550,7 +6550,7 @@ type User implements Node & ObjectWithMetadata {
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
   addresses: [Address]
-  checkout: Checkout @deprecated(reason: "Will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
+  checkout: Checkout @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use the `checkout_tokens` field to fetch the user checkouts.")
   checkoutTokens(channel: String): [UUID!]
   giftCards(before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
   orders(before: String, after: String, first: Int, last: Int): OrderCountableConnection
@@ -6565,19 +6565,19 @@ type User implements Node & ObjectWithMetadata {
 
 type UserAvatarDelete {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserAvatarUpdate {
   user: User
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
 type UserBulkSetActive {
   count: Int!
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6638,14 +6638,14 @@ enum VariantAttributeScope {
 type VariantMediaAssign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
 type VariantMediaUnassign {
   productVariant: ProductVariant
   media: ProductMedia
-  productErrors: [ProductError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  productErrors: [ProductError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [ProductError!]!
 }
 
@@ -6662,7 +6662,7 @@ type VerifyToken {
   user: User
   isValid: Boolean!
   payload: GenericScalar
-  accountErrors: [AccountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  accountErrors: [AccountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [AccountError!]!
 }
 
@@ -6711,13 +6711,13 @@ type Voucher implements Node & ObjectWithMetadata {
 
 type VoucherAddCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
 type VoucherBulkDelete {
   count: Int!
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6742,7 +6742,7 @@ input VoucherChannelListingInput {
 
 type VoucherChannelListingUpdate {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6758,13 +6758,13 @@ type VoucherCountableEdge {
 }
 
 type VoucherCreate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
 
 type VoucherDelete {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6804,7 +6804,7 @@ input VoucherInput {
 
 type VoucherRemoveCatalogues {
   voucher: Voucher
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
 }
 
@@ -6828,11 +6828,11 @@ type VoucherTranslatableContent implements Node {
   id: ID!
   name: String
   translation(languageCode: LanguageCodeEnum!): VoucherTranslation
-  voucher: Voucher @deprecated(reason: "Will be removed in Saleor 4.0. Get model fields from the root level.")
+  voucher: Voucher @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Get model fields from the root level queries.")
 }
 
 type VoucherTranslate {
-  translationErrors: [TranslationError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  translationErrors: [TranslationError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [TranslationError!]!
   voucher: Voucher
 }
@@ -6850,7 +6850,7 @@ enum VoucherTypeEnum {
 }
 
 type VoucherUpdate {
-  discountErrors: [DiscountError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  discountErrors: [DiscountError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [DiscountError!]!
   voucher: Voucher
 }
@@ -6864,7 +6864,7 @@ type Warehouse implements Node & ObjectWithMetadata {
   email: String!
   privateMetadata: [MetadataItem]!
   metadata: [MetadataItem]!
-  companyName: String! @deprecated(reason: "Use address.CompanyName. This field will be removed in Saleor 4.0.")
+  companyName: String! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `Address.companyName` instead.")
 }
 
 type WarehouseCountableConnection {
@@ -6879,7 +6879,7 @@ type WarehouseCountableEdge {
 }
 
 type WarehouseCreate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6893,7 +6893,7 @@ input WarehouseCreateInput {
 }
 
 type WarehouseDelete {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6919,13 +6919,13 @@ input WarehouseFilterInput {
 }
 
 type WarehouseShippingZoneAssign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
 
 type WarehouseShippingZoneUnassign {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6940,7 +6940,7 @@ input WarehouseSortingInput {
 }
 
 type WarehouseUpdate {
-  warehouseErrors: [WarehouseError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  warehouseErrors: [WarehouseError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WarehouseError!]!
   warehouse: Warehouse
 }
@@ -6963,7 +6963,7 @@ type Webhook implements Node {
 }
 
 type WebhookCreate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -6978,7 +6978,7 @@ input WebhookCreateInput {
 }
 
 type WebhookDelete {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }
@@ -7078,7 +7078,7 @@ enum WebhookSampleEventTypeEnum {
 }
 
 type WebhookUpdate {
-  webhookErrors: [WebhookError!]! @deprecated(reason: "Use errors field instead. This field will be removed in Saleor 4.0.")
+  webhookErrors: [WebhookError!]! @deprecated(reason: "DEPRECATED: this field will be removed in Saleor 4.0. Use `errors` field instead.")
   errors: [WebhookError!]!
   webhook: Webhook
 }

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -16,7 +16,7 @@ from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
 from ..checkout.types import PaymentGateway
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_INPUT
 from ..core.enums import LanguageCodeEnum, WeightUnitsEnum
 from ..core.types.common import CountryDisplay, LanguageDisplay, Permission
 from ..core.utils import str_to_enum
@@ -86,7 +86,7 @@ class Shop(graphene.ObjectType):
             graphene.String,
             description=(
                 "A currency for which gateways will be returned. "
-                f"{DEPRECATED_IN_3X} Use `channel` argument instead."
+                f"{DEPRECATED_IN_3X_INPUT} Use `channel` argument instead."
             ),
             required=False,
         ),
@@ -130,7 +130,8 @@ class Shop(graphene.ObjectType):
         language_code=graphene.Argument(
             LanguageCodeEnum,
             description=(
-                f"A language code to return the translation for. {DEPRECATED_IN_3X}"
+                "A language code to return the translation for. "
+                f"{DEPRECATED_IN_3X_INPUT}"
             ),
         ),
         description="List of countries available in the shop.",

--- a/saleor/graphql/shop/types.py
+++ b/saleor/graphql/shop/types.py
@@ -16,6 +16,7 @@ from ...site import models as site_models
 from ..account.types import Address, AddressInput, StaffNotificationRecipient
 from ..checkout.types import PaymentGateway
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import LanguageCodeEnum, WeightUnitsEnum
 from ..core.types.common import CountryDisplay, LanguageDisplay, Permission
 from ..core.utils import str_to_enum
@@ -84,9 +85,8 @@ class Shop(graphene.ObjectType):
         currency=graphene.Argument(
             graphene.String,
             description=(
-                "DEPRECATED: use `channel` argument instead. This argument will be "
-                "removed in Saleor 4.0."
-                "A currency for which gateways will be returned."
+                "A currency for which gateways will be returned. "
+                f"{DEPRECATED_IN_3X} Use `channel` argument instead."
             ),
             required=False,
         ),
@@ -130,8 +130,7 @@ class Shop(graphene.ObjectType):
         language_code=graphene.Argument(
             LanguageCodeEnum,
             description=(
-                "DEPRECATED: This argument will be removed in Saleor 4.0. "
-                "A language code to return the translation for."
+                f"A language code to return the translation for. {DEPRECATED_IN_3X}"
             ),
         ),
         description="List of countries available in the shop.",

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -16,6 +16,7 @@ from ...shipping import models as shipping_models
 from ...site import models as site_models
 from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..core.enums import LanguageCodeEnum
 from ..core.types import LanguageDisplay
 from ..core.utils import str_to_enum
@@ -89,7 +90,7 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
         "saleor.graphql.attribute.types.AttributeValue",
         description="Represents a value of an attribute.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -116,7 +117,7 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
         "saleor.graphql.attribute.types.Attribute",
         description="Custom attribute of a product.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -147,7 +148,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
             "Represents a version of a product such as different size or color."
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -177,9 +178,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 class ProductTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
 
     class Meta:
@@ -196,16 +195,14 @@ class ProductTranslation(BaseTranslationType):
 class ProductTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the product (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     translation = TranslationField(ProductTranslation, type_name="product")
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
         description="Represents an individual item for sale in the storefront.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -240,9 +237,7 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 class CollectionTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
 
     class Meta:
@@ -259,16 +254,14 @@ class CollectionTranslation(BaseTranslationType):
 class CollectionTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the collection (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     collection = graphene.Field(
         "saleor.graphql.product.types.products.Collection",
         description="Represents a collection of products.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -293,9 +286,7 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 class CategoryTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
 
     class Meta:
@@ -312,16 +303,14 @@ class CategoryTranslation(BaseTranslationType):
 class CategoryTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the category (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `description` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
     )
     translation = TranslationField(CategoryTranslation, type_name="category")
     category = graphene.Field(
         "saleor.graphql.product.types.products.Category",
         description="Represents a single category of products.",
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -343,9 +332,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 class PageTranslation(BaseTranslationType):
     content_json = graphene.JSONString(
         description="Translated description of the page (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `content` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
     )
 
     class Meta:
@@ -368,9 +355,7 @@ class PageTranslation(BaseTranslationType):
 class PageTranslatableContent(CountableDjangoObjectType):
     content_json = graphene.JSONString(
         description="Content of the page (JSON).",
-        deprecation_reason=(
-            "Will be removed in Saleor 4.0. Use the `content` field instead."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
     )
     translation = TranslationField(PageTranslation, type_name="page")
     page = graphene.Field(
@@ -380,7 +365,7 @@ class PageTranslatableContent(CountableDjangoObjectType):
             "through the dashboard.",
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -439,7 +424,7 @@ class VoucherTranslatableContent(CountableDjangoObjectType):
             "providing valid voucher codes."
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -470,7 +455,7 @@ class SaleTranslatableContent(CountableDjangoObjectType):
             "or products and are visible to all the customers."
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -508,7 +493,7 @@ class MenuItemTranslatableContent(CountableDjangoObjectType):
             "collection or pages."
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 
@@ -540,7 +525,7 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
             " to them. They are directly exposed to the customers."
         ),
         deprecation_reason=(
-            "Will be removed in Saleor 4.0. " "Get model fields from the root level."
+            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
         ),
     )
 

--- a/saleor/graphql/translations/types.py
+++ b/saleor/graphql/translations/types.py
@@ -16,7 +16,7 @@ from ...shipping import models as shipping_models
 from ...site import models as site_models
 from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..core.enums import LanguageCodeEnum
 from ..core.types import LanguageDisplay
 from ..core.utils import str_to_enum
@@ -90,7 +90,7 @@ class AttributeValueTranslatableContent(CountableDjangoObjectType):
         "saleor.graphql.attribute.types.AttributeValue",
         description="Represents a value of an attribute.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -117,7 +117,7 @@ class AttributeTranslatableContent(CountableDjangoObjectType):
         "saleor.graphql.attribute.types.Attribute",
         description="Custom attribute of a product.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -148,7 +148,7 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
             "Represents a version of a product such as different size or color."
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -178,7 +178,9 @@ class ProductVariantTranslatableContent(CountableDjangoObjectType):
 class ProductTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
 
     class Meta:
@@ -195,14 +197,16 @@ class ProductTranslation(BaseTranslationType):
 class ProductTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the product (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     translation = TranslationField(ProductTranslation, type_name="product")
     product = graphene.Field(
         "saleor.graphql.product.types.products.Product",
         description="Represents an individual item for sale in the storefront.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -237,7 +241,9 @@ class ProductTranslatableContent(CountableDjangoObjectType):
 class CollectionTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
 
     class Meta:
@@ -254,14 +260,16 @@ class CollectionTranslation(BaseTranslationType):
 class CollectionTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the collection (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     translation = TranslationField(CollectionTranslation, type_name="collection")
     collection = graphene.Field(
         "saleor.graphql.product.types.products.Collection",
         description="Represents a collection of products.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -286,7 +294,9 @@ class CollectionTranslatableContent(CountableDjangoObjectType):
 class CategoryTranslation(BaseTranslationType):
     description_json = graphene.JSONString(
         description="Translated description of the product (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
 
     class Meta:
@@ -303,14 +313,16 @@ class CategoryTranslation(BaseTranslationType):
 class CategoryTranslatableContent(CountableDjangoObjectType):
     description_json = graphene.JSONString(
         description="Description of the category (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `description` field instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use the `description` field instead."
+        ),
     )
     translation = TranslationField(CategoryTranslation, type_name="category")
     category = graphene.Field(
         "saleor.graphql.product.types.products.Category",
         description="Represents a single category of products.",
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -332,7 +344,7 @@ class CategoryTranslatableContent(CountableDjangoObjectType):
 class PageTranslation(BaseTranslationType):
     content_json = graphene.JSONString(
         description="Translated description of the page (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use the `content` field instead.",
     )
 
     class Meta:
@@ -355,7 +367,7 @@ class PageTranslation(BaseTranslationType):
 class PageTranslatableContent(CountableDjangoObjectType):
     content_json = graphene.JSONString(
         description="Content of the page (JSON).",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use the `content` field instead.",
+        deprecation_reason=f"{DEPRECATED_IN_3X_FIELD} Use the `content` field instead.",
     )
     translation = TranslationField(PageTranslation, type_name="page")
     page = graphene.Field(
@@ -365,7 +377,7 @@ class PageTranslatableContent(CountableDjangoObjectType):
             "through the dashboard.",
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
     attribute_values = graphene.List(
@@ -424,7 +436,7 @@ class VoucherTranslatableContent(CountableDjangoObjectType):
             "providing valid voucher codes."
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -455,7 +467,7 @@ class SaleTranslatableContent(CountableDjangoObjectType):
             "or products and are visible to all the customers."
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -493,7 +505,7 @@ class MenuItemTranslatableContent(CountableDjangoObjectType):
             "collection or pages."
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 
@@ -525,7 +537,7 @@ class ShippingMethodTranslatableContent(CountableDjangoObjectType):
             " to them. They are directly exposed to the customers."
         ),
         deprecation_reason=(
-            f"{DEPRECATED_IN_3X} Get model fields from the root level queries."
+            f"{DEPRECATED_IN_3X_FIELD} Get model fields from the root level queries."
         ),
     )
 

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -7,7 +7,7 @@ from ...warehouse import models
 from ..account.dataloaders import AddressByIdLoader
 from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
-from ..core.descriptions import DEPRECATED_IN_3X
+from ..core.descriptions import DEPRECATED_IN_3X_FIELD
 from ..decorators import one_of_permissions_required
 from ..meta.types import ObjectWithMetadata
 
@@ -42,7 +42,9 @@ class Warehouse(CountableDjangoObjectType):
     company_name = graphene.String(
         required=True,
         description="Warehouse company name.",
-        deprecation_reason=f"{DEPRECATED_IN_3X} Use `Address.companyName` instead.",
+        deprecation_reason=(
+            f"{DEPRECATED_IN_3X_FIELD} Use `Address.companyName` instead."
+        ),
     )
 
     class Meta:

--- a/saleor/graphql/warehouse/types.py
+++ b/saleor/graphql/warehouse/types.py
@@ -7,6 +7,7 @@ from ...warehouse import models
 from ..account.dataloaders import AddressByIdLoader
 from ..channel import ChannelContext
 from ..core.connection import CountableDjangoObjectType
+from ..core.descriptions import DEPRECATED_IN_3X
 from ..decorators import one_of_permissions_required
 from ..meta.types import ObjectWithMetadata
 
@@ -41,9 +42,7 @@ class Warehouse(CountableDjangoObjectType):
     company_name = graphene.String(
         required=True,
         description="Warehouse company name.",
-        deprecation_reason=(
-            "Use address.CompanyName. This field will be removed in Saleor 4.0."
-        ),
+        deprecation_reason=f"{DEPRECATED_IN_3X} Use `Address.companyName` instead.",
     )
 
     class Meta:


### PR DESCRIPTION
Use a constant to construct all deprecation messages in a unified way. In the follow-up PR, I'll add a constant to describe in which version of Saleor a field was introduced.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
