### PR TITLE
Remove use of Order#get_last_payment in tests

### DIFF
--- a/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
+++ b/saleor/order/tests/test_order_actions_create_fulfillments_for_returned_products.py
@@ -27,7 +27,7 @@ def test_create_return_fulfillment_only_order_lines(
     staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
 
     order_lines_to_return = order_with_lines.lines.all()
     original_quantity = {
@@ -101,7 +101,7 @@ def test_create_return_fulfillment_only_order_lines_with_refund(
     staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
 
     order_lines_to_return = order_with_lines.lines.all()
     original_quantity = {
@@ -173,7 +173,7 @@ def test_create_return_fulfillment_only_order_lines_included_shipping_costs(
     staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
 
     order_lines_to_return = order_with_lines.lines.all()
     original_quantity = {
@@ -250,7 +250,7 @@ def test_create_return_fulfillment_only_order_lines_with_replace_request(
     staff_user,
 ):
     order_with_lines.payments.add(payment_dummy_fully_charged)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
 
     order_lines_to_return = order_with_lines.lines.all()
     original_quantity = {
@@ -380,7 +380,7 @@ def test_create_return_fulfillment_only_fulfillment_lines(
     staff_user,
 ):
     fulfilled_order.payments.add(payment_dummy_fully_charged)
-    payment = fulfilled_order.get_last_payment()
+    payment = fulfilled_order.payments.latest("pk")
     order_line_ids = fulfilled_order.lines.all().values_list("id", flat=True)
     fulfillment_lines = FulfillmentLine.objects.filter(order_line_id__in=order_line_ids)
     original_quantity = {line.id: line.quantity for line in fulfillment_lines}
@@ -428,7 +428,7 @@ def test_create_return_fulfillment_only_fulfillment_lines_replace_order(
     staff_user,
 ):
     fulfilled_order.payments.add(payment_dummy_fully_charged)
-    payment = fulfilled_order.get_last_payment()
+    payment = fulfilled_order.payments.latest("pk")
     order_line_ids = fulfilled_order.lines.all().values_list("id", flat=True)
     fulfillment_lines = FulfillmentLine.objects.filter(order_line_id__in=order_line_ids)
     original_quantity = {line.id: line.quantity for line in fulfillment_lines}
@@ -537,7 +537,7 @@ def test_create_return_fulfillment_with_lines_already_refunded(
     warehouse,
 ):
     fulfilled_order.payments.add(payment_dummy_fully_charged)
-    payment = fulfilled_order.get_last_payment()
+    payment = fulfilled_order.payments.latest("pk")
     order_line_ids = fulfilled_order.lines.all().values_list("id", flat=True)
     fulfillment_lines = FulfillmentLine.objects.filter(order_line_id__in=order_line_ids)
     original_quantity = {line.id: line.quantity for line in fulfillment_lines}

--- a/saleor/order/tests/test_order_actions_refund_products.py
+++ b/saleor/order/tests/test_order_actions_refund_products.py
@@ -19,7 +19,7 @@ def test_create_refund_fulfillment_only_order_lines(
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
     payment_dummy.save()
     order_with_lines.payments.add(payment_dummy)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
 
     order_lines_to_refund = order_with_lines.lines.all()
     original_quantity = {
@@ -82,7 +82,7 @@ def test_create_refund_fulfillment_included_shipping_costs(
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
     payment_dummy.save()
     order_with_lines.payments.add(payment_dummy)
-    payment = order_with_lines.get_last_payment()
+    payment = order_with_lines.payments.latest("pk")
     order_lines_to_refund = order_with_lines.lines.all()
     original_quantity = {
         line.id: line.quantity_unfulfilled for line in order_with_lines.lines.all()
@@ -136,7 +136,7 @@ def test_create_refund_fulfillment_only_fulfillment_lines(
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
     payment_dummy.save()
     fulfilled_order.payments.add(payment_dummy)
-    payment = fulfilled_order.get_last_payment()
+    payment = fulfilled_order.payments.latest("pk")
     order_line_ids = fulfilled_order.lines.all().values_list("id", flat=True)
     fulfillment_lines = FulfillmentLine.objects.filter(order_line_id__in=order_line_ids)
     original_quantity = {line.id: line.quantity for line in fulfillment_lines}
@@ -186,7 +186,7 @@ def test_create_refund_fulfillment_custom_amount(
     payment_dummy.charge_status = ChargeStatus.FULLY_CHARGED
     payment_dummy.save()
     fulfilled_order.payments.add(payment_dummy)
-    payment = fulfilled_order.get_last_payment()
+    payment = fulfilled_order.payments.latest("pk")
     order_line_ids = fulfilled_order.lines.all().values_list("id", flat=True)
     fulfillment_lines = FulfillmentLine.objects.filter(order_line_id__in=order_line_ids)
     original_quantity = {line.id: line.quantity for line in fulfillment_lines}


### PR DESCRIPTION
I want to merge this change because we are dropping the function `Order#get_last_payment` in favour of processing a list of all active payments. This pull request gets rid of the occurrences in tests, so that further PRs can focus on the actual changes in the business logic (`can_refund` etc.)

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
