### PR TITLE
Make sentry settings configurable

### DIFF
--- a/saleor/core/app.py
+++ b/saleor/core/app.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django.db.models import Field
 
 from .db.filters import PostgresILike
@@ -9,3 +10,6 @@ class CoreAppConfig(AppConfig):
 
     def ready(self):
         Field.register_lookup(PostgresILike)
+
+        if settings.SENTRY_DSN:
+            settings.SENTRY_INIT(settings.SENTRY_DSN, settings.SENTRY_OPTS)

--- a/saleor/demo/settings.py
+++ b/saleor/demo/settings.py
@@ -17,6 +17,7 @@ import logging
 import re
 
 from sentry_sdk.integrations.celery import CeleryIntegration
+from sentry_sdk.integrations.logging import ignore_logger
 
 from ..settings import *  # noqa: F403, lgtm [py/polluting-import]
 
@@ -85,3 +86,4 @@ if DEMO_SENTRY_DSN:
         integrations=[CeleryIntegration(), DjangoIntegration()],
         before_send=before_send,
     )
+    ignore_logger("graphql.execution.utils")

--- a/saleor/settings.py
+++ b/saleor/settings.py
@@ -502,11 +502,18 @@ DEFAULT_CHANNEL_SLUG = os.environ.get("DEFAULT_CHANNEL_SLUG", "default-channel")
 #  Sentry
 sentry_sdk.utils.MAX_STRING_LENGTH = 4096
 SENTRY_DSN = os.environ.get("SENTRY_DSN")
-if SENTRY_DSN:
-    sentry_sdk.init(
-        dsn=SENTRY_DSN, integrations=[CeleryIntegration(), DjangoIntegration()]
-    )
+SENTRY_OPTS = {"integrations": [CeleryIntegration(), DjangoIntegration()]}
+
+
+def SENTRY_INIT(dsn: str, sentry_opts: dict):
+    """Init function for sentry.
+
+    Will only be called if SENTRY_DSN is not None, during core start, can be
+    overriden in separate settings file.
+    """
+    sentry_sdk.init(dsn, **sentry_opts)
     ignore_logger("graphql.execution.utils")
+
 
 GRAPHENE = {
     "RELAY_CONNECTION_ENFORCE_FIRST_OR_LAST": True,


### PR DESCRIPTION
I want to merge this change because it makes sentry settings overridable by separate settings file.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
