### PR TITLE
Fix fulfillments refund with waiting for approval state

### DIFF
--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -654,10 +654,14 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
 
         Delete fulfillments themselves if metioned lines were only lines inside.
         """
+        if not lines_info:
+            return [], []
+
         lines_to_remove = []
         lines_to_update = []
-        remaining_lines = []
-        quantity = 0
+        remaining_fulfillment_lines = []
+        order_lines_map = defaultdict(lambda: 0)
+
         for line_data in lines_info:
             if (
                 line_data.line.fulfillment.status
@@ -667,12 +671,11 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
                     _line = line_data.line
                     _line.quantity = _line.quantity - line_data.quantity
                     lines_to_update.append(_line)
-                    quantity += line_data.quantity
                 else:
                     lines_to_remove.append(line_data.line.id)
-                    quantity += line_data.quantity
+                order_lines_map[line_data.line.order_line] += line_data.quantity
             else:
-                remaining_lines.append(line_data)
+                remaining_fulfillment_lines.append(line_data)
 
         lines_to_delete = order_models.FulfillmentLine.objects.filter(
             id__in=set(lines_to_remove)
@@ -681,45 +684,64 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
         related_fulfillment_ids = [f.fulfillment.pk for f in lines_to_delete]
         related_fulfillment_ids.extend([f.fulfillment.pk for f in lines_to_update])
 
-        order_line = None
         if lines_to_update:
-            order_line = lines_to_update[0].order_line
             order_models.FulfillmentLine.objects.bulk_update(
                 lines_to_update, ["quantity"]
             )
 
         if lines_to_delete:
-            order_line = lines_to_delete[0].order_line
             lines_to_delete.delete()
 
-        if order_line:
-            order_line.quantity_fulfilled += quantity
-            order_line.save(update_fields=["quantity_fulfilled"])
-
-        # Delete fulfillment objects if they are empty
         order_models.Fulfillment.objects.filter(
             pk__in=related_fulfillment_ids, lines=None
         ).delete()
 
-        return remaining_lines
+        return order_lines_map, remaining_fulfillment_lines
+
+    @classmethod
+    def extend_order_lines(cls, order_lines, lines_data):
+        """Extend order_lines with data from lines_data.
+
+        If order line entry existed, increase it's quantity, create if it didn't.
+        """
+        for line, quantity in lines_data.items():
+            appended = False
+            for item in order_lines:
+                if item.line == line:
+                    item.quantity += quantity
+                    appended = True
+            if not appended:
+                order_lines.append(
+                    OrderLineData(
+                        line=line,
+                        quantity=quantity,
+                        variant=None,
+                        replace=False,
+                        warehouse_pk=None,
+                    )
+                )
+        return order_lines
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         cleaned_input = cls.clean_input(info, data.get("order"), data.get("input"))
         order = cleaned_input["order"]
 
-        if fulfillment_lines := cleaned_input.get("fulfillment_lines", []):
-            cleaned_input["fulfillment_lines"] = cls.remove_waiting_fulfillments(
-                fulfillment_lines
-            )
+        order_lines_map, remaining_fulfillment_lines = cls.remove_waiting_fulfillments(
+            cleaned_input.get("fulfillment_lines", [])
+        )
+
+        order_lines = cls.extend_order_lines(
+            cleaned_input.get("order_lines", []), order_lines_map
+        )
 
         refund_fulfillment = create_refund_fulfillment(
             info.context.user,
             info.context.app,
             order,
             cleaned_input["payment"],
-            cleaned_input.get("order_lines", []),
-            fulfillment_lines,
+            order_lines,
+            remaining_fulfillment_lines,
             info.context.plugins,
             cleaned_input["amount_to_refund"],
             cleaned_input["include_shipping_costs"],

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -655,7 +655,7 @@ class FulfillmentRefundProducts(FulfillmentRefundAndReturnProductBase):
         Delete fulfillments themselves if metioned lines were only lines inside.
         """
         if not lines_info:
-            return [], []
+            return {}, []
 
         lines_to_remove = []
         lines_to_update = []

--- a/saleor/graphql/order/tests/test_fulfillment_refund_products.py
+++ b/saleor/graphql/order/tests/test_fulfillment_refund_products.py
@@ -6,7 +6,7 @@ from prices import Money, TaxedMoney
 
 from ....core.prices import quantize_price
 from ....order.error_codes import OrderErrorCode
-from ....order.models import FulfillmentStatus
+from ....order.models import FulfillmentLine, FulfillmentStatus
 from ....payment import ChargeStatus, PaymentError
 from ....warehouse.models import Allocation, Stock
 from ...tests.utils import get_graphql_content
@@ -296,6 +296,59 @@ def test_fulfillment_refund_products_fulfillment_lines(
     assert len(refund_fulfillment["lines"]) == 1
     assert refund_fulfillment["lines"][0]["orderLine"]["id"] == order_line_id
     assert refund_fulfillment["lines"][0]["quantity"] == 2
+    mocked_refund.assert_called_with(
+        payment_dummy,
+        ANY,
+        amount=fulfillment_line_to_refund.order_line.unit_price_gross_amount * 2,
+        channel_slug=fulfilled_order.channel.slug,
+    )
+
+
+@patch("saleor.order.actions.gateway.refund")
+def test_fulfillment_refund_products_waiting_fulfillment_lines(
+    mocked_refund,
+    staff_api_client,
+    permission_manage_orders,
+    fulfilled_order,
+    payment_dummy,
+):
+    payment_dummy.total = fulfilled_order.total_gross_amount
+    payment_dummy.captured_amount = payment_dummy.total
+    payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
+    payment_dummy.save()
+    fulfillment = fulfilled_order.fulfillments.first()
+    fulfillment.status = FulfillmentStatus.WAITING_FOR_APPROVAL
+    fulfillment.save(update_fields=["status"])
+    fulfilled_order.payments.add(payment_dummy)
+    fulfillment_line_to_refund = fulfilled_order.fulfillments.first().lines.first()
+    order_id = graphene.Node.to_global_id("Order", fulfilled_order.pk)
+    fulfillment_line_id = graphene.Node.to_global_id(
+        "FulfillmentLine", fulfillment_line_to_refund.pk
+    )
+    order_line_id = graphene.Node.to_global_id(
+        "OrderLine", fulfillment_line_to_refund.order_line.pk
+    )
+    variables = {
+        "order": order_id,
+        "input": {
+            "fulfillmentLines": [
+                {"fulfillmentLineId": fulfillment_line_id, "quantity": 2}
+            ]
+        },
+    }
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(ORDER_FULFILL_REFUND_MUTATION, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["orderFulfillmentRefundProducts"]
+    refund_fulfillment = data["fulfillment"]
+    errors = data["errors"]
+
+    assert not errors
+    assert refund_fulfillment["status"] == FulfillmentStatus.REFUNDED.upper()
+    assert len(refund_fulfillment["lines"]) == 1
+    assert refund_fulfillment["lines"][0]["orderLine"]["id"] == order_line_id
+    assert refund_fulfillment["lines"][0]["quantity"] == 2
+    assert not FulfillmentLine.objects.filter(pk=fulfillment_line_to_refund.pk).exists()
     mocked_refund.assert_called_with(
         payment_dummy,
         ANY,


### PR DESCRIPTION
I want to merge this change because it fixes fulfillments waiting for approval not properly handled on refund option.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
