### PR TITLE
Handle SameSite cookie attribute in jwt refresh token middleware

### DIFF
--- a/saleor/core/middleware.py
+++ b/saleor/core/middleware.py
@@ -98,6 +98,7 @@ def jwt_refresh_token_middleware(get_response):
         jwt_refresh_token = getattr(request, "refresh_token", None)
         if jwt_refresh_token:
             expires = None
+            secure = not settings.DEBUG
             if settings.JWT_EXPIRE:
                 refresh_token_payload = jwt_decode_with_exception_handler(
                     jwt_refresh_token
@@ -111,7 +112,8 @@ def jwt_refresh_token_middleware(get_response):
                 jwt_refresh_token,
                 expires=expires,
                 httponly=True,  # protects token from leaking
-                secure=not settings.DEBUG,
+                secure=secure,
+                samesite="None" if secure else "Lax",
             )
         return response
 

--- a/saleor/core/tests/test_middleware.py
+++ b/saleor/core/tests/test_middleware.py
@@ -46,3 +46,35 @@ def test_jwt_refresh_token_middleware_token_without_expire(rf, customer_user, se
     response = handler.get_response(request)
     cookie = response.cookies.get(JWT_REFRESH_TOKEN_COOKIE_NAME)
     assert cookie.value == refresh_token
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_jwt_refresh_token_middleware_samesite_debug_mode(rf, customer_user, settings):
+    refresh_token = create_refresh_token(customer_user)
+    settings.MIDDLEWARE = [
+        "saleor.core.middleware.jwt_refresh_token_middleware",
+    ]
+    settings.DEBUG = True
+    request = rf.request()
+    request.refresh_token = refresh_token
+    handler = BaseHandler()
+    handler.load_middleware()
+    response = handler.get_response(request)
+    cookie = response.cookies.get(JWT_REFRESH_TOKEN_COOKIE_NAME)
+    assert cookie["samesite"] == "Lax"
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_jwt_refresh_token_middleware_samesite_none(rf, customer_user, settings):
+    refresh_token = create_refresh_token(customer_user)
+    settings.MIDDLEWARE = [
+        "saleor.core.middleware.jwt_refresh_token_middleware",
+    ]
+    settings.DEBUG = False
+    request = rf.request()
+    request.refresh_token = refresh_token
+    handler = BaseHandler()
+    handler.load_middleware()
+    response = handler.get_response(request)
+    cookie = response.cookies.get(JWT_REFRESH_TOKEN_COOKIE_NAME)
+    assert cookie["samesite"] == "None"


### PR DESCRIPTION
I want to merge this change because in jwt refresh token middleware `SameSite` cookies attribute should be explicitly set to "None" when `Secure` attribute is also set (Cookies will be sent in all contexts, i.e. in responses to both first-party and cross-origin requests). Otherwise it should be set to default ("Lax")

Zendesk link: https://saleorcloud.zendesk.com/agent/tickets/70
<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
