### PR TITLE
Add kind to ProductTypes in populatedb_data.json

### DIFF
--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -280,7 +280,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -297,7 +298,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "0.2:kg"
+      "weight": "0.2:kg",
+      "kind": "normal"
     }
   },
   {
@@ -314,7 +316,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -331,7 +334,8 @@
       "has_variants": false,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -348,7 +352,8 @@
       "has_variants": false,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -365,7 +370,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "0.5:kg"
+      "weight": "0.5:kg",
+      "kind": "normal"
     }
   },
   {
@@ -382,7 +388,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -399,7 +406,8 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg"
+      "weight": "1.0:kg",
+      "kind": "normal"
     }
   },
   {
@@ -413,7 +421,8 @@
       "has_variants": true,
       "is_shipping_required": false,
       "is_digital": true,
-      "weight": "0.0:kg"
+      "weight": "0.0:kg",
+      "kind": "normal"
     }
   },
   {


### PR DESCRIPTION
I want to merge this change because it updates "populatedb_data.json" to include "kind" in "product.producttype" models.

<!-- Please mention all relevant issue numbers. -->
Fixes #8202 

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
