### PR TITLE
Add missing usage of new auth header for apps

### DIFF
--- a/saleor/core/auth.py
+++ b/saleor/core/auth.py
@@ -1,0 +1,18 @@
+from typing import Optional
+
+from django.core.handlers.wsgi import WSGIRequest
+
+SALEOR_AUTH_HEADER = "HTTP_AUTHORIZATION_BEARER"
+DEFAULT_AUTH_HEADER = "HTTP_AUTHORIZATION"
+AUTH_HEADER_PREFIXES = ["JWT", "BEARER"]
+
+
+def get_token_from_request(request: WSGIRequest) -> Optional[str]:
+    auth_token = request.META.get(SALEOR_AUTH_HEADER)
+
+    if not auth_token:
+        auth = request.META.get(DEFAULT_AUTH_HEADER, "").split(maxsplit=1)
+
+        if len(auth) == 2 and auth[0].upper() in AUTH_HEADER_PREFIXES:
+            auth_token = auth[1]
+    return auth_token

--- a/saleor/core/auth_backend.py
+++ b/saleor/core/auth_backend.py
@@ -1,7 +1,8 @@
 from django.contrib.auth.backends import ModelBackend
 
 from ..account.models import User
-from .jwt import get_token_from_request, get_user_from_access_token
+from .auth import get_token_from_request
+from .jwt import get_user_from_access_token
 
 
 class JSONWebTokenBackend(ModelBackend):

--- a/saleor/core/jwt.py
+++ b/saleor/core/jwt.py
@@ -5,7 +5,6 @@ import graphene
 import jwt
 from django.conf import settings
 from django.contrib.auth.models import Permission
-from django.core.handlers.wsgi import WSGIRequest
 
 from ..account.models import User
 from ..app.models import App, AppExtension
@@ -17,10 +16,6 @@ from .permissions import (
 
 JWT_ALGORITHM = "HS256"
 
-SALEOR_AUTH_HEADER = "HTTP_AUTHORIZATION_BEARER"
-DEFAULT_AUTH_HEADER = "HTTP_AUTHORIZATION"
-
-AUTH_HEADER_PREFIXES = ["JWT", "BEARER"]
 JWT_ACCESS_TYPE = "access"
 JWT_REFRESH_TYPE = "refresh"
 JWT_THIRDPARTY_ACCESS_TYPE = "thirdparty"
@@ -114,17 +109,6 @@ def create_refresh_token(
         additional_payload,
     )
     return jwt_encode(payload)
-
-
-def get_token_from_request(request: WSGIRequest) -> Optional[str]:
-    auth_token = request.META.get(SALEOR_AUTH_HEADER)
-
-    if not auth_token:
-        auth = request.META.get(DEFAULT_AUTH_HEADER, "").split(maxsplit=1)
-
-        if len(auth) == 2 and auth[0].upper() in AUTH_HEADER_PREFIXES:
-            auth_token = auth[1]
-    return auth_token
 
 
 def get_user_from_payload(payload: Dict[str, Any]) -> Optional[User]:

--- a/saleor/graphql/core/tests/test_middleware.py
+++ b/saleor/graphql/core/tests/test_middleware.py
@@ -5,13 +5,40 @@ from django.urls import reverse
 from ...middleware import app_middleware
 
 
-def test_app_middleware_accepts_api_requests(app, rf):
-
+def test_app_middleware_accepts_app_requests(app, rf):
+    # given
     # Retrieve sample request object
     request = rf.get(reverse("api"))
     token = app.tokens.first().auth_token
     request.META = {"HTTP_AUTHORIZATION": f"Bearer {token}"}
 
+    # when
     app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
 
+    # then
     assert request.app == app
+
+
+def test_app_middleware_accepts_saleors_header(app, rf):
+    # given
+    request = rf.get(reverse("api"))
+    token = app.tokens.first().auth_token
+    request.META = {"HTTP_AUTHORIZATION_BEARER": f"{token}"}
+
+    # when
+    app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
+
+    # then
+    assert request.app == app
+
+
+def test_app_middleware_skips_when_token_length_is_different_than_30(app, rf):
+    # given
+    request = rf.get(reverse("api"))
+    request.META = {"HTTP_AUTHORIZATION_BEARER": "a" * 31}
+
+    # when
+    app_middleware(lambda root, info: info.context, Mock(), Mock(context=request))
+
+    # then
+    assert not request.app


### PR DESCRIPTION
I want to merge this change because we added a new auth header but we didn't add support for it for Apps

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
