### PR TITLE
Allow filtering product and product types by gift cards

### DIFF
--- a/saleor/graphql/product/filters.py
+++ b/saleor/graphql/product/filters.py
@@ -20,6 +20,7 @@ from ...attribute.models import (
     AttributeValue,
 )
 from ...channel.models import Channel
+from ...product import ProductTypeKind
 from ...product.models import (
     Category,
     Collection,
@@ -48,6 +49,7 @@ from .enums import (
     CollectionPublished,
     ProductTypeConfigurable,
     ProductTypeEnum,
+    ProductTypeKindEnum,
     StockAvailability,
 )
 
@@ -465,6 +467,12 @@ def _filter_collections_is_published(qs, _, value, channel_slug):
     )
 
 
+def filter_gift_card(qs, _, value):
+    product_types = ProductType.objects.filter(kind=ProductTypeKind.GIFT_CARD)
+    lookup = Exists(product_types.filter(id=OuterRef("product_type_id")))
+    return qs.filter(lookup) if value is True else qs.exclude(lookup)
+
+
 def filter_product_type_configurable(qs, _, value):
     if value == ProductTypeConfigurable.CONFIGURABLE:
         qs = qs.filter(has_variants=True)
@@ -478,6 +486,12 @@ def filter_product_type(qs, _, value):
         qs = qs.filter(is_digital=True)
     elif value == ProductTypeEnum.SHIPPABLE:
         qs = qs.filter(is_shipping_required=True)
+    return qs
+
+
+def filter_product_type_kind(qs, _, value):
+    if value:
+        qs = qs.filter(kind=value)
     return qs
 
 
@@ -561,6 +575,7 @@ class ProductFilter(MetadataFilterBase):
     product_types = GlobalIDMultipleChoiceFilter(method=filter_product_types)
     stocks = ObjectTypeFilter(input_class=ProductStockFilterInput, method=filter_stocks)
     search = django_filters.CharFilter(method=filter_search)
+    gift_card = django_filters.BooleanFilter(method=filter_gift_card)
     ids = GlobalIDMultipleChoiceFilter(method=filter_product_ids)
 
     class Meta:
@@ -655,6 +670,7 @@ class ProductTypeFilter(MetadataFilterBase):
     )
 
     product_type = EnumFilter(input_class=ProductTypeEnum, method=filter_product_type)
+    kind = EnumFilter(input_class=ProductTypeKindEnum, method=filter_product_type_kind)
     ids = GlobalIDMultipleChoiceFilter(field_name="id")
 
     class Meta:

--- a/saleor/graphql/product/tests/benchmark/test_product.py
+++ b/saleor/graphql/product/tests/benchmark/test_product.py
@@ -555,27 +555,28 @@ def test_update_product(
     assert not data["errors"]
 
 
+QUERY_PRODUCTS_WITH_FILTER = """
+    query ($channel: String, $filter: ProductFilterInput){
+        products(
+            channel: $channel,
+            filter: $filter,
+            first: 20,
+        ) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+"""
+
+
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
 def test_filter_products_by_attributes(
     api_client, product_list, channel_USD, count_queries
 ):
-    query = """
-      query ($channel: String, $filter: ProductFilterInput){
-          products(
-              channel: $channel,
-              filter: $filter,
-              first: 20,
-          ) {
-              edges {
-                  node {
-                      name
-                  }
-              }
-          }
-      }
-    """
-
     product = product_list[0]
     attr_assignment = product.attributes.first()
     attr = attr_assignment.attribute
@@ -587,7 +588,7 @@ def test_filter_products_by_attributes(
             ]
         },
     }
-    get_graphql_content(api_client.post_graphql(query, variables))
+    get_graphql_content(api_client.post_graphql(QUERY_PRODUCTS_WITH_FILTER, variables))
 
 
 @pytest.mark.django_db
@@ -595,22 +596,6 @@ def test_filter_products_by_attributes(
 def test_filter_products_by_numeric_attributes(
     api_client, product_list, numeric_attribute, channel_USD, count_queries
 ):
-    query = """
-      query ($channel: String,  $filter: ProductFilterInput){
-          products(
-              channel: $channel,
-              filter: $filter,
-              first: 20,
-          ) {
-              edges {
-                  node {
-                      name
-                  }
-              }
-          }
-      }
-    """
-
     product = product_list[0]
     product.product_type.product_attributes.add(numeric_attribute)
     associate_attribute_values_to_instance(
@@ -630,7 +615,7 @@ def test_filter_products_by_numeric_attributes(
             ]
         },
     }
-    get_graphql_content(api_client.post_graphql(query, variables))
+    get_graphql_content(api_client.post_graphql(QUERY_PRODUCTS_WITH_FILTER, variables))
 
 
 @pytest.mark.django_db
@@ -638,22 +623,6 @@ def test_filter_products_by_numeric_attributes(
 def test_filter_products_by_boolean_attributes(
     api_client, product_list, boolean_attribute, channel_USD, count_queries
 ):
-    query = """
-      query ($channel: String,  $filter: ProductFilterInput){
-          products(
-              channel: $channel,
-              filter: $filter,
-              first: 20,
-          ) {
-              edges {
-                  node {
-                      name
-                  }
-              }
-          }
-      }
-    """
-
     product = product_list[0]
     product.product_type.product_attributes.add(boolean_attribute)
     associate_attribute_values_to_instance(
@@ -670,7 +639,24 @@ def test_filter_products_by_boolean_attributes(
             ]
         },
     }
-    get_graphql_content(api_client.post_graphql(query, variables))
+    get_graphql_content(api_client.post_graphql(QUERY_PRODUCTS_WITH_FILTER, variables))
+
+
+@pytest.mark.django_db
+@pytest.mark.count_queries(autouse=False)
+def test_filter_products_by_gift_card(
+    staff_api_client,
+    product_list,
+    boolean_attribute,
+    channel_USD,
+    count_queries,
+    shippable_gift_card_product,
+):
+    variables = {"filter": {"giftCard": True}}
+
+    get_graphql_content(
+        staff_api_client.post_graphql(QUERY_PRODUCTS_WITH_FILTER, variables)
+    )
 
 
 @pytest.mark.django_db

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5269,6 +5269,7 @@ input ProductFilterInput {
   price: PriceRangeInput
   minimalPrice: PriceRangeInput
   productTypes: [ID]
+  giftCard: Boolean
   ids: [ID]
   channel: String
 }
@@ -5483,6 +5484,7 @@ input ProductTypeFilterInput {
   configurable: ProductTypeConfigurable
   productType: ProductTypeEnum
   metadata: [MetadataFilter]
+  kind: ProductTypeKindEnum
   ids: [ID]
 }
 


### PR DESCRIPTION
Extend `ProductFilterInput` with `giftCard` field.
Extend `ProductTypeFilterInput` with `kind` field.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
