### PR TITLE
Fix missing transaction id in Braintree in 3.1 

### DIFF
--- a/saleor/payment/gateways/braintree/__init__.py
+++ b/saleor/payment/gateways/braintree/__init__.py
@@ -48,7 +48,7 @@ def get_billing_data(payment_information: PaymentData) -> Dict:
 def get_customer_data(payment_information: PaymentData) -> Dict:
     """Provide customer info, use only for new customer creation."""
     return {
-        "order_id": payment_information.order_id,
+        "order_id": payment_information.graphql_payment_id,
         "billing": get_billing_data(payment_information),
         "risk_data": {"customer_ip": payment_information.customer_ip_address or ""},
         "customer": {"email": payment_information.customer_email},

--- a/saleor/payment/gateways/braintree/tests/test_braintree.py
+++ b/saleor/payment/gateways/braintree/tests/test_braintree.py
@@ -1,6 +1,7 @@
 from decimal import Decimal
 from unittest.mock import Mock, patch
 
+import graphene
 import pytest
 from braintree import Environment, ErrorResult, SuccessfulResult, Transaction
 from braintree.errors import Errors
@@ -92,8 +93,9 @@ def test_get_customer_data(payment_dummy):
     payment = payment_dummy
     payment_info = create_payment_information(payment)
     result = get_customer_data(payment_info)
+    payment_global_id = graphene.Node.to_global_id("Payment", payment.id)
     expected_result = {
-        "order_id": payment.order_id,
+        "order_id": payment_global_id,
         "billing": {
             "first_name": payment.billing_first_name,
             "last_name": payment.billing_last_name,


### PR DESCRIPTION
I want to merge this change because coping changes from #8110 to master.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
