### PR TITLE
Reduce number of spans generated by PluginManager in 3.1

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -118,16 +118,13 @@ class PluginsManager(PaymentInterface):
         **kwargs
     ):
         """Try to run a method with the given name on each declared plugin."""
-        with opentracing.global_tracer().start_active_span(
-            f"PluginsManager.{method_name}"
-        ):
-            value = default_value
-            plugins = self.get_plugins(channel_slug=channel_slug)
-            for plugin in plugins:
-                value = self.__run_method_on_single_plugin(
-                    plugin, method_name, value, *args, **kwargs
-                )
-            return value
+        value = default_value
+        plugins = self.get_plugins(channel_slug=channel_slug)
+        for plugin in plugins:
+            value = self.__run_method_on_single_plugin(
+                plugin, method_name, value, *args, **kwargs
+            )
+        return value
 
     def __run_method_on_single_plugin(
         self,

--- a/saleor/plugins/vatlayer/plugin.py
+++ b/saleor/plugins/vatlayer/plugin.py
@@ -1,6 +1,8 @@
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Union
 
+import opentracing
+import opentracing.tags
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
@@ -533,7 +535,13 @@ class VatlayerPlugin(BasePlugin):
         """Triggered when ShopFetchTaxRates mutation is called."""
         if not self.active:
             return previous_value
-        fetch_rates(self.config.access_key)
+        with opentracing.global_tracer().start_active_span(
+            "vatlayer.fetch_taxes_data"
+        ) as scope:
+            span = scope.span
+            span.set_tag(opentracing.tags.COMPONENT, "tax")
+            span.set_tag("service.name", "vatlayer")
+            fetch_rates(self.config.access_key)
         return True
 
     @classmethod

--- a/saleor/product/utils/availability.py
+++ b/saleor/product/utils/availability.py
@@ -111,30 +111,29 @@ def get_product_price_range(
     discounts: Iterable[DiscountInfo],
     channel: Channel,
 ) -> Optional[MoneyRange]:
-    with opentracing.global_tracer().start_active_span("get_product_price_range"):
-        if variants:
-            variants_channel_listing_dict = {
-                channel_listing.variant_id: channel_listing
-                for channel_listing in variants_channel_listing
-                if channel_listing
-            }
-            prices = []
-            for variant in variants:
-                variant_channel_listing = variants_channel_listing_dict.get(variant.id)
-                if variant_channel_listing:
-                    price = get_variant_price(
-                        variant=variant,
-                        variant_channel_listing=variant_channel_listing,
-                        product=product,
-                        collections=collections,
-                        discounts=discounts,
-                        channel=channel,
-                    )
-                    prices.append(price)
-            if prices:
-                return MoneyRange(min(prices), max(prices))
+    if variants:
+        variants_channel_listing_dict = {
+            channel_listing.variant_id: channel_listing
+            for channel_listing in variants_channel_listing
+            if channel_listing
+        }
+        prices = []
+        for variant in variants:
+            variant_channel_listing = variants_channel_listing_dict.get(variant.id)
+            if variant_channel_listing:
+                price = get_variant_price(
+                    variant=variant,
+                    variant_channel_listing=variant_channel_listing,
+                    product=product,
+                    collections=collections,
+                    discounts=discounts,
+                    channel=channel,
+                )
+                prices.append(price)
+        if prices:
+            return MoneyRange(min(prices), max(prices))
 
-        return None
+    return None
 
 
 def get_product_availability(


### PR DESCRIPTION
I want to merge this change because coping changes from #7957 to master.


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
