### PR TITLE
Add order.number to the email order payload

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -218,6 +218,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
     order_payload = model_to_dict(order, fields=ORDER_MODEL_FIELDS)
     order_payload.update(
         {
+            "number": order.id,
             "channel_slug": order.channel.slug,
             "created": str(order.created),
             "shipping_price_net_amount": order.shipping_price_net_amount,

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -191,6 +191,7 @@ def test_get_default_order_payload(order_line):
         ],
         "channel_slug": order.channel.slug,
         "id": order.id,
+        "number": order.id,
         "token": order.token,
         "created": str(order.created),
         "display_gross_prices": order.display_gross_prices,

--- a/saleor/plugins/admin_email/constants.py
+++ b/saleor/plugins/admin_email/constants.py
@@ -34,7 +34,7 @@ CSV_EXPORT_FAILED_SUBJECT_FIELD = "csv_export_failed_subject"
 STAFF_PASSWORD_RESET_SUBJECT_FIELD = "staff_password_reset_subject"
 
 
-STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.id }} details"
+STAFF_ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.number }} details"
 SET_STAFF_PASSWORD_DEFAULT_SUBJECT = "Set password e-mail"
 CSV_PRODUCT_EXPORT_SUCCESS_DEFAULT_SUBJECT = "Export products data"
 CSV_EXPORT_FAILED_DEFAULT_SUBJECT = "Export products data"

--- a/saleor/plugins/user_email/constants.py
+++ b/saleor/plugins/user_email/constants.py
@@ -83,7 +83,7 @@ INVOICE_READY_DEFAULT_SUBJECT = "Invoice"
 ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order #{{ order.number }} details"
 ORDER_CONFIRMED_DEFAULT_SUBJECT = "Order #{{ order.number }} confirmed"
 ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_SUBJECT = (
-    "Your order {{ number }} has been fulfilled"
+    "Your order {{ order.number }} has been fulfilled"
 )
 ORDER_FULFILLMENT_UPDATE_DEFAULT_SUBJECT = (
     "Shipping update for order {{ order.number }}"

--- a/saleor/plugins/user_email/constants.py
+++ b/saleor/plugins/user_email/constants.py
@@ -80,12 +80,14 @@ ACCOUNT_CHANGE_EMAIL_CONFIRM_DEFAULT_SUBJECT = "Email change e-mail"
 ACCOUNT_CHANGE_EMAIL_REQUEST_DEFAULT_SUBJECT = "Email change e-mail"
 ACCOUNT_PASSWORD_RESET_DEFAULT_SUBJECT = "Password reset e-mail"
 INVOICE_READY_DEFAULT_SUBJECT = "Invoice"
-ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order #{{ order.id }} details"
-ORDER_CONFIRMED_DEFAULT_SUBJECT = "Order #{{ order.id }} confirmed"
+ORDER_CONFIRMATION_DEFAULT_SUBJECT = "Order #{{ order.number }} details"
+ORDER_CONFIRMED_DEFAULT_SUBJECT = "Order #{{ order.number }} confirmed"
 ORDER_FULFILLMENT_CONFIRMATION_DEFAULT_SUBJECT = (
-    "Your order {{ id }} has been fulfilled"
+    "Your order {{ number }} has been fulfilled"
 )
-ORDER_FULFILLMENT_UPDATE_DEFAULT_SUBJECT = "Shipping update for order {{ order.id }}"
-ORDER_PAYMENT_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.id }} payment details"
-ORDER_CANCELED_DEFAULT_SUBJECT = "Order {{ order.id }} canceled"
-ORDER_REFUND_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.id }} refunded"
+ORDER_FULFILLMENT_UPDATE_DEFAULT_SUBJECT = (
+    "Shipping update for order {{ order.number }}"
+)
+ORDER_PAYMENT_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.number }} payment details"
+ORDER_CANCELED_DEFAULT_SUBJECT = "Order {{ order.number }} canceled"
+ORDER_REFUND_CONFIRMATION_DEFAULT_SUBJECT = "Order {{ order.number }} refunded"

--- a/saleor/plugins/user_email/default_email_templates/order_cancel.html
+++ b/saleor/plugins/user_email/default_email_templates/order_cancel.html
@@ -5,7 +5,7 @@
         <title>
 
         </title>
-        <!--[if !mso]><!-- -->
+        <!--[if !mso]><!-->
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <!--<![endif]-->
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
@@ -57,19 +57,13 @@
   }</style>
 
       </head>
-      <body>
+      <body style="word-spacing:normal;">
 
 
       <div style>
 
 
-      <!--[if mso | IE]>
-      <table
-         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-      >
-        <tr>
-          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-      <![endif]-->
+      <!--[if mso | IE]><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
       <div style="margin:0px auto;max-width:600px;">
@@ -78,47 +72,35 @@
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
-                <!--[if mso | IE]>
-                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-
-        <tr>
-
-            <td
-               class="" style="vertical-align:top;width:600px;"
-            >
-          <![endif]-->
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
 
-            <tr>
-              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+              <tr>
+                <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:16px;line-height:1;text-align:left;color:#000000;">Hi!</div>
 
-              </td>
-            </tr>
+                </td>
+              </tr>
 
-            <tr>
-              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+              <tr>
+                <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
-      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Your order #{{order.id}} has been canceled.</div>
+      <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">Your order #{{order.number}} has been canceled.</div>
 
-              </td>
-            </tr>
+                </td>
+              </tr>
 
+        </tbody>
       </table>
 
       </div>
 
-          <!--[if mso | IE]>
-            </td>
-
-        </tr>
-
-                  </table>
-                <![endif]-->
+          <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
@@ -127,17 +109,7 @@
       </div>
 
 
-      <!--[if mso | IE]>
-          </td>
-        </tr>
-      </table>
-
-      <table
-         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-      >
-        <tr>
-          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-      <![endif]-->
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
       <div style="margin:0px auto;max-width:600px;">
@@ -146,39 +118,27 @@
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
-                <!--[if mso | IE]>
-                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-
-        <tr>
-
-            <td
-               class="" style="vertical-align:top;width:600px;"
-            >
-          <![endif]-->
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
 
-            <tr>
-              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+              <tr>
+                <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">This is an automatically generated e-mail, please do not reply.</div>
 
-              </td>
-            </tr>
+                </td>
+              </tr>
 
+        </tbody>
       </table>
 
       </div>
 
-          <!--[if mso | IE]>
-            </td>
-
-        </tr>
-
-                  </table>
-                <![endif]-->
+          <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
@@ -187,17 +147,7 @@
       </div>
 
 
-      <!--[if mso | IE]>
-          </td>
-        </tr>
-      </table>
-
-      <table
-         align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600"
-      >
-        <tr>
-          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-      <![endif]-->
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
       <div style="background:#F2F2F2;background-color:#F2F2F2;margin:0px auto;max-width:600px;">
@@ -206,39 +156,27 @@
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
-                <!--[if mso | IE]>
-                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-
-        <tr>
-
-            <td
-               class="" style="vertical-align:top;width:600px;"
-            >
-          <![endif]-->
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
 
-            <tr>
-              <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+              <tr>
+                <td align="center" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:center;color:#000000;">Sincerely, {{ site_name }}</div>
 
-              </td>
-            </tr>
+                </td>
+              </tr>
 
+        </tbody>
       </table>
 
       </div>
 
-          <!--[if mso | IE]>
-            </td>
-
-        </tr>
-
-                  </table>
-                <![endif]-->
+          <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
@@ -247,17 +185,7 @@
       </div>
 
 
-      <!--[if mso | IE]>
-          </td>
-        </tr>
-      </table>
-
-      <table
-         align="center" border="0" cellpadding="0" cellspacing="0" class="no-display-outlook" style="width:600px;" width="600"
-      >
-        <tr>
-          <td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;">
-      <![endif]-->
+      <!--[if mso | IE]></td></tr></table><table align="center" border="0" cellpadding="0" cellspacing="0" class="no-display-outlook" style="width:600px;" width="600" ><tr><td style="line-height:0px;font-size:0px;mso-line-height-rule:exactly;"><![endif]-->
 
 
       <div class="no-display" style="display: none; margin: 0px auto; max-width: 600px;">
@@ -266,22 +194,15 @@
           <tbody>
             <tr>
               <td style="direction: ltr; font-size: 0px; padding: 20px 0; text-align: center;" align="center">
-                <!--[if mso | IE]>
-                  <table role="presentation" border="0" cellpadding="0" cellspacing="0">
-
-        <tr>
-
-            <td
-               class="" style="vertical-align:top;width:600px;"
-            >
-          <![endif]-->
+                <!--[if mso | IE]><table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td class="" style="vertical-align:top;width:600px;" ><![endif]-->
 
       <div class="mj-column-per-100 mj-outlook-group-fix" style="font-size:0px;text-align:left;direction:ltr;display:inline-block;vertical-align:top;width:100%;">
 
       <table border="0" cellpadding="0" cellspacing="0" role="presentation" style="vertical-align:top;" width="100%">
+        <tbody>
 
-            <tr>
-              <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
+              <tr>
+                <td align="left" style="font-size: 0px; padding: 10px 25px; word-break: break-word;">
 
       <div style="font-family:Ubuntu, Helvetica, Arial, sans-serif;font-size:13px;line-height:1;text-align:left;color:#000000;">{{#if order}}
         <script type="application/ld+json">
@@ -289,20 +210,15 @@
         </script>
       {{/if}}</div>
 
-              </td>
-            </tr>
+                </td>
+              </tr>
 
+        </tbody>
       </table>
 
       </div>
 
-          <!--[if mso | IE]>
-            </td>
-
-        </tr>
-
-                  </table>
-                <![endif]-->
+          <!--[if mso | IE]></td></tr></table><![endif]-->
               </td>
             </tr>
           </tbody>
@@ -311,11 +227,7 @@
       </div>
 
 
-      <!--[if mso | IE]>
-          </td>
-        </tr>
-      </table>
-      <![endif]-->
+      <!--[if mso | IE]></td></tr></table><![endif]-->
 
 
       </div>


### PR DESCRIPTION
Add `order.number` in email templates.  `saleor/plugins/user_email/default_email_templates/order_cancel.html ` has been compiled in [saleor-email-templates](https://github.com/saleor/saleor-email-templates/) and moved to this repository (related [PR](https://github.com/saleor/saleor-email-templates/pull/6/files)).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
