### PR TITLE
Fix bug with handling orders containing deleted variants in 3.1

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -91,13 +91,19 @@ def get_order_line_payload(line: "OrderLine"):
     if line.is_digital:
         content = DigitalContentUrl.objects.filter(line=line).first()
         digital_url = content.get_absolute_url() if content else None  # type: ignore
+    variant_dependent_fields = {}
+    if line.variant:
+        variant_dependent_fields = {
+            "product": get_product_payload(line.variant.product),
+            "variant": get_product_variant_payload(line.variant),
+        }
     return {
         "id": line.id,
-        "product": get_product_payload(line.variant.product),  # type: ignore
+        "product": variant_dependent_fields.get("product"),  # type: ignore
         "product_name": line.product_name,
         "translated_product_name": line.translated_product_name or line.product_name,
         "variant_name": line.variant_name,
-        "variant": get_product_variant_payload(line.variant),  # type: ignore
+        "variant": variant_dependent_fields.get("variant"),  # type: ignore
         "translated_variant_name": line.translated_variant_name or line.variant_name,
         "product_sku": line.product_sku,
         "quantity": line.quantity,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -160,6 +160,14 @@ def test_get_order_line_payload(order_line):
     }
 
 
+def test_get_order_line_payload_deleted_variant(order_line):
+    order_line.variant = None
+    payload = get_order_line_payload(order_line)
+
+    assert payload["variant"] is None
+    assert payload["product"] is None
+
+
 def test_get_address_payload(address):
     payload = get_address_payload(address)
     assert payload == {

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -473,10 +473,16 @@ def generate_fulfillment_lines_payload(fulfillment: Fulfillment):
             "product_name": lambda fl: fl.order_line.product_name,
             "variant_name": lambda fl: fl.order_line.variant_name,
             "product_sku": lambda fl: fl.order_line.product_sku,
-            "weight": (lambda fl: fl.order_line.variant.get_weight().g),
+            "weight": (
+                lambda fl: fl.order_line.variant.get_weight().g
+                if fl.order_line.variant
+                else None
+            ),
             "weight_unit": "gram",
             "product_type": (
                 lambda fl: fl.order_line.variant.product.product_type.name
+                if fl.order_line.variant
+                else None
             ),
             "unit_price_net": lambda fl: fl.order_line.unit_price_net_amount,
             "unit_price_gross": lambda fl: fl.order_line.unit_price_gross_amount,


### PR DESCRIPTION
I want to merge this change because copying changes from #8053 
Additional changes: testing only specific changes instead of whole payload
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
