### PR TITLE
Allow filtering gift cards by code

### DIFF
--- a/saleor/graphql/giftcard/filters.py
+++ b/saleor/graphql/giftcard/filters.py
@@ -68,6 +68,12 @@ def _filter_by_price(qs, field, value):
     return qs.filter(**lookup)
 
 
+def filter_code(qs, _, value):
+    if not value:
+        return qs
+    return qs.filter(code=value)
+
+
 class GiftCardFilter(django_filters.FilterSet):
     tag = django_filters.CharFilter(method=filter_gift_card_tag)
     tags = ListObjectTypeFilter(input_class=graphene.String, method=filter_tags_list)
@@ -81,6 +87,7 @@ class GiftCardFilter(django_filters.FilterSet):
         input_class=PriceRangeInput, method="filter_initial_balance"
     )
     is_active = django_filters.BooleanFilter()
+    code = django_filters.CharFilter(method=filter_code)
 
     class Meta:
         model = models.GiftCard

--- a/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
+++ b/saleor/graphql/giftcard/tests/queries/test_gift_card_filtering.py
@@ -424,3 +424,50 @@ def test_query_filter_gift_cards_by_initial_balance(
         graphene.Node.to_global_id("GiftCard", gift_cards[i].pk)
         for i in expected_gift_card_indexes
     }
+
+
+def test_query_filter_gift_cards_by_code(
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    permission_manage_gift_card,
+):
+    # given
+    query = QUERY_GIFT_CARDS
+
+    variables = {"filter": {"code": gift_card.code}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_gift_card]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCards"]["edges"]
+    assert len(data) == 1
+    assert data[0]["node"]["id"] == graphene.Node.to_global_id("GiftCard", gift_card.pk)
+
+
+def test_query_filter_gift_cards_by_code_no_gift_card(
+    staff_api_client,
+    gift_card,
+    gift_card_expiry_date,
+    gift_card_used,
+    permission_manage_gift_card,
+):
+    # given
+    query = QUERY_GIFT_CARDS
+
+    variables = {"filter": {"code": "code-does-not-exist"}}
+
+    # when
+    response = staff_api_client.post_graphql(
+        query, variables, permissions=[permission_manage_gift_card]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    data = content["data"]["giftCards"]["edges"]
+    assert len(data) == 0

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -2427,6 +2427,7 @@ input GiftCardFilterInput {
   currency: String
   currentBalance: PriceRangeInput
   initialBalance: PriceRangeInput
+  code: String
 }
 
 type GiftCardResend {


### PR DESCRIPTION
Allow filtering gift cards by `code`.
Extend `GiftCardFilterInput` with `code` field.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
