### PR TITLE
Fix passing replace flag to check_stock_quantity_bulk

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -119,6 +119,7 @@ def check_lines_quantity(
     channel_slug,
     allow_zero_quantity=False,
     existing_lines=None,
+    replace=False,
 ):
     """Clean quantities and check if stock is sufficient for each checkout line.
 
@@ -161,7 +162,7 @@ def check_lines_quantity(
             )
     try:
         check_stock_quantity_bulk(
-            variants, country, quantities, channel_slug, existing_lines
+            variants, country, quantities, channel_slug, existing_lines, replace
         )
     except InsufficientStock as e:
         errors = [
@@ -570,6 +571,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
             channel_slug,
             allow_zero_quantity=True,
             existing_lines=lines,
+            replace=True,
         )
 
     @classmethod

--- a/saleor/graphql/checkout/tests/test_checkout_lines.py
+++ b/saleor/graphql/checkout/tests/test_checkout_lines.py
@@ -491,6 +491,27 @@ def test_checkout_lines_update_channel_without_shipping_zones(
     assert errors[0]["field"] == "quantity"
 
 
+def test_checkout_lines_update_variant_quantity_over_avability_stock(
+    user_api_client, checkout_with_item
+):
+    checkout = checkout_with_item
+    line = checkout.lines.first()
+    variant_id = graphene.Node.to_global_id("ProductVariant", line.variant.pk)
+    current_stock = line.variant.stocks.first()
+    line.quantity = current_stock.quantity - 1
+    line.save()
+
+    variables = {
+        "token": checkout.token,
+        "lines": [{"variantId": variant_id, "quantity": current_stock.quantity - 2}],
+        "channelSlug": checkout.channel.slug,
+    }
+    response = user_api_client.post_graphql(MUTATION_CHECKOUT_LINES_UPDATE, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkoutLinesUpdate"]
+    assert data["checkout"]["lines"][0]["quantity"] == variables["lines"][0]["quantity"]
+
+
 @mock.patch(
     "saleor.graphql.checkout.mutations.update_checkout_shipping_method_if_invalid",
     wraps=update_checkout_shipping_method_if_invalid,

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -47,6 +47,7 @@ def check_stock_quantity_bulk(
     quantities: Iterable[int],
     channel_slug: str,
     existing_lines: Iterable = None,
+    replace=False,
 ):
     """Validate if there is stock available for given variants in given country.
 
@@ -67,8 +68,8 @@ def check_stock_quantity_bulk(
         line.variant.pk: line.line.quantity for line in existing_lines or []
     }
     for variant, quantity in zip(variants, quantities):
-
-        quantity += variants_quantities.get(variant.pk, 0)
+        if not replace:
+            quantity += variants_quantities.get(variant.pk, 0)
 
         stocks = variant_stocks.get(variant.pk, [])
         available_quantity = sum(


### PR DESCRIPTION
I want to merge this change because it fixes bug with wrong behaviour of CheckoutLinesUpdate mutation.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
