### PR TITLE
[SALEOR-3764] Extend PaymentData with new fields

### DIFF
--- a/saleor/payment/gateways/stripe/deprecated/tests/test_utils.py
+++ b/saleor/payment/gateways/stripe/deprecated/tests/test_utils.py
@@ -109,7 +109,7 @@ def test_checkout_token_from_checkout(payment_dummy, checkout):
 
 
 def test_checkout_token_from_order(payment_dummy, order):
-    order.checkout_token = uuid.UUID("0edbb71f-e3ca-4600-9e77-65b35ba55465")
+    order.checkout_token = str(uuid.UUID("0edbb71f-e3ca-4600-9e77-65b35ba55465"))
     payment_dummy.order = order
     payment_info = create_payment_information(payment_dummy)
 

--- a/saleor/payment/gateways/stripe/deprecated/tests/test_utils.py
+++ b/saleor/payment/gateways/stripe/deprecated/tests/test_utils.py
@@ -1,3 +1,4 @@
+import uuid
 from decimal import Decimal
 from math import isclose
 
@@ -96,3 +97,28 @@ def test_shipping_address_to_stripe_dict(address):
         },
     }
     assert shipping_to_stripe_dict(address_data) == expected_address_dict
+
+
+def test_checkout_token_from_checkout(payment_dummy, checkout):
+    payment_dummy.checkout = checkout
+    payment_info = create_payment_information(payment_dummy)
+
+    token = str(payment_dummy.checkout.token)
+
+    assert payment_info.checkout_token == token
+
+
+def test_checkout_token_from_order(payment_dummy, order):
+    order.checkout_token = uuid.UUID("0edbb71f-e3ca-4600-9e77-65b35ba55465")
+    payment_dummy.order = order
+    payment_info = create_payment_information(payment_dummy)
+
+    token = "0edbb71f-e3ca-4600-9e77-65b35ba55465"
+
+    assert payment_info.checkout_token == token
+
+
+def test_checkout_token_from_none(payment_dummy, order):
+    payment_info = create_payment_information(payment_dummy)
+
+    assert payment_info.checkout_token is None

--- a/saleor/payment/gateways/stripe/plugin.py
+++ b/saleor/payment/gateways/stripe/plugin.py
@@ -1,11 +1,12 @@
 import logging
-from typing import TYPE_CHECKING, List, Tuple
+from typing import TYPE_CHECKING, Any, List, Optional, Tuple
 
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
 from django.core.handlers.wsgi import WSGIRequest
 from django.http import HttpResponse, HttpResponseNotFound
 from django.http.request import split_domain_port
+from stripe.stripe_object import StripeObject
 
 from ....graphql.core.enums import PluginErrorCode
 from ....plugins.base_plugin import BasePlugin, ConfigurationTypeField
@@ -170,6 +171,8 @@ class StripeGatewayPlugin(BasePlugin):
 
         auto_capture = self.config.auto_capture
         if self.order_auto_confirmation is False:
+            auto_capture = False
+        if payment_information.partial:
             auto_capture = False
 
         data = payment_information.data

--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -770,6 +770,45 @@ def test_process_payment_with_manual_capture(
 
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_partial(
+    mocked_payment_intent, stripe_plugin, payment_stripe_for_checkout, channel_USD
+):
+    payment_intent = Mock()
+    mocked_payment_intent.return_value = payment_intent
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+
+    plugin = stripe_plugin(auto_capture=True)
+
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        partial=True,
+    )
+
+    plugin.process_payment(payment_info, None)
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=MANUAL_CAPTURE_METHOD,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
+        stripe_version=STRIPE_API_VERSION,
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
 def test_process_payment_with_error(
     mocked_payment_intent, stripe_plugin, payment_stripe_for_checkout, channel_USD
 ):

--- a/saleor/payment/interface.py
+++ b/saleor/payment/interface.py
@@ -82,6 +82,8 @@ class PaymentData:
     reuse_source: bool = False
     data: Optional[dict] = None
     graphql_customer_id: Optional[str] = None
+    partial: bool = False
+    checkout_token: Optional[str] = None
 
 
 @dataclass

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -41,23 +41,20 @@ def create_payment_information(
     billing/shipping addresses for optional fraud-prevention mechanisms.
     """
     checkout = payment.checkout
-    checkout_token = None
     if checkout:
         billing = checkout.billing_address
         shipping = checkout.shipping_address
         email = checkout.get_customer_email()
         user_id = checkout.user_id
-        checkout_token = str(checkout.token)
+        checkout_token: Optional[str] = str(checkout.token)
     elif payment.order:
         billing = payment.order.billing_address
         shipping = payment.order.shipping_address
         email = payment.order.user_email
         user_id = payment.order.user_id
-        checkout_token = str(payment.order.checkout_token)
+        checkout_token = payment.order.checkout_token or None
     else:
         billing, shipping, email, user_id = None, None, payment.billing_email, None
-
-    if not checkout_token:  # Either not empty uuid or None
         checkout_token = None
 
     billing_address = AddressData(**billing.as_data()) if billing else None

--- a/saleor/payment/utils.py
+++ b/saleor/payment/utils.py
@@ -33,6 +33,7 @@ def create_payment_information(
     customer_id: str = None,
     store_source: bool = False,
     additional_data: Optional[dict] = None,
+    partial: bool = False,
 ) -> PaymentData:
     """Extract order information along with payment details.
 
@@ -40,18 +41,24 @@ def create_payment_information(
     billing/shipping addresses for optional fraud-prevention mechanisms.
     """
     checkout = payment.checkout
+    checkout_token = None
     if checkout:
         billing = checkout.billing_address
         shipping = checkout.shipping_address
         email = checkout.get_customer_email()
         user_id = checkout.user_id
+        checkout_token = str(checkout.token)
     elif payment.order:
         billing = payment.order.billing_address
         shipping = payment.order.shipping_address
         email = payment.order.user_email
         user_id = payment.order.user_id
+        checkout_token = str(payment.order.checkout_token)
     else:
         billing, shipping, email, user_id = None, None, payment.billing_email, None
+
+    if not checkout_token:  # Either not empty uuid or None
+        checkout_token = None
 
     billing_address = AddressData(**billing.as_data()) if billing else None
     shipping_address = AddressData(**shipping.as_data()) if shipping else None
@@ -79,6 +86,8 @@ def create_payment_information(
         reuse_source=store_source,
         data=additional_data or {},
         graphql_customer_id=graphql_customer_id,
+        partial=partial,
+        checkout_token=checkout_token,
     )
 
 


### PR DESCRIPTION
I want to merge this change because...

I need flag partial and checkout_token bind to PaymantData. Stripe payment gateway should only authorize payments when paymentData.partial == True

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
