### PR TITLE
Drop duplicated kind field from producttype in populatedb

### DIFF
--- a/saleor/static/populatedb_data.json
+++ b/saleor/static/populatedb_data.json
@@ -301,8 +301,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -320,8 +319,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "0.2:kg",
-      "kind": "normal"
+      "weight": "0.2:kg"
     }
   },
   {
@@ -339,8 +337,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -358,8 +355,7 @@
       "has_variants": false,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -377,8 +373,7 @@
       "has_variants": false,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -396,8 +391,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "0.5:kg",
-      "kind": "normal"
+      "weight": "0.5:kg"
     }
   },
   {
@@ -415,8 +409,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -434,8 +427,7 @@
       "has_variants": true,
       "is_shipping_required": true,
       "is_digital": false,
-      "weight": "1.0:kg",
-      "kind": "normal"
+      "weight": "1.0:kg"
     }
   },
   {
@@ -450,8 +442,7 @@
       "has_variants": true,
       "is_shipping_required": false,
       "is_digital": true,
-      "weight": "0.0:kg",
-      "kind": "normal"
+      "weight": "0.0:kg"
     }
   },
   {


### PR DESCRIPTION
Drop duplicated `kind` field from `producttype` in `populatedb`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
