### PR TITLE
Add giftCardCurrencies query

### DIFF
--- a/saleor/graphql/giftcard/schema.py
+++ b/saleor/graphql/giftcard/schema.py
@@ -2,6 +2,7 @@ import graphene
 from graphql.error import GraphQLError
 
 from ...core.permissions import GiftcardPermissions
+from ...giftcard import models
 from ..core.descriptions import ADDED_IN_31
 from ..core.fields import FilterInputConnectionField
 from ..core.utils import from_global_id_or_error
@@ -42,6 +43,11 @@ class GiftCardQueries(graphene.ObjectType):
         ),
         description="List of gift cards.",
     )
+    gift_card_currencies = graphene.Field(
+        graphene.List(graphene.NonNull(graphene.String)),
+        description=f"{ADDED_IN_31} List of gift card currencies.",
+        required=True,
+    )
 
     @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
     def resolve_gift_card(self, info, **data):
@@ -57,6 +63,10 @@ class GiftCardQueries(graphene.ObjectType):
         if sorting_by_balance and not filtering_by_currency:
             raise GraphQLError("Sorting by balance requires filtering by currency.")
         return resolve_gift_cards()
+
+    @permission_required(GiftcardPermissions.MANAGE_GIFT_CARD)
+    def resolve_gift_card_currencies(self, info, **data):
+        return set(models.GiftCard.objects.values_list("currency", flat=True))
 
 
 class GiftCardMutations(graphene.ObjectType):

--- a/saleor/graphql/giftcard/tests/queries/test_gift_cards_currencies.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_cards_currencies.py
@@ -1,0 +1,86 @@
+from .....giftcard.models import GiftCard
+from ....tests.utils import assert_no_permission, get_graphql_content
+
+QUERY_GIFT_CARD_CURRENCIES = """
+    query {
+        giftCardCurrencies
+    }
+"""
+
+
+def test_fetch_gift_card_currencies(
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    staff_api_client,
+    permission_manage_gift_card,
+):
+    # given
+    gift_card_expiry_date.currency = "PLN"
+    gift_card_used.currency = "EUR"
+    GiftCard.objects.bulk_update([gift_card_expiry_date, gift_card_used], ["currency"])
+
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GIFT_CARD_CURRENCIES,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCardCurrencies"]
+    assert set(data) == {gift_card.currency, "PLN", "EUR"}
+
+
+def test_fetch_gift_card_currencies_by_app(
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    app_api_client,
+    permission_manage_gift_card,
+):
+    # given
+    gift_card_used.currency = "EUR"
+    gift_card_used.save(update_fields=["currency"])
+
+    # when
+    response = app_api_client.post_graphql(
+        QUERY_GIFT_CARD_CURRENCIES,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCardCurrencies"]
+    assert set(data) == {gift_card.currency, gift_card_expiry_date.currency, "EUR"}
+
+
+def test_fetch_gift_card_currencies_no_permission(api_client):
+    # when
+    response = api_client.post_graphql(
+        QUERY_GIFT_CARD_CURRENCIES,
+    )
+
+    # then
+    assert_no_permission(response)
+
+
+def test_fetch_gift_card_currencies_no_gift_cards(
+    staff_api_client, permission_manage_gift_card
+):
+    # when
+    response = staff_api_client.post_graphql(
+        QUERY_GIFT_CARD_CURRENCIES,
+        permissions=[
+            permission_manage_gift_card,
+        ],
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCardCurrencies"]
+    assert data == []

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -5828,6 +5828,7 @@ type Query {
   menuItems(channel: String, sortBy: MenuItemSortingInput, filter: MenuItemFilterInput, before: String, after: String, first: Int, last: Int): MenuItemCountableConnection
   giftCard(id: ID!): GiftCard
   giftCards(sortBy: GiftCardSortingInput, filter: GiftCardFilterInput, before: String, after: String, first: Int, last: Int): GiftCardCountableConnection
+  giftCardCurrencies: [String!]!
   plugin(id: ID!): Plugin
   plugins(filter: PluginFilterInput, sortBy: PluginSortingInput, before: String, after: String, first: Int, last: Int): PluginCountableConnection
   sale(id: ID!, channel: String): Sale


### PR DESCRIPTION
Add `giftCardCurrencies` query to return currencies for which gift cards already exist.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
