### PR TITLE
Calculate authorized amount using multiple payments

### DIFF
--- a/saleor/order/models.py
+++ b/saleor/order/models.py
@@ -27,7 +27,7 @@ from ..discount import DiscountValueType
 from ..discount.models import Voucher
 from ..giftcard.models import GiftCard
 from ..payment import ChargeStatus, TransactionKind
-from ..payment.model_helpers import get_subtotal, get_total_authorized
+from ..payment.model_helpers import get_subtotal
 from ..payment.models import Payment
 from ..shipping.models import ShippingMethod
 from . import FulfillmentStatus, OrderEvents, OrderOrigin, OrderStatus
@@ -378,10 +378,6 @@ class Order(ModelWithMetadata):
         if not payments:
             payments = self.payments.all()
         return len(payments) == 0
-
-    @property
-    def total_authorized(self):
-        return get_total_authorized(self.payments.all(), self.currency)
 
     @property
     def total_captured(self):

--- a/saleor/payment/model_helpers.py
+++ b/saleor/payment/model_helpers.py
@@ -13,11 +13,11 @@ def get_last_payment(payments: List[Payment]):
 
 
 def get_total_authorized(payments: List[Payment], fallback_currency: str):
-    # FIXME adjust to multiple payments in the future
-    if last_payment := get_last_payment(payments):
-        if last_payment.is_active:
-            return last_payment.get_authorized_amount()
-    return zero_money(fallback_currency)
+    authorized_payments = [p for p in payments if p.is_authorized and p.is_active]
+    total = zero_money(fallback_currency)
+    for payment in authorized_payments:
+        total.amount += payment.total
+    return total
 
 
 def get_subtotal(order_lines: List["OrderLine"], fallback_currency: str):


### PR DESCRIPTION
I want to merge this change because this piece of code has previously called `Order#get_last_payment` which is being deprecated right now.

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
