### PR TITLE
Use exact permission to determine if user has access to resources 3.0

### DIFF
--- a/saleor/account/tests/test_account.py
+++ b/saleor/account/tests/test_account.py
@@ -12,7 +12,7 @@ from ...order.models import Order
 from .. import forms, i18n
 from ..models import User
 from ..templatetags.i18n_address_tags import format_address
-from ..utils import remove_staff_member, requestor_is_staff_member_or_app
+from ..utils import remove_staff_member
 from ..validators import validate_possible_number
 
 
@@ -306,36 +306,6 @@ def test_remove_staff_member_with_orders(staff_user, permission_manage_products,
 def test_remove_staff_member(staff_user):
     remove_staff_member(staff_user)
     assert not User.objects.filter(pk=staff_user.pk).exists()
-
-
-def test_requestor_is_staff_member_or_app_active_app(app):
-    assert app.is_active is True
-    assert requestor_is_staff_member_or_app(app) is True
-
-
-def test_requestor_is_staff_member_or_app_not_active_app(app):
-    app.is_active = False
-    app.save(update_fields=["is_active"])
-    assert requestor_is_staff_member_or_app(app) is False
-
-
-def test_requestor_is_staff_member_or_app_not_active_staff_user(staff_user):
-    staff_user.is_active = False
-    staff_user.save(update_fields=["is_active"])
-    assert requestor_is_staff_member_or_app(staff_user) is False
-
-
-def test_requestor_is_staff_member_or_app_active_staff_user(staff_user):
-    assert staff_user.is_active is True
-    assert requestor_is_staff_member_or_app(staff_user) is True
-
-
-def test_requestor_is_staff_member_or_app_superuser(superuser):
-    assert requestor_is_staff_member_or_app(superuser) is True
-
-
-def test_requestor_is_staff_member_or_app_customer_user(customer_user):
-    assert requestor_is_staff_member_or_app(customer_user) is False
 
 
 def test_customers_doesnt_return_duplicates(customer_user, channel_USD):

--- a/saleor/account/utils.py
+++ b/saleor/account/utils.py
@@ -1,6 +1,5 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
-from ..app.models import App
 from ..checkout import AddressType
 from ..core.utils import create_thumbnails
 from .models import User
@@ -85,13 +84,3 @@ def remove_staff_member(staff):
         staff.save()
     else:
         staff.delete()
-
-
-def requestor_is_staff_member_or_app(requestor: Union[User, App]):
-    """Return true if requestor is an active app or active staff user."""
-    is_staff = False
-    if isinstance(requestor, User):
-        is_staff = getattr(requestor, "is_staff")
-    elif isinstance(requestor, App):
-        is_staff = True
-    return is_staff and requestor.is_active

--- a/saleor/attribute/models/base.py
+++ b/saleor/attribute/models/base.py
@@ -4,9 +4,13 @@ from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from django.db.models import F, Q
 
-from ...account.utils import requestor_is_staff_member_or_app
 from ...core.db.fields import SanitizedJSONField
 from ...core.models import ModelWithMetadata, SortableModel
+from ...core.permissions import (
+    PageTypePermissions,
+    ProductTypePermissions,
+    has_one_of_permissions,
+)
 from ...core.units import MeasurementUnits
 from ...core.utils.editorjs import clean_editor_js
 from ...core.utils.translations import Translation, TranslationProxy
@@ -41,7 +45,13 @@ class BaseAttributeQuerySet(models.QuerySet):
         raise NotImplementedError
 
     def get_visible_to_user(self, requestor: Union["User", "App"]):
-        if requestor_is_staff_member_or_app(requestor):
+        if has_one_of_permissions(
+            requestor,
+            [
+                PageTypePermissions.MANAGE_PAGE_TYPES_AND_ATTRIBUTES,
+                ProductTypePermissions.MANAGE_PRODUCT_TYPES_AND_ATTRIBUTES,
+            ],
+        ):
             return self.all()
         return self.get_public_attributes()
 

--- a/saleor/core/models.py
+++ b/saleor/core/models.py
@@ -48,13 +48,6 @@ class PublishedQuerySet(models.QuerySet):
             is_published=True,
         )
 
-    def visible_to_user(self, requestor):
-        from ..account.utils import requestor_is_staff_member_or_app
-
-        if requestor_is_staff_member_or_app(requestor):
-            return self.all()
-        return self.published()
-
 
 class PublishableModel(models.Model):
     publication_date = models.DateField(blank=True, null=True)

--- a/saleor/graphql/attribute/filters.py
+++ b/saleor/graphql/attribute/filters.py
@@ -2,9 +2,10 @@ import django_filters
 from django.db.models import Q
 from graphene_django.filter import GlobalIDFilter, GlobalIDMultipleChoiceFilter
 
-from ...account.utils import requestor_is_staff_member_or_app
 from ...attribute.models import Attribute, AttributeValue
+from ...core.permissions import has_one_of_permissions
 from ...product import models
+from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..attribute.enums import AttributeTypeEnum
 from ..channel.filters import get_channel_slug_from_filter_data
 from ..core.filters import EnumFilter, MetadataFilterBase
@@ -30,7 +31,7 @@ def filter_attributes_by_product_types(qs, field, value, requestor, channel_slug
         tree = category.get_descendants(include_self=True)
         product_qs = product_qs.filter(category__in=tree)
 
-        if not requestor_is_staff_member_or_app(requestor):
+        if not has_one_of_permissions(requestor, ALL_PRODUCTS_PERMISSIONS):
             product_qs = product_qs.annotate_visible_in_listings(channel_slug).exclude(
                 visible_in_listings=False
             )

--- a/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
+++ b/saleor/graphql/attribute/tests/queries/test_attribute_filter.py
@@ -333,7 +333,7 @@ def test_filter_attributes_in_category_not_in_listings_by_staff_without_manage_p
     )["data"]["attributes"]["edges"]
 
     # then
-    assert len(attributes) == attribute_count
+    assert len(attributes) == attribute_count - 1  # product not listed will not count
 
 
 def test_filter_attributes_in_category_not_visible_in_listings_by_app_with_perm(
@@ -422,7 +422,7 @@ def test_filter_attributes_in_category_not_in_listings_by_app_without_manage_pro
     )["data"]["attributes"]["edges"]
 
     # then
-    assert len(attributes) == attribute_count
+    assert len(attributes) == attribute_count - 1  # product not visible will not count
 
 
 def test_filter_attributes_in_category_not_published_by_customer(

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -1,9 +1,9 @@
 import graphene
 from graphene import relay
 
-from ...account.utils import requestor_is_staff_member_or_app
-from ...core.permissions import PagePermissions
+from ...core.permissions import PagePermissions, has_one_of_permissions
 from ...menu import models
+from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.dataloaders import ChannelBySlugLoader
 from ..channel.types import (
     ChannelContext,
@@ -104,8 +104,11 @@ class MenuItem(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             return None
 
         requestor = get_user_or_app_from_context(info.context)
-        is_staff = requestor_is_staff_member_or_app(requestor)
-        if is_staff:
+
+        has_required_permission = has_one_of_permissions(
+            requestor, ALL_PRODUCTS_PERMISSIONS
+        )
+        if has_required_permission:
             return (
                 CollectionByIdLoader(info.context)
                 .load(root.node.collection_id)

--- a/saleor/graphql/order/types.py
+++ b/saleor/graphql/order/types.py
@@ -9,7 +9,6 @@ from graphene import relay
 from promise import Promise
 
 from ...account.models import Address
-from ...account.utils import requestor_is_staff_member_or_app
 from ...core.anonymize import obfuscate_address, obfuscate_email
 from ...core.exceptions import PermissionDenied
 from ...core.permissions import (
@@ -17,6 +16,7 @@ from ...core.permissions import (
     AppPermission,
     OrderPermissions,
     ProductPermissions,
+    has_one_of_permissions,
 )
 from ...core.taxes import display_gross_prices
 from ...core.tracing import traced_resolver
@@ -34,6 +34,7 @@ from ...payment.model_helpers import (
     get_total_authorized,
 )
 from ...product import ProductMediaTypes
+from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ...product.product_images import get_product_image_thumbnail
 from ..account.dataloaders import AddressByIdLoader, UserByUserIdLoader
 from ..account.types import User
@@ -549,8 +550,10 @@ class OrderLine(CountableDjangoObjectType):
             variant, channel = data
 
             requester = get_user_or_app_from_context(context)
-            is_staff = requestor_is_staff_member_or_app(requester)
-            if is_staff:
+            has_required_permission = has_one_of_permissions(
+                requester, ALL_PRODUCTS_PERMISSIONS
+            )
+            if has_required_permission:
                 return ChannelContext(node=variant, channel_slug=channel.slug)
 
             def product_is_available(product_channel_listing):

--- a/saleor/graphql/page/tests/test_page.py
+++ b/saleor/graphql/page/tests/test_page.py
@@ -113,7 +113,28 @@ def test_customer_query_unpublished_page(user_api_client, page):
     assert content["data"]["page"] is None
 
 
-def test_staff_query_unpublished_page(staff_api_client, page):
+def test_staff_query_unpublished_page_by_id(
+    staff_api_client, page, permission_manage_pages
+):
+    page.is_published = False
+    page.save()
+
+    # query by ID
+    variables = {"id": graphene.Node.to_global_id("Page", page.id)}
+    response = staff_api_client.post_graphql(
+        PAGE_QUERY,
+        variables,
+        permissions=[permission_manage_pages],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    assert content["data"]["page"] is not None
+
+
+def test_staff_query_unpublished_page_by_id_without_required_permission(
+    staff_api_client,
+    page,
+):
     page.is_published = False
     page.save()
 
@@ -121,13 +142,39 @@ def test_staff_query_unpublished_page(staff_api_client, page):
     variables = {"id": graphene.Node.to_global_id("Page", page.id)}
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)
+    assert content["data"]["page"] is None
+
+
+def test_staff_query_unpublished_page_by_slug(
+    staff_api_client, page, permission_manage_pages
+):
+    page.is_published = False
+    page.save()
+
+    # query by slug
+    variables = {"slug": page.slug}
+    response = staff_api_client.post_graphql(
+        PAGE_QUERY,
+        variables,
+        permissions=[permission_manage_pages],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
     assert content["data"]["page"] is not None
+
+
+def test_staff_query_unpublished_page_by_slug_without_required_permission(
+    staff_api_client,
+    page,
+):
+    page.is_published = False
+    page.save()
 
     # query by slug
     variables = {"slug": page.slug}
     response = staff_api_client.post_graphql(PAGE_QUERY, variables)
     content = get_graphql_content(response)
-    assert content["data"]["page"] is not None
+    assert content["data"]["page"] is None
 
 
 def test_staff_query_page_by_invalid_id(staff_api_client, page):

--- a/saleor/graphql/product/tests/test_category.py
+++ b/saleor/graphql/product/tests/test_category.py
@@ -246,7 +246,9 @@ def test_query_category_product_visible_in_listings_as_staff_without_manage_prod
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert len(content["data"]["category"]["products"]["edges"]) == product_count
+    assert (
+        len(content["data"]["category"]["products"]["edges"]) == product_count - 1
+    )  # invisible doesn't count
 
 
 def test_query_category_product_only_visible_in_listings_as_staff_with_perm(
@@ -291,7 +293,9 @@ def test_query_category_product_only_visible_in_listings_as_app_without_manage_p
 
     # then
     content = get_graphql_content(response, ignore_errors=True)
-    assert len(content["data"]["category"]["products"]["edges"]) == product_count
+    assert (
+        len(content["data"]["category"]["products"]["edges"]) == product_count - 1
+    )  # invisible doesn't count
 
 
 def test_query_category_product_only_visible_in_listings_as_app_with_perm(

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -1497,7 +1497,7 @@ def test_fetch_all_products_visible_in_listings_by_staff_without_manage_products
     # then
     content = get_graphql_content(response)
     product_data = content["data"]["products"]["edges"]
-    assert len(product_data) == product_count
+    assert len(product_data) == product_count - 1  # invisible doesn't count
 
 
 def test_fetch_all_products_visible_in_listings_by_app_with_perm(
@@ -1538,7 +1538,7 @@ def test_fetch_all_products_visible_in_listings_by_app_without_manage_products(
     # then
     content = get_graphql_content(response)
     product_data = content["data"]["products"]["edges"]
-    assert len(product_data) == product_count
+    assert len(product_data) == product_count - 1  # invisible doesn't count
 
 
 def test_fetch_product_from_category_query(
@@ -8629,7 +8629,27 @@ QUERY_PRODUCT_VARAINT_BY_ID = """
 """
 
 
-def test_product_variant_without_price_by_id_as_staff(
+def test_product_variant_without_price_by_id_as_staff_with_permission(
+    staff_api_client, variant, channel_USD, permission_manage_products
+):
+    query = QUERY_PRODUCT_VARAINT_BY_ID
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_id_as_staff_without_permission(
     staff_api_client, variant, channel_USD
 ):
     query = QUERY_PRODUCT_VARAINT_BY_ID
@@ -8640,11 +8660,10 @@ def test_product_variant_without_price_by_id_as_staff(
     variables = {"id": variant_id, "channel": channel_USD.slug}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
-    data = content["data"]["productVariant"]
-    assert data["id"] == variant_id
+    assert not content["data"]["productVariant"]
 
 
-def test_product_variant_without_price_by_id_as_app(
+def test_product_variant_without_price_by_id_as_app_without_permission(
     app_api_client, variant, channel_USD
 ):
     query = QUERY_PRODUCT_VARAINT_BY_ID
@@ -8654,6 +8673,25 @@ def test_product_variant_without_price_by_id_as_app(
 
     variables = {"id": variant_id, "channel": channel_USD.slug}
     response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert not content["data"]["productVariant"]
+
+
+def test_product_variant_without_price_by_id_as_app_with_permission(
+    app_api_client, variant, channel_USD, permission_manage_products
+):
+    query = QUERY_PRODUCT_VARAINT_BY_ID
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"id": variant_id, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariant"]
     assert data["id"] == variant_id
@@ -8711,7 +8749,35 @@ def test_variant_query_with_invalid_object_type(user_api_client, variant, channe
     assert content["data"]["productVariant"] is None
 
 
-def test_product_variant_without_price_by_sku_as_staff(
+def test_product_variant_without_price_by_sku_as_staff_with_permission(
+    staff_api_client, variant, channel_USD, permission_manage_products
+):
+    query = """
+        query getProductVariant($sku: String!, $channel: String) {
+            productVariant(sku: $sku, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"sku": variant.sku, "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariant"]
+    assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_sku_as_staff_without_permission(
     staff_api_client, variant, channel_USD
 ):
     query = """
@@ -8725,17 +8791,15 @@ def test_product_variant_without_price_by_sku_as_staff(
     """
     variant.channel_listings.all().delete()
     variant.channel_listings.create(channel=channel_USD)
-    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
 
     variables = {"sku": variant.sku, "channel": channel_USD.slug}
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
-    data = content["data"]["productVariant"]
-    assert data["id"] == variant_id
+    assert not content["data"]["productVariant"]
 
 
-def test_product_variant_without_price_by_sku_as_app(
-    app_api_client, variant, channel_USD
+def test_product_variant_without_price_by_sku_as_app_with_permission(
+    app_api_client, variant, channel_USD, permission_manage_products
 ):
     query = """
         query getProductVariant($sku: String!, $channel: String) {
@@ -8751,10 +8815,38 @@ def test_product_variant_without_price_by_sku_as_app(
     variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
 
     variables = {"sku": variant.sku, "channel": channel_USD.slug}
-    response = app_api_client.post_graphql(query, variables)
+    response = app_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariant"]
     assert data["id"] == variant_id
+
+
+def test_product_variant_without_price_by_sku_as_app_without_permission(
+    app_api_client,
+    variant,
+    channel_USD,
+):
+    query = """
+        query getProductVariant($sku: String!, $channel: String) {
+            productVariant(sku: $sku, channel: $channel) {
+                id
+                name
+                sku
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+
+    variables = {"sku": variant.sku, "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert not content["data"]["productVariant"]
 
 
 def test_product_variant_without_price_by_sku_as_user(
@@ -8815,7 +8907,7 @@ def test_product_variants_by_ids(staff_api_client, variant, channel_USD):
     assert len(data["edges"]) == 1
 
 
-def test_product_variants_without_price_by_ids_as_staff(
+def test_product_variants_without_price_by_ids_as_staff_without_permission(
     staff_api_client, variant, channel_USD
 ):
     query = """
@@ -8851,6 +8943,50 @@ def test_product_variants_without_price_by_ids_as_staff(
     response = staff_api_client.post_graphql(query, variables)
     content = get_graphql_content(response)
     data = content["data"]["productVariants"]
+    assert len(data["edges"]) == 0
+
+
+def test_product_variants_without_price_by_ids_as_staff_with_permission(
+    staff_api_client, variant, channel_USD, permission_manage_products
+):
+    query = """
+        query getProductVariants($ids: [ID!], $channel: String) {
+            productVariants(ids: $ids, first: 1, channel: $channel) {
+                edges {
+                    node {
+                        id
+                        name
+                        sku
+                        channelListings {
+                            channel {
+                                id
+                                isActive
+                                name
+                                currencyCode
+                            }
+                            price {
+                                amount
+                                currency
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"ids": [variant_id], "channel": channel_USD.slug}
+    response = staff_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["productVariants"]
     assert data["edges"][0]["node"]["id"] == variant_id
     assert len(data["edges"]) == 1
 
@@ -8882,7 +9018,7 @@ def test_product_variants_without_price_by_ids_as_user(
     assert len(data["edges"]) == 0
 
 
-def test_product_variants_without_price_by_ids_as_app(
+def test_product_variants_without_price_by_ids_as_app_without_permission(
     app_api_client, variant, channel_USD
 ):
     query = """
@@ -8916,6 +9052,49 @@ def test_product_variants_without_price_by_ids_as_app(
 
     variables = {"ids": [variant_id], "channel": channel_USD.slug}
     response = app_api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    assert len(content["data"]["productVariants"]["edges"]) == 0
+
+
+def test_product_variants_without_price_by_ids_as_app_with_permission(
+    app_api_client, variant, channel_USD, permission_manage_products
+):
+    query = """
+        query getProductVariants($ids: [ID!], $channel: String) {
+            productVariants(ids: $ids, first: 1, channel: $channel) {
+                edges {
+                    node {
+                        id
+                        name
+                        sku
+                        channelListings {
+                            channel {
+                                id
+                                isActive
+                                name
+                                currencyCode
+                            }
+                            price {
+                                amount
+                                currency
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    """
+    variant.channel_listings.all().delete()
+    variant.channel_listings.create(channel=channel_USD)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+
+    variables = {"ids": [variant_id], "channel": channel_USD.slug}
+    response = app_api_client.post_graphql(
+        query,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
     content = get_graphql_content(response)
     data = content["data"]["productVariants"]
     assert data["edges"][0]["node"]["id"] == variant_id
@@ -9056,7 +9235,7 @@ def test_product_variant_without_price_as_user(
     assert len(variants_data) == 1
 
 
-def test_product_variant_without_price_as_staff(
+def test_product_variant_without_price_as_staff_without_permission(
     staff_api_client,
     variant,
     stock,
@@ -9080,12 +9259,41 @@ def test_product_variant_without_price_as_staff(
     content = get_graphql_content(response)
     variants_data = content["data"]["product"]["variants"]
 
-    assert variants_data[0]["pricing"] is not None
+    assert len(variants_data) == 1
 
-    assert variants_data[1]["id"] == variant_id
-    assert variants_data[1]["pricing"] is None
+    assert variants_data[0]["pricing"] is not None
+    assert variants_data[0]["id"] != variant_id
+
+
+def test_product_variant_without_price_as_staff_with_permission(
+    staff_api_client, variant, stock, channel_USD, permission_manage_products
+):
+
+    variant_channel_listing = variant.channel_listings.first()
+    variant_channel_listing.price_amount = None
+    variant_channel_listing.save()
+
+    product_id = graphene.Node.to_global_id("Product", variant.product.id)
+    variant_id = graphene.Node.to_global_id("ProductVariant", variant.id)
+    variables = {
+        "id": product_id,
+        "channel": channel_USD.slug,
+        "address": {"country": "US"},
+    }
+    response = staff_api_client.post_graphql(
+        QUERY_GET_PRODUCT_VARIANTS_PRICING,
+        variables,
+        permissions=[permission_manage_products],
+        check_no_permissions=False,
+    )
+    content = get_graphql_content(response)
+    variants_data = content["data"]["product"]["variants"]
 
     assert len(variants_data) == 2
+
+    assert variants_data[0]["pricing"] is not None
+    assert variants_data[1]["id"] == variant_id
+    assert variants_data[1]["pricing"] is None
 
 
 QUERY_GET_PRODUCT_VARIANTS_PRICING_NO_ADDRESS = """

--- a/saleor/graphql/product/tests/test_variant.py
+++ b/saleor/graphql/product/tests/test_variant.py
@@ -3173,7 +3173,7 @@ def test_product_variants_visible_in_listings_by_staff_without_manage_products(
         staff_api_client, variables={"channel": channel_USD.slug}
     )
 
-    assert data["totalCount"] == product_count
+    assert data["totalCount"] == product_count - 1  # invisible doesn't count
 
 
 def test_product_variants_visible_in_listings_by_staff_with_perm(
@@ -3205,7 +3205,7 @@ def test_product_variants_visible_in_listings_by_app_without_manage_products(
     # when
     data = _fetch_all_variants(app_api_client, variables={"channel": channel_USD.slug})
 
-    assert data["totalCount"] == product_count
+    assert data["totalCount"] == product_count - 1  # invisible doesn't count
 
 
 def test_product_variants_visible_in_listings_by_app_with_perm(

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -7,13 +7,17 @@ from django_countries.fields import Country
 from graphene import relay
 from graphene_federation import key
 
-from ....account.utils import requestor_is_staff_member_or_app
 from ....attribute import models as attribute_models
-from ....core.permissions import OrderPermissions, ProductPermissions
+from ....core.permissions import (
+    OrderPermissions,
+    ProductPermissions,
+    has_one_of_permissions,
+)
 from ....core.tracing import traced_resolver
 from ....core.utils import get_currency_for_country
 from ....core.weight import convert_weight_to_default_weight_unit
 from ....product import models
+from ....product.models import ALL_PRODUCTS_PERMISSIONS
 from ....product.product_images import get_product_image_thumbnail, get_thumbnail
 from ....product.utils import calculate_revenue_for_variant
 from ....product.utils.availability import (
@@ -735,7 +739,10 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         country_code = address.country if address is not None else None
 
         requestor = get_user_or_app_from_context(info.context)
-        is_staff = requestor_is_staff_member_or_app(requestor)
+
+        has_required_permissions = has_one_of_permissions(
+            requestor, ALL_PRODUCTS_PERMISSIONS
+        )
         channel_slug = str(root.channel_slug)
 
         def calculate_is_available(quantities):
@@ -751,11 +758,11 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
             ).load_many(keys)
 
         def check_variant_availability():
-            if is_staff and not channel_slug:
+            if has_required_permissions and not channel_slug:
                 variants = ProductVariantsByProductIdLoader(info.context).load(
                     root.node.id
                 )
-            elif is_staff and channel_slug:
+            elif has_required_permissions and channel_slug:
                 variants = ProductVariantsByProductIdAndChannel(info.context).load(
                     (root.node.id, channel_slug)
                 )
@@ -804,10 +811,12 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @staticmethod
     def resolve_variants(root: ChannelContext[models.Product], info, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
-        is_staff = requestor_is_staff_member_or_app(requestor)
-        if is_staff and not root.channel_slug:
+        has_required_permissions = has_one_of_permissions(
+            requestor, ALL_PRODUCTS_PERMISSIONS
+        )
+        if has_required_permissions and not root.channel_slug:
             variants = ProductVariantsByProductIdLoader(info.context).load(root.node.id)
-        elif is_staff and root.channel_slug:
+        elif has_required_permissions and root.channel_slug:
             variants = ProductVariantsByProductIdAndChannel(info.context).load(
                 (root.node.id, root.channel_slug)
             )
@@ -833,10 +842,13 @@ class Product(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
     @traced_resolver
     def resolve_collections(root: ChannelContext[models.Product], info, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
-        is_staff = requestor_is_staff_member_or_app(requestor)
+
+        has_required_permissions = has_one_of_permissions(
+            requestor, ALL_PRODUCTS_PERMISSIONS
+        )
 
         def return_collections(collections):
-            if is_staff:
+            if has_required_permissions:
                 return [
                     ChannelContext(node=collection, channel_slug=root.channel_slug)
                     for collection in collections
@@ -1188,12 +1200,14 @@ class Category(CountableDjangoObjectType):
     @traced_resolver
     def resolve_products(root: models.Category, info, channel=None, **_kwargs):
         requestor = get_user_or_app_from_context(info.context)
-        is_staff = requestor_is_staff_member_or_app(requestor)
+        has_required_permissions = has_one_of_permissions(
+            requestor, ALL_PRODUCTS_PERMISSIONS
+        )
         tree = root.get_descendants(include_self=True)
-        if channel is None and not is_staff:
+        if channel is None and not has_required_permissions:
             channel = get_default_channel_slug_or_graphql_error()
         qs = models.Product.objects.all()
-        if not is_staff:
+        if not has_required_permissions:
             qs = (
                 qs.published(channel)
                 .annotate_visible_in_listings(channel)
@@ -1201,7 +1215,7 @@ class Category(CountableDjangoObjectType):
                     visible_in_listings=False,
                 )
             )
-        if channel and is_staff:
+        if channel and has_required_permissions:
             qs = qs.filter(channel_listings__channel__slug=channel)
         qs = qs.filter(category__in=tree)
         return ChannelQsContext(qs=qs, channel_slug=channel)

--- a/saleor/page/models.py
+++ b/saleor/page/models.py
@@ -1,25 +1,15 @@
-import datetime
-
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
-from django.db.models import Q
 
 from ..core.db.fields import SanitizedJSONField
-from ..core.models import ModelWithMetadata, PublishableModel
+from ..core.models import ModelWithMetadata, PublishableModel, PublishedQuerySet
 from ..core.permissions import PagePermissions, PageTypePermissions
 from ..core.utils.editorjs import clean_editor_js
 from ..core.utils.translations import TranslationProxy
 from ..seo.models import SeoModel, SeoModelTranslation
 
 
-class PageQueryset(models.QuerySet):
-    def published(self):
-        today = datetime.date.today()
-        return self.filter(
-            Q(publication_date__lte=today) | Q(publication_date__isnull=True),
-            is_published=True,
-        )
-
+class PageQueryset(PublishedQuerySet):
     def visible_to_user(self, requestor):
         if requestor.has_perm(PagePermissions.MANAGE_PAGES):
             return self.all()

--- a/saleor/page/models.py
+++ b/saleor/page/models.py
@@ -1,5 +1,8 @@
+import datetime
+
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
+from django.db.models import Q
 
 from ..core.db.fields import SanitizedJSONField
 from ..core.models import ModelWithMetadata, PublishableModel
@@ -7,6 +10,20 @@ from ..core.permissions import PagePermissions, PageTypePermissions
 from ..core.utils.editorjs import clean_editor_js
 from ..core.utils.translations import TranslationProxy
 from ..seo.models import SeoModel, SeoModelTranslation
+
+
+class PageQueryset(models.QuerySet):
+    def published(self):
+        today = datetime.date.today()
+        return self.filter(
+            Q(publication_date__lte=today) | Q(publication_date__isnull=True),
+            is_published=True,
+        )
+
+    def visible_to_user(self, requestor):
+        if requestor.has_perm(PagePermissions.MANAGE_PAGES):
+            return self.all()
+        return self.published()
 
 
 class Page(ModelWithMetadata, SeoModel, PublishableModel):
@@ -19,6 +36,8 @@ class Page(ModelWithMetadata, SeoModel, PublishableModel):
     created = models.DateTimeField(auto_now_add=True)
 
     translated = TranslationProxy()
+
+    objects = models.Manager.from_queryset(PageQueryset)()
 
     class Meta(ModelWithMetadata.Meta):
         ordering = ("slug",)


### PR DESCRIPTION
I want to merge this change because:
 - drop function `requestor_is_staff_member_or_app` 
 - replace all usage of this method by calling check for exact permissions

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
