### PR TITLE
[SALEOR-3794] Adyen - include checkout_token as a merchantOrderReference

### DIFF
--- a/saleor/payment/gateways/adyen/tests/utils/test_common.py
+++ b/saleor/payment/gateways/adyen/tests/utils/test_common.py
@@ -206,6 +206,7 @@ def test_request_data_for_payment(dummy_payment_data, dummy_address_data):
         "browserInfo": data["browserInfo"],
         "channel": "web",
         "shopperEmail": "example@test.com",
+        "merchantOrderReference": "1-2-3-4",
         "shopperName": {
             "firstName": dummy_payment_data.billing.first_name,
             "lastName": dummy_payment_data.billing.last_name,
@@ -425,6 +426,7 @@ def test_request_data_for_payment_without_shipping(
             "stateOrProvince": "",
             "street": "Tęczowa 7",
         },
+        "merchantOrderReference": "1-2-3-4",
     }
 
 
@@ -471,6 +473,7 @@ def test_request_data_for_payment_native_3d_secure(
         "channel": "web",
         "additionalData": {"allow3DS2": "true"},
         "shopperEmail": "example@test.com",
+        "merchantOrderReference": "1-2-3-4",
         "shopperName": {
             "firstName": dummy_payment_data.billing.first_name,
             "lastName": dummy_payment_data.billing.last_name,
@@ -527,6 +530,7 @@ def test_request_data_for_payment_channel_different_than_web(
         "channel": "iOS",
         "additionalData": {"allow3DS2": "true"},
         "shopperEmail": "example@test.com",
+        "merchantOrderReference": "1-2-3-4",
         "shopperName": {
             "firstName": dummy_payment_data.billing.first_name,
             "lastName": dummy_payment_data.billing.last_name,

--- a/saleor/payment/gateways/adyen/utils/common.py
+++ b/saleor/payment/gateways/adyen/utils/common.py
@@ -154,6 +154,8 @@ def request_data_for_payment(
     if native_3d_secure and "scheme" == method:
         extra_request_params["additionalData"] = {"allow3DS2": "true"}
 
+    order_reference = payment_information.checkout_token
+
     extra_request_params["shopperEmail"] = payment_information.customer_email
 
     if payment_information.billing:
@@ -174,6 +176,7 @@ def request_data_for_payment(
         "merchantAccount": merchant_account,
         "shopperEmail": payment_information.customer_email,
         "shopperReference": payment_information.customer_email,
+        "merchantOrderReference": order_reference,
         **extra_request_params,
     }
 

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3248,6 +3248,7 @@ def dummy_payment_data(payment_dummy):
         order_id=None,
         customer_ip_address=None,
         customer_email="example@test.com",
+        checkout_token="1-2-3-4",
     )
 
 


### PR DESCRIPTION
I want to merge this change because...

I need to link payment together on Adyen side, during the payment we need to provide merchantOrderReference to each payment request which we send to Adyen

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
