### PR TITLE
Fix cursor in product search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable, unreleased changes to this project will be documented in this file.
 - Possibility to pass metadata in input of `checkoutPaymentCreate` - #8076 by @mateuszgrzyb
 - Fix shipping address issue in `availableCollectionPoints` resolver for checkout - #8143 by @kuchichan
 - Improve draft orders and orders webhooks by @jakubkuc
+- Fix cursor-based pagination in products search - #8011 by @rafalp
 
 
 # 3.0.0 [Unreleased]

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -80,6 +80,12 @@ def _prepare_filter(
                 ('first_field', 'first_value_form_cursor'))
         )
     """
+    if sorting_fields == ["rank", "id"]:
+        # Fast path for filtering by rank
+        if sorting_direction == "gt":
+            return Q(rank__gte=cursor[0], id__lt=cursor[1])
+        return Q(rank__lte=cursor[0], id__gt=cursor[1])
+
     filter_kwargs = Q()
     for index, field_name in enumerate(sorting_fields):
         if cursor[index] is None and sorting_direction == "gt":
@@ -219,6 +225,9 @@ def connection_from_queryset_slice(
     filter_kwargs = (
         _prepare_filter(cursor, sorting_fields, sorting_direction) if cursor else Q()
     )
+    print("filter_kwargs", filter_kwargs)
+    print("sort_by", sort_by)
+    print(qs.query.order_by)
     qs = qs.filter(filter_kwargs)
     qs = qs[:end_margin]
     edges, page_info = _get_edges_for_connection(edge_type, qs, args, sorting_fields)

--- a/saleor/graphql/core/connection.py
+++ b/saleor/graphql/core/connection.py
@@ -52,6 +52,9 @@ def _prepare_filter_by_rank_expression(
     except (InvalidOperation, ValueError, TypeError, KeyError):
         raise ValueError("Invalid cursor for sorting by rank.")
 
+    # Because rank is float number, it gets mangled by PostgreSQL's query parser
+    # making equal comparisons impossible. Instead we compare rank against small
+    # range of values, constructed using epsilon.
     if sorting_direction == "gt":
         return Q(rank__range=(rank - EPSILON, rank + EPSILON), id__lt=cursor[1]) | Q(
             rank__gt=rank + EPSILON

--- a/saleor/graphql/product/sorters.py
+++ b/saleor/graphql/product/sorters.py
@@ -123,7 +123,7 @@ class CollectionSortingInput(ChannelSortInputObjectType):
 
 class ProductOrderField(graphene.Enum):
     NAME = ["name", "slug"]
-    RANK = ["rank"]
+    RANK = ["rank", "id"]
     PRICE = ["min_variants_price_amount", "name", "slug"]
     MINIMAL_PRICE = ["discounted_price_amount", "name", "slug"]
     DATE = ["updated_at", "name", "slug"]

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -37,7 +37,7 @@ def sort_queryset_for_connection(iterable, args):
             or get_default_channel_slug_or_graphql_error(),
         )
     elif query and "-rank" in query.order_by:
-        return iterable, {"field": "rank", "direction": "-"}
+        return iterable, {"field": ["rank", "id"], "direction": "-"}
     else:
         iterable, sort_by = sort_queryset_by_default(
             queryset=iterable, reversed=reversed
@@ -72,7 +72,6 @@ def sort_queryset(
 
     sorting_field = sort_by.field
     sorting_attribute = getattr(sort_by, "attribute_id", None)
-
     if sorting_field is not None and sorting_attribute is not None:
         raise GraphQLError(
             "You must provide either `field` or `attributeId` to sort the products."

--- a/saleor/graphql/utils/sorting.py
+++ b/saleor/graphql/utils/sorting.py
@@ -89,8 +89,15 @@ def sort_queryset(
     if custom_sort_by:
         queryset = custom_sort_by(queryset, channel_slug=channel_slug)
 
-    sorting_field_value = sorting_fields.value
-    sorting_list = [f"{sorting_direction}{field}" for field in sorting_field_value]
+    if sorting_field_name == "rank":
+        # In rank sorting ID is sorted in opposite direction to rank
+        if sorting_direction == "-":
+            sorting_list = ["-rank", "id"]
+        else:
+            sorting_list = ["rank", "-id"]
+    else:
+        sorting_field_value = sorting_fields.value
+        sorting_list = [f"{sorting_direction}{field}" for field in sorting_field_value]
 
     return queryset.order_by(*sorting_list)
 


### PR DESCRIPTION
Fixes `RANK` based sorting for products so `cursor` value returned for each edge is correct. Also fixes `before` and `after` pagination for same sorting.

Fixes #8011 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

* [x] Privileged queries and mutations are guarded by proper permission checks
* [x] Database queries are optimized and the number of queries is constant
* [x] Database migration files are up to date
* [x] The changes are tested
* [x] GraphQL schema and type definitions are up to date
* [x] Changes are mentioned in the changelog
