### PR TITLE
Fix inccorect handling of last response object 3.0

### DIFF
--- a/saleor/payment/gateways/stripe/tests/test_plugin.py
+++ b/saleor/payment/gateways/stripe/tests/test_plugin.py
@@ -595,7 +595,7 @@ def test_process_payment_offline(
 
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
 @patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
-def test_process_payment_with_customer_and_payment_method_raises_card_error(
+def test_process_payment_with_customer_and_payment_method_raises_authentication_error(
     mocked_payment_intent,
     mocked_customer_create,
     stripe_plugin,
@@ -609,6 +609,7 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
     payment_intent = Mock()
     stripe_error_object = StripeError()
     stripe_error_object.error = StripeError()
+    stripe_error_object.code = "authentication_required"
     stripe_error_object.error.payment_intent = payment_intent
     mocked_payment_intent.side_effect = stripe_error_object
 
@@ -648,6 +649,86 @@ def test_process_payment_with_customer_and_payment_method_raises_card_error(
         "client_secret": client_secret,
         "id": payment_intent_id,
     }
+
+    api_key = plugin.config.connection_params["secret_api_key"]
+    mocked_payment_intent.assert_called_once_with(
+        api_key=api_key,
+        amount=price_to_minor_unit(payment_info.amount, payment_info.currency),
+        currency=payment_info.currency,
+        capture_method=AUTOMATIC_CAPTURE_METHOD,
+        customer=customer,
+        payment_method="pm_ID",
+        confirm=True,
+        off_session=True,
+        metadata={
+            "channel": channel_USD.slug,
+            "payment_id": payment_info.graphql_payment_id,
+        },
+        receipt_email=payment_stripe_for_checkout.checkout.email,
+        stripe_version=STRIPE_API_VERSION,
+    )
+
+    mocked_customer_create.assert_called_once_with(
+        api_key="secret_key",
+        email=customer_user.email,
+        stripe_version=STRIPE_API_VERSION,
+    )
+
+
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.Customer.create")
+@patch("saleor.payment.gateways.stripe.stripe_api.stripe.PaymentIntent.create")
+def test_process_payment_with_customer_and_payment_method_raises_error(
+    mocked_payment_intent,
+    mocked_customer_create,
+    stripe_plugin,
+    payment_stripe_for_checkout,
+    channel_USD,
+    customer_user,
+):
+    customer = Mock()
+    mocked_customer_create.return_value = customer
+
+    payment_intent = Mock()
+    stripe_error_object = StripeError(
+        message="Card declined", json_body={"error": "body"}
+    )
+    stripe_error_object.error = StripeError()
+    stripe_error_object.code = "card_declined"
+    stripe_error_object.error.payment_intent = payment_intent
+    mocked_payment_intent.side_effect = stripe_error_object
+
+    client_secret = "client-secret"
+    dummy_response = {
+        "id": "evt_1Ip9ANH1Vac4G4dbE9ch7zGS",
+    }
+    payment_intent_id = "payment-intent-id"
+    payment_intent.id = payment_intent_id
+    payment_intent.client_secret = client_secret
+    payment_intent.last_response.data = dummy_response
+
+    plugin = stripe_plugin(auto_capture=True)
+
+    payment_stripe_for_checkout.checkout.user = customer_user
+    payment_stripe_for_checkout.checkout.email = customer_user.email
+
+    payment_info = create_payment_information(
+        payment_stripe_for_checkout,
+        customer_id=None,
+        store_source=True,
+        additional_data={"payment_method_id": "pm_ID", "off_session": True},
+    )
+
+    response = plugin.process_payment(payment_info, None)
+
+    assert response.is_success is False
+    assert response.action_required is True
+    assert response.kind == TransactionKind.ACTION_TO_CONFIRM
+    assert response.amount == payment_info.amount
+    assert response.currency == payment_info.currency
+    assert not response.transaction_id
+    assert response.error == "Card declined"
+    assert response.raw_response == {"error": "body"}
+    assert response.action_required_data == {"client_secret": None, "id": None}
 
     api_key = plugin.config.connection_params["secret_api_key"]
     mocked_payment_intent.assert_called_once_with(
@@ -773,7 +854,9 @@ def test_process_payment_with_manual_capture(
 def test_process_payment_with_error(
     mocked_payment_intent, stripe_plugin, payment_stripe_for_checkout, channel_USD
 ):
-    mocked_payment_intent.side_effect = StripeError(message="stripe-error")
+    mocked_payment_intent.side_effect = StripeError(
+        message="stripe-error", json_body={"error": "body"}
+    )
 
     plugin = stripe_plugin()
 
@@ -790,7 +873,7 @@ def test_process_payment_with_error(
     assert response.currency == payment_info.currency
     assert response.transaction_id == ""
     assert response.error == "stripe-error"
-    assert response.raw_response is None
+    assert response.raw_response == {"error": "body"}
     assert response.action_required_data == {"client_secret": None, "id": None}
 
     api_key = plugin.config.connection_params["secret_api_key"]


### PR DESCRIPTION
I want to merge this change because it fixes an issue with trying to fetch non-existing object from stripe response

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
