### PR TITLE
Extend order filtering.

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -21,6 +21,7 @@ from ....core.notify_events import NotifyEventType
 from ....core.prices import quantize_price
 from ....core.taxes import TaxError, zero_taxed_money
 from ....discount.models import OrderDiscount
+from ....giftcard.events import gift_cards_bought_event, gift_cards_used_in_order_event
 from ....order import FulfillmentStatus, OrderOrigin, OrderStatus
 from ....order import events as order_events
 from ....order.error_codes import OrderErrorCode
@@ -5812,6 +5813,118 @@ def test_order_query_with_filter_channels_with_empty_channel(
     content = get_graphql_content(response)
     orders = content["data"]["orders"]["edges"]
     assert len(orders) == 0
+
+
+def test_order_query_with_filter_gift_card_used_true(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    gift_card,
+    orders,
+):
+    # given
+    gift_card_order = orders[0]
+    gift_cards_used_in_order_event(
+        [(gift_card, 20.0)], gift_card_order.id, staff_api_client.user, None
+    )
+    variables = {"filter": {"giftCardUsed": True}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+    assert len(orders) == 1
+    assert orders[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Order", gift_card_order.id
+    )
+
+
+def test_order_query_with_filter_gift_card_used_false(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    gift_card,
+    orders,
+):
+    # given
+    gift_card_order = orders[0]
+    gift_card_order_id = graphene.Node.to_global_id("Order", gift_card_order.id)
+    gift_cards_used_in_order_event(
+        [(gift_card, 20.0)], gift_card_order.id, staff_api_client.user, None
+    )
+    variables = {"filter": {"giftCardUsed": False}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders_data = content["data"]["orders"]["edges"]
+    assert gift_card_order_id not in {
+        order_data["node"]["id"] for order_data in orders_data
+    }
+
+
+def test_order_query_with_filter_gift_card_bough_true(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    gift_card,
+    orders,
+):
+    # given
+    gift_card_order = orders[-1]
+    gift_cards_bought_event(
+        [gift_card], gift_card_order.id, staff_api_client.user, None
+    )
+    variables = {"filter": {"giftCardBought": True}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders = content["data"]["orders"]["edges"]
+    assert len(orders) == 1
+    assert orders[0]["node"]["id"] == graphene.Node.to_global_id(
+        "Order", gift_card_order.id
+    )
+
+
+def test_order_query_with_filter_gift_card_bought_false(
+    orders_query_with_filter,
+    staff_api_client,
+    permission_manage_orders,
+    gift_card,
+    orders,
+):
+    # given
+    gift_card_order = orders[-1]
+    gift_card_order_id = graphene.Node.to_global_id("Order", gift_card_order.id)
+    gift_cards_bought_event(
+        [gift_card], gift_card_order.id, staff_api_client.user, None
+    )
+    variables = {"filter": {"giftCardBought": False}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        orders_query_with_filter, variables, permissions=(permission_manage_orders,)
+    )
+
+    # then
+    content = get_graphql_content(response)
+    orders_data = content["data"]["orders"]["edges"]
+    assert gift_card_order_id not in {
+        order_data["node"]["id"] for order_data in orders_data
+    }
 
 
 @pytest.mark.parametrize(

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -4301,6 +4301,8 @@ input OrderFilterInput {
   search: String
   metadata: [MetadataFilter]
   channels: [ID]
+  giftCardUsed: Boolean
+  giftCardBought: Boolean
 }
 
 type OrderFulfill {


### PR DESCRIPTION
Allow filtering orders where gift cards was bought or used.
Extend `OrderFilterInput` with `giftCardUsed` and `giftCardBought` fields.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
