### PR TITLE
Fix sending gift card multiple times

### DIFF
--- a/saleor/giftcard/notifications.py
+++ b/saleor/giftcard/notifications.py
@@ -2,7 +2,7 @@ from ..core.notifications import get_site_context
 from ..core.notify_events import NotifyEventType
 
 
-def send_gift_card_notification(user, app, email, gift_card, manager):
+def send_gift_card_notification(user, app, email, gift_card, manager, channel_slug):
     """Trigger sending a gift card notification for the given recipient."""
     payload = {
         "requester": {
@@ -24,4 +24,6 @@ def send_gift_card_notification(user, app, email, gift_card, manager):
         },
         **get_site_context(),
     }
-    manager.notify(NotifyEventType.SEND_GIFT_CARD, payload=payload)
+    manager.notify(
+        NotifyEventType.SEND_GIFT_CARD, payload=payload, channel_slug=channel_slug
+    )

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -245,7 +245,12 @@ def test_gift_cards_create(
     assert shippable_event.parameters == {"order_id": order.id, "expiry_date": None}
 
     send_notification_mock.assert_called_once_with(
-        staff_user, None, user_email, non_shippable_gift_card, manager
+        staff_user,
+        None,
+        user_email,
+        non_shippable_gift_card,
+        manager,
+        order.channel.slug,
     )
 
 
@@ -311,7 +316,12 @@ def test_gift_cards_create_expiry_date_set(
     }
 
     send_notification_mock.assert_called_once_with(
-        staff_user, None, user_email, non_shippable_gift_card, manager
+        staff_user,
+        None,
+        user_email,
+        non_shippable_gift_card,
+        manager,
+        order.channel.slug,
     )
 
 

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -198,9 +198,10 @@ def gift_cards_create(
     gift_cards = GiftCard.objects.bulk_create(gift_cards)
     events.gift_cards_bought(gift_cards, order.id, requestor_user, app)
 
+    channel_slug = order.channel.slug
     # send to customer all non-shippable gift cards
     send_gift_cards_to_customer(
-        non_shippable_gift_cards, user_email, requestor_user, app, manager
+        non_shippable_gift_cards, user_email, requestor_user, app, manager, channel_slug
     )
     return gift_cards
 
@@ -222,8 +223,11 @@ def send_gift_cards_to_customer(
     requestor_user: Optional["User"],
     app: Optional["App"],
     manager: "PluginsManager",
+    channel_slug: str,
 ):
     for gift_card in gift_cards:
-        send_gift_card_notification(requestor_user, app, user_email, gift_card, manager)
+        send_gift_card_notification(
+            requestor_user, app, user_email, gift_card, manager, channel_slug
+        )
 
     events.gift_cards_sent(gift_cards, requestor_user, app, user_email)

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -175,6 +175,7 @@ class GiftCardCreate(ModelMutation):
             cleaned_input["user_email"],
             instance,
             info.context.plugins,
+            channel_slug=None,
         )
         events.gift_card_sent(
             gift_card_id=instance.id,
@@ -364,6 +365,8 @@ class GiftCardResend(BaseMutation):
             target_email,
             gift_card,
             info.context.plugins,
+            # TODO: should be fulfill with channel_slug from input
+            channel_slug="",
         )
         events.gift_card_resent(
             gift_card_id=gift_card.id,

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -47,6 +47,9 @@ class GiftCardCreateInput(GiftCardInput):
         required=False,
         description="Email of the customer to whom gift card will be sent.",
     )
+    channel = graphene.String(
+        description="Slug of a channel from which the email should be sent."
+    )
     is_active = graphene.Boolean(
         required=True, description="Determine if gift card is active."
     )
@@ -101,6 +104,16 @@ class GiftCardCreate(ModelMutation):
                         "email": ValidationError(
                             "Provided email is invalid.",
                             code=GiftCardErrorCode.INVALID.value,
+                        )
+                    }
+                )
+            if not data.get("channel"):
+                raise ValidationError(
+                    {
+                        "channel": ValidationError(
+                            "Channel slug must be specified "
+                            "when user_email is provided.",
+                            code=GiftCardErrorCode.REQUIRED.value,
                         )
                     }
                 )
@@ -169,20 +182,23 @@ class GiftCardCreate(ModelMutation):
             user=info.context.user,
             app=info.context.app,
         )
-        send_gift_card_notification(
-            cleaned_input.get("created_by"),
-            cleaned_input.get("app"),
-            cleaned_input["user_email"],
-            instance,
-            info.context.plugins,
-            channel_slug=None,
-        )
-        events.gift_card_sent(
-            gift_card_id=instance.id,
-            user_id=info.context.user.id if info.context.user else None,
-            app_id=info.context.app.id if info.context.app else None,
-            email=cleaned_input["user_email"],
-        )
+        if email := cleaned_input.get("user_email"):
+            user = cleaned_input.get("created_by")
+            app = cleaned_input.get("app")
+            send_gift_card_notification(
+                user,
+                app,
+                email,
+                instance,
+                info.context.plugins,
+                channel_slug=cleaned_input["channel"],
+            )
+            events.gift_card_sent(
+                gift_card_id=instance.id,
+                user_id=user.id if user else None,
+                app_id=app.id if app else None,
+                email=email,
+            )
 
 
 class GiftCardUpdate(GiftCardCreate):
@@ -311,6 +327,10 @@ class GiftCardResendInput(graphene.InputObjectType):
     email = graphene.String(
         required=False, description="Email to which gift card should be send."
     )
+    channel = graphene.String(
+        description="Slug of a channel from which the email should be sent.",
+        required=True,
+    )
 
 
 class GiftCardResend(BaseMutation):
@@ -356,22 +376,22 @@ class GiftCardResend(BaseMutation):
             info, gift_card_id, field="gift_card_id", only_type=GiftCard
         )
         target_email = cls.get_target_email(data, gift_card)
-        user = None
-        if user_is_valid(info.context.user):
-            user = info.context.user
+        user = info.context.user
+        if not user_is_valid(user):
+            user = None
+        app = info.context.app
         send_gift_card_notification(
             user,
-            info.context.app,
+            app,
             target_email,
             gift_card,
             info.context.plugins,
-            # TODO: should be fulfill with channel_slug from input
-            channel_slug="",
+            channel_slug=data.get("channel"),
         )
         events.gift_card_resent(
             gift_card_id=gift_card.id,
             user_id=user.id if user else None,
-            app_id=info.context.app.id if info.context.app else None,
+            app_id=app.id if app else None,
             email=target_email,
         )
         return GiftCardResend(gift_card=gift_card)

--- a/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/benchmark/test_gift_card_mutations.py
@@ -8,11 +8,11 @@ from ....tests.utils import get_graphql_content
 
 CREATE_GIFT_CARD_MUTATION = """
     mutation giftCardCreate(
-        $balance: PriceInput!, $userEmail: String, $tag: String,
+        $balance: PriceInput!, $userEmail: String, $tag: String, $channel: String,
         $note: String, $expiryDate: Date, $isActive: Boolean!
     ){
         giftCardCreate(input: {
-                balance: $balance, userEmail: $userEmail, tag: $tag,
+                balance: $balance, userEmail: $userEmail, tag: $tag, channel: $channel,
                 expiryDate: $expiryDate, note: $note, isActive: $isActive }) {
             giftCard {
                 id
@@ -88,6 +88,7 @@ CREATE_GIFT_CARD_MUTATION = """
 def test_create_never_expiry_gift_card(
     staff_api_client,
     customer_user,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -103,6 +104,7 @@ def test_create_never_expiry_gift_card(
             "currency": currency,
         },
         "userEmail": customer_user.email,
+        "channel": channel_USD.slug,
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "expiry_date": None,

--- a/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
+++ b/saleor/graphql/giftcard/tests/deprecated/test_gift_card_mutations.py
@@ -4,13 +4,13 @@ from ....tests.utils import get_graphql_content
 
 CREATE_GIFT_CARD_MUTATION = """
     mutation giftCardCreate(
-        $startDate: Date, $endDate: Date, $expiryDate: Date
+        $startDate: Date, $endDate: Date, $expiryDate: Date, $channel: String,
         $balance: PriceInput!, $userEmail: String, $isActive: Boolean!
     ){
         giftCardCreate(input: {
                 startDate: $startDate,
                 endDate: $endDate,
-                balance: $balance, userEmail: $userEmail,
+                balance: $balance, userEmail: $userEmail, channel: $channel
                 expiryDate: $expiryDate, isActive: $isActive
             }) {
             giftCard {
@@ -49,6 +49,7 @@ CREATE_GIFT_CARD_MUTATION = """
 def test_create_never_expiry_gift_card(
     staff_api_client,
     customer_user,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -65,6 +66,7 @@ def test_create_never_expiry_gift_card(
             "currency": currency,
         },
         "userEmail": customer_user.email,
+        "channel": channel_USD.slug,
         "tag": tag,
         "note": "This is gift card note that will be save in gift card event.",
         "startDate": start_date.isoformat(),

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_create.py
@@ -5,15 +5,8 @@ from .....giftcard.error_codes import GiftCardErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 CREATE_GIFT_CARD_MUTATION = """
-    mutation giftCardCreate(
-        $balance: PriceInput!, $userEmail: String, $tag: String,
-        $expiryDate: Date, $note: String, $isActive: Boolean!
-    ){
-        giftCardCreate(input: {
-                balance: $balance, userEmail: $userEmail, tag: $tag,
-                expiryDate: $expiryDate, note: $note,
-                isActive: $isActive
-            }) {
+    mutation giftCardCreate($input: GiftCardCreateInput!){
+        giftCardCreate(input: $input) {
             giftCard {
                 id
                 code
@@ -86,6 +79,7 @@ CREATE_GIFT_CARD_MUTATION = """
 def test_create_never_expiry_gift_card(
     staff_api_client,
     customer_user,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -95,14 +89,17 @@ def test_create_never_expiry_gift_card(
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "channel": channel_USD.slug,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "isActive": True,
+        }
     }
 
     # when
@@ -165,15 +162,16 @@ def test_create_gift_card_by_app(
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "expiryDate": None,
-        "isActive": False,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "expiryDate": None,
+            "isActive": False,
+        }
     }
 
     # when
@@ -203,8 +201,8 @@ def test_create_gift_card_by_app(
     assert data["initialBalance"]["amount"] == initial_balance
     assert data["currentBalance"]["amount"] == initial_balance
 
-    assert len(data["events"]) == 2
-    created_event, sent_event = data["events"]
+    assert len(data["events"]) == 1
+    created_event = data["events"][0]
 
     assert created_event["type"] == GiftCardEvents.ISSUED.upper()
     assert not created_event["user"]
@@ -216,26 +214,25 @@ def test_create_gift_card_by_app(
     assert not created_event["balance"]["oldInitialBalance"]
     assert not created_event["balance"]["oldCurrentBalance"]
 
-    assert sent_event["type"] == GiftCardEvents.SENT_TO_CUSTOMER.upper()
-    assert not sent_event["user"]
-    assert sent_event["app"]["name"] == app_api_client.app.name
 
-
-def test_create_gift_card_by_customer(api_client, customer_user):
+def test_create_gift_card_by_customer(api_client, customer_user, channel_USD):
     # given
     initial_balance = 100
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "expiryDate": None,
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "channel": channel_USD.slug,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "expiryDate": None,
+            "isActive": True,
+        }
     }
 
     # when
@@ -254,14 +251,16 @@ def test_create_gift_card_no_premissions(staff_api_client):
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "expiryDate": None,
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "expiryDate": None,
+            "isActive": True,
+        }
     }
 
     # when
@@ -286,14 +285,16 @@ def test_create_gift_card_with_too_many_decimal_places_in_balance_amount(
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "isActive": True,
+        }
     }
 
     # when
@@ -329,14 +330,16 @@ def test_create_gift_card_with_malformed_email(
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": "malformed",
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": "malformed",
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "isActive": True,
+        }
     }
 
     # when
@@ -362,6 +365,53 @@ def test_create_gift_card_with_malformed_email(
     assert error["code"] == GiftCardErrorCode.INVALID.name
 
 
+def test_create_gift_card_lack_of_channel(
+    staff_api_client,
+    customer_user,
+    permission_manage_gift_card,
+    permission_manage_users,
+    permission_manage_apps,
+):
+    # given
+    initial_balance = 10
+    currency = "USD"
+    tag = "gift-card-tag"
+    variables = {
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "isActive": True,
+        }
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        CREATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_users,
+            permission_manage_apps,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCardCreate"]["giftCard"]
+    errors = content["data"]["giftCardCreate"]["errors"]
+
+    assert not data
+    assert len(errors) == 1
+    error = errors[0]
+    assert error["field"] == "channel"
+    assert error["code"] == GiftCardErrorCode.REQUIRED.name
+
+
 def test_create_gift_card_with_zero_balance_amount(
     staff_api_client,
     customer_user,
@@ -373,14 +423,16 @@ def test_create_gift_card_with_zero_balance_amount(
     currency = "USD"
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": 0,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": 0,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "isActive": True,
+        }
     }
 
     # when
@@ -408,6 +460,7 @@ def test_create_gift_card_with_zero_balance_amount(
 def test_create_gift_card_with_expiry_date(
     staff_api_client,
     customer_user,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -418,15 +471,18 @@ def test_create_gift_card_with_expiry_date(
     date_value = date.today() + timedelta(days=365)
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "expiryDate": date_value,
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "channel": channel_USD.slug,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "expiryDate": date_value,
+            "isActive": True,
+        }
     }
 
     # when
@@ -481,15 +537,17 @@ def test_create_gift_card_with_expiry_date_type_date_in_past(
     date_value = date(1999, 1, 1)
     tag = "gift-card-tag"
     variables = {
-        "balance": {
-            "amount": initial_balance,
-            "currency": currency,
-        },
-        "userEmail": customer_user.email,
-        "tag": tag,
-        "note": "This is gift card note that will be save in gift card event.",
-        "expiryDate": date_value,
-        "isActive": True,
+        "input": {
+            "balance": {
+                "amount": initial_balance,
+                "currency": currency,
+            },
+            "userEmail": customer_user.email,
+            "tag": tag,
+            "note": "This is gift card note that will be save in gift card event.",
+            "expiryDate": date_value,
+            "isActive": True,
+        }
     }
 
     # when

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_resend.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_resend.py
@@ -49,6 +49,7 @@ def test_resend_gift_card(
     notify_mock,
     staff_api_client,
     gift_card,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -59,6 +60,7 @@ def test_resend_gift_card(
         "input": {
             "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
             "email": email,
+            "channel": channel_USD.slug,
         }
     }
 
@@ -96,6 +98,7 @@ def test_resend_gift_card_as_app(
     notify_mock,
     app_api_client,
     gift_card,
+    channel_USD,
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
@@ -104,6 +107,7 @@ def test_resend_gift_card_as_app(
     variables = {
         "input": {
             "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
+            "channel": channel_USD.slug,
         }
     }
 
@@ -142,11 +146,13 @@ def test_update_gift_card_no_permission(
     notify_mock,
     staff_api_client,
     gift_card,
+    channel_USD,
 ):
     # given
     variables = {
         "input": {
             "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
+            "channel": channel_USD.slug,
         }
     }
 
@@ -171,12 +177,14 @@ def test_resend_gift_card_malformed_email(
     permission_manage_gift_card,
     permission_manage_users,
     permission_manage_apps,
+    channel_USD,
 ):
     # given
     variables = {
         "input": {
             "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
             "email": "malformed",
+            "channel": channel_USD.slug,
         }
     }
 

--- a/saleor/graphql/order/tests/test_fulfillment.py
+++ b/saleor/graphql/order/tests/test_fulfillment.py
@@ -306,7 +306,12 @@ def test_order_fulfill_with_gift_cards(
     )
 
     mock_send_notification.assert_called_once_with(
-        staff_user, None, order.user_email, non_shippable_gift_card, ANY
+        staff_user,
+        None,
+        order.user_email,
+        non_shippable_gift_card,
+        ANY,
+        order.channel.slug,
     )
 
 

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2294,6 +2294,7 @@ input GiftCardCreateInput {
   endDate: Date
   balance: PriceInput!
   userEmail: String
+  channel: String
   isActive: Boolean!
   code: String
   note: String
@@ -2383,6 +2384,7 @@ type GiftCardResend {
 input GiftCardResendInput {
   id: ID!
   email: String
+  channel: String!
 }
 
 type GiftCardSettings {

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2234,6 +2234,7 @@ type GiftCard implements Node & ObjectWithMetadata {
   app: App
   product: Product
   events: [GiftCardEvent!]!
+  boughtInChannel: String
   user: User @deprecated(reason: "Will be removed in Saleor 4.0. Use created_by field instead")
   endDate: DateTime @deprecated(reason: "Will be removed in Saleor 4.0. Use expiry_date field instead.")
   startDate: DateTime @deprecated(reason: "Will be removed in Saleor 4.0.")


### PR DESCRIPTION
For creating gift cards in fulfillment use channel from order.

For gift card mutations:
- extend `GiftCardResendInput` with `channel` field
- extend `GiftCardCreateInput` with `channel` field

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
