### PR TITLE
Block mutations for expired gift cards

### DIFF
--- a/saleor/giftcard/error_codes.py
+++ b/saleor/giftcard/error_codes.py
@@ -8,3 +8,4 @@ class GiftCardErrorCode(Enum):
     NOT_FOUND = "not_found"
     REQUIRED = "required"
     UNIQUE = "unique"
+    EXPIRED_GIFT_CARD = "expired_gift_card"

--- a/saleor/giftcard/tests/test_utils.py
+++ b/saleor/giftcard/tests/test_utils.py
@@ -22,6 +22,7 @@ from ..utils import (
     get_gift_card_lines,
     get_non_shippable_gift_card_lines,
     gift_cards_create,
+    is_gift_card_expired,
     remove_gift_card_code_from_checkout,
 )
 
@@ -585,3 +586,41 @@ def test_fulfill_gift_card_lines_lack_of_stock(
     # when
     with pytest.raises(ValidationError):
         fulfill_gift_card_lines(lines, staff_user, None, order, manager)
+
+
+def test_is_gift_card_expired_never_expired_gift_card(gift_card):
+    # given
+    assert not gift_card.expiry_date
+
+    # when
+    result = is_gift_card_expired(gift_card)
+
+    # then
+    assert result is False
+
+
+def test_is_gift_card_expired_true(gift_card):
+    # given
+    gift_card.expiry_date = date.today() - timedelta(days=1)
+    gift_card.save(update_fields=["expiry_date"])
+
+    # when
+    result = is_gift_card_expired(gift_card)
+
+    # then
+    assert result is True
+
+
+@pytest.mark.parametrize(
+    "expiry_date", [date.today(), date.today() + timedelta(days=1)]
+)
+def test_is_gift_card_expired_false(expiry_date, gift_card):
+    # given
+    gift_card.expiry_date = expiry_date
+    gift_card.save(update_fields=["expiry_date"])
+
+    # when
+    result = is_gift_card_expired(gift_card)
+
+    # then
+    assert result is False

--- a/saleor/giftcard/utils.py
+++ b/saleor/giftcard/utils.py
@@ -243,3 +243,9 @@ def send_gift_cards_to_customer(
             channel_slug,
             resending=False,
         )
+
+
+def is_gift_card_expired(gift_card: GiftCard):
+    """Return True when gift card expiry date pass."""
+    today = timezone.now().date()
+    return bool(gift_card.expiry_date) and gift_card.expiry_date < today  # type: ignore

--- a/saleor/graphql/giftcard/bulk_mutations.py
+++ b/saleor/graphql/giftcard/bulk_mutations.py
@@ -7,6 +7,7 @@ from ...core.utils.promo_code import generate_promo_code
 from ...core.utils.validators import is_date_in_future
 from ...giftcard import events, models
 from ...giftcard.error_codes import GiftCardErrorCode
+from ...giftcard.utils import is_gift_card_expired
 from ..core.descriptions import ADDED_IN_31
 from ..core.mutations import BaseBulkMutation, BaseMutation, ModelBulkDeleteMutation
 from ..core.types.common import GiftCardError, PriceInput
@@ -150,6 +151,14 @@ class GiftCardBulkActivate(BaseBulkMutation):
         model = models.GiftCard
         permissions = (GiftcardPermissions.MANAGE_GIFT_CARD,)
         error_type_class = GiftCardError
+
+    @classmethod
+    def clean_instance(cls, info, instance):
+        if is_gift_card_expired(instance):
+            raise ValidationError(
+                "Cannot activate expired card.",
+                code=GiftCardErrorCode.EXPIRED_GIFT_CARD,
+            )
 
     @classmethod
     @traced_atomic_transaction()

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -11,7 +11,11 @@ from ...core.utils.validators import is_date_in_future, user_is_valid
 from ...giftcard import events, models
 from ...giftcard.error_codes import GiftCardErrorCode
 from ...giftcard.notifications import send_gift_card_notification
-from ...giftcard.utils import activate_gift_card, deactivate_gift_card
+from ...giftcard.utils import (
+    activate_gift_card,
+    deactivate_gift_card,
+    is_gift_card_expired,
+)
 from ..core.descriptions import ADDED_IN_31, DEPRECATED_IN_3X_INPUT
 from ..core.mutations import BaseMutation, ModelDeleteMutation, ModelMutation
 from ..core.scalars import PositiveDecimal
@@ -19,6 +23,18 @@ from ..core.types.common import GiftCardError, PriceInput
 from ..core.utils import validate_required_string_field
 from ..core.validators import validate_price_precision
 from .types import GiftCard, GiftCardEvent
+
+
+def clean_gift_card(gift_card: GiftCard):
+    if is_gift_card_expired(gift_card):
+        raise ValidationError(
+            {
+                "id": ValidationError(
+                    "Expired gift card can only be deleted.",
+                    code=GiftCardErrorCode.EXPIRED_GIFT_CARD.value,
+                )
+            }
+        )
 
 
 class GiftCardInput(graphene.InputObjectType):
@@ -240,6 +256,8 @@ class GiftCardUpdate(GiftCardCreate):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         instance = cls.get_instance(info, **data)
+        clean_gift_card(instance)
+
         old_instance = deepcopy(instance)
 
         data = data.get("input")
@@ -322,6 +340,7 @@ class GiftCardActivate(BaseMutation):
         gift_card = cls.get_node_or_error(
             info, gift_card_id, field="gift_card_id", only_type=GiftCard
         )
+        clean_gift_card(gift_card)
         # create event only when is_active value has changed
         create_event = not gift_card.is_active
         activate_gift_card(gift_card)
@@ -391,6 +410,7 @@ class GiftCardResend(BaseMutation):
         gift_card = cls.get_node_or_error(
             info, gift_card_id, field="gift_card_id", only_type=GiftCard
         )
+        clean_gift_card(gift_card)
         target_email = cls.get_target_email(data, gift_card)
         customer_user = cls.get_customer_user(target_email)
         user = info.context.user
@@ -449,6 +469,7 @@ class GiftCardAddNote(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         gift_card = cls.get_node_or_error(info, data.get("id"), only_type=GiftCard)
+        clean_gift_card(gift_card)
         cleaned_input = cls.clean_input(info, gift_card, data)
         event = events.gift_card_note_added_event(
             gift_card=gift_card,

--- a/saleor/graphql/giftcard/mutations.py
+++ b/saleor/graphql/giftcard/mutations.py
@@ -30,7 +30,7 @@ def clean_gift_card(gift_card: GiftCard):
         raise ValidationError(
             {
                 "id": ValidationError(
-                    "Expired gift card can only be deleted.",
+                    "Expired gift card cannot be activated and resend.",
                     code=GiftCardErrorCode.EXPIRED_GIFT_CARD.value,
                 )
             }
@@ -256,7 +256,6 @@ class GiftCardUpdate(GiftCardCreate):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         instance = cls.get_instance(info, **data)
-        clean_gift_card(instance)
 
         old_instance = deepcopy(instance)
 
@@ -469,7 +468,6 @@ class GiftCardAddNote(BaseMutation):
     @classmethod
     def perform_mutation(cls, _root, info, **data):
         gift_card = cls.get_node_or_error(info, data.get("id"), only_type=GiftCard)
-        clean_gift_card(gift_card)
         cleaned_input = cls.clean_input(info, gift_card, data)
         event = events.gift_card_note_added_event(
             gift_card=gift_card,

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_activate.py
@@ -1,6 +1,9 @@
+from datetime import date, timedelta
+
 import graphene
 
 from .....giftcard import GiftCardEvents
+from .....giftcard.error_codes import GiftCardErrorCode
 from ....tests.utils import assert_no_permission, get_graphql_content
 
 ACTIVATE_GIFT_CARD_MUTATION = """
@@ -8,6 +11,7 @@ ACTIVATE_GIFT_CARD_MUTATION = """
         giftCardActivate(id: $id) {
             errors {
                 field
+                code
                 message
             }
             giftCard {
@@ -139,3 +143,39 @@ def test_activate_active_gift_card(
     data = content["data"]["giftCardActivate"]["giftCard"]
     assert data["isActive"]
     assert not data["events"]
+
+
+def test_activate_expired_gift_card(
+    staff_api_client,
+    gift_card,
+    permission_manage_gift_card,
+    permission_manage_users,
+    permission_manage_apps,
+):
+    # given
+    gift_card.is_active = False
+    gift_card.expiry_date = date.today() - timedelta(days=1)
+    gift_card.save(update_fields=["expiry_date", "is_active"])
+
+    variables = {"id": graphene.Node.to_global_id("GiftCard", gift_card.id)}
+
+    # when
+    response = staff_api_client.post_graphql(
+        ACTIVATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+            permission_manage_users,
+            permission_manage_apps,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardActivate"]["errors"]
+    data = content["data"]["giftCardActivate"]["giftCard"]
+
+    assert not data
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == GiftCardErrorCode.EXPIRED_GIFT_CARD.name

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_add_note.py
@@ -1,3 +1,5 @@
+from datetime import date, timedelta
+
 import graphene
 import pytest
 
@@ -38,10 +40,13 @@ def test_gift_card_add_note_as_staff_user(
     gift_card,
     staff_user,
 ):
+    # given
     assert not gift_card.events.all()
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.id)
     message = "nuclear note"
     variables = {"id": gift_card_id, "message": message}
+
+    # when
     response = staff_api_client.post_graphql(
         GIFT_CARD_ADD_NOTE_MUTATION,
         variables,
@@ -51,6 +56,8 @@ def test_gift_card_add_note_as_staff_user(
             permission_manage_gift_card,
         ],
     )
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["giftCardAddNote"]
 
@@ -73,10 +80,13 @@ def test_gift_card_add_note_as_app(
     gift_card,
     staff_user,
 ):
+    # given
     assert not gift_card.events.all()
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.id)
     message = "nuclear note"
     variables = {"id": gift_card_id, "message": message}
+
+    # when
     response = app_api_client.post_graphql(
         GIFT_CARD_ADD_NOTE_MUTATION,
         variables,
@@ -86,6 +96,8 @@ def test_gift_card_add_note_as_app(
             permission_manage_gift_card,
         ],
     )
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["giftCardAddNote"]
 
@@ -116,8 +128,11 @@ def test_gift_card_add_note_fail_on_empty_message(
     permission_manage_gift_card,
     gift_card,
 ):
+    # given
     gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.id)
     variables = {"id": gift_card_id, "message": message}
+
+    # when
     response = staff_api_client.post_graphql(
         GIFT_CARD_ADD_NOTE_MUTATION,
         variables,
@@ -127,7 +142,42 @@ def test_gift_card_add_note_fail_on_empty_message(
             permission_manage_gift_card,
         ],
     )
+
+    # then
     content = get_graphql_content(response)
     data = content["data"]["giftCardAddNote"]
     assert data["errors"][0]["field"] == "message"
     assert data["errors"][0]["code"] == GiftCardErrorCode.REQUIRED.name
+
+
+def test_gift_card_add_note_expired_card(
+    staff_api_client,
+    permission_manage_apps,
+    permission_manage_users,
+    permission_manage_gift_card,
+    gift_card,
+):
+    # given
+    gift_card.expiry_date = date.today() - timedelta(days=1)
+    gift_card.save(update_fields=["expiry_date"])
+
+    gift_card_id = graphene.Node.to_global_id("GiftCard", gift_card.id)
+    message = "nuclear note"
+    variables = {"id": gift_card_id, "message": message}
+
+    # when
+    response = staff_api_client.post_graphql(
+        GIFT_CARD_ADD_NOTE_MUTATION,
+        variables,
+        permissions=[
+            permission_manage_apps,
+            permission_manage_users,
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCardAddNote"]
+    assert data["errors"][0]["field"] == "id"
+    assert data["errors"][0]["code"] == GiftCardErrorCode.EXPIRED_GIFT_CARD.name

--- a/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
+++ b/saleor/graphql/giftcard/tests/mutations/test_gift_card_update.py
@@ -308,7 +308,7 @@ def test_update_gift_card_by_app(
         assert event in events
 
 
-def test_update_gift_card_by_customer(api_client, customer_user, gift_card):
+def test_update_gift_card_by_customer(api_client, gift_card):
     # given
     initial_balance = 100.0
     tag = "new-gift-card-tag"
@@ -581,3 +581,40 @@ def test_update_gift_card_date_in_past(
     assert len(errors) == 1
     assert errors[0]["field"] == "expiryDate"
     assert errors[0]["code"] == GiftCardErrorCode.INVALID.name
+
+
+def test_update_gift_card_cannot_update_expired_card(
+    staff_api_client, gift_card, permission_manage_gift_card
+):
+    # given
+    gift_card.expiry_date = date.today() - timedelta(days=1)
+    gift_card.save(update_fields=["expiry_date"])
+
+    initial_balance = 100.0
+    tag = "new-gift-card-tag"
+    variables = {
+        "id": graphene.Node.to_global_id("GiftCard", gift_card.pk),
+        "input": {
+            "balanceAmount": initial_balance,
+            "tag": tag,
+        },
+    }
+
+    # when
+    response = staff_api_client.post_graphql(
+        UPDATE_GIFT_CARD_MUTATION,
+        variables,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    errors = content["data"]["giftCardUpdate"]["errors"]
+    data = content["data"]["giftCardUpdate"]["giftCard"]
+
+    assert not data
+    assert len(errors) == 1
+    assert errors[0]["field"] == "id"
+    assert errors[0]["code"] == GiftCardErrorCode.EXPIRED_GIFT_CARD.name

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2388,6 +2388,7 @@ enum GiftCardErrorCode {
   NOT_FOUND
   REQUIRED
   UNIQUE
+  EXPIRED_GIFT_CARD
 }
 
 type GiftCardEvent implements Node {


### PR DESCRIPTION
Expired gift cards can only be deleted. Block another mutations for expired gift cards.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
