### PR TITLE
Create NOTE_ADDED when note provided in GiftCardCreate mutation

### DIFF
--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -183,11 +183,17 @@ class GiftCardCreate(ModelMutation):
 
     @classmethod
     def post_save_action(cls, info, instance, cleaned_input):
+        user = info.context.user
+        app = info.context.app
         events.gift_card_issued_event(
             gift_card=instance,
-            user=info.context.user,
-            app=info.context.app,
+            user=user,
+            app=app,
         )
+        if note := cleaned_input.get("note"):
+            events.gift_card_note_added_event(
+                gift_card=instance, user=user, app=app, message=note
+            )
         if email := cleaned_input.get("user_email"):
             send_gift_card_notification(
                 cleaned_input.get("created_by"),


### PR DESCRIPTION
Create `NOTE_ADDED` event when note provided in `GiftCardCreate` mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
