### PR TITLE
Fix adyen do not assume that checkout exists for additional action 3.0

### DIFF
--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
@@ -9,9 +9,9 @@ import pytest
 from ..... import PaymentError, TransactionKind
 from ...webhooks import handle_additional_actions
 
-ERROR_MSG_MISSING_PAYMENT = "Cannot perform payment.There is no active adyen payment."
+ERROR_MSG_MISSING_PAYMENT = "Cannot perform payment. There is no active Adyen payment."
 ERROR_MSG_MISSING_CHECKOUT = (
-    "Cannot perform payment.There is no checkout with this payment."
+    "Cannot perform payment. There is no checkout with this payment."
 )
 
 

--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_additional_actions.py
@@ -62,6 +62,46 @@ def test_handle_additional_actions_post(
     assert payment_adyen_for_checkout.checkout is None
 
 
+@mock.patch("saleor.payment.gateways.adyen.webhooks.api_call")
+def test_handle_additional_actions_order_already_created(
+    api_call_mock, payment_adyen_for_order, adyen_plugin, order
+):
+    # given
+    adyen_plugin()
+    payment_adyen_for_order.to_confirm = True
+    payment_adyen_for_order.extra_data = json.dumps(
+        [{"payment_data": "test_data", "parameters": ["payload"]}]
+    )
+    payment_adyen_for_order.save(update_fields=["to_confirm", "extra_data"])
+
+    payment_id = graphene.Node.to_global_id("Payment", payment_adyen_for_order.pk)
+    checkout_id = graphene.Node.to_global_id("Checkout", "1")
+
+    request_mock = mock.Mock()
+    request_mock.GET = {"payment": payment_id, "checkout": "1"}
+    request_mock.POST = {"payload": "test"}
+
+    payment_details_mock = mock.Mock()
+    message = {
+        "pspReference": "11111",
+        "resultCode": "Test",
+    }
+    api_call_mock.return_value.message = message
+
+    # when
+    response = handle_additional_actions(request_mock, payment_details_mock)
+
+    # then
+    payment_adyen_for_order.refresh_from_db()
+    assert response.status_code == 302
+    assert f"checkout={quote_plus(checkout_id)}" in response.url
+    assert f"resultCode={message['resultCode']}" in response.url
+    assert f"payment={quote_plus(payment_id)}" in response.url
+
+    assert payment_adyen_for_order.order
+    assert payment_adyen_for_order.checkout is None
+
+
 @pytest.mark.parametrize(
     "custom_url",
     [

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -703,7 +703,7 @@ def handle_additional_actions(
     payment = get_payment(payment_id, transaction_id=None)
     if not payment:
         logger.warning(
-            "Payment doesn't exist or is not active", extra={"payment_id": payment_id}
+            "Payment doesn't exist or is not active.", extra={"payment_id": payment_id}
         )
         return HttpResponseNotFound(
             "Cannot perform payment.There is no active adyen payment."
@@ -714,7 +714,7 @@ def handle_additional_actions(
     if not payment.order_id:
         if not payment.checkout or str(payment.checkout.token) != checkout_pk:
             logger.warning(
-                "There is no checkout with this payment",
+                "There is no checkout with this payment.",
                 extra={"checkout_pk": checkout_pk, "payment_id": payment_id},
             )
             return HttpResponseNotFound(
@@ -728,7 +728,7 @@ def handle_additional_actions(
 
     if not return_url:
         logger.warning(
-            "Missing return_url for payment",
+            "Missing return_url for payment.",
             extra={"payment_id": payment_id, "checkout_pk": checkout_pk},
         )
         return HttpResponseNotFound(

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -694,17 +694,32 @@ def handle_additional_actions(
     checkout_pk = request.GET.get("checkout")
 
     if not payment_id or not checkout_pk:
+        logger.warning(
+            "Missing payment_id or checkout id in Adyen's request.",
+            extra={"payment_id": payment_id, "checkout_id": checkout_pk},
+        )
         return HttpResponseNotFound()
 
     payment = get_payment(payment_id, transaction_id=None)
     if not payment:
+        logger.warning(
+            "Payment doesn't exist or is not active", extra={"payment_id": payment_id}
+        )
         return HttpResponseNotFound(
             "Cannot perform payment.There is no active adyen payment."
         )
-    if not payment.checkout or str(payment.checkout.token) != checkout_pk:
-        return HttpResponseNotFound(
-            "Cannot perform payment.There is no checkout with this payment."
-        )
+
+    # Adyen for some payment methods can call success notification before we will
+    # call an additional_action.
+    if not payment.order_id:
+        if not payment.checkout or str(payment.checkout.token) != checkout_pk:
+            logger.warning(
+                "There is no checkout with this payment",
+                extra={"checkout_pk": checkout_pk, "payment_id": payment_id},
+            )
+            return HttpResponseNotFound(
+                "Cannot perform payment.There is no checkout with this payment."
+            )
 
     extra_data = json.loads(payment.extra_data)
     data = extra_data[-1] if isinstance(extra_data, list) else extra_data
@@ -712,6 +727,10 @@ def handle_additional_actions(
     return_url = payment.return_url
 
     if not return_url:
+        logger.warning(
+            "Missing return_url for payment",
+            extra={"payment_id": payment_id, "checkout_pk": checkout_pk},
+        )
         return HttpResponseNotFound(
             "Cannot perform payment. Lack of data about returnUrl."
         )

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -706,7 +706,7 @@ def handle_additional_actions(
             "Payment doesn't exist or is not active.", extra={"payment_id": payment_id}
         )
         return HttpResponseNotFound(
-            "Cannot perform payment.There is no active adyen payment."
+            "Cannot perform payment. There is no active Adyen payment."
         )
 
     # Adyen for some payment methods can call success notification before we will
@@ -718,7 +718,7 @@ def handle_additional_actions(
                 extra={"checkout_pk": checkout_pk, "payment_id": payment_id},
             )
             return HttpResponseNotFound(
-                "Cannot perform payment.There is no checkout with this payment."
+                "Cannot perform payment. There is no checkout with this payment."
             )
 
     extra_data = json.loads(payment.extra_data)


### PR DESCRIPTION
I want to merge this change because it fixes an issue for iDEAL payment method. The webhook notification from Adyen can come before we will finish an additional action on Saleor side.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
