### PR TITLE
Fix the example query displayed in Playground in 3.1

### DIFF
--- a/templates/graphql/playground.html
+++ b/templates/graphql/playground.html
@@ -10,7 +10,7 @@
   <meta http-equiv="content-security-policy" content="default-src 'none'; connect-src {{ api_url }}; script-src 'sha256-24AcA5M3t+KN6ZRQvfqBG51OyLciyk0UJwVBAX94SZI=' 'sha256-jpQ7CLb9c8nrwEY+pDfFNOgGpKzrNTRsWVv4yB8QVnQ='; style-src https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/css/index.css 'sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4='; img-src data: https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/static/media/logo.8c98d067.png https://cdn.jsdelivr.net/npm/graphql-playground-react@1.7.22/build/favicon.png">
 </head>
 <body>
-  <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query|safe }}"{% endif %}>
+  <div id="root" data-endpoint="{{ api_url }}" {% if query %}data-query="{{ query }}"{% endif %}>
     {# sha256-jkwxzyKPdPQHgIYu9x7it0jbIOtzMGr9iFmRtSaiwX4= #}
     <style>
       body {


### PR DESCRIPTION
It can't be marked as `safe` as it breaks HTML if not escaped properly.

This is a cherry-pick of #8020 for Saleor 3.1

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
