### PR TITLE
Schedule preorder settings cleanup after end date

### DIFF
--- a/saleor/graphql/order/mutations/draft_orders.py
+++ b/saleor/graphql/order/mutations/draft_orders.py
@@ -440,7 +440,7 @@ class DraftOrderComplete(BaseMutation):
         order.save()
 
         for line in order.lines.all():
-            if line.variant.track_inventory or line.variant.is_preorder:
+            if line.variant.track_inventory or line.variant.is_preorder_active():
                 line_data = OrderLineData(
                     line=line, quantity=line.quantity, variant=line.variant
                 )

--- a/saleor/graphql/order/mutations/fulfillments.py
+++ b/saleor/graphql/order/mutations/fulfillments.py
@@ -161,7 +161,7 @@ class OrderFulfill(BaseMutation):
     @classmethod
     def check_lines_for_preorder(cls, order_lines):
         for order_line in order_lines:
-            if order_line.variant_id and order_line.variant.is_preorder:
+            if order_line.variant_id and order_line.variant.is_preorder_active():
                 order_line_global_id = graphene.Node.to_global_id(
                     "OrderLine", order_line.pk
                 )

--- a/saleor/graphql/product/tests/test_product.py
+++ b/saleor/graphql/product/tests/test_product.py
@@ -10,6 +10,7 @@ import pytest
 import pytz
 from django.core.exceptions import ValidationError
 from django.db.models import Sum
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from django.utils.html import strip_tags
 from django.utils.text import slugify
@@ -2698,6 +2699,48 @@ def test_products_query_with_filter_has_preordered_variants_true(
     assert len(products) == 1
     assert products[0]["node"]["id"] == product_id
     assert products[0]["node"]["name"] == product.name
+
+
+def test_products_query_with_filter_has_preordered_variants_before_end_date(
+    query_products_with_filter,
+    staff_api_client,
+    preorder_variant_global_threshold,
+    permission_manage_products,
+):
+    variant = preorder_variant_global_threshold
+    variant.preorder_end_date = timezone.now() + timedelta(days=3)
+    variant.save(update_fields=["preorder_end_date"])
+
+    product = preorder_variant_global_threshold.product
+    variables = {"filter": {"hasPreorderedVariants": True}}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+    content = get_graphql_content(response)
+    product_id = graphene.Node.to_global_id("Product", product.id)
+    products = content["data"]["products"]["edges"]
+
+    assert len(products) == 1
+    assert products[0]["node"]["id"] == product_id
+    assert products[0]["node"]["name"] == product.name
+
+
+def test_products_query_with_filter_has_preordered_variants_after_end_date(
+    query_products_with_filter,
+    staff_api_client,
+    preorder_variant_global_threshold,
+    permission_manage_products,
+):
+    variant = preorder_variant_global_threshold
+    variant.preorder_end_date = timezone.now() - timedelta(days=3)
+    variant.save(update_fields=["preorder_end_date"])
+
+    variables = {"filter": {"hasPreorderedVariants": True}}
+    staff_api_client.user.user_permissions.add(permission_manage_products)
+    response = staff_api_client.post_graphql(query_products_with_filter, variables)
+    content = get_graphql_content(response)
+    products = content["data"]["products"]["edges"]
+
+    assert len(products) == 0
 
 
 QUERY_PRODUCT_MEDIA_BY_ID = """

--- a/saleor/graphql/product/tests/test_variant_with_filtering.py
+++ b/saleor/graphql/product/tests/test_variant_with_filtering.py
@@ -1,4 +1,7 @@
+from datetime import timedelta
+
 import pytest
+from django.utils import timezone
 
 from ....product.models import Product, ProductVariant
 from ...tests.utils import get_graphql_content
@@ -84,6 +87,18 @@ def products_for_variant_filtering(product_type, category):
                 sku="Preorder-V1",
                 is_preorder=True,
             ),
+            ProductVariant(
+                product=products[5],
+                sku="Preorder-V2",
+                is_preorder=True,
+                preorder_end_date=timezone.now() + timedelta(days=1),
+            ),
+            ProductVariant(
+                product=products[5],
+                sku="Preorder-V3",
+                is_preorder=True,
+                preorder_end_date=timezone.now() - timedelta(days=1),
+            ),
         ]
     )
     return products
@@ -103,10 +118,10 @@ def products_for_variant_filtering(product_type, category):
         ({"sku": ["P1-V1", "P1-V2", "PP1-V1"]}, ["P1-V1", "P1-V2", "PP1-V1"]),
         ({"sku": ["PP1-V1", "PP2-V1"]}, ["PP1-V1", "PP2-V1"]),
         ({"sku": ["invalid"]}, []),
-        ({"isPreorder": True}, ["Preorder-V1"]),
+        ({"isPreorder": True}, ["Preorder-V1", "Preorder-V2"]),
         (
             {"isPreorder": False},
-            ["P1-V1", "P1-V2", "P2-V1", "P3-V1", "PP1-V1", "PP2-V1"],
+            ["P1-V1", "P1-V2", "P2-V1", "P3-V1", "PP1-V1", "PP2-V1", "Preorder-V3"],
         ),
     ],
 )

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -338,7 +338,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
         if address is not None:
             country_code = address.country
 
-        if root.node.is_preorder:
+        if root.node.is_preorder_active():
             variant = root.node
             channel_listing = VariantChannelListingByVariantIdAndChannelSlugLoader(
                 info.context
@@ -611,7 +611,7 @@ class ProductVariant(ChannelContextTypeWithMetadata, CountableDjangoObjectType):
                     global_sold_units=global_sold_units,
                     end_date=variant.preorder_end_date,
                 )
-                if variant.is_preorder
+                if variant.is_preorder_active()
                 else None
             )
 

--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -82,7 +82,7 @@ def get_product_variant_payload(variant: ProductVariant):
     return {
         "id": variant.id,
         "weight": str(variant.weight or ""),
-        "is_preorder": variant.is_preorder,
+        "is_preorder": variant.is_preorder_active(),
         "preorder_global_threshold": variant.preorder_global_threshold,
         "preorder_end_date": variant.preorder_end_date,
         **get_default_images_payload(images),

--- a/saleor/product/models.py
+++ b/saleor/product/models.py
@@ -27,6 +27,7 @@ from django.db.models import (
 )
 from django.db.models.functions import Coalesce
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.encoding import smart_text
 from django_measurement.models import MeasurementField
 from django_prices.models import MoneyField
@@ -609,6 +610,11 @@ class ProductVariant(SortableModel, ModelWithMetadata):
 
     def get_ordering_queryset(self):
         return self.product.variants.all()
+
+    def is_preorder_active(self):
+        return self.is_preorder and (
+            self.preorder_end_date is None or timezone.now() <= self.preorder_end_date
+        )
 
 
 class ProductVariantTranslation(Translation):

--- a/saleor/product/tasks.py
+++ b/saleor/product/tasks.py
@@ -1,11 +1,15 @@
 import logging
 from typing import Iterable, List, Optional
 
+from celery.utils.log import get_task_logger
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils import timezone
 
 from ..attribute.models import Attribute
 from ..celeryconf import app
+from ..core.exceptions import PreorderAllocationError
 from ..discount.models import Sale
+from ..warehouse.management import deactivate_preorder_for_variant
 from .models import Product, ProductType, ProductVariant
 from .utils.variant_prices import (
     update_product_discounted_price,
@@ -16,6 +20,7 @@ from .utils.variant_prices import (
 from .utils.variants import generate_and_set_variant_name
 
 logger = logging.getLogger(__name__)
+task_logger = get_task_logger(__name__)
 
 
 def _update_variants_names(instance: ProductType, saved_attributes: Iterable):
@@ -85,3 +90,20 @@ def update_products_discounted_prices_of_discount_task(discount_pk: int):
 def update_products_discounted_prices_task(product_ids: List[int]):
     products = Product.objects.filter(pk__in=product_ids)
     update_products_discounted_prices(products)
+
+
+@app.task
+def deactivate_preorder_for_variants_task():
+    variants_to_clean = _get_preorder_variants_to_clean()
+
+    for variant in variants_to_clean:
+        try:
+            deactivate_preorder_for_variant(variant)
+        except PreorderAllocationError as e:
+            task_logger.warning(str(e))
+
+
+def _get_preorder_variants_to_clean():
+    return ProductVariant.objects.filter(
+        is_preorder=True, preorder_end_date__lt=timezone.now()
+    )

--- a/saleor/product/tests/test_tasks.py
+++ b/saleor/product/tests/test_tasks.py
@@ -1,7 +1,11 @@
 import logging
+from datetime import timedelta
 from unittest.mock import patch
 
+from django.utils import timezone
+
 from ..tasks import (
+    _get_preorder_variants_to_clean,
     update_product_discounted_price_task,
     update_products_discounted_prices_of_discount_task,
     update_variants_names,
@@ -87,3 +91,26 @@ def test_update_variants_names_product_type_does_not_exist(
     # then
     update_variants_names_mock.assert_not_called()
     assert f"Cannot find product type with id: {product_type_id}" in caplog.text
+
+
+def test_get_preorder_variants_to_clean(
+    variant,
+    preorder_variant_global_threshold,
+    preorder_variant_channel_threshold,
+    preorder_variant_global_and_channel_threshold,
+):
+    preorder_variant_before_end_date = preorder_variant_channel_threshold
+    preorder_variant_before_end_date.preorder_end_date = timezone.now() + timedelta(
+        days=1
+    )
+    preorder_variant_before_end_date.save(update_fields=["preorder_end_date"])
+
+    preorder_variant_after_end_date = preorder_variant_global_and_channel_threshold
+    preorder_variant_after_end_date.preorder_end_date = timezone.now() - timedelta(
+        days=1
+    )
+    preorder_variant_after_end_date.save(update_fields=["preorder_end_date"])
+
+    variants_to_clean = _get_preorder_variants_to_clean()
+    assert len(variants_to_clean) == 1
+    assert variants_to_clean[0] == preorder_variant_after_end_date

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -486,6 +486,10 @@ CELERY_BEAT_SCHEDULE = {
         "task": "saleor.warehouse.tasks.delete_empty_allocations_task",
         "schedule": timedelta(days=1),
     },
+    "deactivate-preorder-for-variants": {
+        "task": "saleor.product.tasks.deactivate_preorder_for_variants_task",
+        "schedule": timedelta(hours=1),
+    },
 }
 
 # Change this value if your application is running behind a proxy,

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -2167,6 +2167,25 @@ def preorder_variant_global_and_channel_threshold(product, channel_USD, channel_
 
 
 @pytest.fixture
+def preorder_variant_with_end_date(product, channel_USD):
+    product_variant = ProductVariant.objects.create(
+        product=product,
+        sku="SKU_D_P",
+        is_preorder=True,
+        preorder_global_threshold=10,
+        preorder_end_date=timezone.now() + datetime.timedelta(days=10),
+    )
+    ProductVariantChannelListing.objects.create(
+        variant=product_variant,
+        channel=channel_USD,
+        price_amount=Decimal(10),
+        cost_price_amount=Decimal(1),
+        currency=channel_USD.currency_code,
+    )
+    return product_variant
+
+
+@pytest.fixture
 def variant_with_many_stocks_different_shipping_zones(
     variant, warehouses_with_different_shipping_zone
 ):

--- a/saleor/warehouse/availability.py
+++ b/saleor/warehouse/availability.py
@@ -31,7 +31,7 @@ def check_stock_and_preorder_quantity(
     :raises InsufficientStock: when there is not enough items in stock for a variant
     or there is not enough available preorder items for a variant.
     """
-    if variant.is_preorder:
+    if variant.is_preorder_active():
         check_preorder_threshold_bulk([variant], [quantity], channel_slug)
     else:
         check_stock_quantity(variant, country_code, channel_slug, quantity)
@@ -97,12 +97,12 @@ def _split_lines_for_trackable_and_preorder(
 ) -> Tuple[
     Iterable["ProductVariant"], Iterable[int], Iterable["ProductVariant"], Iterable[int]
 ]:
-    """Return variants and quantities splitted by "is_preorder" flag."""
+    """Return variants and quantities splitted by "is_preorder_active"."""
     stock_variants, stock_quantities = [], []
     preorder_variants, preorder_quantities = [], []
 
     for variant, quantity in zip(variants, quantities):
-        if variant.is_preorder:
+        if variant.is_preorder_active():
             preorder_variants.append(variant)
             preorder_quantities.append(quantity)
         else:

--- a/saleor/warehouse/management.py
+++ b/saleor/warehouse/management.py
@@ -435,7 +435,7 @@ def get_order_lines_with_track_inventory(
         for line_info in order_lines_info
         if line_info.variant
         and line_info.variant.track_inventory
-        and not line_info.variant.is_preorder
+        and not line_info.variant.is_preorder_active()
     ]
 
 
@@ -532,7 +532,7 @@ def get_order_lines_with_preorder(
     return [
         line_info
         for line_info in order_lines_info
-        if line_info.variant and line_info.variant.is_preorder
+        if line_info.variant and line_info.variant.is_preorder_active()
     ]
 
 

--- a/saleor/warehouse/tests/test_preorder_availability.py
+++ b/saleor/warehouse/tests/test_preorder_availability.py
@@ -1,8 +1,10 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.db.models import F, Sum
 from django.db.models.functions import Coalesce
+from freezegun import freeze_time
 
 from ...core.exceptions import InsufficientStock
 from ..availability import (
@@ -41,20 +43,35 @@ def test_check_stock_and_preorder_quantity_bulk(
     mock_check_preorder_threshold_bulk,
     variant,
     preorder_variant_channel_threshold,
+    preorder_variant_with_end_date,
     channel_USD,
 ):
     stock_variant_quantity = 2
     preorder_quantity = 1
-    check_stock_and_preorder_quantity_bulk(
-        [variant, preorder_variant_channel_threshold],
-        "US",
-        [stock_variant_quantity, preorder_quantity],
-        channel_USD.slug,
-    )
+
+    with freeze_time(
+        preorder_variant_with_end_date.preorder_end_date + timedelta(days=3)
+    ):
+        check_stock_and_preorder_quantity_bulk(
+            [
+                variant,
+                preorder_variant_channel_threshold,
+                preorder_variant_with_end_date,
+            ],
+            "US",
+            [stock_variant_quantity, preorder_quantity, stock_variant_quantity],
+            channel_USD.slug,
+        )
 
     mock_check_stock_quantity_bulk.assert_called_once()
-    assert mock_check_stock_quantity_bulk.call_args[0][0] == [variant]
-    assert mock_check_stock_quantity_bulk.call_args[0][2] == [stock_variant_quantity]
+    assert mock_check_stock_quantity_bulk.call_args[0][0] == [
+        variant,
+        preorder_variant_with_end_date,
+    ]
+    assert mock_check_stock_quantity_bulk.call_args[0][2] == [
+        stock_variant_quantity,
+        stock_variant_quantity,
+    ]
 
     mock_check_preorder_threshold_bulk.assert_called_once()
     assert mock_check_preorder_threshold_bulk.call_args[0][0] == [


### PR DESCRIPTION
I want to merge this change because it adds an asynchronous task to clean up preorder settings and preorder allocation after preorder end date was reached. Moreover, it changes how preorder variants are interpreted - now it's not only the `is_preorder` flag, but also compares current time with preorder end date (if it's set).

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
