### PR TITLE
Too many fields from payment object are accessible for customer in ordertype

### DIFF
--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -6543,6 +6543,9 @@ QUERY_ORDER_BY_TOKEN_WITH_PAYMENT = """
 
               }
               actions
+              capturedAmount{
+                amount
+              }
               availableCaptureAmount{
                 amount
               }
@@ -6573,6 +6576,9 @@ QUERY_ORDER_WITH_PAYMENT_AVAILABLE_FIELDS = """
               created
               modified
               paymentMethodType
+              capturedAmount{
+                amount
+              }
               chargeStatus
               creditCard{
                 brand

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -6573,10 +6573,7 @@ QUERY_ORDER_WITH_PAYMENT_AVAILABLE_FIELDS = """
               created
               modified
               paymentMethodType
-              availableCaptureAmount{
-                amount
-              }
-            chargeStatus
+              chargeStatus
               creditCard{
                 brand
                 firstDigits

--- a/saleor/graphql/order/tests/test_order.py
+++ b/saleor/graphql/order/tests/test_order.py
@@ -46,6 +46,7 @@ from ...tests.utils import (
     get_graphql_content_from_response,
 )
 from ..utils import validate_draft_order
+from .utils import assert_order_and_payment_ids
 
 
 @pytest.fixture
@@ -6597,23 +6598,43 @@ def test_order_by_token_query_for_payment_details_without_permissions(
     )
     assert_no_permission(response)
 
+
+def test_order_by_token_query_for_payment_details_with_permissions(
+    staff_api_client, payment_txn_captured, permission_manage_orders
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(
+        QUERY_ORDER_BY_TOKEN_WITH_PAYMENT,
+        {"token": payment_txn_captured.order.token},
+    )
+
+    content = get_graphql_content(response)
+
+    assert_order_and_payment_ids(content, payment_txn_captured)
+
+
+def test_order_by_token_query_payment_details_available_fields_without_permissions(
+    api_client, payment_txn_captured
+):
     response = api_client.post_graphql(
         QUERY_ORDER_WITH_PAYMENT_AVAILABLE_FIELDS,
         {"token": payment_txn_captured.order.token},
     )
 
     content = get_graphql_content(response)
-    assert "errors" not in content, content
+
+    assert_order_and_payment_ids(content, payment_txn_captured)
 
 
-def test_order_by_token_query_payment_details_with_permissions(
+def test_order_by_token_query_payment_details_available_fields_with_permissions(
     staff_api_client, payment_txn_captured, permission_manage_orders
 ):
     staff_api_client.user.user_permissions.add(permission_manage_orders)
-
     response = staff_api_client.post_graphql(
-        QUERY_ORDER_BY_TOKEN_WITH_PAYMENT, {"token": payment_txn_captured.order.token}
+        QUERY_ORDER_WITH_PAYMENT_AVAILABLE_FIELDS,
+        {"token": payment_txn_captured.order.token},
     )
 
     content = get_graphql_content(response)
-    assert "errors" not in content, content
+
+    assert_order_and_payment_ids(content, payment_txn_captured)

--- a/saleor/graphql/order/tests/utils.py
+++ b/saleor/graphql/order/tests/utils.py
@@ -1,0 +1,10 @@
+import graphene
+
+
+def assert_order_and_payment_ids(content, payment):
+    data = content["data"]["orderByToken"]
+    expected_order_id = graphene.Node.to_global_id("Order", payment.order.pk)
+    assert data["id"] == expected_order_id
+
+    expected_payment_id = graphene.Node.to_global_id("Payment", payment.pk)
+    assert data["payments"][0]["id"] == expected_payment_id

--- a/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
+++ b/saleor/graphql/payment/tests/deprecated/test_checkout_payment_create.py
@@ -15,10 +15,6 @@ CREATE_PAYMENT_MUTATION = """
     ) {
         checkoutPaymentCreate(checkoutId: $checkoutId, token: $token, input: $input) {
             payment {
-                transactions {
-                    kind,
-                    token
-                }
                 chargeStatus
             }
             errors {
@@ -56,8 +52,6 @@ def test_checkout_add_payment_by_checkout_id(
     content = get_graphql_content(response)
     data = content["data"]["checkoutPaymentCreate"]
     assert not data["errors"]
-    transactions = data["payment"]["transactions"]
-    assert not transactions
     payment = Payment.objects.get()
     assert payment.checkout == checkout
     assert payment.is_active

--- a/saleor/graphql/payment/tests/test_payment.py
+++ b/saleor/graphql/payment/tests/test_payment.py
@@ -94,10 +94,6 @@ CREATE_PAYMENT_MUTATION = """
     mutation CheckoutPaymentCreate($token: UUID, $input: PaymentInput!) {
         checkoutPaymentCreate(token: $token, input: $input) {
             payment {
-                transactions {
-                    kind,
-                    token
-                }
                 chargeStatus
             }
             errors {
@@ -134,8 +130,6 @@ def test_checkout_add_payment_without_shipping_method_and_not_shipping_required(
     content = get_graphql_content(response)
     data = content["data"]["checkoutPaymentCreate"]
     assert not data["errors"]
-    transactions = data["payment"]["transactions"]
-    assert not transactions
     payment = Payment.objects.get()
     assert payment.checkout == checkout
     assert payment.is_active
@@ -206,8 +200,6 @@ def test_checkout_add_payment_with_shipping_method_and_shipping_required(
     data = content["data"]["checkoutPaymentCreate"]
 
     assert not data["errors"]
-    transactions = data["payment"]["transactions"]
-    assert not transactions
     payment = Payment.objects.get()
     assert payment.checkout == checkout
     assert payment.is_active
@@ -250,8 +242,6 @@ def test_checkout_add_payment(
     data = content["data"]["checkoutPaymentCreate"]
 
     assert not data["errors"]
-    transactions = data["payment"]["transactions"]
-    assert not transactions
     payment = Payment.objects.get()
     assert payment.checkout == checkout
     assert payment.is_active
@@ -288,8 +278,6 @@ def test_checkout_add_payment_default_amount(
     content = get_graphql_content(response)
     data = content["data"]["checkoutPaymentCreate"]
     assert not data["errors"]
-    transactions = data["payment"]["transactions"]
-    assert not transactions
     payment = Payment.objects.get()
     assert payment.checkout == checkout
     assert payment.is_active
@@ -1070,3 +1058,81 @@ def test_payment_initialize_plugin_raises_error(
     assert len(errors) == 1
     assert errors[0]["field"] == "paymentData"
     assert errors[0]["message"] == error_msg
+
+
+QUERY_PAYMENT_REFUND_AMOUNT = """
+     query payment($id: ID!) {
+        payment(id: $id) {
+            id,
+            availableRefundAmount{
+                amount
+            }
+            availableCaptureAmount{
+                amount
+            }
+        }
+    }
+"""
+
+QUERY_PAYMENT_CAPTURE_AMOUNT = """
+     query payment($id: ID!) {
+        payment(id: $id) {
+            id,
+            availableCaptureAmount{
+                amount
+            }
+        }
+    }
+"""
+
+
+def test_resolve_available_refund_amount_cannot_refund(
+    staff_api_client, payment_cancelled, permission_manage_orders
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_REFUND_AMOUNT,
+        {"id": graphene.Node.to_global_id("Payment", payment_cancelled.pk)},
+    )
+    content = get_graphql_content(response)
+
+    assert not content["data"]["payment"]["availableRefundAmount"]
+
+
+def test_resolve_available_refund_amount(
+    staff_api_client, payment_dummy_fully_charged, permission_manage_orders
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_REFUND_AMOUNT,
+        {"id": graphene.Node.to_global_id("Payment", payment_dummy_fully_charged.pk)},
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["payment"]["availableRefundAmount"]["amount"] == 98.4
+
+
+def test_resolve_available_capture_amount_cannot_capture(
+    staff_api_client, payment_cancelled, permission_manage_orders
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_CAPTURE_AMOUNT,
+        {"id": graphene.Node.to_global_id("Payment", payment_cancelled.pk)},
+    )
+    content = get_graphql_content(response)
+
+    assert not content["data"]["payment"]["availableCaptureAmount"]
+
+
+def test_resolve_available_capture_amount(
+    staff_api_client, payment_dummy, permission_manage_orders
+):
+    staff_api_client.user.user_permissions.add(permission_manage_orders)
+    response = staff_api_client.post_graphql(
+        QUERY_PAYMENT_CAPTURE_AMOUNT,
+        {"id": graphene.Node.to_global_id("Payment", payment_dummy.pk)},
+    )
+    content = get_graphql_content(response)
+
+    assert content["data"]["payment"]["availableCaptureAmount"]["amount"] == 98.4

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -151,6 +151,7 @@ class Payment(CountableDjangoObjectType):
         return root.get_captured_amount()
 
     @staticmethod
+    @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_available_capture_amount(root: models.Payment, _info):
         if not root.can_capture():
             return None

--- a/saleor/graphql/payment/types.py
+++ b/saleor/graphql/payment/types.py
@@ -1,10 +1,12 @@
 import graphene
 from graphene import relay
 
+from ...core.permissions import OrderPermissions
 from ...core.tracing import traced_resolver
 from ...payment import models
 from ..core.connection import CountableDjangoObjectType
 from ..core.types import Money
+from ..decorators import permission_required
 from .enums import OrderAction, PaymentChargeStatusEnum
 
 
@@ -111,6 +113,12 @@ class Payment(CountableDjangoObjectType):
         ]
 
     @staticmethod
+    @permission_required(OrderPermissions.MANAGE_ORDERS)
+    def resolve_customer_ip_address(root: models.Payment, _info):
+        return root.customer_ip_address
+
+    @staticmethod
+    @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_actions(root: models.Payment, _info):
         actions = []
         if root.can_capture():
@@ -131,22 +139,22 @@ class Payment(CountableDjangoObjectType):
         return root.get_captured_amount()
 
     @staticmethod
+    @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_transactions(root: models.Payment, _info):
         return root.transactions.all()
 
     @staticmethod
+    @permission_required(OrderPermissions.MANAGE_ORDERS)
     def resolve_available_refund_amount(root: models.Payment, _info):
-        # FIXME TESTME
         if not root.can_refund():
             return None
         return root.get_captured_amount()
 
     @staticmethod
     def resolve_available_capture_amount(root: models.Payment, _info):
-        # FIXME TESTME
         if not root.can_capture():
             return None
-        return root.get_charge_amount()
+        return Money(amount=root.get_charge_amount(), currency=root.currency)
 
     @staticmethod
     def resolve_credit_card(root: models.Payment, _info):

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3748,6 +3748,13 @@ def payment_dummy(db, order_with_lines):
 
 
 @pytest.fixture
+def payment_cancelled(payment_dummy):
+    payment_dummy.charge_status = ChargeStatus.CANCELLED
+    payment_dummy.save()
+    return payment_dummy
+
+
+@pytest.fixture
 def payment_dummy_fully_charged(payment_dummy):
     payment_dummy.captured_amount = payment_dummy.total
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED


### PR DESCRIPTION
* Limit fields in response for non staff users for accessing Payment object to:
```
id
gateway
isActive
created
modified
paymentMethodType
creditCard
total
capturedAmount
chargeStatus
```
* Removed forbidden fields in some tests which are using non staff user.

* Also added missing tests for `resolve_available_refund_amount` and `resolve_available_capture_amount`. 
Regarding `resolve_available_capture_amount` I noticed a bug. When we have a situation when `payment.is_active=True` and `payment.charge_status='not-charged'` we have an error during the query. See details below.
Query:
```
{
  orderByToken(token:"7aa0edd0-5188-4e14-8374-41f3f1ec1f5d"){
    id
    payments{
      id
      availableCaptureAmount{
        amount
      }
    }
  }
}
```
Response:
```
  {
  "errors": [
    {
      "message": "'decimal.Decimal' object has no attribute 'amount'",
      "locations": [
        {
    ....
```

It has been fixed by returning casted value to `Money` in `resolve_available_capture_amount`. Unfortunately it cannot be fixed on the `Payment` model level because of lot of usage a method `get_charge_amount` 
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
