### PR TITLE
Fix/click and collect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Introduce gift card feature - #7827 by @IKarbowiak, @tomaszszymanski129
 - Deprecate `setup_future_usage` from `checkoutComplete.paymentData` input - will be removed in Saleor 4.0 - #7994 by @mateuszgrzyb
 - Possibility to pass metadata in input of `checkoutPaymentCreate` - #8076 by @mateuszgrzyb
+- Fix shipping address issue in `availableCollectionPoints` resolver for checkout - #8143 by @kuchichan
 
 
 # 3.0.0 [Unreleased]

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -246,7 +246,7 @@ def fetch_checkout_info(
         checkout_info, shipping_address, lines, discounts, manager
     )
     valid_pick_up_points = get_valid_collection_points_for_checkout_info(
-        shipping_address, lines
+        shipping_address, lines, checkout_info
     )
     checkout_info.valid_shipping_methods = valid_shipping_methods
     checkout_info.valid_pick_up_points = valid_pick_up_points
@@ -299,10 +299,15 @@ def get_valid_shipping_method_list_for_checkout_info(
 def get_valid_collection_points_for_checkout_info(
     shipping_address: Optional["Address"],
     lines: Iterable[CheckoutLineInfo],
+    checkout_info: CheckoutInfo,
 ):
     from .utils import get_valid_collection_points_for_checkout
 
-    country_code = shipping_address.country.code if shipping_address else None
+    if shipping_address:
+        country_code = shipping_address.country.code
+    else:
+        country_code = checkout_info.channel.default_country.code
+
     valid_collection_points = get_valid_collection_points_for_checkout(
         lines, country_code=country_code, quantity_check=False
     )

--- a/saleor/checkout/fetch.py
+++ b/saleor/checkout/fetch.py
@@ -246,7 +246,7 @@ def fetch_checkout_info(
         checkout_info, shipping_address, lines, discounts, manager
     )
     valid_pick_up_points = get_valid_collection_points_for_checkout_info(
-        checkout_info, shipping_address, lines
+        shipping_address, lines
     )
     checkout_info.valid_shipping_methods = valid_shipping_methods
     checkout_info.valid_pick_up_points = valid_pick_up_points
@@ -297,7 +297,6 @@ def get_valid_shipping_method_list_for_checkout_info(
 
 
 def get_valid_collection_points_for_checkout_info(
-    checkout_info: "CheckoutInfo",
     shipping_address: Optional["Address"],
     lines: Iterable[CheckoutLineInfo],
 ):
@@ -305,7 +304,7 @@ def get_valid_collection_points_for_checkout_info(
 
     country_code = shipping_address.country.code if shipping_address else None
     valid_collection_points = get_valid_collection_points_for_checkout(
-        lines, checkout_info, country_code=country_code, quantity_check=False
+        lines, country_code=country_code, quantity_check=False
     )
     return list(valid_collection_points)
 

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -611,7 +611,6 @@ def get_valid_shipping_methods_for_checkout(
 
 def get_valid_collection_points_for_checkout(
     lines: Iterable["CheckoutLineInfo"],
-    checkout_info: "CheckoutInfo",
     country_code: Optional[str] = None,
     quantity_check: bool = True,
 ):

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -624,7 +624,7 @@ def get_valid_collection_points_for_checkout(
 
     if not is_shipping_required(lines):
         return []
-    if not checkout_info.shipping_address:
+    if not checkout_info.shipping_address or not country_code:
         return []
     line_ids = [line_info.line.id for line_info in lines]
     lines = CheckoutLine.objects.filter(id__in=line_ids)

--- a/saleor/checkout/utils.py
+++ b/saleor/checkout/utils.py
@@ -624,7 +624,7 @@ def get_valid_collection_points_for_checkout(
 
     if not is_shipping_required(lines):
         return []
-    if not checkout_info.shipping_address or not country_code:
+    if not country_code:
         return []
     line_ids = [line_info.line.id for line_info in lines]
     lines = CheckoutLine.objects.filter(id__in=line_ids)

--- a/saleor/core/utils/random_data.py
+++ b/saleor/core/utils/random_data.py
@@ -847,7 +847,7 @@ def create_product_sales(how_many=5):
         yield "Sale: %s" % (sale,)
 
 
-def create_channel(channel_name, currency_code, slug=None):
+def create_channel(channel_name, currency_code, slug=None, country=None):
     if not slug:
         slug = slugify(channel_name)
     channel, _ = Channel.objects.get_or_create(
@@ -856,6 +856,7 @@ def create_channel(channel_name, currency_code, slug=None):
             "name": channel_name,
             "currency_code": currency_code,
             "is_active": True,
+            "default_country": country,
         },
     )
     return f"Channel: {channel}"
@@ -866,11 +867,9 @@ def create_channels():
         channel_name="Channel-USD",
         currency_code="USD",
         slug=settings.DEFAULT_CHANNEL_SLUG,
+        country=settings.DEFAULT_COUNTRY,
     )
-    yield create_channel(
-        channel_name="Channel-PLN",
-        currency_code="PLN",
-    )
+    yield create_channel(channel_name="Channel-PLN", currency_code="PLN", country="PL")
 
 
 def create_shipping_zone(shipping_methods_names, countries, shipping_zone_name):

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -90,7 +90,7 @@ def clean_delivery_method(
             ERROR_DOES_NOT_SHIP, code=CheckoutErrorCode.SHIPPING_NOT_REQUIRED.value
         )
 
-    if not checkout_info.shipping_address:
+    if not checkout_info.shipping_address and isinstance(method, models.ShippingMethod):
         raise ValidationError(
             "Cannot choose a shipping method for a checkout without the "
             "shipping address.",
@@ -512,7 +512,7 @@ class CheckoutLinesAdd(BaseMutation):
         )
         checkout_info.valid_pick_up_points = (
             get_valid_collection_points_for_checkout_info(
-                checkout_info.shipping_address, lines
+                checkout_info.shipping_address, lines, checkout_info
             )
         )
         return lines
@@ -562,7 +562,7 @@ class CheckoutLinesAdd(BaseMutation):
         )
         checkout_info.valid_pick_up_points = (
             get_valid_collection_points_for_checkout_info(
-                checkout_info.shipping_address, lines
+                checkout_info.shipping_address, lines, checkout_info
             )
         )
 

--- a/saleor/graphql/checkout/mutations.py
+++ b/saleor/graphql/checkout/mutations.py
@@ -512,7 +512,7 @@ class CheckoutLinesAdd(BaseMutation):
         )
         checkout_info.valid_pick_up_points = (
             get_valid_collection_points_for_checkout_info(
-                checkout_info, checkout_info.shipping_address, lines
+                checkout_info.shipping_address, lines
             )
         )
         return lines
@@ -562,7 +562,7 @@ class CheckoutLinesAdd(BaseMutation):
         )
         checkout_info.valid_pick_up_points = (
             get_valid_collection_points_for_checkout_info(
-                checkout_info, checkout_info.shipping_address, lines
+                checkout_info.shipping_address, lines
             )
         )
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1547,6 +1547,21 @@ def test_checkout_avail_collect_points_returns_empty_list_when_not_in_shipping_z
     assert not data["availableCollectionPoints"]
 
 
+def test_checkout_avail_collect_points_returns_empty_list_when_no_shipping_address(
+    api_client, warehouse_for_cc, checkout_with_items_for_cc
+):
+    query = GET_CHECKOUT_AVAILABLE_COLLECTION_POINTS
+    checkout_with_items_for_cc.shipping_address = None
+    checkout_with_items_for_cc.save()
+
+    variables = {"token": checkout_with_items_for_cc.token}
+    response = api_client.post_graphql(query, variables)
+    content = get_graphql_content(response)
+    data = content["data"]["checkout"]
+
+    assert not data["availableCollectionPoints"]
+
+
 def test_create_checkout_with_unpublished_product(
     user_api_client, checkout_with_item, stock, channel_USD
 ):

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1547,7 +1547,7 @@ def test_checkout_avail_collect_points_returns_empty_list_when_not_in_shipping_z
     assert not data["availableCollectionPoints"]
 
 
-def test_checkout_avail_collect_points_returns_empty_list_when_no_shipping_address(
+def test_checkout_avail_collect_fallbacks_to_channel_country_when_no_shipping_address(
     api_client, warehouse_for_cc, checkout_with_items_for_cc
 ):
     query = GET_CHECKOUT_AVAILABLE_COLLECTION_POINTS
@@ -1559,7 +1559,9 @@ def test_checkout_avail_collect_points_returns_empty_list_when_no_shipping_addre
     content = get_graphql_content(response)
     data = content["data"]["checkout"]
 
-    assert not data["availableCollectionPoints"]
+    assert data["availableCollectionPoints"] == [
+        {"address": {"streetAddress1": "Tęczowa 7"}, "name": "Local Warehouse"}
+    ]
 
 
 def test_create_checkout_with_unpublished_product(

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -1560,7 +1560,10 @@ def test_checkout_avail_collect_fallbacks_to_channel_country_when_no_shipping_ad
     data = content["data"]["checkout"]
 
     assert data["availableCollectionPoints"] == [
-        {"address": {"streetAddress1": "Tęczowa 7"}, "name": "Local Warehouse"}
+        {
+            "address": {"streetAddress1": warehouse_for_cc.address.street_address_1},
+            "name": warehouse_for_cc.name,
+        }
     ]
 
 

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -493,7 +493,9 @@ class Checkout(CountableDjangoObjectType):
         def get_available_collection_points(data):
             address, lines, checkout_info = data
             return get_valid_collection_points_for_checkout(
-                lines, checkout_info, country_code=address.country.code
+                lines,
+                checkout_info,
+                country_code=address.country.code if address else None,
             )
 
         lines = CheckoutLinesInfoByCheckoutTokenLoader(info.context).load(root.token)


### PR DESCRIPTION
I want to merge this change because it fixes quite harsh error, when no shipping address has been passed to checkout query (in `availableCollectionPoints` resolver). Although country code is needed in order to calculate availableCollectionPoints, we can fallback to channel, because in most cases passing entire `shipping_address` for C&C would be superfluous.  What is more, country are now used in `populatedb` for generated channels.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
