### PR TITLE
Proper login error handling for deactivated users

### DIFF
--- a/saleor/account/error_codes.py
+++ b/saleor/account/error_codes.py
@@ -34,6 +34,7 @@ class AccountErrorCode(Enum):
     JWT_INVALID_CSRF_TOKEN = "invalid_csrf_token"
     CHANNEL_INACTIVE = "channel_inactive"
     MISSING_CHANNEL_SLUG = "missing_channel_slug"
+    ACCOUNT_NOT_CONFIRMED = "account_not_confirmed"
 
 
 class PermissionGroupErrorCode(Enum):

--- a/saleor/graphql/account/mutations/authentication.py
+++ b/saleor/graphql/account/mutations/authentication.py
@@ -82,7 +82,7 @@ class CreateToken(BaseMutation):
 
     @classmethod
     def _retrieve_user_from_credentials(cls, email, password) -> Optional[models.User]:
-        user = models.User.objects.filter(email=email, is_active=True).first()
+        user = models.User.objects.filter(email=email).first()
         if user and user.check_password(password):
             return user
         return None
@@ -96,6 +96,25 @@ class CreateToken(BaseMutation):
                     "email": ValidationError(
                         "Please, enter valid credentials",
                         code=AccountErrorCode.INVALID_CREDENTIALS.value,
+                    )
+                }
+            )
+        if not user.is_active and not user.last_login:
+            raise ValidationError(
+                {
+                    "email": ValidationError(
+                        "Account needs to be confirmed via email.",
+                        code=AccountErrorCode.ACCOUNT_NOT_CONFIRMED.value,
+                    )
+                }
+            )
+
+        if not user.is_active and user.last_login:
+            raise ValidationError(
+                {
+                    "email": ValidationError(
+                        "Account inactive.",
+                        code=AccountErrorCode.INACTIVE.value,
                     )
                 }
             )

--- a/saleor/graphql/account/tests/mutations/test_token_create.py
+++ b/saleor/graphql/account/tests/mutations/test_token_create.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import graphene
 from django.middleware.csrf import _get_new_csrf_token
@@ -109,3 +109,72 @@ def test_create_token_invalid_email(api_client, customer_user):
     response_error = content["data"]["tokenCreate"]["errors"][0]
     assert response_error["code"] == expected_error_code
     assert response_error["field"] == "email"
+
+
+def test_create_token_unconfirmed_email(api_client, customer_user):
+    # given
+    variables = {"email": customer_user.email, "password": customer_user._password}
+    customer_user.is_active = False
+    customer_user.save()
+    expected_error_code = AccountErrorCode.ACCOUNT_NOT_CONFIRMED.value.upper()
+
+    # when
+    response = api_client.post_graphql(MUTATION_CREATE_TOKEN, variables)
+    content = get_graphql_content(response)
+    response_error = content["data"]["tokenCreate"]["errors"][0]
+
+    # then
+    assert response_error["code"] == expected_error_code
+    assert response_error["field"] == "email"
+
+
+def test_create_token_deactivated_user(api_client, customer_user):
+    # given
+    variables = {"email": customer_user.email, "password": customer_user._password}
+    customer_user.is_active = False
+    customer_user.last_login = datetime(2020, 3, 18, tzinfo=timezone.utc)
+    customer_user.save()
+    expected_error_code = AccountErrorCode.INACTIVE.value.upper()
+
+    # when
+    response = api_client.post_graphql(MUTATION_CREATE_TOKEN, variables)
+    content = get_graphql_content(response)
+    response_error = content["data"]["tokenCreate"]["errors"][0]
+
+    # then
+    assert response_error["code"] == expected_error_code
+    assert response_error["field"] == "email"
+
+
+@freeze_time("2020-03-18 12:00:00")
+def test_create_token_active_user_logged_before(api_client, customer_user, settings):
+    variables = {"email": customer_user.email, "password": customer_user._password}
+    customer_user.last_login = datetime(2020, 3, 18, tzinfo=timezone.utc)
+    customer_user.save()
+    response = api_client.post_graphql(MUTATION_CREATE_TOKEN, variables)
+    content = get_graphql_content(response)
+
+    data = content["data"]["tokenCreate"]
+
+    user_email = data["user"]["email"]
+    assert customer_user.email == user_email
+    assert content["data"]["tokenCreate"]["errors"] == []
+
+    token = data["token"]
+    refreshToken = data["refreshToken"]
+
+    payload = jwt_decode(token)
+    assert payload["email"] == customer_user.email
+    assert payload["user_id"] == graphene.Node.to_global_id("User", customer_user.id)
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
+    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_ACCESS
+    assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
+    assert payload["type"] == JWT_ACCESS_TYPE
+
+    payload = jwt_decode(refreshToken)
+    assert payload["email"] == customer_user.email
+    assert datetime.fromtimestamp(payload["iat"]) == datetime.utcnow()
+    expected_expiration_datetime = datetime.utcnow() + settings.JWT_TTL_REFRESH
+    assert datetime.fromtimestamp(payload["exp"]) == expected_expiration_datetime
+    assert payload["type"] == JWT_REFRESH_TYPE
+    assert payload["token"] == customer_user.jwt_token_key

--- a/saleor/graphql/schema.graphql
+++ b/saleor/graphql/schema.graphql
@@ -70,6 +70,7 @@ enum AccountErrorCode {
   JWT_INVALID_CSRF_TOKEN
   CHANNEL_INACTIVE
   MISSING_CHANNEL_SLUG
+  ACCOUNT_NOT_CONFIRMED
 }
 
 input AccountInput {


### PR DESCRIPTION
I want to merge this change because error message and code should be proper for users that are not yet activated by email and deactivated.

<!-- Please mention all relevant issue numbers. -->
Port from #8250 
# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
