### PR TITLE
Add order status verification to DraftOrderDelete mutation

### DIFF
--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -360,6 +360,18 @@ class DraftOrderDelete(ModelDeleteMutation):
         error_type_class = OrderError
         error_type_field = "order_errors"
 
+    @classmethod
+    def clean_instance(cls, info, instance):
+        if instance.status != OrderStatus.DRAFT:
+            raise ValidationError(
+                {
+                    "id": ValidationError(
+                        "Provided order id belongs to non-draft order.",
+                        code=OrderErrorCode.INVALID,
+                    )
+                }
+            )
+
 
 class DraftOrderComplete(BaseMutation):
     order = graphene.Field(Order, description="Completed order.")

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -2582,10 +2582,8 @@ def test_draft_order_update_doing_nothing_generates_no_events(
     assert not OrderEvent.objects.exists()
 
 
-def test_draft_order_delete(
-    staff_api_client, permission_manage_orders, order_with_lines
-):
-    order = order_with_lines
+def test_draft_order_delete(staff_api_client, permission_manage_orders, draft_order):
+    order = draft_order
     query = """
         mutation draftDelete($id: ID!) {
             draftOrderDelete(id: $id) {
@@ -2602,6 +2600,49 @@ def test_draft_order_delete(
     )
     with pytest.raises(order._meta.model.DoesNotExist):
         order.refresh_from_db()
+
+
+@pytest.mark.parametrize(
+    "order_status",
+    [
+        OrderStatus.UNFULFILLED,
+        OrderStatus.UNCONFIRMED,
+        OrderStatus.CANCELED,
+        OrderStatus.PARTIALLY_FULFILLED,
+        OrderStatus.FULFILLED,
+        OrderStatus.PARTIALLY_RETURNED,
+        OrderStatus.RETURNED,
+    ],
+)
+def test_draft_order_delete_non_draft_order(
+    staff_api_client, permission_manage_orders, order_with_lines, order_status
+):
+    order = order_with_lines
+    order.status = order_status
+    order.save(update_fields=["status"])
+    query = """
+        mutation draftDelete($id: ID!) {
+            draftOrderDelete(id: $id) {
+                order {
+                    id
+                }
+                errors {
+                    code
+                    field
+                }
+            }
+        }
+        """
+    order_id = graphene.Node.to_global_id("Order", order.id)
+    variables = {"id": order_id}
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_orders]
+    )
+    content = get_graphql_content(response)
+    account_errors = content["data"]["draftOrderDelete"]["errors"]
+    assert len(account_errors) == 1
+    assert account_errors[0]["field"] == "id"
+    assert account_errors[0]["code"] == OrderErrorCode.INVALID.name
 
 
 ORDER_CAN_FINALIZE_QUERY = """


### PR DESCRIPTION
I want to merge this change because DraftOrderDelete mutation should not be able to delete orders that are not drafts.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
