### PR TITLE
Add collection_point_name field to order confirmation webhook

### DIFF
--- a/saleor/order/notifications.py
+++ b/saleor/order/notifications.py
@@ -244,6 +244,7 @@ def get_default_order_payload(order: "Order", redirect_url: str = ""):
             "billing_address": get_address_payload(order.billing_address),
             "shipping_address": get_address_payload(order.shipping_address),
             "shipping_method_name": order.shipping_method_name,
+            "collection_point_name": order.collection_point_name,
             **get_discounts_payload(order),
         }
     )

--- a/saleor/order/tests/test_notifications.py
+++ b/saleor/order/tests/test_notifications.py
@@ -74,6 +74,7 @@ def test_get_custom_order_payload(order):
                 "phone": "+48713988102",
             },
             "shipping_method_name": None,
+            "collection_point_name": None,
             "voucher_discount": None,
             "discounts": [],
             "discount_amount": 0,
@@ -234,6 +235,7 @@ def test_get_default_order_payload(order_line):
         "total_gross_amount": order.total_gross_amount,
         "total_net_amount": order.total_net_amount,
         "shipping_method_name": order.shipping_method_name,
+        "collection_point_name": order.collection_point_name,
         "status": order.status,
         "metadata": order.metadata,
         "private_metadata": order.private_metadata,
@@ -335,6 +337,31 @@ def test_send_email_order_confirmation(mocked_notify, order, site_settings):
         expected_payload,
         channel_slug=order.channel.slug,
     )
+
+
+@mock.patch("saleor.plugins.manager.PluginsManager.notify")
+def test_send_email_order_confirmation_for_cc(
+    mocked_notify, order_with_lines_for_cc, site_settings, warehouse_for_cc
+):
+    manager = get_plugins_manager()
+    redirect_url = "https://www.example.com"
+
+    notifications.send_order_confirmation(
+        order_with_lines_for_cc, redirect_url, manager
+    )
+
+    expected_payload = {
+        "order": get_default_order_payload(order_with_lines_for_cc, redirect_url),
+        "recipient_email": order_with_lines_for_cc.get_customer_email(),
+        "site_name": "mirumee.com",
+        "domain": "mirumee.com",
+    }
+    mocked_notify.assert_called_once_with(
+        NotifyEventType.ORDER_CONFIRMATION,
+        expected_payload,
+        channel_slug=order_with_lines_for_cc.channel.slug,
+    )
+    assert expected_payload["order"]["collection_point_name"] == warehouse_for_cc.name
 
 
 @mock.patch("saleor.plugins.manager.PluginsManager.notify")

--- a/saleor/tests/fixtures.py
+++ b/saleor/tests/fixtures.py
@@ -3172,6 +3172,7 @@ def order_with_lines_for_cc(
     )
 
     order.collection_point = warehouse_for_cc
+    order.collection_point_name = warehouse_for_cc.name
     order.save()
 
     recalculate_order(order)

--- a/saleor/webhook/payloads.py
+++ b/saleor/webhook/payloads.py
@@ -66,6 +66,7 @@ ORDER_FIELDS = (
     "origin",
     "user_email",
     "shipping_method_name",
+    "collection_point_name",
     "shipping_price_net_amount",
     "shipping_price_gross_amount",
     "shipping_tax_rate",

--- a/saleor/webhook/tests/test_webhook_payloads.py
+++ b/saleor/webhook/tests/test_webhook_payloads.py
@@ -76,8 +76,11 @@ def test_generate_order_payload(
     payload = json.loads(generate_order_payload(order_with_lines))[0]
 
     assert order_id == payload["id"]
-    for field in ORDER_FIELDS:
+    non_empty_fields = [f for f in ORDER_FIELDS if f != "collection_point_name"]
+    for field in non_empty_fields:
         assert payload.get(field) is not None
+
+    assert payload["collection_point_name"] is None
 
     assert payload.get("shipping_method")
     assert payload.get("shipping_tax_rate")
@@ -465,6 +468,7 @@ def test_generate_invoice_payload(fulfilled_order):
             "origin": OrderOrigin.CHECKOUT,
             "user_email": "test@example.com",
             "shipping_method_name": "DHL",
+            "collection_point_name": None,
             "shipping_price_net_amount": "10.000",
             "shipping_price_gross_amount": "12.300",
             "shipping_tax_rate": "0.0000",


### PR DESCRIPTION
I want to merge this change because it extends order confirmation webhook by `collection_point_name` which will be more convenient than checking that `shipping_method_name` is nullable type. 

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
