### PR TITLE
Fix account address update with anonymous user

### DIFF
--- a/saleor/graphql/account/mutations/base.py
+++ b/saleor/graphql/account/mutations/base.py
@@ -46,7 +46,7 @@ def can_edit_address(context, address):
     requester = get_user_or_app_from_context(context)
     if requester.has_perm(AccountPermissions.MANAGE_USERS):
         return True
-    if not context.app:
+    if not context.app and not context.user.is_anonymous:
         return requester.addresses.filter(pk=address.pk).exists()
 
 

--- a/saleor/graphql/account/tests/test_account.py
+++ b/saleor/graphql/account/tests/test_account.py
@@ -3322,6 +3322,20 @@ def test_customer_update_own_address(
     assert address_obj.city == address_data["city"].upper()
 
 
+def test_update_address_as_anonymous_user(
+    api_client, customer_user, graphql_address_data
+):
+    query = ACCOUNT_ADDRESS_UPDATE_MUTATION
+    address_obj = customer_user.addresses.first()
+
+    variables = {
+        "addressId": graphene.Node.to_global_id("Address", address_obj.id),
+        "address": graphql_address_data,
+    }
+    response = api_client.post_graphql(query, variables)
+    assert_no_permission(response)
+
+
 def test_customer_update_own_address_not_updated_when_validation_fails(
     user_api_client, customer_user, graphql_address_data
 ):


### PR DESCRIPTION
I want to merge this change because it fixes account address update mutation when provided with valid address ID but as anonymous user. Mutation raised AttributeError while it should return classic permission denied response.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
