### PR TITLE
Fix call handler with incorrect function arguments

### DIFF
--- a/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
+++ b/saleor/payment/gateways/adyen/tests/webhooks/test_handle_notifications.py
@@ -302,9 +302,8 @@ def test_handle_cancel(
         value=price_to_minor_unit(payment.total, payment.currency),
     )
     config = adyen_plugin().config
-    manager = get_plugins_manager()
 
-    handle_cancellation(notification, config, manager)
+    handle_cancellation(notification, config)
 
     payment.order.refresh_from_db()
     assert payment.transactions.count() == 2
@@ -332,9 +331,8 @@ def test_handle_cancel_invalid_payment_id(
     transaction_count = payment.transactions.count()
 
     caplog.set_level(logging.WARNING)
-    manager = get_plugins_manager()
 
-    handle_cancellation(notification, config, manager)
+    handle_cancellation(notification, config)
 
     payment.order.refresh_from_db()
     assert payment.transactions.count() == transaction_count
@@ -356,9 +354,8 @@ def test_handle_cancel_already_canceled(
     )
     config = adyen_plugin().config
     create_new_transaction(notification, payment, TransactionKind.CANCEL)
-    manager = get_plugins_manager()
 
-    handle_cancellation(notification, config, manager)
+    handle_cancellation(notification, config)
 
     assert payment.transactions.count() == 2
 
@@ -972,7 +969,7 @@ def test_handle_cancel_or_refund_action_cancel(
 
     handle_cancel_or_refund(notification, config)
 
-    mock_handle_cancellation.assert_called_once_with(notification, config, mock.ANY)
+    mock_handle_cancellation.assert_called_once_with(notification, config)
 
 
 def test_handle_cancel_or_refund_action_cancel_invalid_payment_id(

--- a/saleor/payment/gateways/adyen/webhooks.py
+++ b/saleor/payment/gateways/adyen/webhooks.py
@@ -5,7 +5,7 @@ import hmac
 import json
 import logging
 from json.decoder import JSONDecodeError
-from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 from urllib.parse import urlencode, urlparse
 
 import Adyen
@@ -51,9 +51,6 @@ from ...utils import (
 from .utils.common import FAILED_STATUSES, api_call
 
 logger = logging.getLogger(__name__)
-
-if TYPE_CHECKING:
-    from ....plugins.manager import PluginsManager
 
 
 def get_payment(
@@ -273,7 +270,6 @@ def handle_authorization(notification: Dict[str, Any], gateway_config: GatewayCo
 def handle_cancellation(
     notification: Dict[str, Any],
     _gateway_config: GatewayConfig,
-    manager: "PluginsManager",
 ):
     # https://docs.adyen.com/checkout/cancel#cancellation-notifciation
     transaction_id = notification.get("pspReference")
@@ -301,6 +297,7 @@ def handle_cancellation(
         payment, success_msg, failed_msg, new_transaction.is_success
     )
     if payment.order and new_transaction.is_success:
+        manager = get_plugins_manager()
         cancel_order(payment.order, None, None, manager)
 
 
@@ -309,14 +306,13 @@ def handle_cancel_or_refund(
 ):
     # https://docs.adyen.com/checkout/cancel-or-refund#cancel-or-refund-notification
     additional_data = notification.get("additionalData")
-    manager = get_plugins_manager()
     if not additional_data:
         return
     action = additional_data.get("modification.action")
     if action == "refund":
         handle_refund(notification, gateway_config)
     elif action == "cancel":
-        handle_cancellation(notification, gateway_config, manager)
+        handle_cancellation(notification, gateway_config)
 
 
 def handle_capture(notification: Dict[str, Any], _gateway_config: GatewayConfig):


### PR DESCRIPTION
I want to merge this change because it fixes the incorrect call of cancellation notification.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
