### PR TITLE
Mute confusing PermissionDenied logs

### DIFF
--- a/saleor/graphql/tests/fixtures.py
+++ b/saleor/graphql/tests/fixtures.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from unittest import mock
 from unittest.mock import Mock
 
 import graphene
@@ -93,7 +94,8 @@ class ApiClient(Client):
 
         if permissions:
             if check_no_permissions:
-                response = super().post(API_PATH, data, **kwargs)
+                with mock.patch("saleor.graphql.views.handled_errors_logger"):
+                    response = super().post(API_PATH, data, **kwargs)
                 assert_no_permission(response)
             if self.app:
                 self.app.permissions.add(*permissions)


### PR DESCRIPTION
I want to merge this change because the error is confusing. It appears whenever there's an error in a test that requires permissions and is obscuring the true reason of the failure.

Before:
![image](https://user-images.githubusercontent.com/2566928/134658715-74246292-430a-4236-b91a-69a51240b926.png)


After:
![image](https://user-images.githubusercontent.com/2566928/134658672-510cff4a-827f-4040-8b9f-8eb37e987009.png)


# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
