### PR TITLE
Fix Insufficient stock error in checkoutLinesUpdate with 0 quantity. 

### DIFF
--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -81,15 +81,14 @@ def check_stock_quantity_bulk(
             [stock.available_quantity for stock in stocks]  # type: ignore
         )
 
-        if not stocks:
-            insufficient_stocks.append(
-                InsufficientStockData(
-                    variant=variant,
-                    available_quantity=available_quantity,
+        if quantity > 0:
+            if not stocks:
+                insufficient_stocks.append(
+                    InsufficientStockData(
+                        variant=variant, available_quantity=available_quantity
+                    )
                 )
-            )
-        elif variant.track_inventory:
-            if quantity > available_quantity:
+            elif variant.track_inventory and quantity > available_quantity:
                 insufficient_stocks.append(
                     InsufficientStockData(
                         variant=variant,


### PR DESCRIPTION
I want to merge this change because it is port changes from 3.0 to 3.1

3.0 PR -> https://github.com/mirumee/saleor/pull/8175


<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
