### PR TITLE
Change PluginsManager to call methods only on active plugins

### DIFF
--- a/saleor/plugins/manager.py
+++ b/saleor/plugins/manager.py
@@ -116,9 +116,9 @@ class PluginsManager(PaymentInterface):
         channel_slug: Optional[str] = None,
         **kwargs
     ):
-        """Try to run a method with the given name on each declared plugin."""
+        """Try to run a method with the given name on each declared active plugin."""
         value = default_value
-        plugins = self.get_plugins(channel_slug=channel_slug)
+        plugins = self.get_plugins(channel_slug=channel_slug, active_only=True)
         for plugin in plugins:
             value = self.__run_method_on_single_plugin(
                 plugin, method_name, value, *args, **kwargs

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -5,6 +5,7 @@ from django_prices_vatlayer.models import VAT
 from django_prices_vatlayer.utils import get_tax_for_rate
 
 from ..base_plugin import ConfigurationTypeField
+from ..manager import PluginsManager
 from ..models import PluginConfiguration
 from .sample_plugins import ChannelPluginSample, PluginInactive, PluginSample
 
@@ -134,3 +135,22 @@ def vatlayer(db, tax_rates, taxes, setup_vatlayer):
     }
     VAT.objects.create(country_code="DE", data=tax_rates_2)
     return taxes
+
+
+@pytest.fixture
+def plugins_manager():
+    return PluginsManager(plugins=[])
+
+
+@pytest.fixture
+def all_plugins_manager():
+    plugins = [
+        "saleor.plugins.tests.sample_plugins.ChannelPluginSample",
+        "saleor.plugins.tests.sample_plugins.InactiveChannelPluginSample",
+        "saleor.plugins.tests.sample_plugins.PluginInactive",
+        "saleor.plugins.tests.sample_plugins.ActivePlugin",
+        "saleor.plugins.tests.sample_plugins.ActivePaymentGateway",
+        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway",
+        "saleor.plugins.tests.sample_plugins.InactivePaymentGateway",
+    ]
+    return PluginsManager(plugins=plugins)

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -7,7 +7,12 @@ from django_prices_vatlayer.utils import get_tax_for_rate
 from ..base_plugin import ConfigurationTypeField
 from ..manager import PluginsManager
 from ..models import PluginConfiguration
-from .sample_plugins import ChannelPluginSample, PluginInactive, PluginSample
+from .sample_plugins import (
+    ALL_PLUGINS,
+    ChannelPluginSample,
+    PluginInactive,
+    PluginSample,
+)
 
 
 @pytest.fixture
@@ -144,13 +149,4 @@ def plugins_manager():
 
 @pytest.fixture
 def all_plugins_manager():
-    plugins = [
-        "saleor.plugins.tests.sample_plugins.ChannelPluginSample",
-        "saleor.plugins.tests.sample_plugins.InactiveChannelPluginSample",
-        "saleor.plugins.tests.sample_plugins.PluginInactive",
-        "saleor.plugins.tests.sample_plugins.ActivePlugin",
-        "saleor.plugins.tests.sample_plugins.ActivePaymentGateway",
-        "saleor.plugins.tests.sample_plugins.ActiveDummyPaymentGateway",
-        "saleor.plugins.tests.sample_plugins.InactivePaymentGateway",
-    ]
-    return PluginsManager(plugins=plugins)
+    return PluginsManager(plugins=ALL_PLUGINS)

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -149,4 +149,5 @@ def plugins_manager():
 
 @pytest.fixture
 def all_plugins_manager():
-    return PluginsManager(plugins=ALL_PLUGINS)
+    plugins_as_module_paths = [p.__module__ + "." + p.__name__ for p in ALL_PLUGINS]
+    return PluginsManager(plugins=plugins_as_module_paths)

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -221,6 +221,9 @@ class PluginSample(BasePlugin):
     def get_order_shipping_tax_rate(self, order: "Order", previous_value: Decimal):
         return Decimal("0.080").quantize(Decimal(".01"))
 
+    def sample_not_implemented(self, previous_value):
+        return NotImplemented
+
 
 class ChannelPluginSample(PluginSample):
     PLUGIN_ID = "channel.plugin.sample"

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -324,3 +324,19 @@ class InactivePaymentGateway(BasePlugin):
 
     def process_payment(self, payment_information, previous_value):
         pass
+
+
+ACTIVE_PLUGINS = (
+    __name__ + "." + ChannelPluginSample.__name__,
+    __name__ + "." + ActivePaymentGateway.__name__,
+    __name__ + "." + ActivePlugin.__name__,
+    __name__ + "." + ActiveDummyPaymentGateway.__name__,
+)
+
+INACTIVE_PLUGINS = (
+    __name__ + "." + InactivePaymentGateway.__name__,
+    __name__ + "." + PluginInactive.__name__,
+    __name__ + "." + InactiveChannelPluginSample.__name__,
+)
+
+ALL_PLUGINS = ACTIVE_PLUGINS + INACTIVE_PLUGINS

--- a/saleor/plugins/tests/sample_plugins.py
+++ b/saleor/plugins/tests/sample_plugins.py
@@ -327,16 +327,16 @@ class InactivePaymentGateway(BasePlugin):
 
 
 ACTIVE_PLUGINS = (
-    __name__ + "." + ChannelPluginSample.__name__,
-    __name__ + "." + ActivePaymentGateway.__name__,
-    __name__ + "." + ActivePlugin.__name__,
-    __name__ + "." + ActiveDummyPaymentGateway.__name__,
+    ChannelPluginSample,
+    ActivePaymentGateway,
+    ActivePlugin,
+    ActiveDummyPaymentGateway,
 )
 
 INACTIVE_PLUGINS = (
-    __name__ + "." + InactivePaymentGateway.__name__,
-    __name__ + "." + PluginInactive.__name__,
-    __name__ + "." + InactiveChannelPluginSample.__name__,
+    InactivePaymentGateway,
+    PluginInactive,
+    InactiveChannelPluginSample,
 )
 
 ALL_PLUGINS = ACTIVE_PLUGINS + INACTIVE_PLUGINS

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -1,5 +1,6 @@
 import json
 from decimal import Decimal
+from unittest import mock
 
 import pytest
 from django.http import HttpResponseNotFound, JsonResponse
@@ -875,3 +876,92 @@ def test_list_external_authentications_active_only(channel_USD):
         "id": PluginSample.PLUGIN_ID,
         "name": PluginSample.PLUGIN_NAME,
     } in external_auths
+
+
+def test_run_method_on_plugins_default_value(plugins_manager):
+    default_value = "default"
+    value = plugins_manager._PluginsManager__run_method_on_plugins(
+        method_name="test_method",
+        default_value=default_value,
+    )
+
+    assert value == default_value
+
+
+def test_run_method_on_plugins_default_value_when_not_existing_method_is_called(
+    channel_USD, all_plugins_manager
+):
+    default_value = "default"
+    value = all_plugins_manager._PluginsManager__run_method_on_plugins(
+        method_name="test_method",
+        default_value=default_value,
+    )
+
+    assert value == default_value
+
+
+def test_run_method_on_plugins_value_overridden_by_plugin_method(
+    channel_USD, all_plugins_manager
+):
+    expected = ActiveDummyPaymentGateway.SUPPORTED_CURRENCIES  # last active plugin
+    value = all_plugins_manager._PluginsManager__run_method_on_plugins(
+        method_name="get_supported_currencies",
+        default_value="default_value",
+    )
+
+    assert value == expected
+
+
+@mock.patch(
+    "saleor.plugins.manager.PluginsManager._PluginsManager__run_method_on_single_plugin"
+)
+def test_run_method_on_plugins_only_on_active_ones(
+    mocked_method, channel_USD, all_plugins_manager
+):
+    all_plugins_manager._PluginsManager__run_method_on_plugins(
+        method_name="test_method_name",
+        default_value="default_value",
+    )
+
+    assert len(all_plugins_manager.all_plugins) == 7
+    assert len([p for p in all_plugins_manager.all_plugins if p.active]) == 4
+    assert mocked_method.call_count == 4
+
+
+def test_run_method_on_single_plugin_method_does_not_exist(plugins_manager):
+    default_value = "default_value"
+    method_name = "method_does_not_exist"
+    plugin = ActivePaymentGateway
+
+    assert (
+        plugins_manager._PluginsManager__run_method_on_single_plugin(
+            plugin, method_name, default_value
+        )
+        == default_value
+    )
+
+
+def test_run_method_on_single_plugin_method_not_implemented(plugins_manager):
+    default_value = "default_value"
+    plugin = ChannelPluginSample(configuration=None, active=True)
+    method_name = ChannelPluginSample.sample_not_implemented.__name__
+
+    assert (
+        plugins_manager._PluginsManager__run_method_on_single_plugin(
+            plugin, method_name, default_value
+        )
+        == default_value
+    )
+
+
+def test_run_method_on_single_plugin_valid_response(plugins_manager):
+    default_value = "default_value"
+    plugin = ActiveDummyPaymentGateway(configuration=None, active=True)
+    method_name = ActivePaymentGateway.get_supported_currencies.__name__
+
+    assert (
+        plugins_manager._PluginsManager__run_method_on_single_plugin(
+            plugin, method_name, default_value
+        )
+        == plugin.SUPPORTED_CURRENCIES
+    )

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -16,6 +16,8 @@ from ..base_plugin import ExternalAccessTokens
 from ..manager import PluginsManager, get_plugins_manager
 from ..models import PluginConfiguration
 from ..tests.sample_plugins import (
+    ACTIVE_PLUGINS,
+    ALL_PLUGINS,
     ActiveDummyPaymentGateway,
     ActivePaymentGateway,
     ChannelPluginSample,
@@ -922,10 +924,14 @@ def test_run_method_on_plugins_only_on_active_ones(
         method_name="test_method_name",
         default_value="default_value",
     )
+    active_plugins_count = len(ACTIVE_PLUGINS)
 
-    assert len(all_plugins_manager.all_plugins) == 7
-    assert len([p for p in all_plugins_manager.all_plugins if p.active]) == 4
-    assert mocked_method.call_count == 4
+    assert len(all_plugins_manager.all_plugins) == len(ALL_PLUGINS)
+    assert (
+        len([p for p in all_plugins_manager.all_plugins if p.active])
+        == active_plugins_count
+    )
+    assert mocked_method.call_count == active_plugins_count
 
 
 def test_run_method_on_single_plugin_method_does_not_exist(plugins_manager):

--- a/saleor/plugins/tests/test_manager.py
+++ b/saleor/plugins/tests/test_manager.py
@@ -933,6 +933,11 @@ def test_run_method_on_plugins_only_on_active_ones(
     )
     assert mocked_method.call_count == active_plugins_count
 
+    called_plugins_id = [arg.args[0].PLUGIN_ID for arg in mocked_method.call_args_list]
+    expected_active_plugins_id = [p.PLUGIN_ID for p in ACTIVE_PLUGINS]
+
+    assert called_plugins_id == expected_active_plugins_id
+
 
 def test_run_method_on_single_plugin_method_does_not_exist(plugins_manager):
     default_value = "default_value"


### PR DESCRIPTION
Fix for `PluginsManager` to call methods only on active plugins. Flag `active_only` is passed into `get_plugins` method in `__run_method_on_plugins` because after investigation it looks like there is no situation when this method should be called on `inactive` plugin.  Actions like that are handled by other methods like `save_plugin_configuration` or `list_external_authentications`.

I've also added missing tests for `__run_method_on_plugins` and `__run_method_on_single_plugin` to be sure that we have proper output from them because for now they are not tested directly - just by functions called from the upper level. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
