### PR TITLE
Add NP Atobarai plugin and configuration

### DIFF
--- a/saleor/payment/gateways/np_atobarai/__init__.py
+++ b/saleor/payment/gateways/np_atobarai/__init__.py
@@ -1,0 +1,19 @@
+from ...interface import GatewayConfig, GatewayResponse, PaymentData
+
+
+def process_payment(
+    payment_information: PaymentData, config: GatewayConfig
+) -> GatewayResponse:
+    raise NotImplementedError
+
+
+def capture(payment_information: PaymentData, config: GatewayConfig) -> GatewayResponse:
+    raise NotImplementedError
+
+
+def void(payment_information: PaymentData, config: GatewayConfig) -> GatewayResponse:
+    raise NotImplementedError
+
+
+def refund(payment_information: PaymentData, config: GatewayConfig) -> GatewayResponse:
+    raise NotImplementedError

--- a/saleor/payment/gateways/np_atobarai/api.py
+++ b/saleor/payment/gateways/np_atobarai/api.py
@@ -4,6 +4,8 @@ from typing import Optional
 import requests
 from requests.auth import HTTPBasicAuth
 
+from saleor.payment import PaymentError
+
 REQUEST_TIMEOUT = 15
 
 
@@ -15,28 +17,32 @@ class ApiConfig:
     sp_code: str
 
 
-def get_url(config: ApiConfig, path="") -> str:
+def get_url(config: ApiConfig, path: str = "") -> str:
     """Resolve test/production URLs based on the api config."""
     if config.test_mode:
         return f"https://ctcp.np-payment-gateway.com/v1{path}"
     return f"https://cp.np-payment-gateway.com/v1{path}"
 
 
-def _request(
-    config: ApiConfig, method: str, path="", json: Optional[dict] = None
+def np_request(
+    config: ApiConfig, method: str, path: str = "", json: Optional[dict] = None
 ) -> requests.Response:
-    if json is None:
-        json = {}
-    return requests.request(
-        method=method,
-        url=get_url(config, path),
-        timeout=REQUEST_TIMEOUT,
-        json=json,
-        auth=HTTPBasicAuth(config.merchant_code, config.sp_code),
-        headers={"X-NP-Terminal-Id": config.terminal_id},
-    )
+    try:
+        return requests.request(
+            method=method,
+            url=get_url(config, path),
+            timeout=REQUEST_TIMEOUT,
+            json=json or {},
+            auth=HTTPBasicAuth(config.merchant_code, config.sp_code),
+            headers={"X-NP-Terminal-Id": config.terminal_id},
+        )
+    except requests.RequestException:
+        raise PaymentError("Cannot connect to NP Atobarai.")
 
 
 def health_check(config: ApiConfig) -> bool:
-    response = _request(config, "post", "/authorizations/find")
-    return response.status_code not in [401, 403]
+    try:
+        response = np_request(config, "post", "/authorizations/find")
+        return response.status_code not in [401, 403]
+    except PaymentError:
+        return False

--- a/saleor/payment/gateways/np_atobarai/api.py
+++ b/saleor/payment/gateways/np_atobarai/api.py
@@ -1,0 +1,42 @@
+from dataclasses import dataclass
+from typing import Optional
+
+import requests
+from requests.auth import HTTPBasicAuth
+
+REQUEST_TIMEOUT = 15
+
+
+@dataclass
+class ApiConfig:
+    test_mode: bool
+    merchant_code: str
+    terminal_id: str
+    sp_code: str
+
+
+def get_url(config: ApiConfig, path="") -> str:
+    """Resolve test/production URLs based on the api config."""
+    if config.test_mode:
+        return f"https://ctcp.np-payment-gateway.com/v1{path}"
+    return f"https://cp.np-payment-gateway.com/v1{path}"
+
+
+def _request(
+    config: ApiConfig, method: str, path="", json: Optional[dict] = None
+) -> requests.Response:
+    if json is None:
+        json = {}
+    return requests.request(
+        method=method,
+        url=get_url(config, path),
+        timeout=REQUEST_TIMEOUT,
+        json=json,
+        auth=HTTPBasicAuth(config.merchant_code, config.sp_code),
+        headers={"X-NP-Terminal-Id": config.terminal_id},
+    )
+
+
+def health_check(config: ApiConfig) -> bool:
+    response = _request(config, "post", "/authorizations/find")
+    return response.status_code not in [401, 403]

--- a/saleor/payment/gateways/np_atobarai/errors.py
+++ b/saleor/payment/gateways/np_atobarai/errors.py
@@ -1,2 +1,2 @@
-class NPAtobarai(Exception):
+class NPAtobaraiError(Exception):
     pass

--- a/saleor/payment/gateways/np_atobarai/errors.py
+++ b/saleor/payment/gateways/np_atobarai/errors.py
@@ -1,0 +1,2 @@
+class NPAtobarai(Exception):
+    pass

--- a/saleor/payment/gateways/np_atobarai/plugin.py
+++ b/saleor/payment/gateways/np_atobarai/plugin.py
@@ -139,7 +139,7 @@ class NPAtobaraiGatewayPlugin(BasePlugin):
         configuration = plugin_configuration.configuration
         configuration = {item["name"]: item["value"] for item in configuration}
         if not configuration[MERCHANT_CODE]:
-            missing_fields.append(TERMINAL_ID)
+            missing_fields.append(MERCHANT_CODE)
         if not configuration[SP_CODE]:
             missing_fields.append(SP_CODE)
         if not configuration[TERMINAL_ID]:
@@ -147,13 +147,14 @@ class NPAtobaraiGatewayPlugin(BasePlugin):
 
         if plugin_configuration.active:
             if missing_fields:
-                error_msg = (
-                    "To enable a plugin, you need to provide values for the "
-                    "following fields: "
-                )
                 raise ValidationError(
-                    error_msg + ", ".join(missing_fields),
-                    code=PluginErrorCode.PLUGIN_MISCONFIGURED.value,
+                    {
+                        field: ValidationError(
+                            f"The parameter is required.",
+                            code=PluginErrorCode.REQUIRED.value,
+                        )
+                        for field in missing_fields
+                    }
                 )
 
             cls.validate_authentication(plugin_configuration)

--- a/saleor/payment/gateways/np_atobarai/plugin.py
+++ b/saleor/payment/gateways/np_atobarai/plugin.py
@@ -91,31 +91,26 @@ class NPAtobaraiGatewayPlugin(BasePlugin):
     def _get_gateway_config(self) -> GatewayConfig:
         return self.config
 
-    @require_active_plugin
     def capture_payment(
         self, payment_information: "PaymentData", previous_value
     ) -> "GatewayResponse":
         return capture(payment_information, self._get_gateway_config())
 
-    @require_active_plugin
     def refund_payment(
         self, payment_information: "PaymentData", previous_value
     ) -> "GatewayResponse":
         return refund(payment_information, self._get_gateway_config())
 
-    @require_active_plugin
     def void_payment(
         self, payment_information: "PaymentData", previous_value
     ) -> "GatewayResponse":
         return void(payment_information, self._get_gateway_config())
 
-    @require_active_plugin
     def process_payment(
         self, payment_information: "PaymentData", previous_value
     ) -> "GatewayResponse":
         return process_payment(payment_information, self._get_gateway_config())
 
-    @require_active_plugin
     def get_supported_currencies(self, previous_value):
         return self.SUPPORTED_CURRENCIES
 

--- a/saleor/payment/gateways/np_atobarai/plugin.py
+++ b/saleor/payment/gateways/np_atobarai/plugin.py
@@ -1,0 +1,164 @@
+from typing import TYPE_CHECKING
+
+import opentracing
+from django.core.exceptions import ValidationError
+
+from saleor.payment.gateways.np_atobarai import api
+from saleor.plugins.base_plugin import BasePlugin, ConfigurationTypeField
+from saleor.plugins.error_codes import PluginErrorCode
+
+from ..utils import require_active_plugin
+from . import GatewayConfig, capture, process_payment, refund, void
+
+GATEWAY_NAME = "NP後払い"
+
+if TYPE_CHECKING:
+    # flake8: noqa
+    from saleor.plugins.models import PluginConfiguration
+
+    from . import GatewayResponse, PaymentData
+
+
+__all__ = ["NPAtobaraiGatewayPlugin"]
+
+
+MERCHANT_CODE = "merchant_code"
+SP_CODE = "sp_code"
+TERMINAL_ID = "terminal_id"
+USE_SANDBOX = "use_sandbox"
+
+
+def get_api_config(conf) -> api.ApiConfig:
+    return api.ApiConfig(
+        test_mode=conf[USE_SANDBOX],
+        merchant_code=conf[MERCHANT_CODE],
+        sp_code=conf[SP_CODE],
+        terminal_id=conf[TERMINAL_ID],
+    )
+
+
+class NPAtobaraiGatewayPlugin(BasePlugin):
+    PLUGIN_ID = "mirumee.payments.np-atobarai"
+    PLUGIN_NAME = GATEWAY_NAME
+    CONFIGURATION_PER_CHANNEL = True
+    SUPPORTED_CURRENCIES = "JPY"
+
+    DEFAULT_CONFIGURATION = [
+        {"name": MERCHANT_CODE, "value": None},
+        {"name": SP_CODE, "value": None},
+        {"name": TERMINAL_ID, "value": None},
+        {"name": USE_SANDBOX, "value": True},
+    ]
+
+    CONFIG_STRUCTURE = {
+        MERCHANT_CODE: {
+            "type": ConfigurationTypeField.SECRET,
+            "help_text": "Provide NP後払い Merchant Code.",
+            "label": "Merchant Code",
+        },
+        SP_CODE: {
+            "type": ConfigurationTypeField.SECRET,
+            "help_text": "Provide NP後払い SP Code.",
+            "label": "SP Code",
+        },
+        TERMINAL_ID: {
+            "type": ConfigurationTypeField.SECRET,
+            "help_text": "Provide NP後払い Terminal ID.",
+            "label": "Terminal ID",
+        },
+        USE_SANDBOX: {
+            "type": ConfigurationTypeField.BOOLEAN,
+            "help_text": "Determines if Saleor should use NP後払い sandbox API.",
+            "label": "Use sandbox",
+        },
+    }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        configuration = {item["name"]: item["value"] for item in self.configuration}
+        self.config = GatewayConfig(
+            gateway_name=GATEWAY_NAME,
+            auto_capture=False,
+            supported_currencies=self.SUPPORTED_CURRENCIES,
+            connection_params={
+                "merchant_code": configuration[MERCHANT_CODE],
+                "sp_code": configuration[SP_CODE],
+                "terminal_id": configuration[TERMINAL_ID],
+                "sandbox_mode": configuration[USE_SANDBOX],
+            },
+        )
+
+    def _get_gateway_config(self) -> GatewayConfig:
+        return self.config
+
+    @require_active_plugin
+    def capture_payment(
+        self, payment_information: "PaymentData", previous_value
+    ) -> "GatewayResponse":
+        return capture(payment_information, self._get_gateway_config())
+
+    @require_active_plugin
+    def refund_payment(
+        self, payment_information: "PaymentData", previous_value
+    ) -> "GatewayResponse":
+        return refund(payment_information, self._get_gateway_config())
+
+    @require_active_plugin
+    def void_payment(
+        self, payment_information: "PaymentData", previous_value
+    ) -> "GatewayResponse":
+        return void(payment_information, self._get_gateway_config())
+
+    @require_active_plugin
+    def process_payment(
+        self, payment_information: "PaymentData", previous_value
+    ) -> "GatewayResponse":
+        return process_payment(payment_information, self._get_gateway_config())
+
+    @require_active_plugin
+    def get_supported_currencies(self, previous_value):
+        return self.SUPPORTED_CURRENCIES
+
+    @classmethod
+    def validate_authentication(cls, plugin_configuration: "PluginConfiguration"):
+        conf = {
+            data["name"]: data["value"] for data in plugin_configuration.configuration
+        }
+        with opentracing.global_tracer().start_active_span(
+            "np-atobarai.utilities.ping"
+        ) as scope:
+            span = scope.span
+            span.set_tag("service.name", "np-atobarai")
+            response = api.health_check(get_api_config(conf))
+
+        if not response:
+            raise ValidationError(
+                "Authentication failed. Please check provided data.",
+                code=PluginErrorCode.PLUGIN_MISCONFIGURED.value,
+            )
+
+    @classmethod
+    def validate_plugin_configuration(cls, plugin_configuration: "PluginConfiguration"):
+        """Validate if provided configuration is correct."""
+        missing_fields = []
+        configuration = plugin_configuration.configuration
+        configuration = {item["name"]: item["value"] for item in configuration}
+        if not configuration[MERCHANT_CODE]:
+            missing_fields.append(TERMINAL_ID)
+        if not configuration[SP_CODE]:
+            missing_fields.append(SP_CODE)
+        if not configuration[TERMINAL_ID]:
+            missing_fields.append(TERMINAL_ID)
+
+        if plugin_configuration.active:
+            if missing_fields:
+                error_msg = (
+                    "To enable a plugin, you need to provide values for the "
+                    "following fields: "
+                )
+                raise ValidationError(
+                    error_msg + ", ".join(missing_fields),
+                    code=PluginErrorCode.PLUGIN_MISCONFIGURED.value,
+                )
+
+            cls.validate_authentication(plugin_configuration)

--- a/saleor/payment/gateways/np_atobarai/tests/conftest.py
+++ b/saleor/payment/gateways/np_atobarai/tests/conftest.py
@@ -1,0 +1,46 @@
+import pytest
+
+from saleor.payment.gateways.np_atobarai.plugin import (
+    MERCHANT_CODE,
+    SP_CODE,
+    TERMINAL_ID,
+    USE_SANDBOX,
+    NPAtobaraiGatewayPlugin,
+)
+
+from .....plugins.manager import get_plugins_manager
+from .....plugins.models import PluginConfiguration
+
+
+@pytest.fixture
+def np_atobarai_plugin(settings, monkeypatch, channel_USD):
+    def fun(
+        merchant_code="merchant-code",
+        sp_code="sp-code",
+        terminal_id="terminal-id",
+        use_sandbox=True,
+        active=True,
+    ):
+        settings.PLUGINS = [
+            "saleor.payment.gateways.np_atobarai.plugin.NPAtobaraiGatewayPlugin"
+        ]
+
+        configuration = [
+            {"name": MERCHANT_CODE, "value": merchant_code},
+            {"name": SP_CODE, "value": sp_code},
+            {"name": TERMINAL_ID, "value": terminal_id},
+            {"name": USE_SANDBOX, "value": use_sandbox},
+        ]
+        PluginConfiguration.objects.create(
+            identifier=NPAtobaraiGatewayPlugin.PLUGIN_ID,
+            name=NPAtobaraiGatewayPlugin.PLUGIN_NAME,
+            description="",
+            active=active,
+            channel=channel_USD,
+            configuration=configuration,
+        )
+
+        manager = get_plugins_manager()
+        return manager.plugins_per_channel[channel_USD.slug][0]
+
+    return fun

--- a/saleor/payment/gateways/np_atobarai/tests/test_np_atobarai.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_np_atobarai.py
@@ -38,3 +38,23 @@ def test_validate_plugin_configuration_invalid_credentials(
     with pytest.raises(ValidationError):
         # when
         plugin.validate_plugin_configuration(configuration)
+
+
+@mock.patch("saleor.payment.gateways.np_atobarai.api.requests.request")
+def test_validate_plugin_configuration_missing_data(mocked_request, np_atobarai_plugin):
+    # given
+    plugin = np_atobarai_plugin()
+    response = Mock()
+    response.status_code = 200
+    mocked_request.return_value = response
+    plugin_configuration = PluginConfiguration.objects.get()
+    for d in plugin_configuration.configuration:
+        d["value"] = None
+    plugin_configuration.save()
+
+    # when
+    with pytest.raises(ValidationError) as excinfo:
+        plugin.validate_plugin_configuration(plugin_configuration)
+
+    # then
+    assert len(excinfo.value.error_dict) == 3

--- a/saleor/payment/gateways/np_atobarai/tests/test_np_atobarai.py
+++ b/saleor/payment/gateways/np_atobarai/tests/test_np_atobarai.py
@@ -1,0 +1,40 @@
+from unittest import mock
+from unittest.mock import Mock
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from saleor.plugins.models import PluginConfiguration
+
+
+@mock.patch("saleor.payment.gateways.np_atobarai.api.requests.request")
+@pytest.mark.parametrize("status_code", [200, 400])
+def test_validate_plugin_configuration_valid_credentials(
+    mocked_request, np_atobarai_plugin, status_code
+):
+    # given
+    plugin = np_atobarai_plugin()
+    response = Mock()
+    response.status_code = status_code
+    mocked_request.return_value = response
+    configuration = PluginConfiguration.objects.get()
+    # when
+    plugin.validate_plugin_configuration(configuration)
+    # then: no exception
+
+
+@mock.patch("saleor.payment.gateways.np_atobarai.api.requests.request")
+@pytest.mark.parametrize("status_code", [401, 403])
+def test_validate_plugin_configuration_invalid_credentials(
+    mocked_request, np_atobarai_plugin, status_code
+):
+    # given
+    plugin = np_atobarai_plugin()
+    response = Mock()
+    response.status_code = status_code
+    mocked_request.return_value = response
+    configuration = PluginConfiguration.objects.get()
+    # then
+    with pytest.raises(ValidationError):
+        # when
+        plugin.validate_plugin_configuration(configuration)

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -529,6 +529,7 @@ BUILTIN_PLUGINS = [
     "saleor.payment.gateways.razorpay.plugin.RazorpayGatewayPlugin",
     "saleor.payment.gateways.adyen.plugin.AdyenGatewayPlugin",
     "saleor.payment.gateways.authorize_net.plugin.AuthorizeNetGatewayPlugin",
+    "saleor.payment.gateways.np_atobarai.plugin.NPAtobaraiGatewayPlugin",
     "saleor.plugins.invoicing.plugin.InvoicingPlugin",
     "saleor.plugins.user_email.plugin.UserEmailPlugin",
     "saleor.plugins.admin_email.plugin.AdminEmailPlugin",


### PR DESCRIPTION
In this pull request I'm adding:
- a simple payment gateway plugin (to be extended in further tasks)
- configuration management for NP Atobarai credentials

I have tested the configuration form with test credentials received from NP.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
