### PR TITLE
[SALEOR-3686] Add active payments to checkout to graphql

### DIFF
--- a/saleor/graphql/checkout/tests/benchmark/conftest.py
+++ b/saleor/graphql/checkout/tests/benchmark/conftest.py
@@ -15,6 +15,14 @@ def customer_checkout(customer_user, checkout_with_voucher_percentage_and_shippi
     return checkout_with_voucher_percentage_and_shipping
 
 
+@pytest.fixture
+def checkout_with_customer_payments(customer_checkout, payment_dummy_factory):
+    customer_checkout.payments.add(payment_dummy_factory())
+    customer_checkout.payments.add(payment_dummy_factory())
+
+    return customer_checkout
+
+
 @pytest.fixture()
 def checkout_with_variants(
     checkout,

--- a/saleor/graphql/checkout/tests/benchmark/test_homepage.py
+++ b/saleor/graphql/checkout/tests/benchmark/test_homepage.py
@@ -5,7 +5,9 @@ from ....tests.utils import get_graphql_content
 
 @pytest.mark.django_db
 @pytest.mark.count_queries(autouse=False)
-def test_user_checkout_details(user_api_client, customer_checkout, count_queries):
+def test_user_checkout_details(
+    user_api_client, checkout_with_customer_payments, count_queries
+):
     query = """
         fragment Price on TaxedMoney {
           gross {
@@ -127,6 +129,15 @@ def test_user_checkout_details(user_api_client, customer_checkout, count_queries
           discountName
           translatedDiscountName
           voucherCode
+          payments {
+            gateway
+            isActive
+            chargeStatus
+            total {
+              currency
+              amount
+            }
+          }
         }
 
         query UserCheckoutDetails {

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -2692,3 +2692,59 @@ def test_get_checkout_with_vatlayer_set(
     # then
     content = get_graphql_content(response)
     assert content["data"]["checkout"]["token"] == str(checkout.token)
+
+
+QUERY_ACTIVE_PAYMENTS_CHECKOUT = """
+    query getCheckout($token: UUID!){
+        checkout(token: $token) {
+            id
+            payments {
+                id
+                gateway
+                isActive
+                chargeStatus
+                total {
+                    currency
+                    amount
+                }
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "active, expected_count",
+    (
+        (True, 2),
+        (False, 0),
+    ),
+)
+def test_checkout_active_payments(
+    checkout_with_item,
+    payment_dummy_factory,
+    staff_api_client,
+    active,
+    expected_count,
+    assert_num_queries,
+):
+    payment_dummy = payment_dummy_factory()
+    payment_dummy.is_active = active
+    payment_dummy.save()
+    checkout_with_item.payments.add(payment_dummy)
+
+    second_payment_dummy = payment_dummy_factory()
+    second_payment_dummy.is_active = active
+    second_payment_dummy.save()
+    checkout_with_item.payments.add(second_payment_dummy)
+
+    with assert_num_queries(3):
+        response = staff_api_client.post_graphql(
+            QUERY_ACTIVE_PAYMENTS_CHECKOUT, {"token": checkout_with_item.token}
+        )
+        content = get_graphql_content(response)
+    checkout = content["data"]["checkout"]
+    assert checkout is not None
+
+    payments = content["data"]["checkout"]["payments"]
+    assert len(payments) == expected_count

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -1008,6 +1008,7 @@ type Checkout implements Node & ObjectWithMetadata {
   token: UUID!
   totalPrice: TaxedMoney
   languageCode: LanguageCodeEnum!
+  payments: [Payment!]!
 }
 
 type CheckoutAddPromoCode {

--- a/saleor/payment/dataloaders.py
+++ b/saleor/payment/dataloaders.py
@@ -13,3 +13,14 @@ class PaymentsByOrderIdLoader(DataLoader):
         for payment in payments.iterator():
             payment_map[payment.order_id].append(payment)
         return [payment_map.get(order_id, []) for order_id in keys]
+
+
+class PaymentsByCheckoutIdLoader(DataLoader):
+    context_key = "payments_by_checkout"
+
+    def batch_load(self, keys):
+        payments = Payment.objects.filter(checkout_id__in=keys).order_by("pk")
+        payment_map = defaultdict(list)
+        for payment in payments.iterator():
+            payment_map[payment.checkout_id].append(payment)
+        return [payment_map.get(checkout_id, []) for checkout_id in keys]

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3849,8 +3849,16 @@ def payment_kwargs(db, order_with_lines):
 
 
 @pytest.fixture
-def payment_dummy(payment_kwargs):
-    return Payment.objects.create(**payment_kwargs)
+def payment_dummy_factory(payment_kwargs):
+    def factory():
+        return Payment.objects.create(**payment_kwargs)
+
+    return factory
+
+
+@pytest.fixture
+def payment_dummy(payment_dummy_factory):
+    return payment_dummy_factory()
 
 
 @pytest.fixture


### PR DESCRIPTION
I want to merge this change because...

I need Extend checkout type to return list of active payments

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
