### PR TITLE
Unify GraphQl span naming across tracers

### DIFF
--- a/saleor/graphql/tests/test_tracing.py
+++ b/saleor/graphql/tests/test_tracing.py
@@ -10,7 +10,7 @@ def _get_graphql_span(spans):
 
 
 def _get_graphql_spans(spans):
-    return filter(lambda item: item.tags["component"] == "GraphQL", spans)
+    return filter(lambda item: item.tags.get("graphql.query_fingerprint"), spans)
 
 
 @patch("saleor.graphql.views.opentracing.global_tracer")

--- a/saleor/graphql/views.py
+++ b/saleor/graphql/views.py
@@ -251,7 +251,7 @@ class GraphQLView(View):
     def execute_graphql_request(self, request: HttpRequest, data: dict):
         with opentracing.global_tracer().start_active_span("graphql_query") as scope:
             span = scope.span
-            span.set_tag(opentracing.tags.COMPONENT, "GraphQL")
+            span.set_tag(opentracing.tags.COMPONENT, "graphql")
 
             query, variables, operation_name = self.get_graphql_params(request, data)
 


### PR DESCRIPTION
I want to merge this change because it ports changes from #8240 to 3.0

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
