### PR TITLE
Allow defining value for attribute value for all attribute types

### DIFF
--- a/saleor/graphql/attribute/mutations.py
+++ b/saleor/graphql/attribute/mutations.py
@@ -636,7 +636,7 @@ class AttributeValueCreate(AttributeMixin, ModelMutation):
         input_type = instance.attribute.input_type
 
         is_swatch_attr = input_type == AttributeInputType.SWATCH
-        only_swatch_fields = ["file_url", "content_type", "value"]
+        only_swatch_fields = ["file_url", "content_type"]
         errors = {}
         if not is_swatch_attr:
             for field in only_swatch_fields:

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_create.py
@@ -198,7 +198,6 @@ def test_create_swatch_attribute_value_with_value_and_file(
 @pytest.mark.parametrize(
     "field, value",
     [
-        ("value", "#ffffff"),
         ("fileUrl", "http://mirumee.com/test_media/test_file.jpeg"),
         ("contentType", "jpeg"),
     ],

--- a/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
+++ b/saleor/graphql/attribute/tests/mutations/test_attribute_value_update.py
@@ -190,7 +190,6 @@ def test_update_swatch_attribute_value_clear_file_value(
 @pytest.mark.parametrize(
     "field, input_value",
     [
-        ("value", "#ffffff"),
         ("fileUrl", "http://mirumee.com/test_media/test_file.jpeg"),
         ("contentType", "jpeg"),
     ],


### PR DESCRIPTION
Drop restriction on defining attribute value `value` field.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
