### PR TITLE
Change behavior of waiting for approval fulfillment cancellation

### DIFF
--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -753,6 +753,9 @@ def test_cancel_fulfillment(
         "warehouse": str(warehouse.pk),
     }
     assert event_restocked_items.user == staff_user
+    assert Fulfillment.objects.filter(
+        pk=fulfillment.pk, status=FulfillmentStatus.CANCELED
+    ).exists()
 
 
 def test_cancel_fulfillment_no_warehouse_id(
@@ -807,6 +810,7 @@ def test_cancel_fulfillment_awaiting_approval(
     assert event_cancelled.type == (OrderEvents.FULFILLMENT_CANCELED)
     assert event_cancelled.parameters == {}
     assert event_cancelled.user == staff_api_client.user
+    assert not Fulfillment.objects.filter(pk=fulfillment.pk).exists()
 
 
 @patch("saleor.order.actions.restock_fulfillment_lines")
@@ -834,6 +838,7 @@ def test_cancel_fulfillment_awaiting_approval_warehouse_specified(
     assert event_cancelled.type == (OrderEvents.FULFILLMENT_CANCELED)
     assert event_cancelled.parameters == {}
     assert event_cancelled.user == staff_api_client.user
+    assert not Fulfillment.objects.filter(pk=fulfillment.pk).exists()
 
 
 def test_cancel_fulfillment_canceled_state(

--- a/saleor/order/events.py
+++ b/saleor/order/events.py
@@ -451,7 +451,7 @@ def external_notification_event(
 
 
 def fulfillment_canceled_event(
-    *, order: Order, user: UserType, app: AppType, fulfillment: Fulfillment
+    *, order: Order, user: UserType, app: AppType, fulfillment: Optional[Fulfillment]
 ) -> OrderEvent:
     if not user_is_valid(user):
         user = None
@@ -460,7 +460,7 @@ def fulfillment_canceled_event(
         type=OrderEvents.FULFILLMENT_CANCELED,
         user=user,
         app=app,
-        parameters={"composed_id": fulfillment.composed_id},
+        parameters={"composed_id": fulfillment.composed_id} if fulfillment else {},
     )
 
 


### PR DESCRIPTION
I want to merge this change because it changes the behavior of waiting for approval fulfillment cancellation.

How it was?
Event was created
Fulfillment ended un in unfulfilled status which prevents it from becoming fulfilled again

How it is?
Event is created (without composed_id in parameters).
Fulfillment is deleted so we are free to create another one.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
