### PR TITLE
Fix passing replace flag to check_stock_quantity_bulk

### DIFF
--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -127,6 +127,7 @@ def check_lines_quantity(
     channel_slug,
     allow_zero_quantity=False,
     existing_lines=None,
+    replace=False,
 ):
     """Clean quantities and check if stock is sufficient for each checkout line.
 
@@ -169,7 +170,12 @@ def check_lines_quantity(
             )
     try:
         check_stock_quantity_bulk(
-            variants, country, quantities, channel_slug, existing_lines=existing_lines
+            variants,
+            country,
+            quantities,
+            channel_slug,
+            existing_lines=existing_lines,
+            replace=replace,
         )
     except InsufficientStock as e:
         errors = [
@@ -587,6 +593,7 @@ class CheckoutLinesUpdate(CheckoutLinesAdd):
             channel_slug,
             allow_zero_quantity=True,
             existing_lines=lines,
+            replace=True,
         )
 
     @classmethod

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -48,6 +48,7 @@ def check_stock_quantity_bulk(
     channel_slug: str,
     additional_filter_lookup: Optional[Dict[str, Any]] = None,
     existing_lines: Iterable = None,
+    replace=False,
 ):
     """Validate if there is stock available for given variants in given country.
 
@@ -72,8 +73,8 @@ def check_stock_quantity_bulk(
         line.variant.pk: line.line.quantity for line in existing_lines or []
     }
     for variant, quantity in zip(variants, quantities):
-
-        quantity += variants_quantities.get(variant.pk, 0)
+        if not replace:
+            quantity += variants_quantities.get(variant.pk, 0)
 
         stocks = variant_stocks.get(variant.pk, [])
         available_quantity = sum(


### PR DESCRIPTION
I want to merge this change because it fixes bug with inappropriate behaviour of CheckoutLineUpdate mutation

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
