### PR TITLE
Add cron job to deactivate expired cards

### DIFF
--- a/saleor/giftcard/tasks.py
+++ b/saleor/giftcard/tasks.py
@@ -1,0 +1,20 @@
+from celery.utils.log import get_task_logger
+from django.utils import timezone
+
+from ..celeryconf import app
+from .events import gift_cards_deactivated_event
+from .models import GiftCard
+
+task_logger = get_task_logger(__name__)
+
+
+@app.task
+def deactivate_expired_cards_task():
+    today = timezone.now().date()
+    gift_cards = GiftCard.objects.filter(expiry_date__lt=today, is_active=True)
+    if not gift_cards:
+        return
+    gift_card_ids = list(gift_cards.values_list("id", flat=True))
+    count = gift_cards.update(is_active=False)
+    gift_cards_deactivated_event(gift_card_ids, user=None, app=None)
+    task_logger.debug("Deactivate %s gift cards", count)

--- a/saleor/giftcard/tests/test_tasks.py
+++ b/saleor/giftcard/tests/test_tasks.py
@@ -1,0 +1,71 @@
+import datetime
+
+import pytest
+
+from .. import GiftCardEvents
+from ..models import GiftCard
+from ..tasks import deactivate_expired_cards_task
+
+
+def test_deactivate_expired_cards_task(
+    gift_card, gift_card_used, gift_card_expiry_date, gift_card_created_by_staff
+):
+    # given
+    gift_card.expiry_date = datetime.date.today() - datetime.timedelta(days=1)
+    gift_card_used.expiry_date = datetime.date.today() - datetime.timedelta(days=10)
+    gift_card_created_by_staff.expiry_date = datetime.date.today() - datetime.timedelta(
+        days=10
+    )
+    gift_card_created_by_staff.is_active = False
+    gift_cards = [gift_card, gift_card_used]
+    GiftCard.objects.bulk_update(
+        gift_cards + [gift_card_created_by_staff], ["expiry_date", "is_active"]
+    )
+
+    for card in gift_cards:
+        assert card.is_active
+
+    # when
+    deactivate_expired_cards_task()
+
+    # then
+    for card in gift_cards:
+        card.refresh_from_db()
+        assert not card.is_active
+        assert card.events.filter(type=GiftCardEvents.DEACTIVATED)
+
+    assert not gift_card_created_by_staff.events.filter(type=GiftCardEvents.DEACTIVATED)
+
+    gift_card_expiry_date.refresh_from_db()
+    assert gift_card_expiry_date.is_active
+
+
+@pytest.mark.parametrize(
+    "expiry_date",
+    [
+        datetime.date.today(),
+        datetime.date.today() + datetime.timedelta(days=1),
+    ],
+)
+def test_deactivate_expired_cards_task_cards_not_deactivated(
+    expiry_date, gift_card, gift_card_used, gift_card_expiry_date
+):
+    # given
+    gift_card.expiry_date = expiry_date
+    gift_card_used.expiry_date = expiry_date
+    gift_cards = [gift_card, gift_card_used]
+    GiftCard.objects.bulk_update(gift_cards, ["expiry_date"])
+
+    for card in gift_cards:
+        assert card.is_active
+
+    # when
+    deactivate_expired_cards_task()
+
+    # then
+    for card in gift_cards:
+        card.refresh_from_db()
+        assert card.is_active
+
+    gift_card_expiry_date.refresh_from_db()
+    assert gift_card_expiry_date.is_active

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -11,6 +11,7 @@ import jaeger_client.config
 import pkg_resources
 import sentry_sdk
 import sentry_sdk.utils
+from celery.schedules import crontab
 from django.core.exceptions import ImproperlyConfigured
 from django.core.management.utils import get_random_secret_key
 from graphql.utils import schema_printer
@@ -485,6 +486,10 @@ CELERY_BEAT_SCHEDULE = {
     "delete-empty-allocations": {
         "task": "saleor.warehouse.tasks.delete_empty_allocations_task",
         "schedule": timedelta(days=1),
+    },
+    "deactivate-expired-gift-cards": {
+        "task": "saleor.giftcard.tasks.deactivate_expired_cards_task",
+        "schedule": crontab(hour=0, minute=0),
     },
 }
 


### PR DESCRIPTION
Run celery task every day at midnight.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
