### PR TITLE
Add email validation during plugin configuration save

### DIFF
--- a/saleor/plugins/email_common.py
+++ b/saleor/plugins/email_common.py
@@ -15,6 +15,7 @@ from babel.numbers import format_currency
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.mail.backends.smtp import EmailBackend
+from django.core.validators import validate_email
 from django_prices.utils.locale import get_locale_data
 
 from ..product.product_images import get_thumbnail_size
@@ -279,6 +280,8 @@ def validate_default_email_configuration(
                 )
             }
         )
+
+    validate_email(config.sender_address)
 
     try:
         validate_email_config(config)

--- a/saleor/plugins/tests/fixtures.py
+++ b/saleor/plugins/tests/fixtures.py
@@ -31,6 +31,20 @@ def plugin_configuration(db):
 
 
 @pytest.fixture
+def email_configuration():
+    return {
+        "use_tls": False,
+        "use_ssl": False,
+        "host": "localhost",
+        "port": 1025,
+        "username": "test",
+        "password": "test",
+        "sender_name": "test_name",
+        "sender_address": "test_address",
+    }
+
+
+@pytest.fixture
 def channel_plugin_configurations(db, channel_USD, channel_PLN):
     usd_configuration = copy.deepcopy(ChannelPluginSample.DEFAULT_CONFIGURATION)
     usd_configuration[0]["value"] = channel_USD.slug

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -1,0 +1,29 @@
+import pytest
+from django.core.exceptions import ValidationError
+
+from saleor.plugins.email_common import validate_default_email_configuration
+
+
+@pytest.mark.parametrize(
+    "email",
+    (
+        "this_is_not_an_email",
+        "@",
+        ".@.test",
+        "almost_correct_email@",
+    ),
+)
+def test_validate_default_email_configuration_bad_email(
+    email, plugin_configuration, email_configuration
+):
+    email_configuration["sender_address"] = email
+
+    with pytest.raises(ValidationError):
+        validate_default_email_configuration(plugin_configuration, email_configuration)
+
+
+def test_validate_default_email_configuration_correct_email(
+    plugin_configuration, email_configuration
+):
+    email_configuration["sender_address"] = "this_is@correct.email"
+    validate_default_email_configuration(plugin_configuration, email_configuration)

--- a/saleor/plugins/tests/test_email_common.py
+++ b/saleor/plugins/tests/test_email_common.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from django.core.exceptions import ValidationError
 
@@ -22,8 +24,10 @@ def test_validate_default_email_configuration_bad_email(
         validate_default_email_configuration(plugin_configuration, email_configuration)
 
 
+@patch("saleor.plugins.email_common.validate_email_config")
 def test_validate_default_email_configuration_correct_email(
-    plugin_configuration, email_configuration
+    mock_email_config, plugin_configuration, email_configuration
 ):
+
     email_configuration["sender_address"] = "this_is@correct.email"
     validate_default_email_configuration(plugin_configuration, email_configuration)


### PR DESCRIPTION
Fix a bug found by accident :)

You can save plugin (email) configuration with bad email for example `test` and system doesn't validate this field. Then if you want to trigger sending and email we receive the following error:
```
ERROR celery.app.trace Task saleor.plugins.user_email.tasks.send_order_canceled_email_task[e7c6c634-1116-4660-926b-2090459fe315] raised unexpected: InvalidHeaderDefect('addr-spec local part with no domain') [PID:24155:Thread-7]
Traceback (most recent call last):
  File "/Users/mateusz/projects/saleor_venv/lib/python3.8/site-packages/celery/app/trace.py", line 450, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/Users/mateusz/projects/saleor/saleor/plugins/user_email/tasks.py", line 230, in send_order_canceled_email_task
    send_email(
  File "/Users/mateusz/projects/saleor/saleor/plugins/email_common.py", line 188, in send_email
    from_email = str(Address(sender_name, addr_spec=sender_address))
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/email/headerregistry.py", line 48, in __init__
    raise a_s.all_defects[0]
email.errors.InvalidHeaderDefect: addr-spec local part with no domain
```
This fix simply add a validation to the  `validate_default_email_configuration`.

<!-- Please mention all relevant issue numbers. -->

# Impact

* [ ] New migrations
* [ ] New/Updated API fields or mutations
* [ ] Deprecated API fields or mutations
* [ ] Removed API types, fields, or mutations
* [ ] Documentation needs to be updated

# Pull Request Checklist

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Privileged queries and mutations are guarded by proper permission checks
* [ ] Database queries are optimized and the number of queries is constant
* [ ] Database migration files are up to date
* [ ] The changes are tested
* [ ] GraphQL schema and type definitions are up to date
* [ ] Changes are mentioned in the changelog
