### PR TITLE
Add exportGiftCards mutation

### DIFF
--- a/saleor/graphql/csv/mutations.py
+++ b/saleor/graphql/csv/mutations.py
@@ -3,20 +3,73 @@ from typing import Dict, List, Mapping, Union
 import graphene
 from django.core.exceptions import ValidationError
 
-from ...core.permissions import ProductPermissions
+from ...core.permissions import GiftcardPermissions, ProductPermissions
 from ...csv import models as csv_models
 from ...csv.events import export_started_event
-from ...csv.tasks import export_products_task
+from ...csv.tasks import export_gift_cards_task, export_products_task
 from ..attribute.types import Attribute
 from ..channel.types import Channel
+from ..core.descriptions import ADDED_IN_31
 from ..core.enums import ExportErrorCode
 from ..core.mutations import BaseMutation
 from ..core.types.common import ExportError
+from ..giftcard.filters import GiftCardFilterInput
+from ..giftcard.types import GiftCard
 from ..product.filters import ProductFilterInput
 from ..product.types import Product
 from ..warehouse.types import Warehouse
 from .enums import ExportScope, FileTypeEnum, ProductFieldEnum
 from .types import ExportFile
+
+
+class BaseExportMutation(BaseMutation):
+    export_file = graphene.Field(
+        ExportFile,
+        description=(
+            "The newly created export file job which is responsible for export data."
+        ),
+    )
+
+    class Meta:
+        abstract = True
+
+    @classmethod
+    def get_scope(cls, input, only_type) -> Mapping[str, Union[list, dict, str]]:
+        scope = input["scope"]
+        if scope == ExportScope.IDS.value:  # type: ignore
+            return cls.clean_ids(input, only_type)
+        elif scope == ExportScope.FILTER.value:  # type: ignore
+            return cls.clean_filter(input)
+        return {"all": ""}
+
+    @classmethod
+    def clean_ids(cls, input, only_type) -> Dict[str, List[str]]:
+        ids = input.get("ids", [])
+        if not ids:
+            raise ValidationError(
+                {
+                    "ids": ValidationError(
+                        "You must provide at least one id.",
+                        code=ExportErrorCode.REQUIRED.value,
+                    )
+                }
+            )
+        pks = cls.get_global_ids_or_error(ids, only_type=only_type, field="ids")
+        return {"ids": pks}
+
+    @staticmethod
+    def clean_filter(input) -> Dict[str, dict]:
+        filter = input.get("filter")
+        if not filter:
+            raise ValidationError(
+                {
+                    "filter": ValidationError(
+                        "You must provide filter input.",
+                        code=ExportErrorCode.REQUIRED.value,
+                    )
+                }
+            )
+        return {"filter": filter}
 
 
 class ExportInfoInput(graphene.InputObjectType):
@@ -47,7 +100,7 @@ class ExportProductsInput(graphene.InputObjectType):
     )
     ids = graphene.List(
         graphene.NonNull(graphene.ID),
-        description="List of products IDS to export.",
+        description="List of products IDs to export.",
         required=False,
     )
     export_info = ExportInfoInput(
@@ -57,17 +110,10 @@ class ExportProductsInput(graphene.InputObjectType):
     file_type = FileTypeEnum(description="Type of exported file.", required=True)
 
 
-class ExportProducts(BaseMutation):
-    export_file = graphene.Field(
-        ExportFile,
-        description=(
-            "The newly created export file job which is responsible for export data."
-        ),
-    )
-
+class ExportProducts(BaseExportMutation):
     class Arguments:
         input = ExportProductsInput(
-            required=True, description="Fields required to export product data"
+            required=True, description="Fields required to export product data."
         )
 
     class Meta:
@@ -79,7 +125,7 @@ class ExportProducts(BaseMutation):
     @classmethod
     def perform_mutation(cls, root, info, **data):
         input = data["input"]
-        scope = cls.get_products_scope(input)
+        scope = cls.get_scope(input, Product)
         export_info = cls.get_export_info(input["export_info"])
         file_type = input["file_type"]
 
@@ -92,44 +138,6 @@ class ExportProducts(BaseMutation):
 
         export_file.refresh_from_db()
         return cls(export_file=export_file)
-
-    @classmethod
-    def get_products_scope(cls, input) -> Mapping[str, Union[list, dict, str]]:
-        scope = input["scope"]
-        if scope == ExportScope.IDS.value:  # type: ignore
-            return cls.clean_ids(input)
-        elif scope == ExportScope.FILTER.value:  # type: ignore
-            return cls.clean_filter(input)
-        return {"all": ""}
-
-    @classmethod
-    def clean_ids(cls, input) -> Dict[str, List[str]]:
-        ids = input.get("ids", [])
-        if not ids:
-            raise ValidationError(
-                {
-                    "ids": ValidationError(
-                        "You must provide at least one product id.",
-                        code=ExportErrorCode.REQUIRED.value,
-                    )
-                }
-            )
-        pks = cls.get_global_ids_or_error(ids, only_type=Product, field="ids")
-        return {"ids": pks}
-
-    @staticmethod
-    def clean_filter(input) -> Dict[str, dict]:
-        filter = input.get("filter")
-        if not filter:
-            raise ValidationError(
-                {
-                    "filter": ValidationError(
-                        "You must provide filter input.",
-                        code=ExportErrorCode.REQUIRED.value,
-                    )
-                }
-            )
-        return {"filter": filter}
 
     @classmethod
     def get_export_info(cls, export_info_input):
@@ -156,3 +164,46 @@ class ExportProducts(BaseMutation):
             return
         pks = cls.get_global_ids_or_error(ids, only_type=graphene_type, field=field)
         return pks
+
+
+class ExportGiftCardsInput(graphene.InputObjectType):
+    scope = ExportScope(
+        description="Determine which gift cards should be exported.", required=True
+    )
+    filter = GiftCardFilterInput(
+        description="Filtering options for gift cards.", required=False
+    )
+    ids = graphene.List(
+        graphene.NonNull(graphene.ID),
+        description="List of gift cards IDs to export.",
+        required=False,
+    )
+    file_type = FileTypeEnum(description="Type of exported file.", required=True)
+
+
+class ExportGiftCards(BaseExportMutation):
+    class Arguments:
+        input = ExportGiftCardsInput(
+            required=True, description="Fields required to export gift cards data."
+        )
+
+    class Meta:
+        description = f"{ADDED_IN_31} Export gift cards to csv file."
+        permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
+        error_type_class = ExportError
+
+    @classmethod
+    def perform_mutation(cls, root, info, **data):
+        input = data["input"]
+        scope = cls.get_scope(input, GiftCard)
+        file_type = input["file_type"]
+
+        app = info.context.app
+        kwargs = {"app": app} if app else {"user": info.context.user}
+
+        export_file = csv_models.ExportFile.objects.create(**kwargs)
+        export_started_event(export_file=export_file, **kwargs)
+        export_gift_cards_task.delay(export_file.pk, scope, file_type)
+
+        export_file.refresh_from_db()
+        return cls(export_file=export_file)

--- a/saleor/graphql/csv/schema.py
+++ b/saleor/graphql/csv/schema.py
@@ -5,7 +5,7 @@ from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
 from ..decorators import permission_required
 from .filters import ExportFileFilterInput
-from .mutations import ExportProducts
+from .mutations import ExportGiftCards, ExportProducts
 from .resolvers import resolve_export_file, resolve_export_files
 from .sorters import ExportFileSortingInput
 from .types import ExportFile
@@ -38,3 +38,4 @@ class CsvQueries(graphene.ObjectType):
 
 class CsvMutations(graphene.ObjectType):
     export_products = ExportProducts.Field()
+    export_gift_cards = ExportGiftCards.Field()

--- a/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
+++ b/saleor/graphql/csv/tests/mutations/test_export_gift_cards.py
@@ -1,0 +1,309 @@
+from unittest.mock import ANY, patch
+
+import graphene
+import pytest
+
+from .....csv import ExportEvents
+from .....csv.error_codes import ExportErrorCode
+from .....csv.models import ExportEvent
+from ....tests.utils import get_graphql_content
+from ...enums import ExportScope, FileTypeEnum
+
+EXPORT_GIFT_CARDS_MUTATION = """
+    mutation ExportGiftCards($input: ExportGiftCardsInput!){
+        exportGiftCards(input: $input){
+            exportFile {
+                id
+                status
+                createdAt
+                updatedAt
+                url
+                user {
+                    email
+                }
+                app {
+                    name
+                }
+            }
+            errors {
+                field
+                code
+                message
+            }
+        }
+    }
+"""
+
+
+@pytest.mark.parametrize(
+    "input, called_data",
+    [
+        (
+            {
+                "scope": ExportScope.ALL.name,
+                "fileType": FileTypeEnum.CSV.name,
+            },
+            {"all": ""},
+        ),
+        (
+            {
+                "scope": ExportScope.FILTER.name,
+                "filter": {"tag": "abc"},
+                "fileType": FileTypeEnum.CSV.name,
+            },
+            {"filter": {"tag": "abc"}},
+        ),
+    ],
+)
+@patch("saleor.graphql.csv.mutations.export_gift_cards_task.delay")
+def test_export_gift_cards_mutation(
+    export_gift_cards_mock,
+    input,
+    called_data,
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    permission_manage_gift_card,
+    permission_manage_apps,
+):
+    query = EXPORT_GIFT_CARDS_MUTATION
+    user = staff_api_client.user
+    variables = {"input": input}
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[permission_manage_gift_card, permission_manage_apps],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportGiftCards"]
+    export_file_data = data["exportFile"]
+
+    export_gift_cards_mock.assert_called_once_with(
+        ANY, called_data, FileTypeEnum.CSV.value
+    )
+
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+    assert export_file_data["createdAt"]
+    assert export_file_data["user"]["email"] == staff_api_client.user.email
+    assert export_file_data["app"] is None
+    assert ExportEvent.objects.filter(
+        user=user, app=None, type=ExportEvents.EXPORT_PENDING
+    ).exists()
+
+
+@patch("saleor.graphql.csv.mutations.export_gift_cards_task.delay")
+def test_export_gift_cards_mutation_by_app(
+    export_gift_cards_mock,
+    app_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    permission_manage_staff,
+):
+    query = EXPORT_GIFT_CARDS_MUTATION
+    app = app_api_client.app
+    variables = {
+        "input": {
+            "scope": ExportScope.ALL.name,
+            "fileType": FileTypeEnum.XLSX.name,
+        }
+    }
+
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_apps,
+            permission_manage_staff,
+        ],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportGiftCards"]
+    export_file_data = data["exportFile"]
+
+    export_gift_cards_mock.assert_called_once_with(
+        ANY, {"all": ""}, FileTypeEnum.XLSX.value
+    )
+
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+    assert export_file_data["createdAt"]
+    assert export_file_data["user"] is None
+    assert export_file_data["app"]["name"] == app.name
+    assert ExportEvent.objects.filter(
+        user=None, app=app, type=ExportEvents.EXPORT_PENDING
+    ).exists()
+
+
+@patch("saleor.graphql.csv.mutations.export_gift_cards_task.delay")
+def test_export_gift_cards_mutation_ids_scope(
+    export_gift_cards_mock,
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    permission_manage_staff,
+):
+    query = EXPORT_GIFT_CARDS_MUTATION
+    user = staff_api_client.user
+
+    gift_cards = [gift_card_expiry_date, gift_card_used]
+
+    ids = [graphene.Node.to_global_id("GiftCard", card.pk) for card in gift_cards]
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "fileType": FileTypeEnum.XLSX.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_apps,
+            permission_manage_staff,
+        ],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportGiftCards"]
+    export_file_data = data["exportFile"]
+
+    export_gift_cards_mock.assert_called_once()
+    (
+        call_args,
+        call_kwargs,
+    ) = export_gift_cards_mock.call_args
+
+    assert set(call_args[1]["ids"]) == {str(card.pk) for card in gift_cards}
+    assert call_args[2] == FileTypeEnum.XLSX.value
+
+    assert not data["errors"]
+    assert data["exportFile"]["id"]
+    assert export_file_data["createdAt"]
+    assert export_file_data["user"]["email"] == staff_api_client.user.email
+    assert export_file_data["app"] is None
+    assert ExportEvent.objects.filter(
+        user=user, app=None, type=ExportEvents.EXPORT_PENDING
+    ).exists()
+
+
+@patch("saleor.graphql.csv.mutations.export_gift_cards_task.delay")
+def test_export_gift_cards_mutation_ids_scope_invalid_object_type(
+    export_gift_cards_mock,
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    permission_manage_staff,
+):
+    query = EXPORT_GIFT_CARDS_MUTATION
+    user = staff_api_client.user
+
+    gift_cards = [gift_card_expiry_date, gift_card_used]
+
+    ids = [graphene.Node.to_global_id("Product", card.pk) for card in gift_cards]
+
+    variables = {
+        "input": {
+            "scope": ExportScope.IDS.name,
+            "ids": ids,
+            "fileType": FileTypeEnum.CSV.name,
+        }
+    }
+
+    response = staff_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_apps,
+            permission_manage_staff,
+        ],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportGiftCards"]
+
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == "ids"
+    assert errors[0]["code"] == ExportErrorCode.GRAPHQL_ERROR.name
+
+    assert not ExportEvent.objects.filter(
+        user=user, app=None, type=ExportEvents.EXPORT_PENDING
+    )
+
+    export_gift_cards_mock.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "input, error_field",
+    [
+        (
+            {
+                "scope": ExportScope.FILTER.name,
+                "fileType": FileTypeEnum.CSV.name,
+            },
+            "filter",
+        ),
+        (
+            {
+                "scope": ExportScope.IDS.name,
+                "fileType": FileTypeEnum.CSV.name,
+            },
+            "ids",
+        ),
+    ],
+)
+@patch("saleor.graphql.csv.mutations.export_gift_cards_task.delay")
+def test_export_gift_cards_mutation_failed(
+    export_gift_cards_mock,
+    input,
+    error_field,
+    app_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    permission_manage_gift_card,
+    permission_manage_apps,
+    permission_manage_staff,
+):
+    query = EXPORT_GIFT_CARDS_MUTATION
+    app = app_api_client.app
+
+    variables = {"input": input}
+
+    response = app_api_client.post_graphql(
+        query,
+        variables=variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_apps,
+            permission_manage_staff,
+        ],
+    )
+    content = get_graphql_content(response)
+    data = content["data"]["exportGiftCards"]
+
+    errors = data["errors"]
+    assert len(errors) == 1
+    assert not data["exportFile"]
+    assert errors[0]["field"] == error_field
+    assert errors[0]["code"] == ExportErrorCode.REQUIRED.name
+
+    assert not ExportEvent.objects.filter(
+        user=None, app=app, type=ExportEvents.EXPORT_PENDING
+    )
+
+    export_gift_cards_mock.assert_not_called()

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2059,6 +2059,18 @@ input ExportFileSortingInput {
   field: ExportFileSortField!
 }
 
+type ExportGiftCards {
+  exportFile: ExportFile
+  errors: [ExportError!]!
+}
+
+input ExportGiftCardsInput {
+  scope: ExportScope!
+  filter: GiftCardFilterInput
+  ids: [ID!]
+  fileType: FileTypesEnum!
+}
+
 input ExportInfoInput {
   attributes: [ID!]
   warehouses: [ID!]
@@ -3870,6 +3882,7 @@ type Mutation {
   voucherTranslate(id: ID!, input: NameTranslationInput!, languageCode: LanguageCodeEnum!): VoucherTranslate
   voucherChannelListingUpdate(id: ID!, input: VoucherChannelListingInput!): VoucherChannelListingUpdate
   exportProducts(input: ExportProductsInput!): ExportProducts
+  exportGiftCards(input: ExportGiftCardsInput!): ExportGiftCards
   fileUpload(file: Upload!): FileUpload
   checkoutAddPromoCode(checkoutId: ID, promoCode: String!, token: UUID): CheckoutAddPromoCode
   checkoutBillingAddressUpdate(billingAddress: AddressInput!, checkoutId: ID, token: UUID): CheckoutBillingAddressUpdate


### PR DESCRIPTION
Add `exportGiftCards` mutation.

```
exportGiftCards(input: ExportGiftCardsInput!): ExportGiftCards

type ExportGiftCards {
  exportFile: ExportFile
  exportErrors: [ExportError!]! @deprecated(reason: "This field will be removed in Saleor 4.0. Use `errors` field instead.")
  errors: [ExportError!]!
}

input ExportGiftCardsInput {
  scope: ExportScope!
  filter: GiftCardFilterInput
  ids: [ID!]
  fileType: FileTypesEnum!
}
```

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
