### PR TITLE
Block shopDomainUpdate mutation for cloud environments

### DIFF
--- a/saleor/graphql/shop/mutations.py
+++ b/saleor/graphql/shop/mutations.py
@@ -1,4 +1,5 @@
 import graphene
+from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from ...account import models as account_models
@@ -142,6 +143,13 @@ class ShopDomainUpdate(BaseMutation):
         permissions = (SitePermissions.MANAGE_SETTINGS,)
         error_type_class = ShopError
         error_type_field = "shop_errors"
+
+    @classmethod
+    def check_permissions(cls, context, permissions=None):
+        # for cloud instances this mutation is disabled and raises PermissionDenied
+        if settings.IS_CLOUD_INSTANCE:
+            return False
+        return super().check_permissions(context, permissions)
 
     @classmethod
     def perform_mutation(cls, _root, info, **data):

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -498,6 +498,8 @@ DEFAULT_MENUS = {"top_menu_name": "navbar", "bottom_menu_name": "footer"}
 # Slug for channel precreated in Django migrations
 DEFAULT_CHANNEL_SLUG = os.environ.get("DEFAULT_CHANNEL_SLUG", "default-channel")
 
+# Set "True" for cloud instances
+IS_CLOUD_INSTANCE = get_bool_from_env("IS_CLOUD_INSTANCE", False)
 
 #  Sentry
 sentry_sdk.utils.MAX_STRING_LENGTH = 4096


### PR DESCRIPTION
I want to merge this change because shopDomainUpdate mutation should not be able to be called in cloud environments

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
