### PR TITLE
Fix bug with handling orders containing deleted variants

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -91,13 +91,19 @@ def get_order_line_payload(line: "OrderLine"):
     if line.is_digital:
         content = DigitalContentUrl.objects.filter(line=line).first()
         digital_url = content.get_absolute_url() if content else None  # type: ignore
+    variant_dependent_fields = {}
+    if line.variant:
+        variant_dependent_fields = {
+            "product": get_product_payload(line.variant.product),
+            "variant": get_product_variant_payload(line.variant),
+        }
     return {
         "id": line.id,
-        "product": get_product_payload(line.variant.product),  # type: ignore
+        "product": variant_dependent_fields.get("product"),  # type: ignore
         "product_name": line.product_name,
         "translated_product_name": line.translated_product_name or line.product_name,
         "variant_name": line.variant_name,
-        "variant": get_product_variant_payload(line.variant),  # type: ignore
+        "variant": variant_dependent_fields.get("variant"),  # type: ignore
         "translated_variant_name": line.translated_variant_name or line.variant_name,
         "product_sku": line.product_sku,
         "quantity": line.quantity,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -96,6 +96,46 @@ def test_get_order_line_payload(order_line):
     }
 
 
+def test_get_order_line_payload_deleted_variant(order_line):
+    order_line.variant = None
+    payload = get_order_line_payload(order_line)
+    unit_tax_amount = (
+        order_line.unit_price_gross_amount - order_line.unit_price_net_amount
+    )
+    total_gross = order_line.unit_price_gross * order_line.quantity
+    total_net = order_line.unit_price_net * order_line.quantity
+    total_tax = total_gross - total_net
+    assert payload == {
+        "variant": None,
+        "product": None,
+        "translated_product_name": order_line.translated_product_name
+        or order_line.product_name,
+        "translated_variant_name": order_line.translated_variant_name
+        or order_line.variant_name,
+        "id": order_line.id,
+        "product_name": order_line.product_name,
+        "variant_name": order_line.variant_name,
+        "product_sku": order_line.product_sku,
+        "is_shipping_required": order_line.is_shipping_required,
+        "quantity": order_line.quantity,
+        "quantity_fulfilled": order_line.quantity_fulfilled,
+        "currency": order_line.currency,
+        "unit_price_net_amount": order_line.unit_price_net_amount,
+        "unit_price_gross_amount": order_line.unit_price_gross_amount,
+        "unit_tax_amount": unit_tax_amount,
+        "total_gross_amount": total_gross.amount,
+        "total_net_amount": total_net.amount,
+        "total_tax_amount": total_tax.amount,
+        "tax_rate": order_line.tax_rate,
+        "is_digital": order_line.is_digital,
+        "digital_url": "",
+        "unit_discount_amount": order_line.unit_discount_amount,
+        "unit_discount_reason": order_line.unit_discount_reason,
+        "unit_discount_type": order_line.unit_discount_type,
+        "unit_discount_value": order_line.unit_discount_value,
+    }
+
+
 def test_get_address_payload(address):
     payload = get_address_payload(address)
     assert payload == {
@@ -313,7 +353,6 @@ def test_send_confirmation_emails_without_addresses_for_payment(
 def test_send_confirmation_emails_without_addresses_for_order(
     mocked_notify, order, site_settings, digital_content, info
 ):
-
     assert not order.lines.count()
 
     line = add_variant_to_order(

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -419,6 +419,7 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
         "order_line__variant__product__product_type", "stock"
     ).filter(fulfillment=fulfillment)
     line_fields = ("quantity",)
+
     return serializer.serialize(
         lines,
         fields=line_fields,
@@ -426,10 +427,16 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
             "product_name": lambda fl: fl.order_line.product_name,
             "variant_name": lambda fl: fl.order_line.variant_name,
             "product_sku": lambda fl: fl.order_line.product_sku,
-            "weight": (lambda fl: fl.order_line.variant.get_weight().g),
+            "weight": (
+                lambda fl: fl.order_line.variant.get_weight().g
+                if fl.order_line.variant
+                else None
+            ),
             "weight_unit": "gram",
             "product_type": (
                 lambda fl: fl.order_line.variant.product.product_type.name
+                if fl.order_line.variant
+                else None
             ),
             "unit_price_net": lambda fl: fl.order_line.unit_price_net_amount,
             "unit_price_gross": lambda fl: fl.order_line.unit_price_gross_amount,

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -126,6 +126,7 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
         ]
     )
     payload = json.loads(generate_fulfillment_lines_payload(fulfillment))[0]
+
     assert payload == {
         "currency": "USD",
         "product_name": line.product_name,

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -126,7 +126,7 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
         ]
     )
     payload = json.loads(generate_fulfillment_lines_payload(fulfillment))[0]
-
+    # line.variant.delete()
     assert payload == {
         "currency": "USD",
         "product_name": line.product_name,
@@ -151,6 +151,52 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
         "warehouse_id": graphene.Node.to_global_id(
             "Warehouse", fulfillment_line.stock.warehouse_id
         ),
+    }
+
+
+def test_generate_fulfillment_lines_payload_deleted_variant(order_with_lines):
+
+    # given
+    fulfillment = order_with_lines.fulfillments.create(tracking_number="123")
+    line = order_with_lines.lines.first()
+    stock = line.allocations.get().stock
+    warehouse_pk = stock.warehouse.pk
+    fulfillment_line = fulfillment.lines.create(
+        order_line=line, quantity=line.quantity, stock=stock
+    )
+    fulfill_order_lines(
+        [
+            OrderLineData(line=line, quantity=line.quantity, warehouse_pk=warehouse_pk),
+        ]
+    )
+
+    # when
+    line.variant.delete()
+    payload = json.loads(generate_fulfillment_lines_payload(fulfillment))[0]
+
+    # then
+    assert payload == {
+        "currency": "USD",
+        "product_name": line.product_name,
+        "variant_name": line.variant_name,
+        "product_sku": line.product_sku,
+        "id": graphene.Node.to_global_id("FulfillmentLine", fulfillment_line.id),
+        "product_type": None,
+        "quantity": fulfillment_line.quantity,
+        "total_price_gross_amount": str(
+            line.unit_price.gross.amount * fulfillment_line.quantity
+        ),
+        "total_price_net_amount": str(
+            line.unit_price.net.amount * fulfillment_line.quantity
+        ),
+        "type": "FulfillmentLine",
+        "undiscounted_unit_price_gross": str(line.undiscounted_unit_price.gross.amount),
+        "undiscounted_unit_price_net": str(line.undiscounted_unit_price.net.amount),
+        "unit_price_gross": str(line.unit_price.gross.amount),
+        "unit_price_net": str(line.unit_price.net.amount),
+        "weight": None,
+        "weight_unit": "gram",
+        "warehouse_id": None,
     }
 
 

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -126,7 +126,6 @@ def test_generate_fulfillment_lines_payload(order_with_lines):
         ]
     )
     payload = json.loads(generate_fulfillment_lines_payload(fulfillment))[0]
-    # line.variant.delete()
     assert payload == {
         "currency": "USD",
         "product_name": line.product_name,


### PR DESCRIPTION
I want to merge this change because user should be able to manage orders (adding tracking number, deleting) containing variants that were deleted after the order was created. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
